### PR TITLE
fix(package): apply handle schema patches during input normalization

### DIFF
--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -2312,7 +2312,7 @@ describe("runCli", () => {
         }
     });
 
-    test("normalizes input ext metadata and keeps output handle schema raw in package info json output", async () => {
+    test("normalizes input ext metadata, applies input schema patches, and keeps output handle schema raw in package info json output", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -2376,6 +2376,14 @@ describe("runCli", () => {
                                         value: null,
                                         json_schema: {
                                             type: "string",
+                                        },
+                                    },
+                                    {
+                                        handle: "fileInput",
+                                        description: "Input file",
+                                        json_schema: {
+                                            "type": "string",
+                                            "ui:widget": "file",
                                         },
                                     },
                                     {
@@ -2460,6 +2468,16 @@ describe("runCli", () => {
                                     type: "string",
                                 },
                                 value: null,
+                            },
+                            fileInput: {
+                                description: "Input file",
+                                ext: {
+                                    widget: "file",
+                                },
+                                schema: {
+                                    format: "uri",
+                                    type: "string",
+                                },
                             },
                             excludes: {
                                 description: "Excluded usernames",

--- a/src/application/commands/cloud-task/validation.ts
+++ b/src/application/commands/cloud-task/validation.ts
@@ -6,10 +6,8 @@ import addFormats from "ajv-formats";
 import ajvEN from "ajv-i18n/localize/en/index.js";
 import ajvZH from "ajv-i18n/localize/zh/index.js";
 import { CliUserError } from "../../contracts/cli.ts";
-import {
-    isPackageInfoInputHandleOptional,
-
-} from "../package/shared.ts";
+import { isPackageInfoInputHandleOptional } from "../package/shared.ts";
+import { patchHandleSchema } from "../shared/handle-schema.ts";
 
 const ajv = createAjv();
 
@@ -352,74 +350,6 @@ function inferPrimitiveType(value: unknown): PrimitiveType {
     }
 
     return typeof value;
-}
-
-function patchHandleSchema(
-    schema: unknown,
-    ext: unknown,
-): unknown {
-    const schemaWithPatchedChildren = patchHandleSchemaChildren(schema, ext);
-    const widget = readWidgetName(ext);
-
-    switch (widget) {
-        case "color":
-            return constrainSchema(schemaWithPatchedChildren, {
-                format: "hex-color",
-                type: "string",
-            });
-        case "file":
-            return constrainSchema(schemaWithPatchedChildren, {
-                format: "uri",
-                type: "string",
-            });
-        default:
-            return schemaWithPatchedChildren;
-    }
-}
-
-function patchHandleSchemaChildren(
-    schema: unknown,
-    ext: unknown,
-): unknown {
-    if (Array.isArray(schema)) {
-        return schema.map((item, index) =>
-            patchHandleSchema(item, Array.isArray(ext) ? ext[index] : undefined),
-        );
-    }
-
-    if (!isPlainObject(schema)) {
-        return schema;
-    }
-
-    const extObject = isPlainObject(ext) ? ext : undefined;
-
-    return Object.fromEntries(
-        Object.entries(schema).map(([key, value]) => [
-            key,
-            patchHandleSchema(value, extObject?.[key]),
-        ]),
-    );
-}
-
-function constrainSchema(
-    schema: unknown,
-    constraint: JsonSchemaObject,
-): JsonSchemaObject {
-    if (schema === undefined) {
-        return constraint;
-    }
-
-    return {
-        allOf: [schema, constraint],
-    };
-}
-
-function readWidgetName(ext: unknown): string | undefined {
-    if (!isPlainObject(ext) || typeof ext.widget !== "string") {
-        return undefined;
-    }
-
-    return ext.widget;
 }
 
 function isHexColorString(value: string): boolean {

--- a/src/application/commands/package/info.test.ts
+++ b/src/application/commands/package/info.test.ts
@@ -85,7 +85,7 @@ describe("packageInfoCommand", () => {
         expect(fetchCount).toBe(1);
         expect(cacheOptions).toHaveLength(2);
         expect(cacheOptions[0]).toEqual({
-            id: "package.info.v4",
+            id: "package.info.v5",
             defaultTtlMs: 2_592_000_000,
             maxEntries: 300,
         });

--- a/src/application/commands/package/shared.test.ts
+++ b/src/application/commands/package/shared.test.ts
@@ -18,7 +18,7 @@ const packageInfoAccount = {
 const packageInfoRequestLanguage = "en" as const;
 
 describe("loadPackageInfo", () => {
-    test("normalizes input ui widget keys while keeping output schema raw and reuses cached normalized responses", async () => {
+    test("normalizes input ui widget keys, applies input schema patches, and keeps output schema raw", async () => {
         const cacheValues = new Map<string, string>();
         let fetchCount = 0;
         const cache = createCache<string>({
@@ -137,6 +137,14 @@ function createRawPackageInfoResponse() {
                             },
                         },
                     },
+                    {
+                        handle: "fileInput",
+                        description: "Input file",
+                        json_schema: {
+                            "type": "string",
+                            "ui:widget": "file",
+                        },
+                    },
                 ],
                 outputHandleDefs: [
                     {
@@ -179,6 +187,16 @@ function createNormalizedPackageInfoResponse() {
                             ],
                         },
                         value: "sample.png",
+                    },
+                    fileInput: {
+                        description: "Input file",
+                        ext: {
+                            widget: "file",
+                        },
+                        schema: {
+                            format: "uri",
+                            type: "string",
+                        },
                     },
                 },
                 outputHandle: {

--- a/src/application/commands/package/shared.ts
+++ b/src/application/commands/package/shared.ts
@@ -9,8 +9,9 @@ import {
     withPackageIdentity,
     withRequestTarget,
 } from "../../logging/log-fields.ts";
+import { patchHandleSchema } from "../shared/handle-schema.ts";
 
-const PACKAGE_INFO_CACHE_ID = "package.info.v4";
+const PACKAGE_INFO_CACHE_ID = "package.info.v5";
 const PACKAGE_INFO_CACHE_MAX_ENTRIES = 300;
 const PACKAGE_INFO_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const LATEST_PACKAGE_VERSION = "latest";
@@ -592,7 +593,10 @@ function transformInputHandleDefinitions(
             const normalizedSchema = splitPackageInfoHandleSchema(handleDef.json_schema);
             const transformedHandle: z.output<typeof transformedInputHandleSchema> = {
                 description: handleDef.description,
-                schema: normalizedSchema.schema,
+                schema: patchHandleSchema(
+                    normalizedSchema.schema,
+                    normalizedSchema.ext,
+                ),
             };
 
             if (normalizedSchema.ext !== undefined) {

--- a/src/application/commands/shared/handle-schema.ts
+++ b/src/application/commands/shared/handle-schema.ts
@@ -1,0 +1,120 @@
+interface JsonSchemaObject {
+    [key: string]: unknown;
+    allOf?: unknown;
+    anyOf?: unknown;
+    else?: unknown;
+    format?: unknown;
+    if?: unknown;
+    not?: unknown;
+    oneOf?: unknown;
+    then?: unknown;
+    type?: unknown;
+    $ref?: unknown;
+}
+
+export function patchHandleSchema(
+    schema: unknown,
+    ext: unknown,
+): unknown {
+    const schemaWithPatchedChildren = patchHandleSchemaChildren(schema, ext);
+    const widget = readWidgetName(ext);
+
+    switch (widget) {
+        case "color":
+            return constrainSchema(schemaWithPatchedChildren, {
+                format: "hex-color",
+                type: "string",
+            });
+        case "file":
+            return constrainSchema(schemaWithPatchedChildren, {
+                format: "uri",
+                type: "string",
+            });
+        default:
+            return schemaWithPatchedChildren;
+    }
+}
+
+function patchHandleSchemaChildren(
+    schema: unknown,
+    ext: unknown,
+): unknown {
+    if (Array.isArray(schema)) {
+        return schema.map((item, index) =>
+            patchHandleSchema(item, Array.isArray(ext) ? ext[index] : undefined),
+        );
+    }
+
+    if (!isPlainObject(schema)) {
+        return schema;
+    }
+
+    const extObject = isPlainObject(ext) ? ext : undefined;
+
+    return Object.fromEntries(
+        Object.entries(schema).map(([key, value]) => [
+            key,
+            patchHandleSchema(value, extObject?.[key]),
+        ]),
+    );
+}
+
+function constrainSchema(
+    schema: unknown,
+    constraint: JsonSchemaObject,
+): JsonSchemaObject {
+    if (schema === undefined) {
+        return constraint;
+    }
+
+    if (isPlainObject(schema) && canMergeConstraint(schema, constraint)) {
+        return {
+            ...schema,
+            ...constraint,
+        };
+    }
+
+    return {
+        allOf: [schema, constraint],
+    };
+}
+
+function canMergeConstraint(
+    schema: JsonSchemaObject,
+    constraint: JsonSchemaObject,
+): boolean {
+    if (
+        schema.$ref !== undefined
+        || schema.allOf !== undefined
+        || schema.anyOf !== undefined
+        || schema.not !== undefined
+        || schema.oneOf !== undefined
+        || schema.if !== undefined
+        || schema.then !== undefined
+        || schema.else !== undefined
+    ) {
+        return false;
+    }
+
+    return Object.entries(constraint).every(([key, value]) =>
+        !Object.hasOwn(schema, key) || Object.is(schema[key], value),
+    );
+}
+
+function readWidgetName(ext: unknown): string | undefined {
+    if (!isPlainObject(ext) || typeof ext.widget !== "string") {
+        return undefined;
+    }
+
+    return ext.widget;
+}
+
+function isPlainObject(value: unknown): value is JsonSchemaObject {
+    if (value === null || typeof value !== "object") {
+        return false;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+
+    return prototype === Object.prototype || prototype === null;
+}


### PR DESCRIPTION
Only extract `ui:widget` into input handle ext metadata; skip all
other `ui:` prefixed keys. Keep output handle schemas raw without
stripping or remapping ui keys. Remove the recursive
normalizePackageInfoExtensionValue helper that is no longer needed.

Bump cache ID to v4 to invalidate entries with the old shape.

Signed-off-by: Kevin Cui <bh@bugs.cc>