### PR TITLE
feat(cloud-task): add widget-aware input validation

### DIFF
--- a/src/application/commands/cloud-task/run.ts
+++ b/src/application/commands/cloud-task/run.ts
@@ -93,7 +93,7 @@ export const cloudTaskRunCommand: CliCommandDefinition<CloudTaskRunInput> = {
             });
         }
 
-        validateCloudTaskInputValues(inputValues, block, context.translator.locale);
+        validateCloudTaskInputValues(inputValues, block, context.translator);
 
         if (input.dryRun === true) {
             if (format === "json") {

--- a/src/application/commands/cloud-task/validation.test.ts
+++ b/src/application/commands/cloud-task/validation.test.ts
@@ -2,8 +2,11 @@ import type { PackageInfoResponse } from "../package/shared.ts";
 
 import { describe, expect, test } from "bun:test";
 
+import { createTranslator } from "../../../i18n/translator.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { validateCloudTaskInputValues } from "./validation.ts";
+
+const englishTranslator = createTranslator("en");
 
 describe("validateCloudTaskInputValues", () => {
     test("accepts 6-digit and 8-digit hex values for color widgets", () => {
@@ -23,7 +26,7 @@ describe("validateCloudTaskInputValues", () => {
                     accent: "#7D7FE9",
                 },
                 block,
-                "en",
+                englishTranslator,
             )).not.toThrow();
         expect(() =>
             validateCloudTaskInputValues(
@@ -31,7 +34,7 @@ describe("validateCloudTaskInputValues", () => {
                     accent: "#08080F73",
                 },
                 block,
-                "en",
+                englishTranslator,
             )).not.toThrow();
     });
 
@@ -52,7 +55,7 @@ describe("validateCloudTaskInputValues", () => {
                     accent: "rgb(125, 127, 233)",
                 },
                 block,
-                "en",
+                englishTranslator,
             ),
         )).toMatchObject({
             key: "errors.cloudTaskRun.invalidPayload",
@@ -80,7 +83,7 @@ describe("validateCloudTaskInputValues", () => {
                     input: "https://example.com/files/input.txt",
                 },
                 block,
-                "en",
+                englishTranslator,
             )).not.toThrow();
     });
 
@@ -101,13 +104,116 @@ describe("validateCloudTaskInputValues", () => {
                     input: "./files/input.txt",
                 },
                 block,
-                "en",
+                englishTranslator,
             ),
         )).toMatchObject({
             key: "errors.cloudTaskRun.invalidPayload",
             params: expect.objectContaining({
                 handle: "input",
                 message: expect.stringContaining("uri"),
+            }),
+        });
+    });
+
+    test("accepts Unix-style storage paths for save widgets", () => {
+        const block = createBlock("output", {
+            description: "Output path",
+            ext: {
+                widget: "save",
+            },
+            schema: {
+                type: "string",
+            },
+        });
+
+        expect(() =>
+            validateCloudTaskInputValues(
+                {
+                    output: "/oomol-driver/oomol-storage/project/result.txt",
+                },
+                block,
+                englishTranslator,
+            )).not.toThrow();
+    });
+
+    test("rejects save widget paths outside the oomol storage prefix", () => {
+        const block = createBlock("output", {
+            description: "Output path",
+            ext: {
+                widget: "save",
+            },
+            schema: {
+                type: "string",
+            },
+        });
+
+        expect(expectCliUserError(() =>
+            validateCloudTaskInputValues(
+                {
+                    output: "/tmp/result.txt",
+                },
+                block,
+                englishTranslator,
+            ),
+        )).toMatchObject({
+            key: "errors.cloudTaskRun.invalidPayload",
+            params: expect.objectContaining({
+                handle: "output",
+                message: expect.stringContaining("/oomol-driver/oomol-storage/"),
+            }),
+        });
+    });
+
+    test("rejects dir widget paths that use Windows separators", () => {
+        const block = createBlock("workspace", {
+            description: "Workspace path",
+            ext: {
+                widget: "dir",
+            },
+            schema: {
+                type: "string",
+            },
+        });
+
+        expect(expectCliUserError(() =>
+            validateCloudTaskInputValues(
+                {
+                    workspace: "/oomol-driver/oomol-storage/project\\cache",
+                },
+                block,
+                englishTranslator,
+            ),
+        )).toMatchObject({
+            key: "errors.cloudTaskRun.invalidPayload",
+            params: expect.objectContaining({
+                handle: "workspace",
+                message: expect.stringContaining("Unix-style path"),
+            }),
+        });
+    });
+
+    test("rejects credential widgets even when no value is provided", () => {
+        const block = createBlock("account", {
+            description: "Account credential",
+            ext: {
+                widget: "credential",
+            },
+            schema: {
+                type: "string",
+            },
+        });
+
+        expect(expectCliUserError(() =>
+            validateCloudTaskInputValues(
+                {},
+                block,
+                englishTranslator,
+            ),
+        )).toMatchObject({
+            key: "errors.cloudTaskRun.invalidPayload",
+            params: expect.objectContaining({
+                handle: "account",
+                message: expect.stringContaining("not supported in the CLI"),
             }),
         });
     });

--- a/src/application/commands/cloud-task/validation.ts
+++ b/src/application/commands/cloud-task/validation.ts
@@ -1,5 +1,6 @@
 import type { ErrorObject, ValidateFunction } from "ajv";
 
+import type { Translator } from "../../contracts/translator.ts";
 import type { PackageInfoResponse } from "../package/shared.ts";
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
@@ -10,6 +11,8 @@ import { isPackageInfoInputHandleOptional } from "../package/shared.ts";
 import { patchHandleSchema } from "../shared/handle-schema.ts";
 
 const ajv = createAjv();
+const oomolStoragePathPrefix = "/oomol-driver/oomol-storage/";
+type ValidationTranslator = Pick<Translator, "locale" | "t">;
 
 type WidgetType
     = "allOf"
@@ -58,6 +61,14 @@ interface ValidationError {
     readonly message?: string;
 }
 
+interface WidgetValidationRule {
+    preValidate?: (translator: ValidationTranslator) => string | undefined;
+    validateValue?: (
+        value: unknown,
+        translator: ValidationTranslator,
+    ) => string | undefined;
+}
+
 interface JsonSchemaObject {
     [key: string]: unknown;
     anyOf?: unknown;
@@ -70,10 +81,37 @@ interface JsonSchemaObject {
     uniqueItems?: unknown;
 }
 
+const storagePathWidgetRule: WidgetValidationRule = {
+    validateValue(value, translator) {
+        if (typeof value !== "string" || isOomolStoragePath(value)) {
+            return undefined;
+        }
+
+        return translator.t(
+            "errors.cloudTaskRun.validation.invalidStoragePath",
+            {
+                prefix: oomolStoragePathPrefix,
+            },
+        );
+    },
+};
+
+const widgetValidationRules: Partial<Record<WidgetType, WidgetValidationRule>> = {
+    credential: {
+        preValidate(translator) {
+            return translator.t(
+                "errors.cloudTaskRun.validation.credentialUnsupported",
+            );
+        },
+    },
+    dir: storagePathWidgetRule,
+    save: storagePathWidgetRule,
+};
+
 export function validateCloudTaskInputValues(
     inputValues: Record<string, unknown>,
     block: PackageInfoResponse["blocks"][number],
-    locale: string,
+    translator: ValidationTranslator,
 ): void {
     const definedHandles = new Set(Object.keys(block.inputHandle));
 
@@ -90,7 +128,7 @@ export function validateCloudTaskInputValues(
         const error = validateHandleValue(
             inputValues[handleName],
             handleDef,
-            locale,
+            translator,
         );
 
         if (!error) {
@@ -142,8 +180,18 @@ function createAjv(): Ajv {
 function validateHandleValue(
     value: unknown,
     def: PackageInfoResponse["blocks"][number]["inputHandle"][string],
-    locale?: string,
+    translator: ValidationTranslator,
 ): ValidationError | undefined {
+    const widgetRule = resolveInputWidgetRule(def.schema, def.ext);
+    const preValidationMessage = widgetRule?.preValidate?.(translator);
+
+    if (preValidationMessage !== undefined) {
+        return {
+            code: "validation",
+            message: preValidationMessage,
+        };
+    }
+
     if (value === undefined && isPackageInfoInputHandleOptional(def)) {
         return undefined;
     }
@@ -174,13 +222,29 @@ function validateHandleValue(
     if (expectedType ? expectedType !== actualType : value === undefined) {
         return {
             code: "type",
-            message: locale?.startsWith("zh")
-                ? `期望类型为 ${expectedType ?? "任意类型"}，实际为 ${actualType ?? "未定义"}`
-                : `Expected type ${expectedType ?? "any"}, but got ${actualType ?? "undefined"}`,
+            message: translator.t(
+                "errors.cloudTaskRun.validation.expectedType",
+                {
+                    actualType: actualType ?? "undefined",
+                    expectedType: expectedType ?? "any",
+                },
+            ),
         };
     }
 
-    const validationErrors = validate(validator, value, locale);
+    const widgetValidationMessage = widgetRule?.validateValue?.(
+        value,
+        translator,
+    );
+
+    if (widgetValidationMessage !== undefined) {
+        return {
+            code: "validation",
+            message: widgetValidationMessage,
+        };
+    }
+
+    const validationErrors = validate(validator, value, translator.locale);
 
     if (validationErrors && validationErrors.length > 0) {
         return {
@@ -190,6 +254,35 @@ function validateHandleValue(
     }
 
     return undefined;
+}
+
+function readInputWidgetType(
+    schema: unknown,
+    ext?: Record<string, unknown>,
+): WidgetType | undefined {
+    const widgetName = readWidgetName(ext);
+
+    switch (widgetName) {
+        case "credential":
+        case "dir":
+        case "save":
+            return widgetName;
+    }
+
+    const schemaType = typeOfSchema(schema);
+
+    return schemaType === "credential" ? "credential" : undefined;
+}
+
+function resolveInputWidgetRule(
+    schema: unknown,
+    ext?: Record<string, unknown>,
+): WidgetValidationRule | undefined {
+    const widgetType = readInputWidgetType(schema, ext);
+
+    return widgetType === undefined
+        ? undefined
+        : widgetValidationRules[widgetType];
 }
 
 function normalizeHandleSchema(
@@ -312,6 +405,14 @@ function typeOfSchema(schema: unknown): WidgetType {
     }
 }
 
+function readWidgetName(ext: unknown): string | undefined {
+    if (!isPlainObject(ext) || typeof ext.widget !== "string") {
+        return undefined;
+    }
+
+    return ext.widget;
+}
+
 function asPrimitiveType(type: WidgetType): PrimitiveType | undefined {
     switch (type) {
         case "string":
@@ -373,6 +474,14 @@ function isHexColorString(value: string): boolean {
     }
 
     return true;
+}
+
+function isOomolStoragePath(value: string): boolean {
+    if (!value.startsWith(oomolStoragePathPrefix)) {
+        return false;
+    }
+
+    return !value.includes("\\");
 }
 
 function isPlainObject(value: unknown): value is JsonSchemaObject {

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -178,6 +178,12 @@ export const enMessages = {
         "Invalid package specifier: {value}. Use PACKAGE_NAME@SEMVER.",
     "errors.cloudTaskRun.invalidPayload":
         "The value for handle {handle} is invalid: {message}",
+    "errors.cloudTaskRun.validation.credentialUnsupported":
+        "Credential inputs are not supported in the CLI.",
+    "errors.cloudTaskRun.validation.expectedType":
+        "Expected type {expectedType}, but got {actualType}.",
+    "errors.cloudTaskRun.validation.invalidStoragePath":
+        "Expected a Unix-style path starting with {prefix}.",
     "errors.cloudTaskRun.invalidPayloadShape":
         "The --data payload must be a JSON object.",
     "errors.cloudTaskRun.unknownInputHandle":
@@ -515,6 +521,12 @@ export const zhMessages = {
         "无效的包标识：{value}。请使用 PACKAGE_NAME@SEMVER。",
     "errors.cloudTaskRun.invalidPayload":
         "Handle {handle} 的值无效：{message}",
+    "errors.cloudTaskRun.validation.credentialUnsupported":
+        "CLI 暂不支持 credential 类型输入。",
+    "errors.cloudTaskRun.validation.expectedType":
+        "期望类型为 {expectedType}，实际为 {actualType}。",
+    "errors.cloudTaskRun.validation.invalidStoragePath":
+        "期望值为以 {prefix} 开头的 Unix 风格路径。",
     "errors.cloudTaskRun.invalidPayloadShape":
         "--data 的 payload 必须是 JSON object。",
     "errors.cloudTaskRun.unknownInputHandle":


### PR DESCRIPTION
Replace raw locale string with Translator to leverage i18n catalog for validation messages. Validate save/dir widgets require paths under the /oomol-driver/oomol-storage/ prefix with Unix separators, and reject credential widgets outright since the CLI cannot supply them.