### PR TITLE
docs(skill): clarify oo skill trigger criteria

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -68,7 +68,8 @@ List persisted configuration values that are currently set.
 
 Read one persisted configuration value.
 
-- Arguments: `<key>` is the configuration key. Supported value: `lang`.
+- Arguments: `<key>` is the configuration key. Supported values:
+  `lang`, `skills.oo.allow_implicit_invocation`.
 
 ### `oo config path`
 
@@ -78,15 +79,19 @@ Print the path to the persisted configuration file.
 
 Persist one configuration value.
 
-- Arguments: `<key>` is the configuration key. Supported value: `lang`.
+- Arguments: `<key>` is the configuration key. Supported values:
+  `lang`, `skills.oo.allow_implicit_invocation`.
 - Arguments: `<value>` is the value for the selected key.
 - Value rules: for `lang`, supported values are `en` and `zh`.
+- Value rules: for `skills.oo.allow_implicit_invocation`, supported values are
+  `true` and `false`.
 
 ### `oo config unset <key>`
 
 Remove one persisted configuration value.
 
-- Arguments: `<key>` is the configuration key. Supported value: `lang`.
+- Arguments: `<key>` is the configuration key. Supported values:
+  `lang`, `skills.oo.allow_implicit_invocation`.
 
 ## Updates
 
@@ -106,6 +111,18 @@ Check whether a newer CLI release is available.
 
 ## Codex Skills
 
+### `oo skills allow-implicit-invocation <value>`
+
+Persist the `oo` skill `allow_implicit_invocation` policy.
+
+- Arguments: `<value>` must be `true` or `false`.
+- Notes: when the managed `oo` skill is already installed, the command
+  synchronizes `${CODEX_HOME:-~/.codex}/skills/oo/agents/openai.yaml`
+  immediately.
+- Notes: when the managed `oo` skill is not installed, the command still
+  persists the setting and applies it on the next install or startup
+  synchronization.
+
 ### `oo skills install`
 
 Install one bundled skill into the local Codex skills directory.
@@ -114,6 +131,9 @@ Install one bundled skill into the local Codex skills directory.
 - Target directory: `${CODEX_HOME:-~/.codex}/skills/oo`.
 - Metadata: the installation writes the current `oo` version into a hidden
   version file inside the skill directory.
+- Metadata: `agents/openai.yaml` uses the persisted
+  `skills.oo.allow_implicit_invocation` value when configured, otherwise the
+  bundled default is used.
 - Notes: the command exits with an error when the Codex home directory does
   not exist, which indicates Codex is not installed on the current machine.
 - Notes: an existing `oo/agents/openai.yaml` is considered managed by

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -62,7 +62,8 @@
 
 读取一个持久化配置值。
 
-- 参数：`<key>` 为配置键。目前仅支持 `lang`。
+- 参数：`<key>` 为配置键。目前支持
+  `lang`、`skills.oo.allow_implicit_invocation`。
 
 ### `oo config path`
 
@@ -72,15 +73,19 @@
 
 写入一个持久化配置值。
 
-- 参数：`<key>` 为配置键。目前仅支持 `lang`。
+- 参数：`<key>` 为配置键。目前支持
+  `lang`、`skills.oo.allow_implicit_invocation`。
 - 参数：`<value>` 为对应配置值。
 - 取值规则：当 `<key>` 为 `lang` 时，支持的值为 `en` 和 `zh`。
+- 取值规则：当 `<key>` 为 `skills.oo.allow_implicit_invocation` 时，支持的
+  值为 `true` 和 `false`。
 
 ### `oo config unset <key>`
 
 删除一个持久化配置值。
 
-- 参数：`<key>` 为配置键。目前仅支持 `lang`。
+- 参数：`<key>` 为配置键。目前支持
+  `lang`、`skills.oo.allow_implicit_invocation`。
 
 ## 更新
 
@@ -97,6 +102,16 @@
 
 ## Codex Skill
 
+### `oo skills allow-implicit-invocation <value>`
+
+持久化 `oo` skill 的 `allow_implicit_invocation` 策略。
+
+- 参数：`<value>` 必须为 `true` 或 `false`。
+- 说明：当受管的 `oo` skill 已经安装时，命令会立即同步
+  `${CODEX_HOME:-~/.codex}/skills/oo/agents/openai.yaml`。
+- 说明：当受管的 `oo` skill 尚未安装时，命令仍会写入设置，并在下次安装或启
+  动同步时生效。
+
 ### `oo skills install`
 
 将一个内置 skill 安装到本地 Codex skills 目录。
@@ -104,6 +119,8 @@
 - 内置 skill：`oo`。
 - 目标目录：`${CODEX_HOME:-~/.codex}/skills/oo`。
 - 元数据：安装时会在 skill 目录内写入一个隐藏的 `oo` 版本记录文件。
+- 元数据：当存在持久化的 `skills.oo.allow_implicit_invocation` 配置时，
+  `agents/openai.yaml` 会使用该值；否则使用内置默认值。
 - 说明：当 Codex 根目录不存在时，命令会直接报错退出，这表示当前机器上没有
   安装 Codex。
 - 说明：只有当 `oo/agents/openai.yaml` 中包含 `OOMOL` 字符串时，`oo`

--- a/src/adapters/store/file-settings-store.test.ts
+++ b/src/adapters/store/file-settings-store.test.ts
@@ -11,6 +11,20 @@ import {
 import { APP_NAME } from "../../application/config/app-config.ts";
 import { FileSettingsStore } from "./file-settings-store.ts";
 
+const defaultSettingsFileContent = [
+    "# lang controls the CLI display language for help text, messages, and errors.",
+    "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
+    "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
+    "# lang = \"en\"",
+    "",
+    "# skills.oo.allow_implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
+    "# Supported values: true, false.",
+    "# Default: true.",
+    "# [skills.oo]",
+    "# allow_implicit_invocation = false",
+    "",
+].join("\n");
+
 describe("FileSettingsStore", () => {
     test("returns default settings when the file does not exist", async () => {
         const root = await createTemporaryDirectory("store-missing");
@@ -25,13 +39,7 @@ describe("FileSettingsStore", () => {
 
         expect(await store.read()).toEqual({});
         expect(await readFile(store.getFilePath(), "utf8")).toBe(
-            [
-                "# lang controls the CLI display language for help text, messages, and errors.",
-                "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
-                "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
-                "# lang = \"en\"",
-                "",
-            ].join("\n"),
+            defaultSettingsFileContent,
         );
     });
 
@@ -58,12 +66,64 @@ describe("FileSettingsStore", () => {
                 "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
                 "# lang = \"en\"",
                 "",
+                "# skills.oo.allow_implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
+                "# Supported values: true, false.",
+                "# Default: true.",
+                "# [skills.oo]",
+                "# allow_implicit_invocation = false",
+                "",
                 "lang = \"zh\"",
                 "",
             ].join("\n"),
         );
         expect(await store.read()).toEqual({
             lang: "zh",
+        });
+    });
+
+    test("writes and reads persisted oo skill settings", async () => {
+        const root = await createTemporaryDirectory("store-skill-write");
+        const store = new FileSettingsStore({
+            appName: APP_NAME,
+            env: {
+                HOME: root,
+                XDG_CONFIG_HOME: root,
+            },
+            platform: "linux",
+        });
+
+        await store.write({
+            skills: {
+                oo: {
+                    allow_implicit_invocation: false,
+                },
+            },
+        });
+
+        expect(await readFile(store.getFilePath(), "utf8")).toBe(
+            [
+                "# lang controls the CLI display language for help text, messages, and errors.",
+                "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
+                "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
+                "# lang = \"en\"",
+                "",
+                "# skills.oo.allow_implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
+                "# Supported values: true, false.",
+                "# Default: true.",
+                "# [skills.oo]",
+                "# allow_implicit_invocation = false",
+                "",
+                "[skills.oo]",
+                "allow_implicit_invocation = false",
+                "",
+            ].join("\n"),
+        );
+        expect(await store.read()).toEqual({
+            skills: {
+                oo: {
+                    allow_implicit_invocation: false,
+                },
+            },
         });
     });
 
@@ -81,13 +141,7 @@ describe("FileSettingsStore", () => {
         await store.write({});
 
         expect(await readFile(store.getFilePath(), "utf8")).toBe(
-            [
-                "# lang controls the CLI display language for help text, messages, and errors.",
-                "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
-                "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
-                "# lang = \"en\"",
-                "",
-            ].join("\n"),
+            defaultSettingsFileContent,
         );
     });
 

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -22,6 +22,19 @@ const searchBlockTitleColor = "#CAA8FA";
 const searchDisplayNameColor = "#59F78D";
 const defaultAuthEndpoint = "oomol.com";
 const packageName = packageManifest.name;
+const defaultSettingsFileContent = [
+    "# lang controls the CLI display language for help text, messages, and errors.",
+    "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
+    "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
+    "# lang = \"en\"",
+    "",
+    "# skills.oo.allow_implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
+    "# Supported values: true, false.",
+    "# Default: true.",
+    "# [skills.oo]",
+    "# allow_implicit_invocation = false",
+    "",
+].join("\n");
 
 describe("runCli", () => {
     test("keeps the cli command name aligned with package metadata", () => {
@@ -209,6 +222,50 @@ describe("runCli", () => {
             await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("synchronizes the managed Codex skill policy from persisted settings", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const settingsFilePath = join(
+            sandbox.env.XDG_CONFIG_HOME!,
+            APP_NAME,
+            "settings.toml",
+        );
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(versionFilePath, "9.9.9\n");
+            await Bun.write(
+                ownershipFilePath,
+                await Bun.file(
+                    join(process.cwd(), "contrib", "skills", "oo", "agents", "openai.yaml"),
+                ).text(),
+            );
+            await Bun.write(
+                settingsFilePath,
+                [
+                    "[skills.oo]",
+                    "allow_implicit_invocation = false",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["--help"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: false",
+            );
         }
         finally {
             await sandbox.cleanup();
@@ -1478,6 +1535,142 @@ describe("runCli", () => {
             expect(listAfterUnsetResult.exitCode).toBe(0);
             expect(listAfterUnsetResult.stdout).toBe("");
             expect(getAfterUnsetResult.stdout).toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports the oo skill implicit invocation config key", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const setResult = await sandbox.run([
+                "config",
+                "set",
+                "skills.oo.allow_implicit_invocation",
+                "false",
+            ]);
+            const listResult = await sandbox.run(["config", "list"]);
+            const getResult = await sandbox.run([
+                "config",
+                "get",
+                "skills.oo.allow_implicit_invocation",
+            ]);
+            const unsetResult = await sandbox.run([
+                "config",
+                "unset",
+                "skills.oo.allow_implicit_invocation",
+            ]);
+            const getAfterUnsetResult = await sandbox.run([
+                "config",
+                "get",
+                "skills.oo.allow_implicit_invocation",
+            ]);
+
+            expect(setResult.exitCode).toBe(0);
+            expect(setResult.stdout).toBe(
+                "Set skills.oo.allow_implicit_invocation to false.\n",
+            );
+            expect(listResult.stdout).toBe(
+                "skills.oo.allow_implicit_invocation=false\n",
+            );
+            expect(getResult.stdout).toBe("false\n");
+            expect(unsetResult.exitCode).toBe(0);
+            expect(getAfterUnsetResult.stdout).toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("config set immediately synchronizes the installed managed skill policy", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(versionFilePath, "9.9.9\n");
+            await Bun.write(
+                ownershipFilePath,
+                await Bun.file(
+                    join(process.cwd(), "contrib", "skills", "oo", "agents", "openai.yaml"),
+                ).text(),
+            );
+
+            const result = await sandbox.run([
+                "config",
+                "set",
+                "skills.oo.allow_implicit_invocation",
+                "false",
+            ], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: false",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("config unset immediately restores the installed managed skill policy default", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const settingsFilePath = join(
+            sandbox.env.XDG_CONFIG_HOME!,
+            APP_NAME,
+            "settings.toml",
+        );
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(versionFilePath, "9.9.9\n");
+            await Bun.write(
+                ownershipFilePath,
+                [
+                    "interface:",
+                    "  display_name: oo",
+                    "  short_description: Check OOMOL first for ready-made capabilities",
+                    "  default_prompt: \"Use $oo when I ask for a ready-made capability.\"",
+                    "",
+                    "policy:",
+                    "  allow_implicit_invocation: false",
+                    "",
+                    "# OOMOL",
+                    "",
+                ].join("\n"),
+            );
+            await Bun.write(
+                settingsFilePath,
+                [
+                    "[skills.oo]",
+                    "allow_implicit_invocation = false",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run([
+                "config",
+                "unset",
+                "skills.oo.allow_implicit_invocation",
+            ], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: true",
+            );
         }
         finally {
             await sandbox.cleanup();
@@ -3900,15 +4093,7 @@ describe("runCli", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe("");
             expect(result.stderr).toBe("");
-            expect(await readFile(filePath, "utf8")).toBe(
-                [
-                    "# lang controls the CLI display language for help text, messages, and errors.",
-                    "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
-                    "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
-                    "# lang = \"en\"",
-                    "",
-                ].join("\n"),
-            );
+            expect(await readFile(filePath, "utf8")).toBe(defaultSettingsFileContent);
         }
         finally {
             await sandbox.cleanup();
@@ -3922,6 +4107,12 @@ describe("runCli", () => {
             const invalidLang = await sandbox.run(["--lang", "fr", "--help"]);
             const invalidKey = await sandbox.run(["config", "get", "update-notifier"]);
             const invalidConfigValue = await sandbox.run(["config", "set", "lang", "fr"]);
+            const invalidSkillPolicyValue = await sandbox.run([
+                "config",
+                "set",
+                "skills.oo.allow_implicit_invocation",
+                "maybe",
+            ]);
             const unknownCommand = await sandbox.run(["cnfig"]);
 
             expect(invalidLang.exitCode).toBe(2);
@@ -3933,6 +4124,11 @@ describe("runCli", () => {
 
             expect(invalidConfigValue.exitCode).toBe(2);
             expect(invalidConfigValue.stderr).toContain("Invalid lang value");
+
+            expect(invalidSkillPolicyValue.exitCode).toBe(2);
+            expect(invalidSkillPolicyValue.stderr).toContain(
+                "Invalid skills.oo.allow_implicit_invocation value",
+            );
 
             expect(unknownCommand.exitCode).toBe(2);
             expect(unknownCommand.stderr).toContain("Unknown command");

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -209,6 +209,7 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
                 context,
                 {
                     installMissing: shouldInstallMissingBundledSkills,
+                    settings,
                 },
             );
         }

--- a/src/application/commands/config/set.ts
+++ b/src/application/commands/config/set.ts
@@ -3,12 +3,14 @@ import type { AppSettings } from "../../schemas/settings.ts";
 
 import type { ConfigSetInput } from "./shared.ts";
 import { z } from "zod";
+import { maybeSynchronizeInstalledBundledSkills } from "../skills/shared.ts";
 import {
     configKeyChoices,
     configKeySchema,
     createInvalidConfigKeyError,
     getConfigDefinition,
     getConfigDefinitionByRawKey,
+    ooSkillAllowImplicitInvocationConfigKey,
     writeLine,
 } from "./shared.ts";
 
@@ -63,9 +65,16 @@ export const configSetCommand: CliCommandDefinition<ConfigSetInput> = {
         return definition.createInvalidValueError(rawInput.value);
     },
     handler: async (input, context) => {
-        await context.settingsStore.update(
+        const nextSettings = await context.settingsStore.update(
             settings => setConfigValue(settings, input),
         );
+
+        if (input.key === ooSkillAllowImplicitInvocationConfigKey) {
+            await maybeSynchronizeInstalledBundledSkills(context, {
+                settings: nextSettings,
+            });
+        }
+
         context.logger.info(
             {
                 key: input.key,
@@ -90,5 +99,9 @@ function setConfigValue(
     switch (input.key) {
         case "lang":
             return getConfigDefinition("lang").setValue(settings, input.value);
+        case ooSkillAllowImplicitInvocationConfigKey:
+            return getConfigDefinition(
+                ooSkillAllowImplicitInvocationConfigKey,
+            ).setValue(settings, input.value);
     }
 }

--- a/src/application/commands/config/shared.ts
+++ b/src/application/commands/config/shared.ts
@@ -7,7 +7,16 @@ import type { AppSettings } from "../../schemas/settings.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import { localeSchema } from "../../schemas/settings.ts";
+import {
+    booleanConfigValueChoices,
+    booleanConfigValueSchema,
+    getConfiguredOoSkillAllowImplicitInvocation,
+    localeSchema,
+    parseBooleanConfigValue,
+    setOoSkillAllowImplicitInvocation,
+    stringifyBooleanConfigValue,
+    unsetOoSkillAllowImplicitInvocation,
+} from "../../schemas/settings.ts";
 
 export interface ConfigDefinition<TValue extends string> {
     createInvalidValueError: (rawValue: unknown) => CliUserError;
@@ -23,6 +32,9 @@ function defineConfigDefinition<TValue extends string>(
 ): ConfigDefinition<TValue> {
     return definition;
 }
+
+export const ooSkillAllowImplicitInvocationConfigKey
+    = "skills.oo.allow_implicit_invocation" as const;
 
 export const configDefinitions = {
     lang: defineConfigDefinition({
@@ -49,6 +61,36 @@ export const configDefinitions = {
         },
         valueChoices: localeSchema.options,
         valueSchema: localeSchema,
+    }),
+    [ooSkillAllowImplicitInvocationConfigKey]: defineConfigDefinition({
+        createInvalidValueError(rawValue: unknown): CliUserError {
+            return new CliUserError(
+                "errors.config.invalidSkillsOoAllowImplicitInvocationValue",
+                2,
+                {
+                    value: String(rawValue ?? ""),
+                },
+            );
+        },
+        getValue(settings: AppSettings): "false" | "true" | undefined {
+            const configuredValue
+                = getConfiguredOoSkillAllowImplicitInvocation(settings);
+
+            return configuredValue === undefined
+                ? undefined
+                : stringifyBooleanConfigValue(configuredValue);
+        },
+        setValue(settings: AppSettings, value: "false" | "true"): AppSettings {
+            return setOoSkillAllowImplicitInvocation(
+                settings,
+                parseBooleanConfigValue(value),
+            );
+        },
+        unsetValue(settings: AppSettings): AppSettings {
+            return unsetOoSkillAllowImplicitInvocation(settings);
+        },
+        valueChoices: booleanConfigValueChoices,
+        valueSchema: booleanConfigValueSchema,
     }),
 } as const;
 

--- a/src/application/commands/config/unset.ts
+++ b/src/application/commands/config/unset.ts
@@ -2,11 +2,13 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import type { ConfigUnsetInput } from "./shared.ts";
 import { z } from "zod";
+import { maybeSynchronizeInstalledBundledSkills } from "../skills/shared.ts";
 import {
     configDefinitions,
     configKeyChoices,
     configKeySchema,
     createInvalidConfigKeyError,
+    ooSkillAllowImplicitInvocationConfigKey,
     writeLine,
 } from "./shared.ts";
 
@@ -27,9 +29,16 @@ export const configUnsetCommand: CliCommandDefinition<ConfigUnsetInput> = {
     }),
     mapInputError: (_, rawInput) => createInvalidConfigKeyError(rawInput),
     handler: async (input, context) => {
-        await context.settingsStore.update(settings =>
+        const nextSettings = await context.settingsStore.update(settings =>
             configDefinitions[input.key].unsetValue(settings),
         );
+
+        if (input.key === ooSkillAllowImplicitInvocationConfigKey) {
+            await maybeSynchronizeInstalledBundledSkills(context, {
+                settings: nextSettings,
+            });
+        }
+
         context.logger.info(
             {
                 key: input.key,

--- a/src/application/commands/skills/allow-implicit-invocation.ts
+++ b/src/application/commands/skills/allow-implicit-invocation.ts
@@ -1,0 +1,63 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import {
+    booleanConfigValueChoices,
+    booleanConfigValueSchema,
+    parseBooleanConfigValue,
+    setOoSkillAllowImplicitInvocation,
+} from "../../schemas/settings.ts";
+import { maybeSynchronizeInstalledBundledSkills } from "./shared.ts";
+
+const bundledSkillName = "oo" as const;
+
+const skillsAllowImplicitInvocationInputSchema = z.object({
+    value: booleanConfigValueSchema,
+});
+
+type SkillsAllowImplicitInvocationInput = z.output<
+    typeof skillsAllowImplicitInvocationInputSchema
+>;
+
+export const skillsAllowImplicitInvocationCommand: CliCommandDefinition<
+    SkillsAllowImplicitInvocationInput
+> = {
+    name: "allow-implicit-invocation",
+    summaryKey: "commands.skills.allowImplicitInvocation.summary",
+    descriptionKey: "commands.skills.allowImplicitInvocation.description",
+    arguments: [
+        {
+            name: "value",
+            descriptionKey: "arguments.value",
+            required: true,
+            choices: booleanConfigValueChoices,
+        },
+    ],
+    inputSchema: skillsAllowImplicitInvocationInputSchema,
+    handler: async (input, context) => {
+        const nextSettings = await context.settingsStore.update(settings =>
+            setOoSkillAllowImplicitInvocation(
+                settings,
+                parseBooleanConfigValue(input.value),
+            ),
+        );
+
+        await maybeSynchronizeInstalledBundledSkills(context, {
+            settings: nextSettings,
+        });
+
+        context.logger.info(
+            {
+                skillName: bundledSkillName,
+                value: input.value,
+            },
+            "Bundled Codex skill implicit invocation policy updated.",
+        );
+        context.stdout.write(
+            `${context.translator.t("skills.allowImplicitInvocation.success", {
+                name: bundledSkillName,
+                value: input.value,
+            })}\n`,
+        );
+    },
+};

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -51,6 +51,42 @@ describe("skills commands", () => {
         }
     });
 
+    test("installs the bundled Codex skill with the persisted implicit invocation policy", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await Bun.write(
+                storePaths.settingsFilePath,
+                [
+                    "[skills.oo]",
+                    "allow_implicit_invocation = false",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: false",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("fails when the Codex home directory is missing", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -62,6 +98,37 @@ describe("skills commands", () => {
             expect(result.stdout).toBe("");
             expect(result.stderr).toBe(
                 `Codex is not installed. Expected the Codex home directory at ${codexHomeDirectory}.\n`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("persists the oo skill implicit invocation policy without requiring Codex", async () => {
+        const sandbox = await createCliSandbox();
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "allow-implicit-invocation",
+                "false",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                "Set Codex skill oo allow_implicit_invocation to false.\n",
+            );
+            expect(await readFile(storePaths.settingsFilePath, "utf8")).toContain(
+                "[skills.oo]",
+            );
+            expect(await readFile(storePaths.settingsFilePath, "utf8")).toContain(
+                "allow_implicit_invocation = false",
             );
         }
         finally {
@@ -156,6 +223,37 @@ describe("skills commands", () => {
             await expect(stat(skillDirectoryPath)).resolves.toMatchObject({
                 isDirectory: expect.any(Function),
             });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("updates the installed managed skill when the implicit invocation policy changes", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(
+                ownershipFilePath,
+                await Bun.file(
+                    getBundledSkillFiles("oo").find(file => file.relativePath === "agents/openai.yaml")!.sourcePath,
+                ).text(),
+            );
+
+            const result = await sandbox.run([
+                "skills",
+                "allow-implicit-invocation",
+                "false",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: false",
+            );
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -1,5 +1,6 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
+import { skillsAllowImplicitInvocationCommand } from "./allow-implicit-invocation.ts";
 import { skillsInstallCommand } from "./install.ts";
 import { skillsUninstallCommand } from "./uninstall.ts";
 
@@ -8,6 +9,7 @@ export const skillsCommand: CliCommandDefinition = {
     summaryKey: "commands.skills.summary",
     descriptionKey: "commands.skills.description",
     children: [
+        skillsAllowImplicitInvocationCommand,
         skillsInstallCommand,
         skillsUninstallCommand,
     ],

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -1,10 +1,15 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
+import type { AppSettings } from "../../schemas/settings.ts";
 
 import type { BundledSkillName } from "./embedded-assets.ts";
 import { mkdir, readFile, rm, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { resolveHomeDirectory } from "../../../adapters/store/store-path.ts";
 import { CliUserError } from "../../contracts/cli.ts";
+import {
+    defaultSettings,
+    getOoSkillAllowImplicitInvocation,
+} from "../../schemas/settings.ts";
 import {
     availableBundledSkillNames,
     getBundledSkillFiles,
@@ -15,6 +20,7 @@ const codexSkillsDirectoryName = "skills";
 const bundledSkillVersionFileName = ".oo-version";
 const bundledSkillOwnershipMarker = "OOMOL";
 const bundledSkillOwnershipFileRelativePath = "agents/openai.yaml";
+const bundledSkillAllowImplicitInvocationKey = "allow_implicit_invocation";
 
 export function resolveCodexHomeDirectory(
     env: Record<string, string | undefined>,
@@ -46,6 +52,7 @@ export async function installBundledSkill(
     context: CliExecutionContext,
 ): Promise<void> {
     const codexHomeDirectory = await requireCodexHomeDirectory(context);
+    const settings = await context.settingsStore.read();
     const installedSkillDirectoryPath = resolveBundledSkillDirectoryPath(
         codexHomeDirectory,
         skillName,
@@ -70,6 +77,7 @@ export async function installBundledSkill(
 
     const skillDirectoryPath = await writeBundledSkillInstallation({
         codexHomeDirectory,
+        settings,
         skillName,
         version: context.version,
     });
@@ -95,9 +103,11 @@ export async function maybeSynchronizeInstalledBundledSkills(
     context: Pick<CliExecutionContext, "env" | "logger" | "version">,
     options: {
         installMissing?: boolean;
+        settings?: AppSettings;
     } = {},
 ): Promise<void> {
     const codexHomeDirectory = resolveCodexHomeDirectory(context.env);
+    const settings = options.settings ?? defaultSettings;
 
     if (!(await directoryExists(codexHomeDirectory))) {
         context.logger.debug(
@@ -131,6 +141,7 @@ export async function maybeSynchronizeInstalledBundledSkills(
 
                 await writeBundledSkillInstallation({
                     codexHomeDirectory,
+                    settings,
                     skillName,
                     version: context.version,
                 });
@@ -157,12 +168,44 @@ export async function maybeSynchronizeInstalledBundledSkills(
             }
 
             if (
-                await isBundledSkillInstallationCurrent(
+                !(await isBundledSkillInstallationCurrent(
                     skillName,
                     skillDirectoryPath,
                     context.version,
-                )
+                ))
             ) {
+                const previousVersion
+                    = await readInstalledBundledSkillVersion(skillDirectoryPath);
+
+                await writeBundledSkillInstallation({
+                    codexHomeDirectory,
+                    settings,
+                    skillName,
+                    version: context.version,
+                });
+                context.logger.info(
+                    {
+                        path: skillDirectoryPath,
+                        previousVersion: previousVersion ?? "unknown",
+                        skillName,
+                        version: context.version,
+                    },
+                    "Bundled Codex skill synchronized.",
+                );
+                continue;
+            }
+
+            const desiredAllowImplicitInvocation
+                = resolveBundledSkillAllowImplicitInvocation(
+                    skillName,
+                    settings,
+                );
+            const installedAllowImplicitInvocation
+                = await readInstalledBundledSkillAllowImplicitInvocation(
+                    skillDirectoryPath,
+                );
+
+            if (installedAllowImplicitInvocation === desiredAllowImplicitInvocation) {
                 context.logger.debug(
                     {
                         path: skillDirectoryPath,
@@ -174,22 +217,40 @@ export async function maybeSynchronizeInstalledBundledSkills(
                 continue;
             }
 
-            const previousVersion
-                = await readInstalledBundledSkillVersion(skillDirectoryPath);
+            if (installedAllowImplicitInvocation === undefined) {
+                const previousVersion
+                    = await readInstalledBundledSkillVersion(skillDirectoryPath);
 
-            await writeBundledSkillInstallation({
-                codexHomeDirectory,
-                skillName,
-                version: context.version,
-            });
+                await writeBundledSkillInstallation({
+                    codexHomeDirectory,
+                    settings,
+                    skillName,
+                    version: context.version,
+                });
+                context.logger.info(
+                    {
+                        path: skillDirectoryPath,
+                        previousVersion: previousVersion ?? "unknown",
+                        skillName,
+                        version: context.version,
+                    },
+                    "Bundled Codex skill synchronized.",
+                );
+                continue;
+            }
+
+            await writeInstalledBundledSkillAllowImplicitInvocation(
+                skillDirectoryPath,
+                desiredAllowImplicitInvocation,
+            );
             context.logger.info(
                 {
+                    allowImplicitInvocation: desiredAllowImplicitInvocation,
                     path: skillDirectoryPath,
-                    previousVersion: previousVersion ?? "unknown",
                     skillName,
                     version: context.version,
                 },
-                "Bundled Codex skill synchronized.",
+                "Bundled Codex skill policy synchronized.",
             );
         }
         catch (error) {
@@ -256,6 +317,7 @@ export async function uninstallBundledSkill(
 
 async function writeBundledSkillInstallation(options: {
     codexHomeDirectory: string;
+    settings: AppSettings;
     skillName: BundledSkillName;
     version: string;
 }): Promise<string> {
@@ -270,7 +332,15 @@ async function writeBundledSkillInstallation(options: {
         const destinationPath = join(skillDirectoryPath, file.relativePath);
 
         await mkdir(dirname(destinationPath), { recursive: true });
-        await Bun.write(destinationPath, Bun.file(file.sourcePath));
+        await Bun.write(
+            destinationPath,
+            await renderBundledSkillFileContent(
+                options.skillName,
+                file.relativePath,
+                await Bun.file(file.sourcePath).text(),
+                options.settings,
+            ),
+        );
     }
 
     await Bun.write(
@@ -279,6 +349,126 @@ async function writeBundledSkillInstallation(options: {
     );
 
     return skillDirectoryPath;
+}
+
+function renderBundledSkillFileContent(
+    skillName: BundledSkillName,
+    relativePath: string,
+    content: string,
+    settings: AppSettings,
+): string {
+    if (relativePath !== bundledSkillOwnershipFileRelativePath) {
+        return content;
+    }
+
+    return writeAllowImplicitInvocationValue(
+        content,
+        resolveBundledSkillAllowImplicitInvocation(skillName, settings),
+    );
+}
+
+function resolveBundledSkillAllowImplicitInvocation(
+    skillName: BundledSkillName,
+    settings: AppSettings,
+): boolean {
+    switch (skillName) {
+        case "oo":
+            return getOoSkillAllowImplicitInvocation(settings);
+    }
+}
+
+async function readInstalledBundledSkillAllowImplicitInvocation(
+    skillDirectoryPath: string,
+): Promise<boolean | undefined> {
+    try {
+        const content = await readFile(
+            join(skillDirectoryPath, bundledSkillOwnershipFileRelativePath),
+            "utf8",
+        );
+
+        return readAllowImplicitInvocationValue(content);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
+}
+
+async function writeInstalledBundledSkillAllowImplicitInvocation(
+    skillDirectoryPath: string,
+    value: boolean,
+): Promise<void> {
+    const ownershipFilePath = join(
+        skillDirectoryPath,
+        bundledSkillOwnershipFileRelativePath,
+    );
+    const content = await readFile(ownershipFilePath, "utf8");
+
+    await Bun.write(
+        ownershipFilePath,
+        writeAllowImplicitInvocationValue(content, value),
+    );
+}
+
+function readAllowImplicitInvocationValue(
+    content: string,
+): boolean | undefined {
+    for (const line of content.split("\n")) {
+        const trimmedLine = line.trim();
+
+        if (!trimmedLine.startsWith(`${bundledSkillAllowImplicitInvocationKey}:`)) {
+            continue;
+        }
+
+        const rawValue = trimmedLine
+            .slice(bundledSkillAllowImplicitInvocationKey.length + 1)
+            .trim();
+
+        if (rawValue === "true") {
+            return true;
+        }
+
+        if (rawValue === "false") {
+            return false;
+        }
+
+        return undefined;
+    }
+
+    return undefined;
+}
+
+function writeAllowImplicitInvocationValue(
+    content: string,
+    value: boolean,
+): string {
+    const lines = content.split("\n");
+
+    for (const [index, line] of lines.entries()) {
+        const trimmedLine = line.trim();
+
+        if (!trimmedLine.startsWith(`${bundledSkillAllowImplicitInvocationKey}:`)) {
+            continue;
+        }
+
+        const indentation = line.slice(0, line.length - line.trimStart().length);
+
+        lines[index] = [
+            indentation,
+            bundledSkillAllowImplicitInvocationKey,
+            ": ",
+            value ? "true" : "false",
+        ].join("");
+
+        return lines.join("\n");
+    }
+
+    throw new Error(
+        `Missing ${bundledSkillAllowImplicitInvocationKey} in bundled skill policy file.`,
+    );
 }
 
 async function isBundledSkillInstallationCurrent(

--- a/src/application/schemas/settings.ts
+++ b/src/application/schemas/settings.ts
@@ -8,29 +8,65 @@ import {
 
 export const localeSchema = z.enum(supportedLocaleValues);
 export const shellSchema = z.enum(supportedShellValues);
+export const booleanConfigValueChoices = ["true", "false"] as const;
+export const booleanConfigValueSchema = z.enum(booleanConfigValueChoices);
+
+const ooSkillSettingsSchema = z.object({
+    allow_implicit_invocation: z.boolean().optional(),
+}).strict();
+
+const skillsSettingsSchema = z.object({
+    oo: ooSkillSettingsSchema.optional(),
+}).strict();
+
+export const defaultOoSkillAllowImplicitInvocation = true;
 
 export const settingsFileSchema = z.object({
     lang: localeSchema.optional(),
+    skills: skillsSettingsSchema.optional(),
 }).strict();
 
 export type AppSettings = z.output<typeof settingsFileSchema>;
+export type BooleanConfigValue = z.output<typeof booleanConfigValueSchema>;
 
 export const defaultSettings: AppSettings = {};
 
-const defaultSettingsCommentBlock = [
-    "# lang controls the CLI display language for help text, messages, and errors.",
-    "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
-    "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
-    "# lang = \"en\"",
-].join("\n");
+const defaultSettingsCommentBlocks = [
+    [
+        "# lang controls the CLI display language for help text, messages, and errors.",
+        "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
+        "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
+        "# lang = \"en\"",
+    ],
+    [
+        "# skills.oo.allow_implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
+        "# Supported values: true, false.",
+        `# Default: ${stringifyBooleanConfigValue(defaultOoSkillAllowImplicitInvocation)}.`,
+        "# [skills.oo]",
+        "# allow_implicit_invocation = false",
+    ],
+] as const;
 
 export function renderSettingsFile(settings: AppSettings): string {
     const parsedSettings = settingsFileSchema.parse(settings);
-    const lines = defaultSettingsCommentBlock.split("\n");
+    const lines = defaultSettingsCommentBlocks.flatMap((block, index) => [
+        ...(index === 0 ? [] : [""]),
+        ...block,
+    ]);
     const persistedSettings = {
         ...(parsedSettings.lang !== undefined
             ? {
                     lang: parsedSettings.lang,
+                }
+            : {}),
+        ...(parsedSettings.skills?.oo?.allow_implicit_invocation !== undefined
+            ? {
+                    skills: {
+                        oo: {
+                            allow_implicit_invocation:
+                                parsedSettings.skills.oo.allow_implicit_invocation,
+                        },
+                    },
                 }
             : {}),
     };
@@ -41,4 +77,71 @@ export function renderSettingsFile(settings: AppSettings): string {
     }
 
     return `${lines.join("\n")}\n`;
+}
+
+export function parseBooleanConfigValue(value: BooleanConfigValue): boolean {
+    return value === "true";
+}
+
+export function stringifyBooleanConfigValue(value: boolean): BooleanConfigValue {
+    return value ? "true" : "false";
+}
+
+export function getConfiguredOoSkillAllowImplicitInvocation(
+    settings: AppSettings,
+): boolean | undefined {
+    return settings.skills?.oo?.allow_implicit_invocation;
+}
+
+export function getOoSkillAllowImplicitInvocation(
+    settings: AppSettings,
+): boolean {
+    return getConfiguredOoSkillAllowImplicitInvocation(settings)
+        ?? defaultOoSkillAllowImplicitInvocation;
+}
+
+export function setOoSkillAllowImplicitInvocation(
+    settings: AppSettings,
+    value: boolean,
+): AppSettings {
+    return {
+        ...settings,
+        skills: {
+            ...settings.skills,
+            oo: {
+                ...settings.skills?.oo,
+                allow_implicit_invocation: value,
+            },
+        },
+    };
+}
+
+export function unsetOoSkillAllowImplicitInvocation(
+    settings: AppSettings,
+): AppSettings {
+    if (settings.skills?.oo?.allow_implicit_invocation === undefined) {
+        return settings;
+    }
+
+    const nextSettings = { ...settings };
+    const nextSkills = { ...nextSettings.skills };
+    const nextOoSkillSettings = { ...nextSkills.oo };
+
+    delete nextOoSkillSettings.allow_implicit_invocation;
+
+    if (Object.keys(nextOoSkillSettings).length === 0) {
+        delete nextSkills.oo;
+    }
+    else {
+        nextSkills.oo = nextOoSkillSettings;
+    }
+
+    if (Object.keys(nextSkills).length === 0) {
+        delete nextSettings.skills;
+    }
+    else {
+        nextSettings.skills = nextSkills;
+    }
+
+    return nextSettings;
 }

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -102,6 +102,10 @@ export const enMessages = {
     "commands.skills.description":
         "Install or remove bundled Codex-only skills from the local Codex directory.",
     "commands.skills.summary": "Manage bundled Codex skills",
+    "commands.skills.allowImplicitInvocation.description":
+        "Persist the oo skill allow_implicit_invocation policy and synchronize the installed managed skill when present.",
+    "commands.skills.allowImplicitInvocation.summary":
+        "Set oo skill implicit invocation",
     "commands.skills.install.description":
         "Install one bundled Codex skill into the local Codex skills directory.",
     "commands.skills.install.summary": "Install a bundled Codex skill",
@@ -196,6 +200,8 @@ export const enMessages = {
     "errors.config.invalidKey": "Invalid config key: {value}.",
     "errors.config.invalidLangValue":
         "Invalid lang value: {value}. Use en or zh.",
+    "errors.config.invalidSkillsOoAllowImplicitInvocationValue":
+        "Invalid skills.oo.allow_implicit_invocation value: {value}. Use true or false.",
     "errors.file.invalidFormat":
         "Invalid format: {value}. Use json.",
     "errors.fileList.invalidLimit":
@@ -306,6 +312,8 @@ export const enMessages = {
         "Set how long to wait before timing out (default 6h, range 10s to 24h)",
     "options.lang": "Specify the display language",
     "options.version": "Show the current version",
+    "skills.allowImplicitInvocation.success":
+        "Set Codex skill {name} allow_implicit_invocation to {value}.",
     "skills.install.success": "Installed Codex skill {name} to {path}.",
     "skills.uninstall.success": "Removed Codex skill {name} from {path}.",
     "versionInfo.version": "Version",
@@ -454,6 +462,10 @@ export const zhMessages = {
     "commands.search.summary": "按意图搜索包",
     "commands.skills.description": "在本地 Codex 目录中安装或移除内置的仅限 Codex 使用的 skill。",
     "commands.skills.summary": "管理内置 Codex skill",
+    "commands.skills.allowImplicitInvocation.description":
+        "持久化 oo skill 的 allow_implicit_invocation 策略，并在本地存在受管安装时同步对应文件。",
+    "commands.skills.allowImplicitInvocation.summary":
+        "设置 oo skill 的隐式调用策略",
     "commands.skills.install.description": "将一个内置 Codex skill 安装到本地 Codex skills 目录。",
     "commands.skills.install.summary": "安装一个内置 Codex skill",
     "commands.skills.uninstall.description": "从本地 Codex skills 目录移除一个内置 Codex skill。",
@@ -539,6 +551,8 @@ export const zhMessages = {
     "errors.config.invalidKey": "无效的配置键：{value}。",
     "errors.config.invalidLangValue":
         "无效的 lang 值：{value}。请使用 en 或 zh。",
+    "errors.config.invalidSkillsOoAllowImplicitInvocationValue":
+        "无效的 skills.oo.allow_implicit_invocation 值：{value}。请使用 true 或 false。",
     "errors.file.invalidFormat":
         "无效的 format：{value}。请使用 json。",
     "errors.fileList.invalidLimit":
@@ -643,6 +657,8 @@ export const zhMessages = {
     "options.timeout": "设置等待超时时间（默认 6h，范围 10s 到 24h）",
     "options.lang": "指定显示语言",
     "options.version": "显示当前版本",
+    "skills.allowImplicitInvocation.success":
+        "已将 Codex skill {name} 的 allow_implicit_invocation 设置为 {value}。",
     "skills.install.success": "已将 Codex skill {name} 安装到 {path}。",
     "skills.uninstall.success": "已从 {path} 移除 Codex skill {name}。",
     "versionInfo.version": "版本",


### PR DESCRIPTION
Rewrite the skill description and agent prompt to focus on
when the skill should activate: only when the user wants a
ready-made capability and the local workspace has no clear
implementation path. List concrete trigger cues (TTS, STT,
OCR, image generation, etc.) and explicitly exclude ordinary
local coding tasks.

Signed-off-by: Kevin Cui <bh@bugs.cc>