### PR TITLE
feat(skill): add file upload workflow to oo skill

### DIFF
--- a/contrib/skills/oo/SKILL.md
+++ b/contrib/skills/oo/SKILL.md
@@ -37,6 +37,7 @@ Before doing anything substantial:
     - `search`
     - `package info`
     - `cloud-task run`
+    - `file upload`
 - Never add `--json` to `cloud-task wait`.
 - Never invent package IDs, versions, block IDs, handle names, defaults, or
   task results.
@@ -50,6 +51,10 @@ Before doing anything substantial:
   infer.
 - Stop when the selected block depends on an input shape that `oo-cli` cannot
   safely submit.
+- Never pass raw file bytes, multipart payloads, or a local filesystem path to
+  `cloud-task run --data`.
+- When a handle expects a URI-compatible file value, upload the local file
+  first and submit the returned `downloadUrl`.
 
 ## Workflow
 
@@ -150,6 +155,25 @@ Rules:
 - Do not guess secrets, credentials, local file paths, filenames, or opaque IDs.
 - Do not force raw user prose into a handle whose schema does not fit.
 
+For file-like inputs, distinguish between URI-safe values and unsupported
+special-media values:
+
+- If the schema or patched widget semantics clearly expect a URI string, ask
+  the user for a local file path when needed, then upload it first:
+
+```bash
+oo file upload "<filePath>" --json
+```
+
+- Read `downloadUrl` from the JSON response and place that URL into the
+  matching handle value for `cloud-task run --data`.
+- Treat file widgets as URI-oriented inputs, because current CLI validation
+  patches them to string values with `format: "uri"`.
+- If the schema already declares a URI-shaped string, you may use an existing
+  user-provided remote URL instead of uploading a local file.
+- Do not upload a file unless the selected handle can safely accept a URI
+  string.
+
 If a required value is missing or ambiguous, ask a focused follow-up question.
 
 A good follow-up question:
@@ -171,9 +195,17 @@ Stop instead of forcing execution when any of the following is true:
 Pay special attention to `schema.contentMediaType`.
 
 If `contentMediaType` exists and is not `oomol/secret`, stop. The current
-`oo-cli` local validation rejects most non-secret content media types, so do
-not pretend file, image, or other special payloads can be passed safely as
-normal JSON values.
+`oo-cli` local validation rejects non-secret content media types, so do not
+pretend file, image, or other special payloads can be passed safely as normal
+JSON values.
+
+Do not confuse the URI-safe path with the unsupported path:
+
+- A handle that can be validated as a URI string may be satisfied by
+  `oo file upload ... --json` plus the returned `downloadUrl`.
+- A handle that still exposes a non-secret `contentMediaType` is not safely
+  supported through `cloud-task run --data`, even if the user wants to provide
+  a local file.
 
 ### 6. Run the task once required inputs are ready
 

--- a/contrib/skills/oo/agents/openai.yaml
+++ b/contrib/skills/oo/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: oo
   short_description: Safely run OOMOL packages and cloud tasks from user requests
-  default_prompt: "Use $oo to translate my request into English search terms, choose the best package and block, stop when auth or input requirements are not proven, ask only for missing inputs, run the task, and handle long waits safely."
+  default_prompt: "Use $oo to translate my request into English search terms, choose the best package and block, reuse existing remote URLs when they already satisfy a URI input, upload local files first when a selected input needs a URI, never pass local paths or raw bytes into `cloud-task run --data`, stop when auth or input requirements are not proven, ask only for missing inputs, run the task, and handle long waits safely."
 
 policy:
   allow_implicit_invocation: true

--- a/contrib/skills/oo/references/oo-cli-contract.md
+++ b/contrib/skills/oo/references/oo-cli-contract.md
@@ -14,8 +14,9 @@ oo ...
 
 ## Authentication
 
-- `search`, `package info`, `cloud-task run`, `cloud-task result`, and
-  `cloud-task wait` all require a current authenticated account.
+- `search`, `package info`, `file upload`, `cloud-task run`,
+  `cloud-task result`, and `cloud-task wait` all require a current
+  authenticated account.
 - Do not run `auth status` as a routine precheck.
 - If a remote command fails and auth might be the cause, use:
 
@@ -148,6 +149,44 @@ user request.
 Sample values, placeholders, empty strings, and defaults should be overridden
 whenever the user request implies a specific input.
 
+File-oriented practical implication:
+
+- Some file-like handles are safely represented as URI strings instead of raw
+  binary payloads.
+- Current CLI validation patches `file` widgets to string values with
+  `format: "uri"`.
+- When the selected handle is URI-compatible and the user only has a local
+  file, upload it first with `file upload --json` and use the returned
+  `downloadUrl` as the submitted handle value.
+
+## `file upload`
+
+Canonical form:
+
+```bash
+oo file upload "<filePath>" --json
+```
+
+Facts:
+
+- `<filePath>` is a local file path.
+- `--json` is an alias for `--format=json`.
+- Successful JSON output includes `downloadUrl`, `expiresAt`, `fileName`,
+  `fileSize`, `id`, `status`, and `uploadedAt`.
+- The uploaded file expires after one day.
+- Files larger than `512 MiB` are rejected.
+- Successful uploads persist a local sqlite record.
+
+Practical implication:
+
+- Use this command when a selected `cloud-task run` input can safely accept a
+  URI string but the user currently has a local file.
+- If the user already provides a remote URL that satisfies the same URI input,
+  reuse it instead of re-uploading the file.
+- Submit the returned `downloadUrl` in `--data`.
+- Do not treat this command as a way to pass raw bytes or bypass unsupported
+  `contentMediaType` validation.
+
 ## `cloud-task run`
 
 Canonical form:
@@ -182,13 +221,17 @@ Hard validation limits:
 - Missing required values are rejected.
 - Type mismatches are rejected.
 - `--data` must decode to a plain JSON object.
+- File widget validation is patched to require URI strings instead of local
+  paths or binary payloads.
 - If an input handle schema contains `contentMediaType` and the value is not
   `oomol/secret`, current local validation rejects it.
 
 Practical implication:
 
-- Stop instead of pretending that file, image, or other special-media handles
-  can be submitted safely through normal JSON payloads.
+- If a handle is URI-compatible, a previously uploaded file's `downloadUrl` may
+  be submitted as the JSON value.
+- Stop instead of pretending that raw file bytes, local paths, or unsupported
+  special-media handles can be submitted safely through normal JSON payloads.
 
 ## `cloud-task result`
 
@@ -264,7 +307,9 @@ Use this order:
 3. Run `package info --json` for the serious candidates.
 4. Choose one primary package and optionally one fallback.
 5. Ask focused follow-up questions only for missing required inputs.
-6. Run `cloud-task run --json`.
-7. Share `taskID` immediately.
-8. Use bounded `cloud-task wait` windows when appropriate.
-9. After a non-zero wait exit, run `cloud-task result --json`.
+6. Upload local files with `file upload --json` when a selected handle needs a
+   URI value.
+7. Run `cloud-task run --json`.
+8. Share `taskID` immediately.
+9. Use bounded `cloud-task wait` windows when appropriate.
+10. After a non-zero wait exit, run `cloud-task result --json`.


### PR DESCRIPTION
Teach the oo skill how to handle file-like inputs: upload local files via `oo file upload --json`, use the returned `downloadUrl` as URI input for `cloud-task run --data`, and distinguish between URI-safe handles and unsupported special-media handles.

Updates the CLI contract reference, agent prompt, and skill rules to prevent raw file bytes or local paths from reaching cloud-task submission.