### PR TITLE
fix(skill): skip bundled skill sync for development builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ bun run dev --help
 ```
 
 This is the fastest way to verify argument parsing and command output while
-iterating on local changes.
+iterating on local changes. Source-based development runs do not auto-install
+or auto-synchronize the bundled Codex skill into `${CODEX_HOME:-~/.codex}`.
 
 Useful commands:
 

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -162,6 +162,35 @@ describe("runCli", () => {
         }
     });
 
+    test("does not auto-install the managed Codex skill during local development runs", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["--help"]);
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).not.toContain("Installed Codex skill");
+            expect(result.stderr).toBe("");
+            await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            expect(content).toContain(`"isFirstRun":true`);
+            expect(content).toContain(`"shouldSynchronizeBundledSkills":false`);
+            expect(content).toContain(`"shouldInstallMissingBundledSkills":false`);
+            expect(content).not.toContain(
+                `"msg":"Bundled Codex skill installed during first-run bootstrap."`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("does not auto-install the managed Codex skill for skills subcommands", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -150,8 +150,11 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
         const buildInfo = resolveCliBuildInfo(packageManifest.version);
         const version = invocation.version ?? buildInfo.version;
         const primaryCommandName = resolvePrimaryCommandName(invocation.argv);
+        const shouldSynchronizeBundledSkills
+            = !isDevelopmentCliVersion(version);
         const shouldInstallMissingBundledSkills
-            = firstRunDetection.isFirstRun
+            = shouldSynchronizeBundledSkills
+                && firstRunDetection.isFirstRun
                 && primaryCommandName !== "skills";
 
         logger.debug(
@@ -169,6 +172,7 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
                 hasSettingsFile: firstRunDetection.hasSettingsFile,
                 isFirstRun: firstRunDetection.isFirstRun,
                 primaryCommandName: primaryCommandName ?? "",
+                shouldSynchronizeBundledSkills,
                 shouldInstallMissingBundledSkills,
             },
             "CLI first-run detection completed.",
@@ -200,12 +204,14 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
                 translator,
             ),
         };
-        await maybeSynchronizeInstalledBundledSkills(
-            context,
-            {
-                installMissing: shouldInstallMissingBundledSkills,
-            },
-        );
+        if (shouldSynchronizeBundledSkills) {
+            await maybeSynchronizeInstalledBundledSkills(
+                context,
+                {
+                    installMissing: shouldInstallMissingBundledSkills,
+                },
+            );
+        }
 
         const adapter = new CommanderCliAdapter();
 
@@ -321,6 +327,11 @@ function resolvePrimaryCommandName(argv: readonly string[]): string | undefined 
     }
 
     return undefined;
+}
+
+function isDevelopmentCliVersion(version: string): boolean {
+    return packageManifest.version.endsWith("-development")
+        && version === packageManifest.version;
 }
 
 async function detectFirstRun(storePaths: {

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -198,6 +198,35 @@ describe("skills commands", () => {
         }
     });
 
+    test("does not silently synchronize installed bundled skills during local development runs", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const managedSkillPath = join(skillDirectoryPath, "SKILL.md");
+        const managedOwnershipPath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const expectedOwnershipContent = await Bun.file(
+            getBundledSkillFiles("oo").find(file => file.relativePath === "agents/openai.yaml")!.sourcePath,
+        ).text();
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(versionFilePath, "0.0.1\n");
+            await Bun.write(managedSkillPath, "stale\n");
+            await Bun.write(managedOwnershipPath, expectedOwnershipContent);
+
+            const result = await sandbox.run(["--help"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(await readFile(versionFilePath, "utf8")).toBe("0.0.1\n");
+            expect(await readFile(managedSkillPath, "utf8")).toBe("stale\n");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("does not install bundled skills automatically after the first run", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);


### PR DESCRIPTION
Local development runs (version ending in "-development") were triggering bundled skill synchronization and first-run installation unnecessarily. This could overwrite local skill changes during iterative development.

Gate both synchronization and auto-install behind a new isDevelopmentCliVersion() check so that `bun run dev` never touches the skill directory under CODEX_HOME.