### PR TITLE
feat(config): ignore unknown settings keys with logged warnings

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -60,6 +60,10 @@ Alias for `oo auth logout`.
 
 ## Configuration
 
+- Notes: when the persisted settings file contains unknown keys, the CLI
+  ignores those keys and writes a warning entry to the debug log. Known keys
+  continue to load normally.
+
 ### `oo config list`
 
 List persisted configuration values that are currently set.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -54,6 +54,9 @@
 
 ## 配置
 
+- 说明：如果持久化 settings 文件里存在未知 key，CLI 会忽略这些 key，并在
+  debug 日志中写入 warning；已知 key 仍会按正常规则生效。
+
 ### `oo config list`
 
 列出当前已经设置的持久化配置。

--- a/src/adapters/store/file-settings-store.test.ts
+++ b/src/adapters/store/file-settings-store.test.ts
@@ -223,27 +223,55 @@ describe("FileSettingsStore", () => {
         );
     });
 
-    test("rejects legacy TOML settings that still include updateNotifier", async () => {
+    test("ignores unknown settings keys and logs a warning", async () => {
         const root = await createTemporaryDirectory("store-toml");
+        const logCapture = createLogCapture();
         const store = new FileSettingsStore({
             appName: APP_NAME,
             env: {
                 HOME: root,
                 XDG_CONFIG_HOME: root,
             },
+            logger: logCapture.logger,
             platform: "linux",
         });
 
         await mkdir(dirname(store.getFilePath()), { recursive: true });
         await writeFile(
             store.getFilePath(),
-            "lang = \"zh\"\nupdateNotifier = false\n",
+            [
+                "lang = \"zh\"",
+                "updateNotifier = false",
+                "",
+                "[skills.oo]",
+                "implicit_invocation = false",
+                "extra = true",
+                "",
+            ].join("\n"),
             "utf8",
         );
 
-        await expect(store.read()).rejects.toMatchObject({
-            key: "errors.store.invalidSchema",
-        } satisfies Partial<CliUserError>);
+        await expect(store.read()).resolves.toEqual({
+            lang: "zh",
+            skills: {
+                oo: {
+                    implicit_invocation: false,
+                },
+            },
+        });
+
+        const logs = logCapture.read();
+
+        expect(logs).toContain(`"level":"warn"`);
+        expect(logs).toContain(
+            `"msg":"Settings store file contained unknown keys that were ignored."`,
+        );
+        expect(logs).toContain(`"unknownKeyCount":2`);
+        expect(logs).toContain(
+            `"unknownKeyPaths":["skills.oo.extra","updateNotifier"]`,
+        );
+
+        logCapture.close();
     });
 
     test("rejects invalid TOML files", async () => {
@@ -276,7 +304,7 @@ describe("FileSettingsStore", () => {
         logCapture.close();
     });
 
-    test("rejects legacy settings with a version field", async () => {
+    test("rejects invalid known settings even when unknown keys are present", async () => {
         const root = await createTemporaryDirectory("store-invalid-schema");
         const store = new FileSettingsStore({
             appName: APP_NAME,
@@ -290,7 +318,7 @@ describe("FileSettingsStore", () => {
         await mkdir(dirname(store.getFilePath()), { recursive: true });
         await writeFile(
             store.getFilePath(),
-            "version = 1\nlang = \"zh\"\n",
+            "version = 1\nlang = 1\n",
             "utf8",
         );
 

--- a/src/adapters/store/file-settings-store.ts
+++ b/src/adapters/store/file-settings-store.ts
@@ -14,8 +14,10 @@ import {
     withStorePath,
 } from "../../application/logging/log-fields.ts";
 import {
+    collectUnknownSettingsFileKeyPaths,
     defaultSettings,
     renderSettingsFile,
+    settingsFileReadSchema,
     settingsFileSchema,
 } from "../../application/schemas/settings.ts";
 import { resolveStoreDirectory } from "./store-path.ts";
@@ -232,7 +234,7 @@ export class FileSettingsStore implements SettingsStore {
             });
         }
 
-        const parsedSettings = settingsFileSchema.safeParse(parsedContent);
+        const parsedSettings = settingsFileReadSchema.safeParse(parsedContent);
 
         if (!parsedSettings.success) {
             this.logger?.error(
@@ -249,6 +251,22 @@ export class FileSettingsStore implements SettingsStore {
             throw new CliUserError("errors.store.invalidSchema", 1, {
                 path: this.filePath,
             });
+        }
+
+        const unknownKeyPaths = collectUnknownSettingsFileKeyPaths(
+            parsedContent,
+            parsedSettings.data,
+        );
+
+        if (unknownKeyPaths.length > 0) {
+            this.logger?.warn(
+                {
+                    unknownKeyCount: unknownKeyPaths.length,
+                    unknownKeyPaths,
+                    ...withStorePath(this.filePath),
+                },
+                "Settings store file contained unknown keys that were ignored.",
+            );
         }
 
         return parsedSettings.data;

--- a/src/application/commands/config/index.cli.test.ts
+++ b/src/application/commands/config/index.cli.test.ts
@@ -399,4 +399,36 @@ describe("config CLI", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("ignores unknown persisted settings keys and logs a warning", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const filePath = join(
+                sandbox.env.XDG_CONFIG_HOME!,
+                APP_NAME,
+                "settings.toml",
+            );
+
+            await Bun.write(
+                filePath,
+                "lang = \"zh\"\nupdateNotifier = false\n",
+            );
+
+            const result = await sandbox.run(["config", "get", "lang"]);
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe("zh\n");
+            expect(result.stderr).toBe("");
+            expect(content).toContain(`"level":"warn"`);
+            expect(content).toContain(
+                `"msg":"Settings store file contained unknown keys that were ignored."`,
+            );
+            expect(content).toContain(`"unknownKeyPaths":["updateNotifier"]`);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });

--- a/src/application/schemas/settings.ts
+++ b/src/application/schemas/settings.ts
@@ -12,23 +12,43 @@ export const booleanConfigValueChoices = ["true", "false"] as const;
 export const booleanConfigValueSchema = z.enum(booleanConfigValueChoices);
 export const fileDownloadOutDirConfigValueSchema = z.string().trim().min(1);
 
-const fileDownloadSettingsSchema = z.object({
+const fileDownloadSettingsShape = {
     out_dir: fileDownloadOutDirConfigValueSchema.optional(),
-}).strict();
+};
+
+const fileDownloadSettingsReadSchema = z.object(fileDownloadSettingsShape);
+const fileDownloadSettingsSchema = z.object(fileDownloadSettingsShape).strict();
+
+const fileSettingsReadSchema = z.object({
+    download: fileDownloadSettingsReadSchema.optional(),
+});
 
 const fileSettingsSchema = z.object({
     download: fileDownloadSettingsSchema.optional(),
 }).strict();
 
-const ooSkillSettingsSchema = z.object({
+const ooSkillSettingsShape = {
     implicit_invocation: z.boolean().optional(),
-}).strict();
+};
+
+const ooSkillSettingsReadSchema = z.object(ooSkillSettingsShape);
+const ooSkillSettingsSchema = z.object(ooSkillSettingsShape).strict();
+
+const skillsSettingsReadSchema = z.object({
+    oo: ooSkillSettingsReadSchema.optional(),
+});
 
 const skillsSettingsSchema = z.object({
     oo: ooSkillSettingsSchema.optional(),
 }).strict();
 
 export const defaultOoSkillImplicitInvocation = true;
+
+export const settingsFileReadSchema = z.object({
+    file: fileSettingsReadSchema.optional(),
+    lang: localeSchema.optional(),
+    skills: skillsSettingsReadSchema.optional(),
+});
 
 export const settingsFileSchema = z.object({
     file: fileSettingsSchema.optional(),
@@ -114,6 +134,13 @@ export function parseBooleanConfigValue(value: BooleanConfigValue): boolean {
 
 export function stringifyBooleanConfigValue(value: boolean): BooleanConfigValue {
     return value ? "true" : "false";
+}
+
+export function collectUnknownSettingsFileKeyPaths(
+    rawInput: unknown,
+    parsedInput: unknown,
+): string[] {
+    return collectStrippedObjectPaths(rawInput, parsedInput).sort();
 }
 
 export function getConfiguredFileDownloadOutDir(
@@ -225,4 +252,41 @@ export function unsetOoSkillImplicitInvocation(
     }
 
     return nextSettings;
+}
+
+function collectStrippedObjectPaths(
+    rawValue: unknown,
+    parsedValue: unknown,
+    path: readonly string[] = [],
+): string[] {
+    if (!isPlainObjectRecord(rawValue) || !isPlainObjectRecord(parsedValue)) {
+        return [];
+    }
+
+    const strippedPaths: string[] = [];
+
+    for (const [key, childRawValue] of Object.entries(rawValue)) {
+        const childPath = [...path, key];
+
+        if (!Object.hasOwn(parsedValue, key)) {
+            strippedPaths.push(childPath.join("."));
+            continue;
+        }
+
+        strippedPaths.push(
+            ...collectStrippedObjectPaths(
+                childRawValue,
+                parsedValue[key],
+                childPath,
+            ),
+        );
+    }
+
+    return strippedPaths;
+}
+
+function isPlainObjectRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null
+        && typeof value === "object"
+        && !Array.isArray(value);
 }


### PR DESCRIPTION
Previously the CLI rejected any settings file that contained unrecognized keys (via strict Zod schemas), which broke forward compatibility when older CLI versions encountered keys introduced by newer releases.

Introduce a parallel set of non-strict "read" schemas that strip unknown keys during parsing. After a successful parse, diff the raw input against the parsed output to collect stripped key paths, then emit a single structured warning to the debug log. Strict schemas are kept for the write path so that programmatic mutations remain validated.

Add unit and CLI-level integration tests covering mixed known/unknown keys, nested unknown keys, and validation of known keys even when unknown keys are present. Update EN and CN command docs to describe the new tolerance behavior.