### PR TITLE
chore(skill): enable implicit invocation for bundled oo skill

### DIFF
--- a/contrib/skills/oo/agents/openai.yaml
+++ b/contrib/skills/oo/agents/openai.yaml
@@ -4,4 +4,4 @@ interface:
   default_prompt: "Use $oo to translate my request into English search terms, choose the best package and block, stop when auth or input requirements are not proven, ask only for missing inputs, run the task, and handle long waits safely."
 
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -147,7 +147,7 @@ describe("runCli", () => {
                 isFile: expect.any(Function),
             });
             expect(await readFile(ownershipFilePath, "utf8")).toContain(
-                "allow_implicit_invocation: false",
+                "allow_implicit_invocation: true",
             );
             expect(await readFile(versionFilePath, "utf8")).toBe("9.9.9\n");
             expect(content).toContain(`"msg":"CLI first-run detection completed."`);

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -40,7 +40,7 @@ describe("skills commands", () => {
                 ).toBe(await Bun.file(file.sourcePath).text());
             }
             expect(await readFile(ownershipFilePath, "utf8")).toContain(
-                "allow_implicit_invocation: false",
+                "allow_implicit_invocation: true",
             );
             expect(await readFile(versionFilePath, "utf8")).toBe(
                 `${resultVersion}\n`,


### PR DESCRIPTION
### Motivation
- Enable the bundled `oo` Codex skill to be invoked implicitly by assistants by switching its agent policy to allow implicit invocation.

### Description
- Set `allow_implicit_invocation: true` in `contrib/skills/oo/agents/openai.yaml` and update test expectations in `src/application/bootstrap/run-cli.test.ts` and `src/application/commands/skills/index.test.ts` to match the new bundled skill content.

### Testing
- Ran `bun run lint:fix` and `bun run ts-check` which succeeded, and ran `bun run test` which executed the test suite but failed due to pre-existing runtime issues in this environment (e.g. `Bun.stripANSI is not a function` and cascading logger-state errors) that are unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3d62478f48320961a758621d3665a)