### PR TITLE
feat(skill): add billing stop condition on HTTP 402 to oo skill

### DIFF
--- a/contrib/skills/oo/SKILL.md
+++ b/contrib/skills/oo/SKILL.md
@@ -16,6 +16,11 @@ Read [references/oo-cli-contract.md](references/oo-cli-contract.md) when you
 need exact command syntax, JSON shapes, auth behavior, timeout rules, or known
 stop conditions.
 
+If any `oo` command output shows HTTP `402` or includes the string
+`OOMOL_INSUFFICIENT_CREDIT`, stop immediately. Tell the user their current
+account has insufficient credit or is overdue, and point them to
+https://console.oomol.com/billing/recharge before continuing.
+
 ## Environment checks
 
 Before doing anything substantial:
@@ -43,6 +48,10 @@ Before doing anything substantial:
   task results.
 - If a remote command fails with an auth-related error or unclear account
   state, inspect with `oo auth status` before retrying.
+- If any command output shows HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`, stop
+  immediately. Treat it as a billing problem, not an auth problem, and tell the
+  user to recharge at https://console.oomol.com/billing/recharge before any
+  retry.
 - `cloud-task run` must use `PACKAGE_NAME@SEMVER`.
 - `cloud-task run` must include a real `--block-id`.
 - If `search` returns zero packages, stop and tell the user that `oo` does not
@@ -276,6 +285,10 @@ Use the result snapshot to distinguish:
 - failed
 - succeeded after the wait command exited
 
+If the wait output or result snapshot shows HTTP `402` or
+`OOMOL_INSUFFICIENT_CREDIT`, stop immediately and direct the user to
+https://console.oomol.com/billing/recharge before any retry.
+
 If the user wants to continue, run another bounded wait window instead of
 re-creating the task.
 
@@ -322,6 +335,10 @@ On failure:
 
 - report whether the failure came from no package match, missing input,
   unsupported input shape, task failure, or environment or auth limitations
+
+If the failure output includes HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`,
+classify it as insufficient credit or overdue billing and direct the user to
+https://console.oomol.com/billing/recharge before retrying anything.
 
 ## Response style
 

--- a/contrib/skills/oo/agents/openai.yaml
+++ b/contrib/skills/oo/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: oo
   short_description: Safely run OOMOL packages and cloud tasks from user requests
-  default_prompt: "Use $oo to translate my request into English search terms, choose the best package and block, reuse existing remote URLs when they already satisfy a URI input, upload local files first when a selected input needs a URI, never pass local paths or raw bytes into `cloud-task run --data`, stop when auth or input requirements are not proven, ask only for missing inputs, run the task, handle long waits safely, and if you download a remote result artifact back to local treat `.` as the only implicit destination root, save to a relative workspace path such as `./result.zip`, and never improvise a source-adjacent, absolute, home, temp, or other external path unless the user explicitly asks for it."
+  default_prompt: "Use $oo to translate my request into English search terms, choose the best package and block, upload local files only when a selected input needs a URI, never pass local paths or raw bytes into `cloud-task run --data`, stop immediately on HTTP 402 or `OOMOL_INSUFFICIENT_CREDIT` and send the user to https://console.oomol.com/billing/recharge, stop when auth or input requirements are not proven, handle long waits safely, and save downloaded artifacts only under `.` unless I explicitly ask for another path."
 
 policy:
   allow_implicit_invocation: true

--- a/contrib/skills/oo/references/oo-cli-contract.md
+++ b/contrib/skills/oo/references/oo-cli-contract.md
@@ -33,6 +33,15 @@ oo auth status
 oo auth login
 ```
 
+## Billing stop conditions
+
+- If any `oo` command output shows HTTP `402` or includes the string
+  `OOMOL_INSUFFICIENT_CREDIT`, stop immediately.
+- Treat that signal as a billing problem, not as a normal auth failure.
+- Tell the user their current account has insufficient credit or is overdue.
+- Direct them to recharge before retrying at
+  https://console.oomol.com/billing/recharge.
+
 ## `search`
 
 Canonical form:
@@ -271,6 +280,10 @@ In-progress statuses include `queued`, `scheduling`, `scheduled`, and
 Use this command after a non-zero `cloud-task wait` exit to distinguish timeout,
 failure, and a late success.
 
+If the result snapshot contains HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`,
+treat the failure as insufficient credit or overdue billing and stop instead of
+retrying.
+
 Result URL implication:
 
 - `resultURL` is a remote artifact location returned by the service.
@@ -304,6 +317,8 @@ Skill policy:
 - Prefer bounded wait windows over a single long wait.
 - Do not treat timeout as task failure.
 - Never re-create a task just because a wait window ended.
+- If the wait output shows HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`, stop and
+  send the user to https://console.oomol.com/billing/recharge.
 
 ## Command selection summary
 
@@ -319,4 +334,5 @@ Use this order:
 7. Run `cloud-task run --json`.
 8. Share `taskID` immediately.
 9. Use bounded `cloud-task wait` windows when appropriate.
-10. After a non-zero wait exit, run `cloud-task result --json`.
+10. After a non-zero wait exit, run `cloud-task result --json` and stop on
+    billing signals such as HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`.


### PR DESCRIPTION
Teach the oo skill to recognize HTTP 402 and
OOMOL_INSUFFICIENT_CREDIT as billing signals rather than auth failures. When either appears in any command output, the skill now stops immediately and directs the user to the billing recharge page instead of retrying.

Updated across SKILL.md workflow sections (environment checks, cloud-task wait, failure handling), the OpenAI agent default prompt, and the CLI contract reference doc so the rule is enforced consistently at every decision point.