### PR TITLE
feat(skills): accept optional skill name argument in install command

### DIFF
--- a/README-ZH_CN.md
+++ b/README-ZH_CN.md
@@ -31,8 +31,9 @@ $oo 帮我生成 OOMOL 字符串的二维码
 
 ## Codex Skill
 
-首次打开 `oo`，或者执行 `oo skills install` 之后，Codex 中会生成内置的
-`oo` skill，位置在 `${CODEX_HOME:-~/.codex}/skills/oo`。
+首次打开 `oo`，或者执行 `oo skills install`（等价于
+`oo skills install oo`）之后，Codex 中会生成内置的 `oo` skill，位置在
+`${CODEX_HOME:-~/.codex}/skills/oo`。
 
 然后你就可以在 Codex 中这样使用：
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ $oo generate a QR code for the string OOMOL
 
 ## Codex Skills
 
-On the first `oo` launch, or after running `oo skills install`, Codex will get
-the bundled `oo` skill under `${CODEX_HOME:-~/.codex}/skills/oo`.
+On the first `oo` launch, or after running `oo skills install` (equivalent to
+`oo skills install oo`), Codex will get the bundled `oo` skill under
+`${CODEX_HOME:-~/.codex}/skills/oo`.
 
 Then you can use it in Codex, for example:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -147,11 +147,13 @@ Persist one skill configuration value.
   persists the setting and applies it on the next install or startup
   synchronization.
 
-### `oo skills install`
+### `oo skills install [skill]`
 
 Install one bundled skill into the local Codex skills directory.
 
-- Managed skill: `oo`.
+- Arguments: `[skill]` is optional. When omitted, the command behaves the same
+  as `oo skills install oo`.
+- Supported skill names: currently `oo`.
 - Target directory: `${CODEX_HOME:-~/.codex}/skills/oo`.
 - Metadata: the installation writes the current `oo` version into a hidden
   version file inside the skill directory.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -132,11 +132,12 @@
 - 说明：当目标受管 skill 尚未安装时，命令仍会写入设置，并在下次安装或启
   动同步时生效。
 
-### `oo skills install`
+### `oo skills install [skill]`
 
 将一个内置 skill 安装到本地 Codex skills 目录。
 
-- 内置 skill：`oo`。
+- 参数：`[skill]` 可选。未提供时，该命令等价于 `oo skills install oo`。
+- 支持的 skill 名称：当前仅 `oo`。
 - 目标目录：`${CODEX_HOME:-~/.codex}/skills/oo`。
 - 元数据：安装时会在 skill 目录内写入一个隐藏的 `oo` 版本记录文件。
 - 元数据：当存在持久化的 `skills.oo.implicit_invocation` 配置时，

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -11,6 +11,23 @@ import {
 } from "./shared.ts";
 
 describe("skills CLI", () => {
+    test("rejects unsupported skill names for skills install", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["skills", "install", "unknown"]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Unsupported skill: unknown. Use oo.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("treats the removed allow-implicit-invocation subcommand as unknown", async () => {
         const sandbox = await createCliSandbox();
 

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -13,7 +13,7 @@ import {
 } from "./shared.ts";
 
 describe("skills commands", () => {
-    test("installs a bundled Codex skill into the Codex skills directory", async () => {
+    test("installs the default bundled Codex skill when no skill name is provided", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
@@ -42,6 +42,34 @@ describe("skills commands", () => {
             expect(await readFile(ownershipFilePath, "utf8")).toContain(
                 "allow_implicit_invocation: true",
             );
+            expect(await readFile(versionFilePath, "utf8")).toBe(
+                `${resultVersion}\n`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("installs a bundled Codex skill by explicit name", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const resultVersion = "9.9.9";
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "install", "oo"], {
+                version: resultVersion,
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Installed Codex skill oo to ${skillDirectoryPath}.\n`,
+            );
+            expect(result.stderr).toBe("");
             expect(await readFile(versionFilePath, "utf8")).toBe(
                 `${resultVersion}\n`,
             );

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -1,16 +1,40 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
+import type { BundledSkillName } from "./embedded-assets.ts";
 
 import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { availableBundledSkillNames } from "./embedded-assets.ts";
 import { installBundledSkill } from "./shared.ts";
 
-const bundledSkillName = "oo" as const;
+interface SkillsInstallInput {
+    skill: BundledSkillName;
+}
 
-export const skillsInstallCommand: CliCommandDefinition = {
+const defaultBundledSkillName = "oo" as const;
+const bundledSkillNameSchema = z.enum(availableBundledSkillNames);
+
+const skillsInstallInputSchema = z.object({
+    skill: bundledSkillNameSchema.default(defaultBundledSkillName),
+});
+
+export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
     name: "install",
     summaryKey: "commands.skills.install.summary",
     descriptionKey: "commands.skills.install.description",
-    inputSchema: z.object({}),
-    handler: async (_, context) => {
-        await installBundledSkill(bundledSkillName, context);
+    arguments: [
+        {
+            name: "skill",
+            descriptionKey: "arguments.skill",
+            required: false,
+        },
+    ],
+    inputSchema: skillsInstallInputSchema,
+    mapInputError: (_, rawInput) =>
+        new CliUserError("errors.skills.invalidName", 2, {
+            choices: availableBundledSkillNames.join(", "),
+            value: String(rawInput.skill ?? ""),
+        }),
+    handler: async (input, context) => {
+        await installBundledSkill(input.skill, context);
     },
 };


### PR DESCRIPTION
The install subcommand now takes an optional positional argument so users can run `oo skills install oo` explicitly. When omitted, it defaults to "oo" preserving backward compatibility. Unsupported names are rejected with a clear error message and exit code 2.