### PR TITLE
feat(cloud-task): add widget-aware input validation for color and file handles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 
 - After each code modification, you must execute: `bun run lint:fix` `bun run ts-check`
 - For any change that affects commands or CLI behavior, you must check whether documentation under `docs/` needs to be updated and update it when necessary
+- Documentation under `docs/commands*.md` should describe the user-facing CLI contract only: command purpose, arguments, options, stable output shapes, and externally observable behavior. Do not document internal implementation details such as validator order, AJV usage, schema patching, or other internal lint mechanics unless the user explicitly asks for that level of detail.
 - Comments must be in English
 - When generating UUIDs, you must use v7 and must use bun's `randomUUIDv7` function
 - Avoid using regular expressions when possible

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@
 
 - After each code modification, you must execute: `bun run lint:fix` `bun run ts-check`
 - For any change that affects commands or CLI behavior, you must check whether documentation under `docs/` needs to be updated and update it when necessary
+- Documentation under `docs/commands*.md` should describe the user-facing CLI contract only: command purpose, arguments, options, stable output shapes, and externally observable behavior. Do not document internal implementation details such as validator order, AJV usage, schema patching, or other internal lint mechanics unless the user explicitly asks for that level of detail.
 - Comments must be in English
 - When generating UUIDs, you must use v7 and must use bun's `randomUUIDv7` function
 - Avoid using regular expressions when possible

--- a/src/application/commands/cloud-task/validation.test.ts
+++ b/src/application/commands/cloud-task/validation.test.ts
@@ -1,0 +1,144 @@
+import type { PackageInfoResponse } from "../package/shared.ts";
+
+import { describe, expect, test } from "bun:test";
+
+import { CliUserError } from "../../contracts/cli.ts";
+import { validateCloudTaskInputValues } from "./validation.ts";
+
+describe("validateCloudTaskInputValues", () => {
+    test("accepts 6-digit and 8-digit hex values for color widgets", () => {
+        const block = createBlock("accent", {
+            description: "Accent color",
+            ext: {
+                widget: "color",
+            },
+            schema: {
+                type: "string",
+            },
+        });
+
+        expect(() =>
+            validateCloudTaskInputValues(
+                {
+                    accent: "#7D7FE9",
+                },
+                block,
+                "en",
+            )).not.toThrow();
+        expect(() =>
+            validateCloudTaskInputValues(
+                {
+                    accent: "#08080F73",
+                },
+                block,
+                "en",
+            )).not.toThrow();
+    });
+
+    test("rejects non-hex values for color widgets", () => {
+        const block = createBlock("accent", {
+            description: "Accent color",
+            ext: {
+                widget: "color",
+            },
+            schema: {
+                type: "string",
+            },
+        });
+
+        expect(expectCliUserError(() =>
+            validateCloudTaskInputValues(
+                {
+                    accent: "rgb(125, 127, 233)",
+                },
+                block,
+                "en",
+            ),
+        )).toMatchObject({
+            key: "errors.cloudTaskRun.invalidPayload",
+            params: expect.objectContaining({
+                handle: "accent",
+                message: expect.stringContaining("hex-color"),
+            }),
+        });
+    });
+
+    test("validates file widgets as uri strings", () => {
+        const block = createBlock("input", {
+            description: "Input file",
+            ext: {
+                widget: "file",
+            },
+            schema: {
+                type: "string",
+            },
+        });
+
+        expect(() =>
+            validateCloudTaskInputValues(
+                {
+                    input: "https://example.com/files/input.txt",
+                },
+                block,
+                "en",
+            )).not.toThrow();
+    });
+
+    test("rejects non-uri values for file widgets", () => {
+        const block = createBlock("input", {
+            description: "Input file",
+            ext: {
+                widget: "file",
+            },
+            schema: {
+                type: "string",
+            },
+        });
+
+        expect(expectCliUserError(() =>
+            validateCloudTaskInputValues(
+                {
+                    input: "./files/input.txt",
+                },
+                block,
+                "en",
+            ),
+        )).toMatchObject({
+            key: "errors.cloudTaskRun.invalidPayload",
+            params: expect.objectContaining({
+                handle: "input",
+                message: expect.stringContaining("uri"),
+            }),
+        });
+    });
+});
+
+function createBlock(
+    handleName: string,
+    handle: PackageInfoResponse["blocks"][number]["inputHandle"][string],
+): PackageInfoResponse["blocks"][number] {
+    return {
+        blockName: "main",
+        description: "Main block",
+        inputHandle: {
+            [handleName]: handle,
+        },
+        outputHandle: {},
+        title: "Main",
+    };
+}
+
+function expectCliUserError(callback: () => void): CliUserError {
+    try {
+        callback();
+    }
+    catch (error) {
+        if (error instanceof CliUserError) {
+            return error;
+        }
+
+        throw error;
+    }
+
+    throw new Error("Expected a CliUserError to be thrown.");
+}

--- a/src/application/commands/cloud-task/validation.ts
+++ b/src/application/commands/cloud-task/validation.ts
@@ -133,6 +133,10 @@ function createAjv(): Ajv {
     });
 
     addFormats(instance);
+    instance.addFormat("hex-color", {
+        type: "string",
+        validate: value => isHexColorString(value),
+    });
 
     return instance;
 }
@@ -150,7 +154,7 @@ function validateHandleValue(
         return undefined;
     }
 
-    const normalizedSchema = normalizeHandleSchema(def.schema);
+    const normalizedSchema = normalizeHandleSchema(def.schema, def.ext);
 
     if ("error" in normalizedSchema) {
         return normalizedSchema.error;
@@ -192,15 +196,20 @@ function validateHandleValue(
 
 function normalizeHandleSchema(
     schema: unknown,
+    ext?: Record<string, unknown>,
 ): { schema: unknown } | { error: ValidationError } {
     if (!isPlainObject(schema)) {
-        return { schema };
+        return {
+            schema: patchHandleSchema(schema, ext),
+        };
     }
 
     const contentMediaType = schema.contentMediaType;
 
     if (typeof contentMediaType !== "string") {
-        return { schema };
+        return {
+            schema: patchHandleSchema(schema, ext),
+        };
     }
 
     if (contentMediaType !== "oomol/secret") {
@@ -216,7 +225,9 @@ function normalizeHandleSchema(
 
     delete normalizedSchema.contentMediaType;
 
-    return { schema: normalizedSchema };
+    return {
+        schema: patchHandleSchema(normalizedSchema, ext),
+    };
 }
 
 function compile(
@@ -341,6 +352,97 @@ function inferPrimitiveType(value: unknown): PrimitiveType {
     }
 
     return typeof value;
+}
+
+function patchHandleSchema(
+    schema: unknown,
+    ext: unknown,
+): unknown {
+    const schemaWithPatchedChildren = patchHandleSchemaChildren(schema, ext);
+    const widget = readWidgetName(ext);
+
+    switch (widget) {
+        case "color":
+            return constrainSchema(schemaWithPatchedChildren, {
+                format: "hex-color",
+                type: "string",
+            });
+        case "file":
+            return constrainSchema(schemaWithPatchedChildren, {
+                format: "uri",
+                type: "string",
+            });
+        default:
+            return schemaWithPatchedChildren;
+    }
+}
+
+function patchHandleSchemaChildren(
+    schema: unknown,
+    ext: unknown,
+): unknown {
+    if (Array.isArray(schema)) {
+        return schema.map((item, index) =>
+            patchHandleSchema(item, Array.isArray(ext) ? ext[index] : undefined),
+        );
+    }
+
+    if (!isPlainObject(schema)) {
+        return schema;
+    }
+
+    const extObject = isPlainObject(ext) ? ext : undefined;
+
+    return Object.fromEntries(
+        Object.entries(schema).map(([key, value]) => [
+            key,
+            patchHandleSchema(value, extObject?.[key]),
+        ]),
+    );
+}
+
+function constrainSchema(
+    schema: unknown,
+    constraint: JsonSchemaObject,
+): JsonSchemaObject {
+    if (schema === undefined) {
+        return constraint;
+    }
+
+    return {
+        allOf: [schema, constraint],
+    };
+}
+
+function readWidgetName(ext: unknown): string | undefined {
+    if (!isPlainObject(ext) || typeof ext.widget !== "string") {
+        return undefined;
+    }
+
+    return ext.widget;
+}
+
+function isHexColorString(value: string): boolean {
+    if (!value.startsWith("#")) {
+        return false;
+    }
+
+    if (value.length !== 7 && value.length !== 9) {
+        return false;
+    }
+
+    for (let index = 1; index < value.length; index += 1) {
+        const charCode = value.charCodeAt(index);
+        const isDigit = charCode >= 48 && charCode <= 57;
+        const isUpperHex = charCode >= 65 && charCode <= 70;
+        const isLowerHex = charCode >= 97 && charCode <= 102;
+
+        if (!isDigit && !isUpperHex && !isLowerHex) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 function isPlainObject(value: unknown): value is JsonSchemaObject {


### PR DESCRIPTION
Patch JSON schemas based on handle ext metadata so that color widgets require valid hex-color strings (#RRGGBB or #RRGGBBAA) and file widgets require valid URIs. Schema constraints are composed via allOf to preserve the original schema alongside the widget-specific format rules.

Also add a documentation scope guideline to AGENTS.md and CLAUDE.md restricting docs/commands*.md to user-facing CLI contract only.