### PR TITLE
feat(skill): add safe artifact download policy to oo skill

### DIFF
--- a/contrib/skills/oo/SKILL.md
+++ b/contrib/skills/oo/SKILL.md
@@ -55,6 +55,13 @@ Before doing anything substantial:
   `cloud-task run --data`.
 - When a handle expects a URI-compatible file value, upload the local file
   first and submit the returned `downloadUrl`.
+- If you choose to download a remote result artifact back to local, save it
+  under `.` inside the current workspace by default.
+- Treat the current workspace root as the only implicit download root.
+- Do not derive the destination from the source file's parent directory.
+- Do not use an absolute path, a path containing `..`, `~/Downloads`, a home
+  directory path, a temp directory, or any other external location unless the
+  user explicitly asks for that exact target.
 
 ## Workflow
 
@@ -272,13 +279,37 @@ Use the result snapshot to distinguish:
 If the user wants to continue, run another bounded wait window instead of
 re-creating the task.
 
-### 8. Report outcomes clearly
+### 8. Materialize remote result artifacts safely
+
+If the final task result exposes a remote artifact URL and pulling it back to
+local would clearly help the user, download it only after the task has
+succeeded.
+
+Rules:
+
+- Default the destination to a relative path rooted at `.` such as
+  `./result.zip`, `./output.pdf`, or `./artifacts/<source-basename>.zip`.
+- Treat `.` as the only implicit destination root. If the user did not name a
+  path, choose one under `.` and stay there.
+- Derive the filename from trusted task output or the source basename, but keep
+  the directory anchored under `.` instead of reusing the source file's parent
+  directory.
+- Never improvise an absolute path, a path containing `..`, `~/Downloads`, a
+  home directory path, a temp directory, or any other external destination.
+- Do not write outside the current workspace unless the user explicitly names a
+  different target path.
+- If the destination filename would collide with an existing workspace file,
+  choose a non-destructive variant or ask the user.
+- When reporting success, include the workspace-local path you used.
+
+### 9. Report outcomes clearly
 
 On success:
 
 - state the final task status first
 - summarize the useful result
 - include package, version, block ID, and task ID
+- if you downloaded a remote artifact, include the workspace-local saved path
 
 On still-running tasks:
 

--- a/contrib/skills/oo/agents/openai.yaml
+++ b/contrib/skills/oo/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: oo
   short_description: Safely run OOMOL packages and cloud tasks from user requests
-  default_prompt: "Use $oo to translate my request into English search terms, choose the best package and block, reuse existing remote URLs when they already satisfy a URI input, upload local files first when a selected input needs a URI, never pass local paths or raw bytes into `cloud-task run --data`, stop when auth or input requirements are not proven, ask only for missing inputs, run the task, and handle long waits safely."
+  default_prompt: "Use $oo to translate my request into English search terms, choose the best package and block, reuse existing remote URLs when they already satisfy a URI input, upload local files first when a selected input needs a URI, never pass local paths or raw bytes into `cloud-task run --data`, stop when auth or input requirements are not proven, ask only for missing inputs, run the task, handle long waits safely, and if you download a remote result artifact back to local treat `.` as the only implicit destination root, save to a relative workspace path such as `./result.zip`, and never improvise a source-adjacent, absolute, home, temp, or other external path unless the user explicitly asks for it."
 
 policy:
   allow_implicit_invocation: true

--- a/contrib/skills/oo/references/oo-cli-contract.md
+++ b/contrib/skills/oo/references/oo-cli-contract.md
@@ -271,6 +271,13 @@ In-progress statuses include `queued`, `scheduling`, `scheduled`, and
 Use this command after a non-zero `cloud-task wait` exit to distinguish timeout,
 failure, and a late success.
 
+Result URL implication:
+
+- `resultURL` is a remote artifact location returned by the service.
+- The CLI does not choose a local download destination for that URL.
+- If an agent decides to download the artifact after success, the local path is
+  agent policy rather than part of the CLI contract.
+
 ## `cloud-task wait`
 
 Canonical form:


### PR DESCRIPTION
Without explicit guidance the agent would improvise download destinations such as absolute paths, ~/Downloads, or the source file's parent directory.  Add a dedicated workflow step ("Materialize remote result artifacts safely") that anchors all implicit downloads under the workspace root `.`, and propagate the same constraint into the agent default_prompt and the CLI contract reference so the rule is enforced consistently.