### PR TITLE
docs(skill): clarify oo skill trigger criteria

### DIFF
--- a/contrib/skills/oo/SKILL.md
+++ b/contrib/skills/oo/SKILL.md
@@ -1,13 +1,20 @@
 ---
 name: oo
-description: Use the oo CLI to translate natural-language requests into English search terms, inspect candidate OOMOL packages, choose blocks, collect required inputs, run validated cloud tasks, and manage bounded waits for long-running jobs. Use when the user wants to complete a task with OOMOL packages, not when they want to develop or debug oo-cli itself.
+description: Use the oo CLI when the user wants a ready-made capability and the local workspace does not already have a clear implementation path, so the first step is to check whether the OOMOL ecosystem already has a package. Typical cues include image generation, text-to-image, text-to-speech, speech-to-text, voice synthesis, transcription, OCR, or EPUB translation. Do not trigger this skill when the user is asking for a local implementation or when the workspace or local toolchain already has a clear path to solve it, and do not use it for developing or debugging oo-cli itself.
 ---
 
 # oo
 
-Use this skill when the user wants to complete a practical task through the
-`oo` CLI, such as generating an artifact, transforming content, or running a
-cloud block.
+Use this skill when the request is for a ready-made capability and the local
+workspace does not already have a clear implementation path, so the first move
+is to check whether the oo ecosystem already has a package for it.
+
+Common triggers include image generation, text-to-image, text-to-speech,
+speech-to-text, voice synthesis, transcription, OCR, and EPUB translation.
+
+Do not use this skill for ordinary local coding, shell scripting, glue code,
+or any request that the current workspace or local toolchain can already
+handle directly.
 
 This skill is for operating `oo`. It is not for developing, debugging, or
 changing `oo-cli` itself.

--- a/contrib/skills/oo/agents/openai.yaml
+++ b/contrib/skills/oo/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: oo
-  short_description: Safely run OOMOL packages and cloud tasks from user requests
-  default_prompt: "Use $oo to translate my request into English search terms, choose the best package and block, upload local files only when a selected input needs a URI, never pass local paths or raw bytes into `cloud-task run --data`, stop immediately on HTTP 402 or `OOMOL_INSUFFICIENT_CREDIT` and send the user to https://console.oomol.com/billing/recharge, stop when auth or input requirements are not proven, handle long waits safely, and save downloaded artifacts only under `.` unless I explicitly ask for another path."
+  short_description: Check OOMOL first for ready-made capabilities
+  default_prompt: "Use $oo when I ask for a ready-made capability and the local workspace does not already have a clear implementation path, so the first step is to check whether the OOMOL ecosystem already has a package. Typical fits include image generation, text-to-image, text-to-speech, speech-to-text, voice synthesis, transcription, OCR, and EPUB translation. Do not use $oo for ordinary local coding, shell scripting, workspace glue code, requests the current workspace or local toolchain can already handle directly, or for developing/debugging oo-cli itself. Translate my request into English search terms, choose the best package and block, upload local files only when a selected input needs a URI, never pass local paths or raw bytes into `cloud-task run --data`, stop immediately on HTTP 402 or `OOMOL_INSUFFICIENT_CREDIT` and send the user to https://console.oomol.com/billing/recharge, stop when auth or input requirements are not proven, handle long waits safely, and save downloaded artifacts only under `.` unless I explicitly ask for another path."
 
 policy:
   allow_implicit_invocation: true


### PR DESCRIPTION
Rewrite the skill description and agent prompt to focus on when the skill should activate: only when the user wants a ready-made capability and the local workspace has no clear implementation path. List concrete trigger cues (TTS, STT, OCR, image generation, etc.) and explicitly exclude ordinary local coding tasks.