### PR TITLE
chore(bin): add dev launcher scripts for unix and windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bat text eol=crlf

--- a/oo
+++ b/oo
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec bun run --silent dev -- "$@"

--- a/oo.bat
+++ b/oo.bat
@@ -1,0 +1,2 @@
+@echo off
+bun run --silent dev -- %*


### PR DESCRIPTION
Provide `./oo` (sh) and `oo.bat` wrappers so developers can invoke the CLI locally without typing the full bun command.