### PR TITLE
refactor(config): rename allow_implicit_invocation to implicit_invocation

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -97,11 +97,11 @@ export const defaultSettingsFileContent = [
     "# [file.download]",
     "# out_dir = \"~/Downloads\"",
     "",
-    "# skills.oo.allow_implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
+    "# skills.oo.implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
     "# Supported values: true, false.",
     "# Default: true.",
     "# [skills.oo]",
-    "# allow_implicit_invocation = false",
+    "# implicit_invocation = false",
     "",
 ].join("\n");
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -69,7 +69,7 @@ List persisted configuration values that are currently set.
 Read one persisted configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported values:
-  `lang`, `file.download.out_dir`, `skills.oo.allow_implicit_invocation`.
+  `lang`, `file.download.out_dir`, `skills.oo.implicit_invocation`.
 
 ### `oo config path`
 
@@ -80,13 +80,13 @@ Print the path to the persisted configuration file.
 Persist one configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported values:
-  `lang`, `file.download.out_dir`, `skills.oo.allow_implicit_invocation`.
+  `lang`, `file.download.out_dir`, `skills.oo.implicit_invocation`.
 - Arguments: `<value>` is the value for the selected key.
 - Value rules: for `lang`, supported values are `en` and `zh`.
 - Value rules: for `file.download.out_dir`, use any non-empty path string. Relative
   paths resolve from the current working directory when `oo file download` runs. A
   leading `~` expands to the current user's home directory.
-- Value rules: for `skills.oo.allow_implicit_invocation`, supported values are
+- Value rules: for `skills.oo.implicit_invocation`, supported values are
   `true` and `false`.
 
 ### `oo config unset <key>`
@@ -94,7 +94,7 @@ Persist one configuration value.
 Remove one persisted configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported values:
-  `lang`, `file.download.out_dir`, `skills.oo.allow_implicit_invocation`.
+  `lang`, `file.download.out_dir`, `skills.oo.implicit_invocation`.
 
 ## Updates
 
@@ -116,7 +116,7 @@ Check whether a newer CLI release is available.
 
 ### `oo skills allow-implicit-invocation <value>`
 
-Persist the `oo` skill `allow_implicit_invocation` policy.
+Persist the `oo` skill implicit invocation policy.
 
 - Arguments: `<value>` must be `true` or `false`.
 - Notes: when the managed `oo` skill is already installed, the command
@@ -135,7 +135,7 @@ Install one bundled skill into the local Codex skills directory.
 - Metadata: the installation writes the current `oo` version into a hidden
   version file inside the skill directory.
 - Metadata: `agents/openai.yaml` uses the persisted
-  `skills.oo.allow_implicit_invocation` value when configured, otherwise the
+  `skills.oo.implicit_invocation` value when configured, otherwise the
   bundled default is used.
 - Notes: the command exits with an error when the Codex home directory does
   not exist, which indicates Codex is not installed on the current machine.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -63,7 +63,7 @@
 读取一个持久化配置值。
 
 - 参数：`<key>` 为配置键。目前支持
-  `lang`、`file.download.out_dir`、`skills.oo.allow_implicit_invocation`。
+  `lang`、`file.download.out_dir`、`skills.oo.implicit_invocation`。
 
 ### `oo config path`
 
@@ -74,13 +74,13 @@
 写入一个持久化配置值。
 
 - 参数：`<key>` 为配置键。目前支持
-  `lang`、`file.download.out_dir`、`skills.oo.allow_implicit_invocation`。
+  `lang`、`file.download.out_dir`、`skills.oo.implicit_invocation`。
 - 参数：`<value>` 为对应配置值。
 - 取值规则：当 `<key>` 为 `lang` 时，支持的值为 `en` 和 `zh`。
 - 取值规则：当 `<key>` 为 `file.download.out_dir` 时，支持任意非空路径字符串。
   相对路径会在执行 `oo file download` 时相对于当前工作目录解析；如果以 `~`
   开头，则会展开为当前用户的 home 目录。
-- 取值规则：当 `<key>` 为 `skills.oo.allow_implicit_invocation` 时，支持的
+- 取值规则：当 `<key>` 为 `skills.oo.implicit_invocation` 时，支持的
   值为 `true` 和 `false`。
 
 ### `oo config unset <key>`
@@ -88,7 +88,7 @@
 删除一个持久化配置值。
 
 - 参数：`<key>` 为配置键。目前支持
-  `lang`、`file.download.out_dir`、`skills.oo.allow_implicit_invocation`。
+  `lang`、`file.download.out_dir`、`skills.oo.implicit_invocation`。
 
 ## 更新
 
@@ -107,7 +107,7 @@
 
 ### `oo skills allow-implicit-invocation <value>`
 
-持久化 `oo` skill 的 `allow_implicit_invocation` 策略。
+持久化 `oo` skill 的隐式调用策略。
 
 - 参数：`<value>` 必须为 `true` 或 `false`。
 - 说明：当受管的 `oo` skill 已经安装时，命令会立即同步
@@ -122,7 +122,7 @@
 - 内置 skill：`oo`。
 - 目标目录：`${CODEX_HOME:-~/.codex}/skills/oo`。
 - 元数据：安装时会在 skill 目录内写入一个隐藏的 `oo` 版本记录文件。
-- 元数据：当存在持久化的 `skills.oo.allow_implicit_invocation` 配置时，
+- 元数据：当存在持久化的 `skills.oo.implicit_invocation` 配置时，
   `agents/openai.yaml` 会使用该值；否则使用内置默认值。
 - 说明：当 Codex 根目录不存在时，命令会直接报错退出，这表示当前机器上没有
   安装 Codex。

--- a/src/adapters/store/file-settings-store.test.ts
+++ b/src/adapters/store/file-settings-store.test.ts
@@ -25,11 +25,11 @@ const defaultSettingsFileContent = [
     "# [file.download]",
     "# out_dir = \"~/Downloads\"",
     "",
-    "# skills.oo.allow_implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
+    "# skills.oo.implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
     "# Supported values: true, false.",
     "# Default: true.",
     "# [skills.oo]",
-    "# allow_implicit_invocation = false",
+    "# implicit_invocation = false",
     "",
 ].join("\n");
 
@@ -82,11 +82,11 @@ describe("FileSettingsStore", () => {
                 "# [file.download]",
                 "# out_dir = \"~/Downloads\"",
                 "",
-                "# skills.oo.allow_implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
+                "# skills.oo.implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
                 "# Supported values: true, false.",
                 "# Default: true.",
                 "# [skills.oo]",
-                "# allow_implicit_invocation = false",
+                "# implicit_invocation = false",
                 "",
                 "lang = \"zh\"",
                 "",
@@ -111,7 +111,7 @@ describe("FileSettingsStore", () => {
         await store.write({
             skills: {
                 oo: {
-                    allow_implicit_invocation: false,
+                    implicit_invocation: false,
                 },
             },
         });
@@ -131,21 +131,21 @@ describe("FileSettingsStore", () => {
                 "# [file.download]",
                 "# out_dir = \"~/Downloads\"",
                 "",
-                "# skills.oo.allow_implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
+                "# skills.oo.implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
                 "# Supported values: true, false.",
                 "# Default: true.",
                 "# [skills.oo]",
-                "# allow_implicit_invocation = false",
+                "# implicit_invocation = false",
                 "",
                 "[skills.oo]",
-                "allow_implicit_invocation = false",
+                "implicit_invocation = false",
                 "",
             ].join("\n"),
         );
         expect(await store.read()).toEqual({
             skills: {
                 oo: {
-                    allow_implicit_invocation: false,
+                    implicit_invocation: false,
                 },
             },
         });
@@ -185,11 +185,11 @@ describe("FileSettingsStore", () => {
                 "# [file.download]",
                 "# out_dir = \"~/Downloads\"",
                 "",
-                "# skills.oo.allow_implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
+                "# skills.oo.implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
                 "# Supported values: true, false.",
                 "# Default: true.",
                 "# [skills.oo]",
-                "# allow_implicit_invocation = false",
+                "# implicit_invocation = false",
                 "",
                 "[file.download]",
                 "out_dir = \"~/Downloads\"",

--- a/src/application/commands/config/index.cli.test.ts
+++ b/src/application/commands/config/index.cli.test.ts
@@ -95,32 +95,32 @@ describe("config CLI", () => {
             const setResult = await sandbox.run([
                 "config",
                 "set",
-                "skills.oo.allow_implicit_invocation",
+                "skills.oo.implicit_invocation",
                 "false",
             ]);
             const listResult = await sandbox.run(["config", "list"]);
             const getResult = await sandbox.run([
                 "config",
                 "get",
-                "skills.oo.allow_implicit_invocation",
+                "skills.oo.implicit_invocation",
             ]);
             const unsetResult = await sandbox.run([
                 "config",
                 "unset",
-                "skills.oo.allow_implicit_invocation",
+                "skills.oo.implicit_invocation",
             ]);
             const getAfterUnsetResult = await sandbox.run([
                 "config",
                 "get",
-                "skills.oo.allow_implicit_invocation",
+                "skills.oo.implicit_invocation",
             ]);
 
             expect(setResult.exitCode).toBe(0);
             expect(setResult.stdout).toBe(
-                "Set skills.oo.allow_implicit_invocation to false.\n",
+                "Set skills.oo.implicit_invocation to false.\n",
             );
             expect(listResult.stdout).toBe(
-                "skills.oo.allow_implicit_invocation=false\n",
+                "skills.oo.implicit_invocation=false\n",
             );
             expect(getResult.stdout).toBe("false\n");
             expect(unsetResult.exitCode).toBe(0);
@@ -194,7 +194,7 @@ describe("config CLI", () => {
             const result = await sandbox.run([
                 "config",
                 "set",
-                "skills.oo.allow_implicit_invocation",
+                "skills.oo.implicit_invocation",
                 "false",
             ], {
                 version: "9.9.9",
@@ -244,7 +244,7 @@ describe("config CLI", () => {
                 settingsFilePath,
                 [
                     "[skills.oo]",
-                    "allow_implicit_invocation = false",
+                    "implicit_invocation = false",
                     "",
                 ].join("\n"),
             );
@@ -252,7 +252,7 @@ describe("config CLI", () => {
             const result = await sandbox.run([
                 "config",
                 "unset",
-                "skills.oo.allow_implicit_invocation",
+                "skills.oo.implicit_invocation",
             ], {
                 version: "9.9.9",
             });
@@ -328,7 +328,7 @@ describe("config CLI", () => {
             const invalidSkillPolicyValue = await sandbox.run([
                 "config",
                 "set",
-                "skills.oo.allow_implicit_invocation",
+                "skills.oo.implicit_invocation",
                 "maybe",
             ]);
 
@@ -341,7 +341,7 @@ describe("config CLI", () => {
 
             expect(invalidSkillPolicyValue.exitCode).toBe(2);
             expect(invalidSkillPolicyValue.stderr).toContain(
-                "Invalid skills.oo.allow_implicit_invocation value",
+                "Invalid skills.oo.implicit_invocation value",
             );
         }
         finally {

--- a/src/application/commands/config/set.ts
+++ b/src/application/commands/config/set.ts
@@ -11,7 +11,7 @@ import {
     fileDownloadOutDirConfigKey,
     getConfigDefinition,
     getConfigDefinitionByRawKey,
-    ooSkillAllowImplicitInvocationConfigKey,
+    ooSkillImplicitInvocationConfigKey,
     writeLine,
 } from "./shared.ts";
 
@@ -70,7 +70,7 @@ export const configSetCommand: CliCommandDefinition<ConfigSetInput> = {
             settings => setConfigValue(settings, input),
         );
 
-        if (input.key === ooSkillAllowImplicitInvocationConfigKey) {
+        if (input.key === ooSkillImplicitInvocationConfigKey) {
             await maybeSynchronizeInstalledBundledSkills(context, {
                 settings: nextSettings,
             });
@@ -105,9 +105,9 @@ function setConfigValue(
                 settings,
                 input.value,
             );
-        case ooSkillAllowImplicitInvocationConfigKey:
+        case ooSkillImplicitInvocationConfigKey:
             return getConfigDefinition(
-                ooSkillAllowImplicitInvocationConfigKey,
+                ooSkillImplicitInvocationConfigKey,
             ).setValue(settings, input.value);
     }
 }

--- a/src/application/commands/config/shared.ts
+++ b/src/application/commands/config/shared.ts
@@ -12,14 +12,14 @@ import {
     booleanConfigValueSchema,
     fileDownloadOutDirConfigValueSchema,
     getConfiguredFileDownloadOutDir,
-    getConfiguredOoSkillAllowImplicitInvocation,
+    getConfiguredOoSkillImplicitInvocation,
     localeSchema,
     parseBooleanConfigValue,
     setFileDownloadOutDir,
-    setOoSkillAllowImplicitInvocation,
+    setOoSkillImplicitInvocation,
     stringifyBooleanConfigValue,
     unsetFileDownloadOutDir,
-    unsetOoSkillAllowImplicitInvocation,
+    unsetOoSkillImplicitInvocation,
 } from "../../schemas/settings.ts";
 
 export interface ConfigDefinition<TValue extends string> {
@@ -37,8 +37,8 @@ function defineConfigDefinition<TValue extends string>(
     return definition;
 }
 
-export const ooSkillAllowImplicitInvocationConfigKey
-    = "skills.oo.allow_implicit_invocation" as const;
+export const ooSkillImplicitInvocationConfigKey
+    = "skills.oo.implicit_invocation" as const;
 export const fileDownloadOutDirConfigKey = "file.download.out_dir" as const;
 
 export const configDefinitions = {
@@ -89,10 +89,10 @@ export const configDefinitions = {
         valueChoices: [],
         valueSchema: fileDownloadOutDirConfigValueSchema,
     }),
-    [ooSkillAllowImplicitInvocationConfigKey]: defineConfigDefinition({
+    [ooSkillImplicitInvocationConfigKey]: defineConfigDefinition({
         createInvalidValueError(rawValue: unknown): CliUserError {
             return new CliUserError(
-                "errors.config.invalidSkillsOoAllowImplicitInvocationValue",
+                "errors.config.invalidSkillsOoImplicitInvocationValue",
                 2,
                 {
                     value: String(rawValue ?? ""),
@@ -101,20 +101,20 @@ export const configDefinitions = {
         },
         getValue(settings: AppSettings): "false" | "true" | undefined {
             const configuredValue
-                = getConfiguredOoSkillAllowImplicitInvocation(settings);
+                = getConfiguredOoSkillImplicitInvocation(settings);
 
             return configuredValue === undefined
                 ? undefined
                 : stringifyBooleanConfigValue(configuredValue);
         },
         setValue(settings: AppSettings, value: "false" | "true"): AppSettings {
-            return setOoSkillAllowImplicitInvocation(
+            return setOoSkillImplicitInvocation(
                 settings,
                 parseBooleanConfigValue(value),
             );
         },
         unsetValue(settings: AppSettings): AppSettings {
-            return unsetOoSkillAllowImplicitInvocation(settings);
+            return unsetOoSkillImplicitInvocation(settings);
         },
         valueChoices: booleanConfigValueChoices,
         valueSchema: booleanConfigValueSchema,

--- a/src/application/commands/config/unset.ts
+++ b/src/application/commands/config/unset.ts
@@ -8,7 +8,7 @@ import {
     configKeyChoices,
     configKeySchema,
     createInvalidConfigKeyError,
-    ooSkillAllowImplicitInvocationConfigKey,
+    ooSkillImplicitInvocationConfigKey,
     writeLine,
 } from "./shared.ts";
 
@@ -33,7 +33,7 @@ export const configUnsetCommand: CliCommandDefinition<ConfigUnsetInput> = {
             configDefinitions[input.key].unsetValue(settings),
         );
 
-        if (input.key === ooSkillAllowImplicitInvocationConfigKey) {
+        if (input.key === ooSkillImplicitInvocationConfigKey) {
             await maybeSynchronizeInstalledBundledSkills(context, {
                 settings: nextSettings,
             });

--- a/src/application/commands/skills/allow-implicit-invocation.ts
+++ b/src/application/commands/skills/allow-implicit-invocation.ts
@@ -5,7 +5,7 @@ import {
     booleanConfigValueChoices,
     booleanConfigValueSchema,
     parseBooleanConfigValue,
-    setOoSkillAllowImplicitInvocation,
+    setOoSkillImplicitInvocation,
 } from "../../schemas/settings.ts";
 import { maybeSynchronizeInstalledBundledSkills } from "./shared.ts";
 
@@ -36,7 +36,7 @@ export const skillsAllowImplicitInvocationCommand: CliCommandDefinition<
     inputSchema: skillsAllowImplicitInvocationInputSchema,
     handler: async (input, context) => {
         const nextSettings = await context.settingsStore.update(settings =>
-            setOoSkillAllowImplicitInvocation(
+            setOoSkillImplicitInvocation(
                 settings,
                 parseBooleanConfigValue(input.value),
             ),

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -126,7 +126,7 @@ describe("skills CLI", () => {
                 settingsFilePath,
                 [
                     "[skills.oo]",
-                    "allow_implicit_invocation = false",
+                    "implicit_invocation = false",
                     "",
                 ].join("\n"),
             );

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -68,7 +68,7 @@ describe("skills commands", () => {
                 storePaths.settingsFilePath,
                 [
                     "[skills.oo]",
-                    "allow_implicit_invocation = false",
+                    "implicit_invocation = false",
                     "",
                 ].join("\n"),
             );
@@ -122,13 +122,13 @@ describe("skills commands", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
-                "Set Codex skill oo allow_implicit_invocation to false.\n",
+                "Set Codex skill oo implicit invocation to false.\n",
             );
             expect(await readFile(storePaths.settingsFilePath, "utf8")).toContain(
                 "[skills.oo]",
             );
             expect(await readFile(storePaths.settingsFilePath, "utf8")).toContain(
-                "allow_implicit_invocation = false",
+                "implicit_invocation = false",
             );
         }
         finally {

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -8,7 +8,7 @@ import { CliUserError } from "../../contracts/cli.ts";
 import { resolveHomeDirectory } from "../../path/home-directory.ts";
 import {
     defaultSettings,
-    getOoSkillAllowImplicitInvocation,
+    getOoSkillImplicitInvocation,
 } from "../../schemas/settings.ts";
 import {
     availableBundledSkillNames,
@@ -20,7 +20,7 @@ const codexSkillsDirectoryName = "skills";
 const bundledSkillVersionFileName = ".oo-version";
 const bundledSkillOwnershipMarker = "OOMOL";
 const bundledSkillOwnershipFileRelativePath = "agents/openai.yaml";
-const bundledSkillAllowImplicitInvocationKey = "allow_implicit_invocation";
+const bundledSkillImplicitInvocationKey = "allow_implicit_invocation";
 
 export function resolveCodexHomeDirectory(
     env: Record<string, string | undefined>,
@@ -195,17 +195,17 @@ export async function maybeSynchronizeInstalledBundledSkills(
                 continue;
             }
 
-            const desiredAllowImplicitInvocation
-                = resolveBundledSkillAllowImplicitInvocation(
+            const desiredImplicitInvocation
+                = resolveBundledSkillImplicitInvocation(
                     skillName,
                     settings,
                 );
-            const installedAllowImplicitInvocation
-                = await readInstalledBundledSkillAllowImplicitInvocation(
+            const installedImplicitInvocation
+                = await readInstalledBundledSkillImplicitInvocation(
                     skillDirectoryPath,
                 );
 
-            if (installedAllowImplicitInvocation === desiredAllowImplicitInvocation) {
+            if (installedImplicitInvocation === desiredImplicitInvocation) {
                 context.logger.debug(
                     {
                         path: skillDirectoryPath,
@@ -217,7 +217,7 @@ export async function maybeSynchronizeInstalledBundledSkills(
                 continue;
             }
 
-            if (installedAllowImplicitInvocation === undefined) {
+            if (installedImplicitInvocation === undefined) {
                 const previousVersion
                     = await readInstalledBundledSkillVersion(skillDirectoryPath);
 
@@ -239,13 +239,13 @@ export async function maybeSynchronizeInstalledBundledSkills(
                 continue;
             }
 
-            await writeInstalledBundledSkillAllowImplicitInvocation(
+            await writeInstalledBundledSkillImplicitInvocation(
                 skillDirectoryPath,
-                desiredAllowImplicitInvocation,
+                desiredImplicitInvocation,
             );
             context.logger.info(
                 {
-                    allowImplicitInvocation: desiredAllowImplicitInvocation,
+                    implicitInvocation: desiredImplicitInvocation,
                     path: skillDirectoryPath,
                     skillName,
                     version: context.version,
@@ -361,23 +361,23 @@ function renderBundledSkillFileContent(
         return content;
     }
 
-    return writeAllowImplicitInvocationValue(
+    return writeImplicitInvocationValue(
         content,
-        resolveBundledSkillAllowImplicitInvocation(skillName, settings),
+        resolveBundledSkillImplicitInvocation(skillName, settings),
     );
 }
 
-function resolveBundledSkillAllowImplicitInvocation(
+function resolveBundledSkillImplicitInvocation(
     skillName: BundledSkillName,
     settings: AppSettings,
 ): boolean {
     switch (skillName) {
         case "oo":
-            return getOoSkillAllowImplicitInvocation(settings);
+            return getOoSkillImplicitInvocation(settings);
     }
 }
 
-async function readInstalledBundledSkillAllowImplicitInvocation(
+async function readInstalledBundledSkillImplicitInvocation(
     skillDirectoryPath: string,
 ): Promise<boolean | undefined> {
     try {
@@ -386,7 +386,7 @@ async function readInstalledBundledSkillAllowImplicitInvocation(
             "utf8",
         );
 
-        return readAllowImplicitInvocationValue(content);
+        return readImplicitInvocationValue(content);
     }
     catch (error) {
         if (isNodeNotFoundError(error)) {
@@ -397,7 +397,7 @@ async function readInstalledBundledSkillAllowImplicitInvocation(
     }
 }
 
-async function writeInstalledBundledSkillAllowImplicitInvocation(
+async function writeInstalledBundledSkillImplicitInvocation(
     skillDirectoryPath: string,
     value: boolean,
 ): Promise<void> {
@@ -409,22 +409,22 @@ async function writeInstalledBundledSkillAllowImplicitInvocation(
 
     await Bun.write(
         ownershipFilePath,
-        writeAllowImplicitInvocationValue(content, value),
+        writeImplicitInvocationValue(content, value),
     );
 }
 
-function readAllowImplicitInvocationValue(
+function readImplicitInvocationValue(
     content: string,
 ): boolean | undefined {
     for (const line of content.split("\n")) {
         const trimmedLine = line.trim();
 
-        if (!trimmedLine.startsWith(`${bundledSkillAllowImplicitInvocationKey}:`)) {
+        if (!trimmedLine.startsWith(`${bundledSkillImplicitInvocationKey}:`)) {
             continue;
         }
 
         const rawValue = trimmedLine
-            .slice(bundledSkillAllowImplicitInvocationKey.length + 1)
+            .slice(bundledSkillImplicitInvocationKey.length + 1)
             .trim();
 
         if (rawValue === "true") {
@@ -441,7 +441,7 @@ function readAllowImplicitInvocationValue(
     return undefined;
 }
 
-function writeAllowImplicitInvocationValue(
+function writeImplicitInvocationValue(
     content: string,
     value: boolean,
 ): string {
@@ -450,7 +450,7 @@ function writeAllowImplicitInvocationValue(
     for (const [index, line] of lines.entries()) {
         const trimmedLine = line.trim();
 
-        if (!trimmedLine.startsWith(`${bundledSkillAllowImplicitInvocationKey}:`)) {
+        if (!trimmedLine.startsWith(`${bundledSkillImplicitInvocationKey}:`)) {
             continue;
         }
 
@@ -458,7 +458,7 @@ function writeAllowImplicitInvocationValue(
 
         lines[index] = [
             indentation,
-            bundledSkillAllowImplicitInvocationKey,
+            bundledSkillImplicitInvocationKey,
             ": ",
             value ? "true" : "false",
         ].join("");
@@ -467,7 +467,7 @@ function writeAllowImplicitInvocationValue(
     }
 
     throw new Error(
-        `Missing ${bundledSkillAllowImplicitInvocationKey} in bundled skill policy file.`,
+        `Missing ${bundledSkillImplicitInvocationKey} in bundled skill policy file.`,
     );
 }
 

--- a/src/application/schemas/settings.ts
+++ b/src/application/schemas/settings.ts
@@ -21,14 +21,14 @@ const fileSettingsSchema = z.object({
 }).strict();
 
 const ooSkillSettingsSchema = z.object({
-    allow_implicit_invocation: z.boolean().optional(),
+    implicit_invocation: z.boolean().optional(),
 }).strict();
 
 const skillsSettingsSchema = z.object({
     oo: ooSkillSettingsSchema.optional(),
 }).strict();
 
-export const defaultOoSkillAllowImplicitInvocation = true;
+export const defaultOoSkillImplicitInvocation = true;
 
 export const settingsFileSchema = z.object({
     file: fileSettingsSchema.optional(),
@@ -59,11 +59,11 @@ const defaultSettingsCommentBlocks = [
         `# out_dir = "${defaultFileDownloadOutDir}"`,
     ],
     [
-        "# skills.oo.allow_implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
+        "# skills.oo.implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
         "# Supported values: true, false.",
-        `# Default: ${stringifyBooleanConfigValue(defaultOoSkillAllowImplicitInvocation)}.`,
+        `# Default: ${stringifyBooleanConfigValue(defaultOoSkillImplicitInvocation)}.`,
         "# [skills.oo]",
-        "# allow_implicit_invocation = false",
+        "# implicit_invocation = false",
     ],
 ] as const;
 
@@ -88,12 +88,12 @@ export function renderSettingsFile(settings: AppSettings): string {
                     },
                 }
             : {}),
-        ...(parsedSettings.skills?.oo?.allow_implicit_invocation !== undefined
+        ...(parsedSettings.skills?.oo?.implicit_invocation !== undefined
             ? {
                     skills: {
                         oo: {
-                            allow_implicit_invocation:
-                                parsedSettings.skills.oo.allow_implicit_invocation,
+                            implicit_invocation:
+                                parsedSettings.skills.oo.implicit_invocation,
                         },
                     },
                 }
@@ -168,20 +168,20 @@ export function unsetFileDownloadOutDir(
     return nextSettings;
 }
 
-export function getConfiguredOoSkillAllowImplicitInvocation(
+export function getConfiguredOoSkillImplicitInvocation(
     settings: AppSettings,
 ): boolean | undefined {
-    return settings.skills?.oo?.allow_implicit_invocation;
+    return settings.skills?.oo?.implicit_invocation;
 }
 
-export function getOoSkillAllowImplicitInvocation(
+export function getOoSkillImplicitInvocation(
     settings: AppSettings,
 ): boolean {
-    return getConfiguredOoSkillAllowImplicitInvocation(settings)
-        ?? defaultOoSkillAllowImplicitInvocation;
+    return getConfiguredOoSkillImplicitInvocation(settings)
+        ?? defaultOoSkillImplicitInvocation;
 }
 
-export function setOoSkillAllowImplicitInvocation(
+export function setOoSkillImplicitInvocation(
     settings: AppSettings,
     value: boolean,
 ): AppSettings {
@@ -191,16 +191,16 @@ export function setOoSkillAllowImplicitInvocation(
             ...settings.skills,
             oo: {
                 ...settings.skills?.oo,
-                allow_implicit_invocation: value,
+                implicit_invocation: value,
             },
         },
     };
 }
 
-export function unsetOoSkillAllowImplicitInvocation(
+export function unsetOoSkillImplicitInvocation(
     settings: AppSettings,
 ): AppSettings {
-    if (settings.skills?.oo?.allow_implicit_invocation === undefined) {
+    if (settings.skills?.oo?.implicit_invocation === undefined) {
         return settings;
     }
 
@@ -208,7 +208,7 @@ export function unsetOoSkillAllowImplicitInvocation(
     const nextSkills = { ...nextSettings.skills };
     const nextOoSkillSettings = { ...nextSkills.oo };
 
-    delete nextOoSkillSettings.allow_implicit_invocation;
+    delete nextOoSkillSettings.implicit_invocation;
 
     if (Object.keys(nextOoSkillSettings).length === 0) {
         delete nextSkills.oo;

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -106,7 +106,7 @@ export const enMessages = {
         "Install or remove bundled Codex-only skills from the local Codex directory.",
     "commands.skills.summary": "Manage bundled Codex skills",
     "commands.skills.allowImplicitInvocation.description":
-        "Persist the oo skill allow_implicit_invocation policy and synchronize the installed managed skill when present.",
+        "Persist the oo skill implicit invocation policy and synchronize the installed managed skill when present.",
     "commands.skills.allowImplicitInvocation.summary":
         "Set oo skill implicit invocation",
     "commands.skills.install.description":
@@ -205,8 +205,8 @@ export const enMessages = {
         "Invalid lang value: {value}. Use en or zh.",
     "errors.config.invalidFileDownloadOutDirValue":
         "Invalid file.download.out_dir value: {value}. Use a non-empty path.",
-    "errors.config.invalidSkillsOoAllowImplicitInvocationValue":
-        "Invalid skills.oo.allow_implicit_invocation value: {value}. Use true or false.",
+    "errors.config.invalidSkillsOoImplicitInvocationValue":
+        "Invalid skills.oo.implicit_invocation value: {value}. Use true or false.",
     "errors.file.invalidFormat":
         "Invalid format: {value}. Use json.",
     "errors.fileDownload.downloadFailed":
@@ -336,7 +336,7 @@ export const enMessages = {
     "options.lang": "Specify the display language",
     "options.version": "Show the current version",
     "skills.allowImplicitInvocation.success":
-        "Set Codex skill {name} allow_implicit_invocation to {value}.",
+        "Set Codex skill {name} implicit invocation to {value}.",
     "skills.install.success": "Installed Codex skill {name} to {path}.",
     "skills.uninstall.success": "Removed Codex skill {name} from {path}.",
     "versionInfo.version": "Version",
@@ -491,7 +491,7 @@ export const zhMessages = {
     "commands.skills.description": "在本地 Codex 目录中安装或移除内置的仅限 Codex 使用的 skill。",
     "commands.skills.summary": "管理内置 Codex skill",
     "commands.skills.allowImplicitInvocation.description":
-        "持久化 oo skill 的 allow_implicit_invocation 策略，并在本地存在受管安装时同步对应文件。",
+        "持久化 oo skill 的隐式调用策略，并在本地存在受管安装时同步对应文件。",
     "commands.skills.allowImplicitInvocation.summary":
         "设置 oo skill 的隐式调用策略",
     "commands.skills.install.description": "将一个内置 Codex skill 安装到本地 Codex skills 目录。",
@@ -581,8 +581,8 @@ export const zhMessages = {
         "无效的 lang 值：{value}。请使用 en 或 zh。",
     "errors.config.invalidFileDownloadOutDirValue":
         "无效的 file.download.out_dir 值：{value}。请使用非空路径。",
-    "errors.config.invalidSkillsOoAllowImplicitInvocationValue":
-        "无效的 skills.oo.allow_implicit_invocation 值：{value}。请使用 true 或 false。",
+    "errors.config.invalidSkillsOoImplicitInvocationValue":
+        "无效的 skills.oo.implicit_invocation 值：{value}。请使用 true 或 false。",
     "errors.file.invalidFormat":
         "无效的 format：{value}。请使用 json。",
     "errors.fileDownload.downloadFailed":
@@ -706,7 +706,7 @@ export const zhMessages = {
     "options.lang": "指定显示语言",
     "options.version": "显示当前版本",
     "skills.allowImplicitInvocation.success":
-        "已将 Codex skill {name} 的 allow_implicit_invocation 设置为 {value}。",
+        "已将 Codex skill {name} 的隐式调用设置为 {value}。",
     "skills.install.success": "已将 Codex skill {name} 安装到 {path}。",
     "skills.uninstall.success": "已从 {path} 移除 Codex skill {name}。",
     "versionInfo.version": "版本",


### PR DESCRIPTION
Shorten the oo skill config key from
`skills.oo.allow_implicit_invocation` to
`skills.oo.implicit_invocation` for brevity. Update all references across schemas, CLI commands, tests, docs, and i18n catalog.