### PR TITLE
refactor(package): simplify ui schema normalization for handles

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -211,8 +211,6 @@ Show package metadata for one package.
   `json`.
 - Options: `--json` is an alias for `--format=json`.
 - Notes: if no version is provided, the CLI resolves the latest version.
-- Notes: in `--json` output, registry schema keys that start with `ui:` are
-  exposed under each handle's `ext` field.
 
 ## Cloud Tasks
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -189,8 +189,6 @@
 - 选项：`--format <format>` 返回结构化输出，目前仅支持 `json`。
 - 选项：`--json` 是 `--format=json` 的别名。
 - 说明：如果未指定版本，CLI 会解析为最新版本。
-- 说明：在 `--json` 输出中，registry schema 里以 `ui:` 开头的键会被暴露到
-  对应 handle 的 `ext` 字段下。
 
 ## Cloud Task
 

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -2312,7 +2312,7 @@ describe("runCli", () => {
         }
     });
 
-    test("includes input handle values and normalized ext metadata in package info json output", async () => {
+    test("normalizes input ext metadata and keeps output handle schema raw in package info json output", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -2360,8 +2360,10 @@ describe("runCli", () => {
                                                 {
                                                     "type": "string",
                                                     "ui:widget": "text",
+                                                    "ui:placeholder": "Base64 text input",
                                                 },
                                             ],
+                                            "ui:help": "ignored",
                                             "ui:options": {
                                                 labels: ["Base64 with Text"],
                                             },
@@ -2413,6 +2415,7 @@ describe("runCli", () => {
                                         json_schema: {
                                             "type": "boolean",
                                             "ui:widget": "switch",
+                                            "ui:tone": "success",
                                         },
                                     },
                                 ],
@@ -2439,9 +2442,6 @@ describe("runCli", () => {
                                             widget: "text",
                                         },
                                     ],
-                                    options: {
-                                        labels: ["Base64 with Text"],
-                                    },
                                 },
                                 nullable: false,
                                 schema: {
@@ -2491,11 +2491,10 @@ describe("runCli", () => {
                         outputHandle: {
                             output: {
                                 description: "Boolean result",
-                                ext: {
-                                    widget: "switch",
-                                },
                                 schema: {
-                                    type: "boolean",
+                                    "ui:tone": "success",
+                                    "ui:widget": "switch",
+                                    "type": "boolean",
                                 },
                             },
                         },

--- a/src/application/commands/package/info.test.ts
+++ b/src/application/commands/package/info.test.ts
@@ -85,7 +85,7 @@ describe("packageInfoCommand", () => {
         expect(fetchCount).toBe(1);
         expect(cacheOptions).toHaveLength(2);
         expect(cacheOptions[0]).toEqual({
-            id: "package.info",
+            id: "package.info.v4",
             defaultTtlMs: 2_592_000_000,
             maxEntries: 300,
         });

--- a/src/application/commands/package/shared.test.ts
+++ b/src/application/commands/package/shared.test.ts
@@ -18,7 +18,7 @@ const packageInfoAccount = {
 const packageInfoRequestLanguage = "en" as const;
 
 describe("loadPackageInfo", () => {
-    test("normalizes ui schema keys into ext and reuses cached normalized responses", async () => {
+    test("normalizes input ui widget keys while keeping output schema raw and reuses cached normalized responses", async () => {
         const cacheValues = new Map<string, string>();
         let fetchCount = 0;
         const cache = createCache<string>({
@@ -128,8 +128,10 @@ function createRawPackageInfoResponse() {
                                 {
                                     "type": "string",
                                     "ui:widget": "text",
+                                    "ui:placeholder": "Base64 text input",
                                 },
                             ],
+                            "ui:help": "ignored",
                             "ui:options": {
                                 labels: ["Base64 with Text"],
                             },
@@ -143,6 +145,7 @@ function createRawPackageInfoResponse() {
                         json_schema: {
                             "type": "boolean",
                             "ui:widget": "switch",
+                            "ui:tone": "success",
                         },
                     },
                 ],
@@ -166,9 +169,6 @@ function createNormalizedPackageInfoResponse() {
                                     widget: "text",
                                 },
                             ],
-                            options: {
-                                labels: ["Base64 with Text"],
-                            },
                         },
                         nullable: false,
                         schema: {
@@ -184,11 +184,10 @@ function createNormalizedPackageInfoResponse() {
                 outputHandle: {
                     output: {
                         description: "Boolean result",
-                        ext: {
-                            widget: "switch",
-                        },
                         schema: {
-                            type: "boolean",
+                            "ui:tone": "success",
+                            "ui:widget": "switch",
+                            "type": "boolean",
                         },
                     },
                 },

--- a/src/application/commands/package/shared.ts
+++ b/src/application/commands/package/shared.ts
@@ -10,7 +10,7 @@ import {
     withRequestTarget,
 } from "../../logging/log-fields.ts";
 
-const PACKAGE_INFO_CACHE_ID = "package.info";
+const PACKAGE_INFO_CACHE_ID = "package.info.v4";
 const PACKAGE_INFO_CACHE_MAX_ENTRIES = 300;
 const PACKAGE_INFO_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const LATEST_PACKAGE_VERSION = "latest";
@@ -624,14 +624,11 @@ function transformOutputHandleDefinitions(
                 return [];
             }
 
-            const normalizedSchema = splitPackageInfoHandleSchema(handleDef.json_schema);
-
             return [[
                 handleDef.handle,
                 {
                     description: handleDef.description,
-                    ext: normalizedSchema.ext,
-                    schema: normalizedSchema.schema,
+                    schema: handleDef.json_schema,
                 },
             ]];
         }),
@@ -690,13 +687,13 @@ function splitPackageInfoSchemaNode(
     const extEntries: [string, unknown][] = [];
 
     for (const [key, nestedValue] of Object.entries(value)) {
-        if (key.startsWith("ui:")) {
-            const uiKey = key.slice("ui:".length);
+        if (key === "ui:widget") {
+            extEntries.push(["widget", nestedValue]);
+            continue;
+        }
 
-            if (uiKey !== "") {
-                extEntries.push([uiKey, normalizePackageInfoExtensionValue(nestedValue)]);
-                continue;
-            }
+        if (key.startsWith("ui:")) {
+            continue;
         }
 
         const normalizedValue = splitPackageInfoSchemaNode(nestedValue);
@@ -716,33 +713,6 @@ function splitPackageInfoSchemaNode(
         ext: Object.fromEntries(extEntries),
         schema: Object.fromEntries(schemaEntries),
     };
-}
-
-function normalizePackageInfoExtensionValue(value: unknown): unknown {
-    if (Array.isArray(value)) {
-        return value.map(item => normalizePackageInfoExtensionValue(item));
-    }
-
-    if (value === null || typeof value !== "object") {
-        return value;
-    }
-
-    const normalizedEntries: [string, unknown][] = [];
-
-    for (const [key, nestedValue] of Object.entries(value)) {
-        if (key.startsWith("ui:")) {
-            const uiKey = key.slice("ui:".length);
-
-            if (uiKey !== "") {
-                normalizedEntries.push([uiKey, normalizePackageInfoExtensionValue(nestedValue)]);
-                continue;
-            }
-        }
-
-        normalizedEntries.push([key, normalizePackageInfoExtensionValue(nestedValue)]);
-    }
-
-    return Object.fromEntries(normalizedEntries);
 }
 
 function hasPackageInfoSchemaDefault(schema: unknown): boolean {


### PR DESCRIPTION
Only extract `ui:widget` into input handle ext metadata; skip all other `ui:` prefixed keys. Keep output handle schemas raw without stripping or remapping ui keys. Remove the recursive normalizePackageInfoExtensionValue helper that is no longer needed.

Bump cache ID to v4 to invalidate entries with the old shape.