### PR TITLE
fix(json): avoid touching stdin for structured output

### DIFF
--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -2059,7 +2059,7 @@ describe("runCli", () => {
             );
 
             expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(JSON.stringify([
+            expect(result.stdout).toBe(`${JSON.stringify([
                 {
                     blocks: [
                         {
@@ -2070,7 +2070,7 @@ describe("runCli", () => {
                     name: "@oomol/image-tools",
                     version: "1.2.3",
                 },
-            ]));
+            ])}\n`);
             expect(result.stderr).toBe("");
             expect(requests).toHaveLength(1);
             expect(
@@ -2127,10 +2127,10 @@ describe("runCli", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
-            expect(result.stdout).toBe(JSON.stringify([
+            expect(result.stdout).toBe(`${JSON.stringify([
                 "@oomol/image-tools@1.2.3",
                 "@oomol/vision-kit@2.0.0",
-            ]));
+            ])}\n`);
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -61,7 +61,6 @@ export async function runCli(argv: string[]): Promise<number> {
         cwd: process.cwd(),
         env: process.env,
         fetcher: fetch,
-        stdin: process.stdin,
         stdout: process.stdout,
         stderr: process.stderr,
         systemLocale: getSystemLocale(),
@@ -183,7 +182,7 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
             cwd: invocation.cwd,
             env: invocation.env,
             fileUploadStore,
-            stdin: invocation.stdin ?? process.stdin,
+            stdin: invocation.stdin ?? createDetachedStdin(),
             logger,
             packageName,
             settingsStore,
@@ -412,6 +411,17 @@ function writeBootstrapError(
     );
 
     return 1;
+}
+
+function createDetachedStdin(): InteractiveInput {
+    return {
+        isTTY: false,
+        setRawMode() {},
+        resume() {},
+        pause() {},
+        on() {},
+        off() {},
+    };
 }
 
 function getSystemLocale(): string | undefined {

--- a/src/application/commands/cloud-task/list.ts
+++ b/src/application/commands/cloud-task/list.ts
@@ -2,7 +2,7 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import { jsonOutputOptions } from "../json-output.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import {
     createCloudTaskTasksUrl,
     parseCloudTaskFormat,
@@ -141,7 +141,7 @@ export const cloudTaskListCommand: CliCommandDefinition<CloudTaskListInput> = {
         );
 
         if (format === "json") {
-            context.stdout.write(JSON.stringify(response));
+            writeJsonOutput(context.stdout, response);
             return;
         }
 

--- a/src/application/commands/cloud-task/log.ts
+++ b/src/application/commands/cloud-task/log.ts
@@ -1,7 +1,7 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
-import { jsonOutputOptions } from "../json-output.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import {
     createCloudTaskTaskUrl,
     parseCloudTaskFormat,
@@ -69,7 +69,7 @@ export const cloudTaskLogCommand: CliCommandDefinition<CloudTaskLogInput> = {
         );
 
         if (format === "json") {
-            context.stdout.write(JSON.stringify(response));
+            writeJsonOutput(context.stdout, response);
             return;
         }
 

--- a/src/application/commands/cloud-task/result.ts
+++ b/src/application/commands/cloud-task/result.ts
@@ -1,7 +1,7 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
-import { jsonOutputOptions } from "../json-output.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import {
     createCloudTaskTaskUrl,
     parseCloudTaskFormat,
@@ -45,7 +45,7 @@ export const cloudTaskResultCommand: CliCommandDefinition<CloudTaskResultInput> 
         );
 
         if (format === "json") {
-            context.stdout.write(JSON.stringify(response));
+            writeJsonOutput(context.stdout, response);
             return;
         }
 

--- a/src/application/commands/cloud-task/run.ts
+++ b/src/application/commands/cloud-task/run.ts
@@ -5,7 +5,7 @@ import { resolve } from "node:path";
 import { z } from "zod";
 import { resolveRequestLanguage } from "../../../i18n/locale.ts";
 import { CliUserError } from "../../contracts/cli.ts";
-import { jsonOutputOptions } from "../json-output.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { loadPackageInfo, parsePackageSpecifier } from "../package/shared.ts";
 import {
     createCloudTaskTasksUrl,
@@ -97,10 +97,10 @@ export const cloudTaskRunCommand: CliCommandDefinition<CloudTaskRunInput> = {
 
         if (input.dryRun === true) {
             if (format === "json") {
-                context.stdout.write(JSON.stringify({
+                writeJsonOutput(context.stdout, {
                     dryRun: true,
                     ok: true,
-                }));
+                });
                 return;
             }
 
@@ -129,7 +129,7 @@ export const cloudTaskRunCommand: CliCommandDefinition<CloudTaskRunInput> = {
         );
 
         if (format === "json") {
-            context.stdout.write(JSON.stringify(response));
+            writeJsonOutput(context.stdout, response);
             return;
         }
 

--- a/src/application/commands/file/cleanup.ts
+++ b/src/application/commands/file/cleanup.ts
@@ -2,7 +2,7 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import { jsonOutputOptions } from "../json-output.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { parseFileFormat } from "./shared.ts";
 
 interface FileCleanupInput {
@@ -23,9 +23,9 @@ export const fileCleanupCommand: CliCommandDefinition<FileCleanupInput> = {
         const deletedCount = context.fileUploadStore.deleteExpired(Date.now());
 
         if (format === "json") {
-            context.stdout.write(JSON.stringify({
+            writeJsonOutput(context.stdout, {
                 deletedCount,
-            }));
+            });
             return;
         }
 

--- a/src/application/commands/file/list.ts
+++ b/src/application/commands/file/list.ts
@@ -2,7 +2,7 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import { jsonOutputOptions } from "../json-output.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import {
     parseFileFormat,
     parseFileLimit,
@@ -56,7 +56,7 @@ export const fileListCommand: CliCommandDefinition<FileListInput> = {
             .map(record => serializeFileUploadRecord(record, now));
 
         if (format === "json") {
-            context.stdout.write(JSON.stringify(records));
+            writeJsonOutput(context.stdout, records);
             return;
         }
 

--- a/src/application/commands/file/upload.ts
+++ b/src/application/commands/file/upload.ts
@@ -4,7 +4,7 @@ import { stat } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import { jsonOutputOptions } from "../json-output.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import {
     initFileUpload,
     maxFileUploadSizeBytes,
@@ -72,7 +72,7 @@ export const fileUploadCommand: CliCommandDefinition<FileUploadInput> = {
         const view = serializeFileUploadRecord(record, uploadedAtMs);
 
         if (format === "json") {
-            context.stdout.write(JSON.stringify(view));
+            writeJsonOutput(context.stdout, view);
             return;
         }
 

--- a/src/application/commands/json-output.ts
+++ b/src/application/commands/json-output.ts
@@ -1,4 +1,4 @@
-import type { CliOptionDefinition } from "../contracts/cli.ts";
+import type { CliOptionDefinition, Writer } from "../contracts/cli.ts";
 
 export const jsonFormatOption = {
     name: "format",
@@ -20,3 +20,16 @@ export const jsonOutputOptions = [
     jsonFormatOption,
     jsonAliasOption,
 ] as const satisfies readonly CliOptionDefinition[];
+
+export function writeJsonOutput(
+    writer: Writer,
+    value: unknown,
+): void {
+    const serialized = JSON.stringify(value);
+
+    if (serialized === undefined) {
+        throw new Error("JSON output value must be serializable.");
+    }
+
+    writer.write(`${serialized}\n`);
+}

--- a/src/application/commands/package/info.ts
+++ b/src/application/commands/package/info.ts
@@ -7,7 +7,7 @@ import { resolveRequestLanguage } from "../../../i18n/locale.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { readCurrentAuth } from "../auth/shared.ts";
-import { jsonOutputOptions } from "../json-output.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import {
     isPackageInfoInputHandleOptional,
     loadPackageInfo,
@@ -55,7 +55,7 @@ export const packageInfoCommand: CliCommandDefinition<PackageInfoInput> = {
         );
 
         if (input.format === "json") {
-            context.stdout.write(JSON.stringify(response));
+            writeJsonOutput(context.stdout, response);
             return;
         }
 

--- a/src/application/commands/search.ts
+++ b/src/application/commands/search.ts
@@ -12,7 +12,7 @@ import {
 } from "../logging/log-fields.ts";
 import { createWriterColors } from "../terminal-colors.ts";
 import { readCurrentAuth } from "./auth/shared.ts";
-import { jsonOutputOptions } from "./json-output.ts";
+import { jsonOutputOptions, writeJsonOutput } from "./json-output.ts";
 
 const MAX_SEARCH_TEXT_LENGTH = 200;
 const SEARCH_CACHE_ID = "search.intent-response";
@@ -108,7 +108,7 @@ export const searchCommand: CliCommandDefinition<SearchInput> = {
             const packageIds = readSearchPackageIds(response.text);
 
             if (input.format === "json") {
-                context.stdout.write(JSON.stringify(packageIds));
+                writeJsonOutput(context.stdout, packageIds);
                 return;
             }
 
@@ -121,7 +121,7 @@ export const searchCommand: CliCommandDefinition<SearchInput> = {
         }
 
         if (input.format === "json") {
-            context.stdout.write(JSON.stringify(response.json.packages));
+            writeJsonOutput(context.stdout, response.json.packages);
             return;
         }
 


### PR DESCRIPTION
Why: Piped --json commands could intermittently leave fx without raw input after Bun materialized process.stdin during startup. What: Default CLI stdin now uses a detached no-op input for non-interactive commands, and structured output goes through one JSON writer helper with a trailing newline.
How: This avoids touching the live TTY unless a command explicitly needs stdin and keeps JSON responses emitted consistently.