### PR TITLE
feat(skills): add Codex skill integration with auto-install

### DIFF
--- a/README-ZH_CN.md
+++ b/README-ZH_CN.md
@@ -12,12 +12,38 @@
 ## 安装
 
 ```bash
-npm install -g @oomol-lab/oo-cli
-# or
-pnpm add -g @oomol-lab/oo-cli
-# or
 bun install -g @oomol-lab/oo-cli
-oo --help
+```
+
+## 快速开始
+
+1. 登录：
+
+```bash
+oo login
+```
+
+2. 打开 Codex，输入下面这句开始工作：
+
+```text
+$oo 帮我生成 OOMOL 字符串的二维码
+```
+
+## Codex Skill
+
+首次打开 `oo`，或者执行 `oo skills install` 之后，Codex 中会生成内置的
+`oo` skill，位置在 `${CODEX_HOME:-~/.codex}/skills/oo`。
+
+然后你就可以在 Codex 中这样使用：
+
+```text
+$oo 帮我生成 OOMOL 字符串的二维码
+```
+
+也可以手动执行安装：
+
+```bash
+oo skills install
 ```
 
 ## 文档

--- a/README.md
+++ b/README.md
@@ -14,12 +14,38 @@ inspection, cloud task execution, and shell completion generation.
 ## Installation
 
 ```bash
-npm install -g @oomol-lab/oo-cli
-# or
-pnpm add -g @oomol-lab/oo-cli
-# or
 bun install -g @oomol-lab/oo-cli
-oo --help
+```
+
+## Quick Start
+
+1. Log in:
+
+```bash
+oo login
+```
+
+2. Open Codex and start working with:
+
+```text
+$oo generate a QR code for the string OOMOL
+```
+
+## Codex Skills
+
+On the first `oo` launch, or after running `oo skills install`, Codex will get
+the bundled `oo` skill under `${CODEX_HOME:-~/.codex}/skills/oo`.
+
+Then you can use it in Codex, for example:
+
+```text
+$oo generate a QR code for the string OOMOL
+```
+
+You can also install it explicitly with:
+
+```bash
+oo skills install
 ```
 
 ## Documentation

--- a/contrib/skills/oo/SKILL.md
+++ b/contrib/skills/oo/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: oo
+description: Use the oo CLI to translate natural-language requests into English search terms, inspect candidate OOMOL packages, choose blocks, collect required inputs, run validated cloud tasks, and manage bounded waits for long-running jobs. Use when the user wants to complete a task with OOMOL packages, not when they want to develop or debug oo-cli itself.
+---
+
+# oo
+
+Use this skill when the user wants to complete a practical task through the
+`oo` CLI, such as generating an artifact, transforming content, or running a
+cloud block.
+
+This skill is for operating `oo`. It is not for developing, debugging, or
+changing `oo-cli` itself.
+
+Read [references/oo-cli-contract.md](references/oo-cli-contract.md) when you
+need exact command syntax, JSON shapes, auth behavior, timeout rules, or known
+stop conditions.
+
+## Environment checks
+
+Before doing anything substantial:
+
+- Prefer `oo --lang en ...`.
+- If `oo` is unavailable, stop and explain that the environment does not have a
+  runnable `oo` CLI.
+- If authentication is uncertain, run `oo --lang en auth status` before the
+  first remote command.
+- Treat auth as usable only when the status output shows a valid active
+  account.
+- If auth status says logged out, missing, invalid, or request failed, stop and
+  ask the user to repair authentication before continuing.
+
+## Non-negotiable rules
+
+- Always use `--json` with:
+    - `search`
+    - `package info`
+    - `cloud-task run`
+- Never add `--json` to `cloud-task wait`.
+- Never invent package IDs, versions, block IDs, handle names, defaults, or
+  task results.
+- Do not continue past auth precheck unless `oo --lang en auth status` confirms
+  a valid active account.
+- `cloud-task run` must use `PACKAGE_NAME@SEMVER`.
+- `cloud-task run` must include a real `--block-id`.
+- If `search` returns zero packages, stop and tell the user that `oo` does not
+  currently have a matching capability.
+- Ask follow-up questions only when required inputs are missing or too risky to
+  infer.
+- Stop when the selected block depends on an input shape that `oo-cli` cannot
+  safely submit.
+
+## Workflow
+
+### 1. Normalize the request into English search terms
+
+Convert the user request into:
+
+- one short internal intent statement
+- `2` to `6` English keywords or short phrases
+
+Rules:
+
+- Keywords must always be in English, regardless of the user's language.
+- Prefer action + object + constraint.
+- Avoid filler words.
+
+Examples:
+
+- `generate qr code`
+- `md5 hash`
+- `image OCR`
+- `summarize pdf`
+
+Combine the keywords into one concise English search query.
+
+### 2. Search for candidate packages
+
+Run:
+
+```bash
+oo --lang en search "<english query>" --json
+```
+
+Then:
+
+- Rank packages only from the returned JSON array.
+- Some search items may be sparse, so rank using whatever package and block
+  fields are present.
+- Prefer semantic matches between the user goal and the package or block text.
+- Keep one primary candidate.
+- Keep one fallback candidate only if it is genuinely plausible.
+- Do not use `--only-package-id` for this step because it removes useful block
+  hints.
+
+If the result is empty, stop.
+
+### 3. Inspect package details and choose a block
+
+For each serious candidate, inspect it with one of these forms:
+
+```bash
+oo --lang en package info "<packageName>@<version>" --json
+```
+
+```bash
+oo --lang en package info "<packageName>" --json
+```
+
+Then choose the best block using only returned metadata.
+
+Prefer a block that:
+
+- directly matches the requested action
+- requires fewer mandatory inputs
+- has clearer input semantics
+- produces output closer to the user's goal
+
+Use `blocks[].blockName` as the block identifier for execution. Do not use the
+human-facing block title as `--block-id`.
+
+If search does not provide a version, inspect the package by name first and use
+the resolved `packageVersion` for any later `cloud-task run`.
+
+If a candidate does not expose a usable package name, do not select it.
+
+If the primary candidate fails inspection and the fallback is still credible,
+switch to the fallback.
+
+### 4. Build the input payload
+
+Use only fields from the selected block's `inputHandle`.
+
+Rules:
+
+- JSON keys in `--data` must exactly match input handle names.
+- Treat a handle as optional only when the metadata proves it:
+    - a non-null `value` already exists
+    - `nullable` is `true` and `value` is `null`
+    - `schema.default` exists
+- If the user request implies a concrete value for a handle, provide it
+  explicitly instead of inheriting a package default or sample value.
+- Treat package-provided `value` and `schema.default` as evidence that omission
+  may pass local validation, not as evidence that the value is correct for the
+  current task.
+- If a handle is technically optional but the task would be underspecified
+  without a user-specific value, ask a follow-up question.
+- Do not submit fields outside `inputHandle`.
+- Do not guess secrets, credentials, local file paths, filenames, or opaque IDs.
+- Do not force raw user prose into a handle whose schema does not fit.
+
+If a required value is missing or ambiguous, ask a focused follow-up question.
+
+A good follow-up question:
+
+- identifies the missing handle
+- offers `2` to `4` concrete options when possible
+- includes one recommended option with a brief reason
+
+### 5. Stop on unsupported input shapes
+
+Stop instead of forcing execution when any of the following is true:
+
+- a required input is still missing
+- the input schema implies a value shape that cannot be safely represented with
+  `cloud-task run --data`
+- the block depends on environment data that cannot be safely constructed
+- both primary and fallback candidates fail
+
+Pay special attention to `schema.contentMediaType`.
+
+If `contentMediaType` exists and is not `oomol/secret`, stop. The current
+`oo-cli` local validation rejects most non-secret content media types, so do
+not pretend file, image, or other special payloads can be passed safely as
+normal JSON values.
+
+### 6. Validate before creating the task
+
+If the payload is non-trivial, or if the user just confirmed important values,
+first run:
+
+```bash
+oo --lang en cloud-task run "<packageName>@<version>" \
+  --block-id "<blockId>" \
+  --data '<json object>' \
+  --dry-run \
+  --json
+```
+
+If dry-run succeeds, run the real task:
+
+```bash
+oo --lang en cloud-task run "<packageName>@<version>" \
+  --block-id "<blockId>" \
+  --data '<json object>' \
+  --json
+```
+
+Read `taskID` from the JSON response.
+
+Immediately report:
+
+- selected package ID and version
+- selected block ID
+- submitted key inputs
+- task ID
+- fallback candidate, if one exists
+
+Do not hide the task ID behind a long wait.
+
+### 7. Handle long-running tasks safely
+
+Do not default to an open-ended wait.
+
+Use bounded waiting windows:
+
+- short tasks: `2m` to `10m`
+- medium tasks: `15m` to `30m`
+- long or unknown tasks: `30m` to `60m`
+
+Use:
+
+```bash
+oo --lang en cloud-task wait "<taskId>" --timeout "<window>"
+```
+
+Rules:
+
+- Wait immediately only if the task looks short or the user explicitly wants to
+  wait now.
+- Do not default to `6h` or longer in one call unless the user explicitly asks.
+- Remember that a single `wait` call cannot exceed `24h`.
+- If `wait` times out, treat that as "still running", not as failure.
+- After any non-zero `wait` exit, immediately check:
+
+```bash
+oo --lang en cloud-task result "<taskId>" --json
+```
+
+Use the result snapshot to distinguish:
+
+- still running
+- failed
+- succeeded after the wait command exited
+
+If the user wants to continue, run another bounded wait window instead of
+re-creating the task.
+
+### 8. Report outcomes clearly
+
+On success:
+
+- state the final task status first
+- summarize the useful result
+- include package, version, block ID, and task ID
+
+On still-running tasks:
+
+- state that the task was created successfully
+- state that it is still running
+- include the task ID
+- offer the next sensible action: wait again or check a result snapshot
+
+On failure:
+
+- report whether the failure came from no package match, missing input,
+  unsupported input shape, task failure, or environment or auth limitations
+
+## Response style
+
+- Be decisive.
+- Prefer the most specific block over a generic block.
+- Prefer recoverable progress over fragile one-shot waiting.
+- Never claim a capability that was not proven by `search`, `package info`, or
+  command output.

--- a/contrib/skills/oo/agents/openai.yaml
+++ b/contrib/skills/oo/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: oo
+  short_description: Safely run OOMOL packages and cloud tasks from user requests
+  default_prompt: "Use $oo to translate my request into English search terms, choose the best package and block, stop when auth or input requirements are not proven, ask only for missing inputs, run the task, and handle long waits safely."
+
+policy:
+  allow_implicit_invocation: false

--- a/contrib/skills/oo/references/oo-cli-contract.md
+++ b/contrib/skills/oo/references/oo-cli-contract.md
@@ -1,0 +1,290 @@
+# oo CLI Contract
+
+This reference captures the concrete `oo-cli` contract that the skill may rely
+on. Use it when you need exact command syntax, JSON expectations, auth behavior,
+or known stop conditions.
+
+## Entrypoints
+
+Canonical entrypoint:
+
+```bash
+oo --lang en ...
+```
+
+If `oo` is unavailable, stop.
+
+## Authentication
+
+- `search`, `package info`, `cloud-task run`, `cloud-task result`, and
+  `cloud-task wait` all require a current authenticated account.
+- If auth state is uncertain, use:
+
+```bash
+oo --lang en auth status
+```
+
+- Treat auth as usable only when the output confirms a valid active account.
+- If auth status reports logged out, missing, invalid, or request failed, stop
+  before any remote command.
+- If the user needs to repair auth, ask them to complete:
+
+```bash
+oo --lang en auth login
+```
+
+## `search`
+
+Canonical form:
+
+```bash
+oo --lang en search "<text>" --json
+```
+
+Facts:
+
+- `<text>` is the only positional argument.
+- `--json` is an alias for `--format=json`.
+- JSON output is a raw array, not an object with a top-level `packages` field.
+- Search text longer than `200` characters is truncated before the request is
+  sent.
+- There is no client-side top-k or limit flag.
+- Do not use `--only-package-id` when choosing candidate blocks.
+
+Representative JSON example:
+
+```json
+[
+  {
+    "blocks": [
+      {
+        "title": "string"
+      }
+    ],
+    "displayName": "string",
+    "name": "string",
+    "version": "1.2.3"
+  }
+]
+```
+
+Treat the array items as loosely shaped service data. Useful fields may be
+missing, sparse, or added over time.
+
+Stop condition:
+
+- If the array is empty, stop and tell the user that `oo` does not currently
+  have a matching capability.
+
+## `package info`
+
+Canonical form:
+
+```bash
+oo --lang en package info "<packageSpecifier>" --json
+```
+
+Supported package specifier examples:
+
+- `pdf`
+- `pdf@1.0.0`
+- `@foo/epub`
+- `@foo/epub@1.0.0`
+
+Facts:
+
+- If no version is provided, the CLI resolves the latest version.
+- `@latest` is valid for `package info`, but not for `cloud-task run`.
+- For execution later, always use the resolved `packageVersion`.
+- Use `blocks[].blockName` for `--block-id`.
+- Do not confuse block `title` with `blockName`.
+
+Expected JSON shape:
+
+```json
+{
+  "blocks": [
+    {
+      "blockName": "main",
+      "description": "string",
+      "inputHandle": {
+        "inputName": {
+          "description": "string",
+          "nullable": false,
+          "schema": {
+            "type": "string"
+          },
+          "value": "optional default value"
+        }
+      },
+      "outputHandle": {
+        "outputName": {
+          "description": "string",
+          "schema": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "Main"
+    }
+  ],
+  "description": "string",
+  "displayName": "Readable package title",
+  "packageName": "package-name",
+  "packageVersion": "1.2.3"
+}
+```
+
+Treat an input handle as optional only when metadata proves it:
+
+- `value` exists and is not `null`
+- `nullable` is `true` and `value` is `null`
+- `schema.default` exists
+
+These signals only show that omission may pass local validation.
+
+They do not prove that the package-provided value is correct for the current
+user request.
+
+Sample values, placeholders, empty strings, and defaults should be overridden
+whenever the user request implies a specific input.
+
+## `cloud-task run`
+
+Canonical form:
+
+```bash
+oo --lang en cloud-task run "<packageName>@<version>" \
+  --block-id "<blockName>" \
+  --data '<json object>' \
+  --json
+```
+
+Dry-run form:
+
+```bash
+oo --lang en cloud-task run "<packageName>@<version>" \
+  --block-id "<blockName>" \
+  --data '<json object>' \
+  --dry-run \
+  --json
+```
+
+Facts:
+
+- The package specifier must contain an explicit semver version.
+- `@latest` is not valid for `cloud-task run`.
+- `--block-id` is required.
+- `--data` must be a JSON object string or `@path/to/file.json`.
+- If `--data` is omitted, the CLI uses `{}`.
+- Local validation runs before task creation.
+
+Expected success JSON:
+
+```json
+{
+  "taskID": "task-id"
+}
+```
+
+Expected dry-run JSON:
+
+```json
+{
+  "dryRun": true,
+  "ok": true
+}
+```
+
+Hard validation limits:
+
+- Unknown input handles are rejected.
+- Missing required values are rejected.
+- Type mismatches are rejected.
+- `--data` must decode to a plain JSON object.
+- If an input handle schema contains `contentMediaType` and the value is not
+  `oomol/secret`, current local validation rejects it.
+
+Practical implication:
+
+- Stop instead of pretending that file, image, or other special-media handles
+  can be submitted safely through normal JSON payloads.
+
+## `cloud-task result`
+
+Canonical form:
+
+```bash
+oo --lang en cloud-task result "<taskId>" --json
+```
+
+Possible JSON shapes:
+
+```json
+{
+  "progress": 0.5,
+  "status": "queued"
+}
+```
+
+```json
+{
+  "resultData": {},
+  "resultURL": null,
+  "status": "success"
+}
+```
+
+```json
+{
+  "error": "message",
+  "status": "failed"
+}
+```
+
+In-progress statuses include `queued`, `scheduling`, `scheduled`, and
+`running`. Treat any of them as not terminal yet.
+
+Use this command after a non-zero `cloud-task wait` exit to distinguish timeout,
+failure, and a late success.
+
+## `cloud-task wait`
+
+Canonical form:
+
+```bash
+oo --lang en cloud-task wait "<taskId>" --timeout "<window>"
+```
+
+Facts:
+
+- `cloud-task wait` does not support `--json`.
+- It polls every `3` seconds.
+- Default timeout is `6h`.
+- Minimum timeout is `10s`.
+- Maximum timeout is `24h`.
+- Supported timeout formats include `1m`, `4h`, `120s`, and `360`.
+- Success exits with code `0` and prints text output.
+- Failed tasks print a result snapshot and then exit non-zero.
+- Timeout also exits non-zero.
+- While the task is still running, the CLI prints periodic status snapshots.
+
+Skill policy:
+
+- Prefer bounded wait windows over a single long wait.
+- Do not treat timeout as task failure.
+- Never re-create a task just because a wait window ended.
+
+## Command selection summary
+
+Use this order:
+
+1. Convert the user request into `2` to `6` English keywords.
+2. Run `search --json`.
+3. Run `package info --json` for the serious candidates.
+4. Choose one primary package and optionally one fallback.
+5. Ask focused follow-up questions only for missing required inputs.
+6. Run `cloud-task run --json`.
+7. Share `taskID` immediately.
+8. Use bounded `cloud-task wait` windows when appropriate.
+9. After a non-zero wait exit, run `cloud-task result --json`.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -88,6 +88,35 @@ Remove one persisted configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported value: `lang`.
 
+## Codex Skills
+
+### `oo skills install`
+
+Install one bundled skill into the local Codex skills directory.
+
+- Managed skill: `oo`.
+- Target directory: `${CODEX_HOME:-~/.codex}/skills/oo`.
+- Metadata: the installation writes the current `oo` version into a hidden
+  version file inside the skill directory.
+- Notes: the command exits with an error when the Codex home directory does
+  not exist, which indicates Codex is not installed on the current machine.
+- Notes: an existing `oo/agents/openai.yaml` is considered managed by
+  `oo` only when it contains the string `OOMOL`. Otherwise `oo` treats it as a
+  different skill and will not overwrite it.
+- Notes: on the first `oo` run, when there is no existing config, auth, or log
+  data yet, `oo` silently installs the managed skill automatically if the
+  Codex home directory already exists.
+- Notes: when a bundled skill is already installed, every `oo` startup checks
+  whether its recorded version matches the current CLI version and silently
+  refreshes the installed files when needed.
+
+### `oo skills uninstall`
+
+Remove one bundled skill from the local Codex skills directory.
+
+- Managed skill: `oo`.
+- Target directory: `${CODEX_HOME:-~/.codex}/skills/oo`.
+
 ## Logs
 
 ### `oo log path`

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -82,6 +82,32 @@
 
 - 参数：`<key>` 为配置键。目前仅支持 `lang`。
 
+## Codex Skill
+
+### `oo skills install`
+
+将一个内置 skill 安装到本地 Codex skills 目录。
+
+- 内置 skill：`oo`。
+- 目标目录：`${CODEX_HOME:-~/.codex}/skills/oo`。
+- 元数据：安装时会在 skill 目录内写入一个隐藏的 `oo` 版本记录文件。
+- 说明：当 Codex 根目录不存在时，命令会直接报错退出，这表示当前机器上没有
+  安装 Codex。
+- 说明：只有当 `oo/agents/openai.yaml` 中包含 `OOMOL` 字符串时，`oo`
+  才会认为这是自己管理的 skill；否则会视为其他 skill，并拒绝覆盖。
+- 说明：如果这是 `oo` 的首次运行，且当前还没有已有的 config、auth、log
+  数据，那么只要 Codex 根目录已经存在，`oo` 就会静默自动安装这个受管
+  skill。
+- 说明：如果内置 skill 已经安装，`oo` 每次启动都会检查其记录版本是否与当前
+  CLI 版本一致；不一致时会静默刷新已安装的文件。
+
+### `oo skills uninstall`
+
+从本地 Codex skills 目录移除一个内置 skill。
+
+- 内置 skill：`oo`。
+- 目标目录：`${CODEX_HOME:-~/.codex}/skills/oo`。
+
 ## 日志
 
 ### `oo log path`

--- a/src/adapters/store/store-path.ts
+++ b/src/adapters/store/store-path.ts
@@ -23,7 +23,7 @@ export interface StorePaths {
     settingsFilePath: string;
 }
 
-function resolveHomeDirectory(
+export function resolveHomeDirectory(
     env: Record<string, string | undefined>,
     explicitHomeDirectory?: string,
 ): string {

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -7,6 +7,10 @@ import { describe, expect, test } from "bun:test";
 import { createCliSandbox, createTextBuffer } from "../../../__tests__/helpers.ts";
 import packageManifest from "../../../package.json" with { type: "json" };
 import { resolveStorePaths } from "../../adapters/store/store-path.ts";
+import {
+    resolveBundledSkillVersionFilePath,
+    resolveCodexHomeDirectory,
+} from "../commands/skills/shared.ts";
 import { APP_NAME } from "../config/app-config.ts";
 import { CliUserError } from "../contracts/cli.ts";
 import { createTerminalColors } from "../terminal-colors.ts";
@@ -114,6 +118,102 @@ describe("runCli", () => {
             expect(firstLine).toContain(`"command":"--help"`);
             expect(content).toContain(`"msg":"CLI invocation started."`);
             expect(content).toContain(`"msg":"CLI invocation completed."`);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("silently installs the managed Codex skill on the first run", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["--help"], {
+                version: "9.9.9",
+            });
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).not.toContain("Installed Codex skill");
+            expect(result.stderr).toBe("");
+            await expect(stat(join(skillDirectoryPath, "SKILL.md"))).resolves.toMatchObject({
+                isFile: expect.any(Function),
+            });
+            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: false",
+            );
+            expect(await readFile(versionFilePath, "utf8")).toBe("9.9.9\n");
+            expect(content).toContain(`"msg":"CLI first-run detection completed."`);
+            expect(content).toContain(`"isFirstRun":true`);
+            expect(content).toContain(`"shouldInstallMissingBundledSkills":true`);
+            expect(content).toContain(
+                `"msg":"Bundled Codex skill installed during first-run bootstrap."`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not auto-install the managed Codex skill for skills subcommands", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "uninstall"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                `Codex skill oo is not installed at ${skillDirectoryPath}.\n`,
+            );
+            await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("writes explicit skills install and uninstall logs", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const installResult = await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
+            });
+            const installContent = await readLatestLogContent(sandbox);
+            const uninstallResult = await sandbox.run(["skills", "uninstall"]);
+            const uninstallContent = await readLatestLogContent(sandbox);
+
+            expect(installResult.exitCode).toBe(0);
+            expect(installContent).toContain(
+                `"msg":"Bundled Codex skill installed explicitly."`,
+            );
+            expect(installContent).toContain(`"skillName":"oo"`);
+            expect(installContent).toContain(`"path":"${skillDirectoryPath}"`);
+            expect(installContent).toContain(`"version":"9.9.9"`);
+
+            expect(uninstallResult.exitCode).toBe(0);
+            expect(uninstallContent).toContain(
+                `"msg":"Bundled Codex skill removed explicitly."`,
+            );
+            expect(uninstallContent).toContain(`"skillName":"oo"`);
+            expect(uninstallContent).toContain(`"path":"${skillDirectoryPath}"`);
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -9,6 +9,7 @@ import type {
 } from "../contracts/cli.ts";
 import type { SettingsStore } from "../contracts/settings-store.ts";
 import type { LogCategory } from "../logging/log-categories.ts";
+import { readdir, stat } from "node:fs/promises";
 import process from "node:process";
 import packageManifest from "../../../package.json" with { type: "json" };
 import { SqliteCacheStore } from "../../adapters/cache/sqlite-cache.ts";
@@ -25,6 +26,7 @@ import {
 } from "../../i18n/locale.ts";
 import { createTranslator } from "../../i18n/translator.ts";
 import { createCliCatalog } from "../commands/catalog.ts";
+import { maybeSynchronizeInstalledBundledSkills } from "../commands/skills/shared.ts";
 import { APP_NAME } from "../config/app-config.ts";
 import {
     formatCliVersionText,
@@ -73,6 +75,7 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
         env: invocation.env,
         platform: process.platform,
     });
+    const firstRunDetection = await detectFirstRun(storePaths);
     const bootstrapTranslator = createTranslator(
         resolvePreferredLocale({
             cliFlag: parsedCliLanguage,
@@ -141,6 +144,10 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
         const packageName = invocation.packageName ?? packageManifest.name;
         const buildInfo = resolveCliBuildInfo(packageManifest.version);
         const version = invocation.version ?? buildInfo.version;
+        const primaryCommandName = resolvePrimaryCommandName(invocation.argv);
+        const shouldInstallMissingBundledSkills
+            = firstRunDetection.isFirstRun
+                && primaryCommandName !== "skills";
 
         logger.debug(
             {
@@ -149,6 +156,17 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
                 version,
             },
             "CLI invocation started.",
+        );
+        logger.debug(
+            {
+                hasAuthFile: firstRunDetection.hasAuthFile,
+                hasLogFiles: firstRunDetection.hasLogFiles,
+                hasSettingsFile: firstRunDetection.hasSettingsFile,
+                isFirstRun: firstRunDetection.isFirstRun,
+                primaryCommandName: primaryCommandName ?? "",
+                shouldInstallMissingBundledSkills,
+            },
+            "CLI first-run detection completed.",
         );
 
         const context: CliExecutionContext = {
@@ -176,6 +194,13 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
                 translator,
             ),
         };
+        await maybeSynchronizeInstalledBundledSkills(
+            context,
+            {
+                installMissing: shouldInstallMissingBundledSkills,
+            },
+        );
+
         const adapter = new CommanderCliAdapter();
 
         exitCode = await adapter.run({
@@ -256,6 +281,80 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
 
 function hasCliDebugFlag(argv: readonly string[]): boolean {
     return argv.includes("--debug");
+}
+
+function resolvePrimaryCommandName(argv: readonly string[]): string | undefined {
+    for (let index = 0; index < argv.length; index += 1) {
+        const token = argv[index];
+
+        if (token === "--lang") {
+            index += 1;
+            continue;
+        }
+
+        if (token?.startsWith("-")) {
+            continue;
+        }
+
+        return token;
+    }
+
+    return undefined;
+}
+
+async function detectFirstRun(storePaths: {
+    authFilePath: string;
+    logDirectoryPath: string;
+    settingsFilePath: string;
+}): Promise<{
+    hasAuthFile: boolean;
+    hasLogFiles: boolean;
+    hasSettingsFile: boolean;
+    isFirstRun: boolean;
+}> {
+    const [hasSettingsFile, hasAuthFile, hasLogFiles] = await Promise.all([
+        pathExists(storePaths.settingsFilePath),
+        pathExists(storePaths.authFilePath),
+        directoryHasEntries(storePaths.logDirectoryPath),
+    ]);
+
+    return {
+        hasAuthFile,
+        hasLogFiles,
+        hasSettingsFile,
+        isFirstRun: !hasSettingsFile && !hasAuthFile && !hasLogFiles,
+    };
+}
+
+async function pathExists(path: string): Promise<boolean> {
+    try {
+        await stat(path);
+        return true;
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+async function directoryHasEntries(path: string): Promise<boolean> {
+    try {
+        return (await readdir(path)).length > 0;
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+function isNodeNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
 function resolveCliErrorLogCategory(error: CliUserError): LogCategory {

--- a/src/application/commands/catalog.ts
+++ b/src/application/commands/catalog.ts
@@ -10,6 +10,7 @@ import { loginCommand } from "./login.ts";
 import { logoutCommand } from "./logout.ts";
 import { packageCommand } from "./package/index.ts";
 import { searchCommand } from "./search.ts";
+import { skillsCommand } from "./skills/index.ts";
 
 const globalOptions = [
     {
@@ -39,6 +40,7 @@ export function createCliCatalog(): CliCatalog {
             logoutCommand,
             completionCommand,
             configCommand,
+            skillsCommand,
             logCommand,
             packageCommand,
             searchCommand,

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -1,0 +1,38 @@
+import ooOpenAIAgentPath from "../../../../contrib/skills/oo/agents/openai.yaml" with { type: "file" };
+import ooCliContractPath from "../../../../contrib/skills/oo/references/oo-cli-contract.md" with { type: "file" };
+import ooSkillPath from "../../../../contrib/skills/oo/SKILL.md" with { type: "file" };
+
+export const availableBundledSkillNames = ["oo"] as const;
+
+export type BundledSkillName = (typeof availableBundledSkillNames)[number];
+
+interface BundledSkillFile {
+    readonly relativePath: string;
+    readonly skillName: BundledSkillName;
+    readonly sourcePath: string;
+}
+
+// Keep this list aligned with contrib/skills so Bun embeds the skill files.
+const bundledSkillFiles = [
+    {
+        relativePath: "SKILL.md",
+        skillName: "oo",
+        sourcePath: ooSkillPath,
+    },
+    {
+        relativePath: "agents/openai.yaml",
+        skillName: "oo",
+        sourcePath: ooOpenAIAgentPath,
+    },
+    {
+        relativePath: "references/oo-cli-contract.md",
+        skillName: "oo",
+        sourcePath: ooCliContractPath,
+    },
+] as const satisfies readonly BundledSkillFile[];
+
+export function getBundledSkillFiles(
+    skillName: BundledSkillName,
+): readonly BundledSkillFile[] {
+    return bundledSkillFiles.filter(file => file.skillName === skillName);
+}

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -1,0 +1,261 @@
+import { mkdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { createCliSandbox } from "../../../../__tests__/helpers.ts";
+import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import { getBundledSkillFiles } from "./embedded-assets.ts";
+import {
+    resolveBundledSkillVersionFilePath,
+    resolveCodexHomeDirectory,
+} from "./shared.ts";
+
+describe("skills commands", () => {
+    test("installs a bundled Codex skill into the Codex skills directory", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const resultVersion = "9.9.9";
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "install"], {
+                version: resultVersion,
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Installed Codex skill oo to ${skillDirectoryPath}.\n`,
+            );
+            expect(result.stderr).toBe("");
+
+            for (const file of getBundledSkillFiles("oo")) {
+                expect(
+                    await readFile(join(skillDirectoryPath, file.relativePath), "utf8"),
+                ).toBe(await Bun.file(file.sourcePath).text());
+            }
+            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: false",
+            );
+            expect(await readFile(versionFilePath, "utf8")).toBe(
+                `${resultVersion}\n`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails when the Codex home directory is missing", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+
+        try {
+            const result = await sandbox.run(["skills", "install"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                `Codex is not installed. Expected the Codex home directory at ${codexHomeDirectory}.\n`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("refuses to overwrite an existing non-OOMOL skill with the same name", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(
+                ownershipFilePath,
+                [
+                    "interface:",
+                    "  display_name: oo",
+                    "  short_description: Custom skill",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["skills", "install"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                `Skill name oo is already used by a non-OOMOL Codex skill at ${skillDirectoryPath}.\n`,
+            );
+            expect(await readFile(ownershipFilePath, "utf8")).not.toContain("OOMOL");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("uninstalls a bundled Codex skill from the Codex skills directory", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const installResult = await sandbox.run(["skills", "install"]);
+            expect(installResult.exitCode).toBe(0);
+
+            const result = await sandbox.run(["skills", "uninstall"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Removed Codex skill oo from ${skillDirectoryPath}.\n`,
+            );
+            expect(result.stderr).toBe("");
+            await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not uninstall a same-name skill that is not managed by OOMOL", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(
+                ownershipFilePath,
+                [
+                    "interface:",
+                    "  display_name: oo",
+                    "  short_description: Custom skill",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["skills", "uninstall"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                `Codex skill oo is not installed at ${skillDirectoryPath}.\n`,
+            );
+            await expect(stat(skillDirectoryPath)).resolves.toMatchObject({
+                isDirectory: expect.any(Function),
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("silently synchronizes installed bundled skills when the oo version changes", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const managedSkillPath = join(skillDirectoryPath, "SKILL.md");
+        const managedOwnershipPath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const expectedSkillContent = await Bun.file(
+            getBundledSkillFiles("oo")[0]!.sourcePath,
+        ).text();
+        const expectedOwnershipContent = await Bun.file(
+            getBundledSkillFiles("oo").find(file => file.relativePath === "agents/openai.yaml")!.sourcePath,
+        ).text();
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(versionFilePath, "0.0.1\n");
+            await Bun.write(managedSkillPath, "stale\n");
+            await Bun.write(managedOwnershipPath, expectedOwnershipContent);
+
+            const result = await sandbox.run(["--help"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(await readFile(versionFilePath, "utf8")).toBe("9.9.9\n");
+            expect(await readFile(managedSkillPath, "utf8")).toBe(
+                expectedSkillContent,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not install bundled skills automatically after the first run", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await Bun.write(storePaths.settingsFilePath, "lang = \"en\"\n");
+
+            const result = await sandbox.run(["--help"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not synchronize a same-name skill that is not managed by OOMOL", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(versionFilePath, "0.0.1\n");
+            await Bun.write(
+                ownershipFilePath,
+                [
+                    "interface:",
+                    "  display_name: oo",
+                    "  short_description: Custom skill",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["--help"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(await readFile(versionFilePath, "utf8")).toBe("0.0.1\n");
+            expect(await readFile(ownershipFilePath, "utf8")).not.toContain("OOMOL");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -1,0 +1,14 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { skillsInstallCommand } from "./install.ts";
+import { skillsUninstallCommand } from "./uninstall.ts";
+
+export const skillsCommand: CliCommandDefinition = {
+    name: "skills",
+    summaryKey: "commands.skills.summary",
+    descriptionKey: "commands.skills.description",
+    children: [
+        skillsInstallCommand,
+        skillsUninstallCommand,
+    ],
+};

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -1,0 +1,16 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import { installBundledSkill } from "./shared.ts";
+
+const bundledSkillName = "oo" as const;
+
+export const skillsInstallCommand: CliCommandDefinition = {
+    name: "install",
+    summaryKey: "commands.skills.install.summary",
+    descriptionKey: "commands.skills.install.description",
+    inputSchema: z.object({}),
+    handler: async (_, context) => {
+        await installBundledSkill(bundledSkillName, context);
+    },
+};

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -1,0 +1,401 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+
+import type { BundledSkillName } from "./embedded-assets.ts";
+import { mkdir, readFile, rm, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { resolveHomeDirectory } from "../../../adapters/store/store-path.ts";
+import { CliUserError } from "../../contracts/cli.ts";
+import {
+    availableBundledSkillNames,
+    getBundledSkillFiles,
+} from "./embedded-assets.ts";
+
+const codexDirectoryName = ".codex";
+const codexSkillsDirectoryName = "skills";
+const bundledSkillVersionFileName = ".oo-version";
+const bundledSkillOwnershipMarker = "OOMOL";
+const bundledSkillOwnershipFileRelativePath = "agents/openai.yaml";
+
+export function resolveCodexHomeDirectory(
+    env: Record<string, string | undefined>,
+): string {
+    const explicitCodexHome = env.CODEX_HOME?.trim();
+
+    if (explicitCodexHome) {
+        return explicitCodexHome;
+    }
+
+    return join(resolveHomeDirectory(env), codexDirectoryName);
+}
+
+export function resolveBundledSkillDirectoryPath(
+    codexHomeDirectory: string,
+    skillName: BundledSkillName,
+): string {
+    return join(codexHomeDirectory, codexSkillsDirectoryName, skillName);
+}
+
+export function resolveBundledSkillVersionFilePath(
+    skillDirectoryPath: string,
+): string {
+    return join(skillDirectoryPath, bundledSkillVersionFileName);
+}
+
+export async function installBundledSkill(
+    skillName: BundledSkillName,
+    context: CliExecutionContext,
+): Promise<void> {
+    const codexHomeDirectory = await requireCodexHomeDirectory(context);
+    const installedSkillDirectoryPath = resolveBundledSkillDirectoryPath(
+        codexHomeDirectory,
+        skillName,
+    );
+
+    if (
+        await directoryExists(installedSkillDirectoryPath)
+        && !(await isManagedBundledSkillInstallation(installedSkillDirectoryPath))
+    ) {
+        context.logger.warn(
+            {
+                path: installedSkillDirectoryPath,
+                skillName,
+            },
+            "Bundled Codex skill install was blocked by an unmanaged directory.",
+        );
+        throw new CliUserError("errors.skills.nameConflict", 1, {
+            name: skillName,
+            path: installedSkillDirectoryPath,
+        });
+    }
+
+    const skillDirectoryPath = await writeBundledSkillInstallation({
+        codexHomeDirectory,
+        skillName,
+        version: context.version,
+    });
+
+    writeLine(
+        context,
+        context.translator.t("skills.install.success", {
+            name: skillName,
+            path: skillDirectoryPath,
+        }),
+    );
+    context.logger.info(
+        {
+            path: skillDirectoryPath,
+            skillName,
+            version: context.version,
+        },
+        "Bundled Codex skill installed explicitly.",
+    );
+}
+
+export async function maybeSynchronizeInstalledBundledSkills(
+    context: Pick<CliExecutionContext, "env" | "logger" | "version">,
+    options: {
+        installMissing?: boolean;
+    } = {},
+): Promise<void> {
+    const codexHomeDirectory = resolveCodexHomeDirectory(context.env);
+
+    if (!(await directoryExists(codexHomeDirectory))) {
+        context.logger.debug(
+            {
+                path: codexHomeDirectory,
+            },
+            "Bundled Codex skill synchronization skipped because Codex home is missing.",
+        );
+        return;
+    }
+
+    for (const skillName of availableBundledSkillNames) {
+        const skillDirectoryPath = resolveBundledSkillDirectoryPath(
+            codexHomeDirectory,
+            skillName,
+        );
+
+        try {
+            if (!(await directoryExists(skillDirectoryPath))) {
+                if (options.installMissing !== true) {
+                    context.logger.debug(
+                        {
+                            path: skillDirectoryPath,
+                            skillName,
+                            version: context.version,
+                        },
+                        "Bundled Codex skill synchronization skipped because the managed skill is not installed.",
+                    );
+                    continue;
+                }
+
+                await writeBundledSkillInstallation({
+                    codexHomeDirectory,
+                    skillName,
+                    version: context.version,
+                });
+                context.logger.info(
+                    {
+                        path: skillDirectoryPath,
+                        skillName,
+                        version: context.version,
+                    },
+                    "Bundled Codex skill installed during first-run bootstrap.",
+                );
+                continue;
+            }
+
+            if (!(await isManagedBundledSkillInstallation(skillDirectoryPath))) {
+                context.logger.debug(
+                    {
+                        path: skillDirectoryPath,
+                        skillName,
+                    },
+                    "Bundled Codex skill synchronization skipped because the existing directory is not managed by OOMOL.",
+                );
+                continue;
+            }
+
+            if (
+                await isBundledSkillInstallationCurrent(
+                    skillName,
+                    skillDirectoryPath,
+                    context.version,
+                )
+            ) {
+                context.logger.debug(
+                    {
+                        path: skillDirectoryPath,
+                        skillName,
+                        version: context.version,
+                    },
+                    "Bundled Codex skill synchronization skipped because the managed skill is already current.",
+                );
+                continue;
+            }
+
+            const previousVersion
+                = await readInstalledBundledSkillVersion(skillDirectoryPath);
+
+            await writeBundledSkillInstallation({
+                codexHomeDirectory,
+                skillName,
+                version: context.version,
+            });
+            context.logger.info(
+                {
+                    path: skillDirectoryPath,
+                    previousVersion: previousVersion ?? "unknown",
+                    skillName,
+                    version: context.version,
+                },
+                "Bundled Codex skill synchronized.",
+            );
+        }
+        catch (error) {
+            context.logger.warn(
+                {
+                    err: error,
+                    path: skillDirectoryPath,
+                    skillName,
+                    version: context.version,
+                },
+                "Failed to synchronize bundled Codex skill.",
+            );
+        }
+    }
+}
+
+export async function uninstallBundledSkill(
+    skillName: BundledSkillName,
+    context: CliExecutionContext,
+): Promise<void> {
+    const codexHomeDirectory = await requireCodexHomeDirectory(context);
+    const skillDirectoryPath = resolveBundledSkillDirectoryPath(
+        codexHomeDirectory,
+        skillName,
+    );
+
+    if (
+        !(await directoryExists(skillDirectoryPath))
+        || !(await isManagedBundledSkillInstallation(skillDirectoryPath))
+    ) {
+        context.logger.warn(
+            {
+                path: skillDirectoryPath,
+                skillName,
+            },
+            "Bundled Codex skill uninstall skipped because no managed installation was found.",
+        );
+        throw new CliUserError("errors.skills.notInstalled", 1, {
+            name: skillName,
+            path: skillDirectoryPath,
+        });
+    }
+
+    const previousVersion = await readInstalledBundledSkillVersion(skillDirectoryPath);
+
+    await rm(skillDirectoryPath, { force: true, recursive: true });
+
+    writeLine(
+        context,
+        context.translator.t("skills.uninstall.success", {
+            name: skillName,
+            path: skillDirectoryPath,
+        }),
+    );
+    context.logger.info(
+        {
+            path: skillDirectoryPath,
+            previousVersion: previousVersion ?? "unknown",
+            skillName,
+        },
+        "Bundled Codex skill removed explicitly.",
+    );
+}
+
+async function writeBundledSkillInstallation(options: {
+    codexHomeDirectory: string;
+    skillName: BundledSkillName;
+    version: string;
+}): Promise<string> {
+    const skillDirectoryPath = resolveBundledSkillDirectoryPath(
+        options.codexHomeDirectory,
+        options.skillName,
+    );
+
+    await mkdir(skillDirectoryPath, { recursive: true });
+
+    for (const file of getBundledSkillFiles(options.skillName)) {
+        const destinationPath = join(skillDirectoryPath, file.relativePath);
+
+        await mkdir(dirname(destinationPath), { recursive: true });
+        await Bun.write(destinationPath, Bun.file(file.sourcePath));
+    }
+
+    await Bun.write(
+        resolveBundledSkillVersionFilePath(skillDirectoryPath),
+        `${options.version}\n`,
+    );
+
+    return skillDirectoryPath;
+}
+
+async function isBundledSkillInstallationCurrent(
+    skillName: BundledSkillName,
+    skillDirectoryPath: string,
+    version: string,
+): Promise<boolean> {
+    if (!(await isManagedBundledSkillInstallation(skillDirectoryPath))) {
+        return false;
+    }
+
+    const installedVersion = await readInstalledBundledSkillVersion(
+        skillDirectoryPath,
+    );
+
+    if (installedVersion !== version) {
+        return false;
+    }
+
+    for (const file of getBundledSkillFiles(skillName)) {
+        if (!(await fileExists(join(skillDirectoryPath, file.relativePath)))) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+async function isManagedBundledSkillInstallation(
+    skillDirectoryPath: string,
+): Promise<boolean> {
+    try {
+        const content = await readFile(
+            join(
+                skillDirectoryPath,
+                bundledSkillOwnershipFileRelativePath,
+            ),
+            "utf8",
+        );
+
+        return content.includes(bundledSkillOwnershipMarker);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+async function readInstalledBundledSkillVersion(
+    skillDirectoryPath: string,
+): Promise<string | undefined> {
+    try {
+        const version = (
+            await readFile(
+                resolveBundledSkillVersionFilePath(skillDirectoryPath),
+                "utf8",
+            )
+        ).trim();
+
+        return version === "" ? undefined : version;
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
+}
+
+async function requireCodexHomeDirectory(
+    context: Pick<CliExecutionContext, "env">,
+): Promise<string> {
+    const codexHomeDirectory = resolveCodexHomeDirectory(context.env);
+
+    if (!(await directoryExists(codexHomeDirectory))) {
+        throw new CliUserError("errors.skills.codexNotInstalled", 1, {
+            path: codexHomeDirectory,
+        });
+    }
+
+    return codexHomeDirectory;
+}
+
+async function directoryExists(path: string): Promise<boolean> {
+    try {
+        return (await stat(path)).isDirectory();
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+    try {
+        return (await stat(path)).isFile();
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+function isNodeNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function writeLine(context: CliExecutionContext, message: string): void {
+    context.stdout.write(`${message}\n`);
+}

--- a/src/application/commands/skills/uninstall.ts
+++ b/src/application/commands/skills/uninstall.ts
@@ -1,0 +1,16 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import { uninstallBundledSkill } from "./shared.ts";
+
+const bundledSkillName = "oo" as const;
+
+export const skillsUninstallCommand: CliCommandDefinition = {
+    name: "uninstall",
+    summaryKey: "commands.skills.uninstall.summary",
+    descriptionKey: "commands.skills.uninstall.description",
+    inputSchema: z.object({}),
+    handler: async (_, context) => {
+        await uninstallBundledSkill(bundledSkillName, context);
+    },
+};

--- a/src/file-imports.d.ts
+++ b/src/file-imports.d.ts
@@ -1,0 +1,9 @@
+declare module "*.md" {
+    const assetPath: string;
+    export default assetPath;
+}
+
+declare module "*.yaml" {
+    const assetPath: string;
+    export default assetPath;
+}

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -85,6 +85,15 @@ export const enMessages = {
     "commands.search.description":
         "Search packages with free-form text against the intent search API.",
     "commands.search.summary": "Search packages by intent",
+    "commands.skills.description":
+        "Install or remove bundled Codex-only skills from the local Codex directory.",
+    "commands.skills.summary": "Manage bundled Codex skills",
+    "commands.skills.install.description":
+        "Install one bundled Codex skill into the local Codex skills directory.",
+    "commands.skills.install.summary": "Install a bundled Codex skill",
+    "commands.skills.uninstall.description":
+        "Remove one bundled Codex skill from the local Codex skills directory.",
+    "commands.skills.uninstall.summary": "Remove a bundled Codex skill",
     "config.set.success": "Set {key} to {value}.",
     "config.unset.success": "Removed {key}.",
     "errors.commander.excessArguments": "Too many arguments were provided.",
@@ -196,6 +205,12 @@ export const enMessages = {
         "The package info request failed: {message}",
     "errors.packageInfo.requestFailed":
         "The package info request returned HTTP {status}.",
+    "errors.skills.codexNotInstalled":
+        "Codex is not installed. Expected the Codex home directory at {path}.",
+    "errors.skills.nameConflict":
+        "Skill name {name} is already used by a non-OOMOL Codex skill at {path}.",
+    "errors.skills.notInstalled":
+        "Codex skill {name} is not installed at {path}.",
     "errors.store.invalidToml":
         "The settings file at {path} is not valid TOML.",
     "errors.store.invalidSchema":
@@ -242,6 +257,8 @@ export const enMessages = {
         "Set how long to wait before timing out (default 6h, range 10s to 24h)",
     "options.lang": "Specify the display language",
     "options.version": "Show the current version",
+    "skills.install.success": "Installed Codex skill {name} to {path}.",
+    "skills.uninstall.success": "Removed Codex skill {name} from {path}.",
     "versionInfo.version": "Version",
     "versionInfo.buildTime": "Build Time",
     "versionInfo.commit": "Commit",
@@ -250,6 +267,7 @@ export const enMessages = {
     "arguments.key": "Configuration key",
     "arguments.packageSpecifier": "Package specifier",
     "arguments.shell": "Target shell",
+    "arguments.skill": "Bundled skill name",
     "arguments.taskId": "Task id",
     "arguments.text": "Search text",
     "arguments.value": "Configuration value",
@@ -360,6 +378,12 @@ export const zhMessages = {
     "commands.package.summary": "包相关工具",
     "commands.search.description": "使用自由文本通过意图搜索 API 搜索包。",
     "commands.search.summary": "按意图搜索包",
+    "commands.skills.description": "在本地 Codex 目录中安装或移除内置的仅限 Codex 使用的 skill。",
+    "commands.skills.summary": "管理内置 Codex skill",
+    "commands.skills.install.description": "将一个内置 Codex skill 安装到本地 Codex skills 目录。",
+    "commands.skills.install.summary": "安装一个内置 Codex skill",
+    "commands.skills.uninstall.description": "从本地 Codex skills 目录移除一个内置 Codex skill。",
+    "commands.skills.uninstall.summary": "移除一个内置 Codex skill",
     "config.set.success": "已将 {key} 设置为 {value}。",
     "config.unset.success": "已移除 {key}。",
     "errors.commander.excessArguments": "提供了过多的参数。",
@@ -464,6 +488,12 @@ export const zhMessages = {
         "包信息请求失败：{message}",
     "errors.packageInfo.requestFailed":
         "包信息请求返回了 HTTP {status}。",
+    "errors.skills.codexNotInstalled":
+        "未检测到 Codex 安装。期望的 Codex 根目录为 {path}。",
+    "errors.skills.nameConflict":
+        "Skill 名称 {name} 已被 {path} 中的非 OOMOL Codex skill 占用。",
+    "errors.skills.notInstalled":
+        "Codex skill {name} 未安装在 {path}。",
     "errors.store.invalidToml": "配置文件 {path} 不是有效的 TOML。",
     "errors.store.invalidSchema": "配置文件 {path} 的结构不受支持。",
     "errors.store.readFailed": "读取配置文件 {path} 失败。",
@@ -505,6 +535,8 @@ export const zhMessages = {
     "options.timeout": "设置等待超时时间（默认 6h，范围 10s 到 24h）",
     "options.lang": "指定显示语言",
     "options.version": "显示当前版本",
+    "skills.install.success": "已将 Codex skill {name} 安装到 {path}。",
+    "skills.uninstall.success": "已从 {path} 移除 Codex skill {name}。",
     "versionInfo.version": "版本",
     "versionInfo.buildTime": "构建时间",
     "versionInfo.commit": "提交",
@@ -513,6 +545,7 @@ export const zhMessages = {
     "arguments.key": "配置键",
     "arguments.packageSpecifier": "包标识",
     "arguments.shell": "目标 shell",
+    "arguments.skill": "内置 skill 名称",
     "arguments.taskId": "任务 ID",
     "arguments.text": "搜索文本",
     "arguments.value": "配置值",


### PR DESCRIPTION
Introduce a bundled `oo` skill for Codex that gets installed to
`${CODEX_HOME:-~/.codex}/skills/oo` on first CLI launch or via
`oo skills install`. The skill teaches Codex how to search packages,
inspect blocks, build input payloads, and run cloud tasks through
the oo CLI.

- Add skills install/uninstall commands with embedded asset copying
- Auto-install skill on CLI startup when skill directory is absent
- Bundle SKILL.md, openai agent config, and CLI contract reference
- Update READMEs with quick start guide and Codex usage examples
- Add file-imports.d.ts for importing .md and .yaml as strings