### PR TITLE
test: introduce CLI snapshot testing across command tests

### DIFF
--- a/__tests__/helpers.test.ts
+++ b/__tests__/helpers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { createTerminalColors } from "../src/application/terminal-colors.ts";
+import { createCliSnapshot } from "./helpers.ts";
+
+describe("test helpers", () => {
+    test("normalizes cli snapshots for paths, ansi output, and replacement precedence", () => {
+        const colors = createTerminalColors(true);
+        const sandbox = {
+            cwd: "C:\\workspace\\oo-cli",
+            env: {
+                APPDATA: undefined,
+                HOME: "C:\\Users\\Tester",
+                LOCALAPPDATA: undefined,
+                USERPROFILE: "C:\\Users\\Tester",
+                XDG_CONFIG_HOME: "C:\\Users\\Tester\\.config",
+                XDG_STATE_HOME: "C:\\Users\\Tester\\.local\\state",
+            },
+        };
+        const outputFilePath = "C:\\workspace\\oo-cli\\artifacts\\result.json";
+
+        expect(createCliSnapshot(
+            {
+                exitCode: 0,
+                stdout: [
+                    "C:/Users/Tester/.config/oo-cli/settings.toml",
+                    outputFilePath,
+                ].join("\r\n"),
+                stderr: `${colors.green("ok")} ${outputFilePath}\r`,
+            },
+            {
+                sandbox,
+                stripAnsi: true,
+                replacements: [
+                    {
+                        placeholder: "<OUTPUT_FILE>",
+                        value: outputFilePath,
+                    },
+                ],
+            },
+        )).toEqual({
+            exitCode: 0,
+            stdout: [
+                "<XDG_CONFIG_HOME>/oo-cli/settings.toml",
+                "<OUTPUT_FILE>",
+            ].join("\n"),
+            stderr: "ok <OUTPUT_FILE>\n",
+        });
+    });
+});

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -62,6 +62,22 @@ export interface CliRunResult {
     readonly stderr: string;
 }
 
+export interface SnapshotReplacement {
+    readonly placeholder: string;
+    readonly value: string | undefined;
+}
+
+export interface CliSnapshotContext {
+    readonly cwd: string;
+    readonly env: Record<string, string | undefined>;
+}
+
+export interface CliSnapshotOptions {
+    readonly replacements?: readonly SnapshotReplacement[];
+    readonly sandbox?: CliSnapshotContext;
+    readonly stripAnsi?: boolean;
+}
+
 export interface LogCapture {
     readonly logger: Logger;
     close: () => void;
@@ -366,6 +382,26 @@ export function readFileDownloadSuccessOutput(path: string): string {
     return `Saved to: ${path}\n`;
 }
 
+export function createCliSnapshot(
+    result: CliRunResult,
+    options: CliSnapshotOptions = {},
+): CliRunResult {
+    const replacements = resolveSnapshotReplacements(options);
+
+    return {
+        exitCode: result.exitCode,
+        stdout: normalizeSnapshotText(result.stdout, replacements, options.stripAnsi),
+        stderr: normalizeSnapshotText(result.stderr, replacements, options.stripAnsi),
+    };
+}
+
+export function expectCliSnapshot(
+    result: CliRunResult,
+    options: CliSnapshotOptions = {},
+): void {
+    expect(createCliSnapshot(result, options)).toMatchSnapshot();
+}
+
 export function readAuthLoginUrlPrefix(endpoint: string): string {
     return `https://api.${endpoint}/v1/auth/redirect?`;
 }
@@ -416,6 +452,106 @@ export function findLoginUrl(output: string): string | undefined {
     return undefined;
 }
 
+function normalizeSnapshotText(
+    value: string,
+    replacements: readonly ResolvedSnapshotReplacement[],
+    stripAnsi = false,
+): string {
+    let normalized = value
+        .split("\r\n")
+        .join("\n")
+        .split("\r")
+        .join("\n");
+
+    if (stripAnsi) {
+        normalized = createTerminalColors(true).strip(normalized);
+    }
+
+    for (const replacement of replacements) {
+        normalized = replaceSnapshotValue(
+            normalized,
+            replacement.value,
+            replacement.placeholder,
+        );
+
+        const portableValue = replacement.value
+            .split("\\")
+            .join("/");
+
+        if (portableValue !== replacement.value) {
+            normalized = replaceSnapshotValue(
+                normalized,
+                portableValue,
+                replacement.placeholder,
+            );
+        }
+    }
+
+    return normalized;
+}
+
+function replaceSnapshotValue(
+    value: string,
+    searchValue: string,
+    replacementValue: string,
+): string {
+    return value.split(searchValue).join(replacementValue);
+}
+
+function resolveSnapshotReplacements(
+    options: CliSnapshotOptions,
+): readonly ResolvedSnapshotReplacement[] {
+    const replacements = [
+        ...createSandboxSnapshotReplacements(options.sandbox),
+        ...(options.replacements ?? []),
+    ];
+
+    return replacements
+        .filter((replacement): replacement is ResolvedSnapshotReplacement =>
+            replacement.value !== undefined && replacement.value.length > 0,
+        )
+        .sort((left, right) => right.value.length - left.value.length);
+}
+
+function createSandboxSnapshotReplacements(
+    sandbox?: CliSnapshotContext,
+): readonly SnapshotReplacement[] {
+    if (!sandbox) {
+        return [];
+    }
+
+    return [
+        {
+            placeholder: "<APPDATA>",
+            value: sandbox.env.APPDATA,
+        },
+        {
+            placeholder: "<CWD>",
+            value: sandbox.cwd,
+        },
+        {
+            placeholder: "<HOME>",
+            value: sandbox.env.HOME,
+        },
+        {
+            placeholder: "<LOCALAPPDATA>",
+            value: sandbox.env.LOCALAPPDATA,
+        },
+        {
+            placeholder: "<USERPROFILE>",
+            value: sandbox.env.USERPROFILE,
+        },
+        {
+            placeholder: "<XDG_CONFIG_HOME>",
+            value: sandbox.env.XDG_CONFIG_HOME,
+        },
+        {
+            placeholder: "<XDG_STATE_HOME>",
+            value: sandbox.env.XDG_STATE_HOME,
+        },
+    ];
+}
+
 async function completeLoginCallback(
     loginUrlValue: string,
     apiKeyValue: string,
@@ -441,4 +577,9 @@ async function completeLoginCallback(
     const response = await fetch(requestUrl);
 
     expect(response.status).toBe(200);
+}
+
+interface ResolvedSnapshotReplacement {
+    readonly placeholder: string;
+    readonly value: string;
 }

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -1,0 +1,254 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`runCli bootstrap prints the package version 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Version: 0.0.0-development
+Build Time: unknown
+Commit: unknown
+"
+,
+}
+`;
+
+exports[`runCli bootstrap prints localized version metadata in Chinese 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"版本: 0.0.0-development
+构建时间: 未知
+提交: 未知
+"
+,
+}
+`;
+
+exports[`runCli bootstrap creates the sqlite cache file during cli startup 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
+
+Options:
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
+
+Commands:
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  package                  Package utilities
+  search [options] <text>  Search packages by intent
+  help [command]           Show help for a command
+"
+,
+}
+`;
+
+exports[`runCli bootstrap writes debug logs to the log directory during cli startup 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
+
+Options:
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
+
+Commands:
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  package                  Package utilities
+  search [options] <text>  Search packages by intent
+  help [command]           Show help for a command
+"
+,
+}
+`;
+
+exports[`runCli bootstrap prints the current log file path to stderr when --debug is set 1`] = `
+{
+  "exitCode": 0,
+  "stderr": 
+"<LOG_FILE_PATH>
+"
+,
+  "stdout": 
+"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
+
+Options:
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
+
+Commands:
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  package                  Package utilities
+  search [options] <text>  Search packages by intent
+  help [command]           Show help for a command
+"
+,
+}
+`;
+
+exports[`runCli bootstrap renders help in English and Chinese 1`] = `
+{
+  "chinese": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"oo 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成
+
+选项：
+  -V, --version            显示当前版本
+  --debug                  在 CLI 退出时打印当前日志文件路径
+  --lang <lang>            指定显示语言
+  -h, --help               显示命令帮助
+
+命令：
+  auth                     管理 CLI 认证
+  check-update             检查 CLI 更新
+  cloud-task               管理云任务
+  file                     管理临时文件传输
+  login                    通过浏览器登录（auth login 的别名）
+  logout                   登出当前账号（auth logout 的别名）
+  completion <shell>       生成 shell 补全脚本
+  config                   管理持久化配置
+  skills                   管理 Codex skill
+  log                      管理持久化 debug 日志
+  package                  包相关工具
+  search [options] <text>  按意图搜索包
+  help [command]           显示命令帮助
+"
+,
+  },
+  "english": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
+
+Options:
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
+
+Commands:
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  package                  Package utilities
+  search [options] <text>  Search packages by intent
+  help [command]           Show help for a command
+"
+,
+  },
+}
+`;
+
+exports[`runCli bootstrap renders branded colors in help when stdout supports colors 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
+
+Options:
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
+
+Commands:
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  package                  Package utilities
+  search [options] <text>  Search packages by intent
+  help [command]           Show help for a command
+"
+,
+}
+`;
+
+exports[`runCli bootstrap returns usage errors for invalid global inputs 1`] = `
+{
+  "invalidLang": {
+    "exitCode": 2,
+    "stderr": 
+"Invalid value for --lang: fr. Use en or zh.
+"
+,
+    "stdout": "",
+  },
+  "unknownCommand": {
+    "exitCode": 2,
+    "stderr": 
+"Unknown command: cnfig.
+Did you mean config?
+"
+,
+    "stdout": "",
+  },
+}
+`;
+
+exports[`runCli bootstrap tags bootstrap user errors with the user_error category 1`] = `
+{
+  "exitCode": 2,
+  "stderr": 
+"Invalid config key: theme.
+"
+,
+  "stdout": "",
+}
+`;

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -3,7 +3,12 @@ import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
-import { createCliSandbox, createTextBuffer, readLatestLogContent } from "../../../__tests__/helpers.ts";
+import {
+    createCliSandbox,
+    createCliSnapshot,
+    createTextBuffer,
+    readLatestLogContent,
+} from "../../../__tests__/helpers.ts";
 import packageManifest from "../../../package.json" with { type: "json" };
 import { resolveStorePaths } from "../../adapters/store/store-path.ts";
 import { APP_NAME } from "../config/app-config.ts";
@@ -22,16 +27,7 @@ describe("runCli bootstrap", () => {
         try {
             const result = await sandbox.run(["--version"]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(
-                [
-                    `Version: ${packageManifest.version}`,
-                    "Build Time: unknown",
-                    "Commit: unknown",
-                    "",
-                ].join("\n"),
-            );
-            expect(result.stderr).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -44,16 +40,7 @@ describe("runCli bootstrap", () => {
         try {
             const result = await sandbox.run(["--lang", "zh", "--version"]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(
-                [
-                    `版本: ${packageManifest.version}`,
-                    "构建时间: 未知",
-                    "提交: 未知",
-                    "",
-                ].join("\n"),
-            );
-            expect(result.stderr).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -72,7 +59,7 @@ describe("runCli bootstrap", () => {
             );
             const result = await sandbox.run(["--help"]);
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             await expect(stat(cacheFilePath)).resolves.toMatchObject({
                 isFile: expect.any(Function),
             });
@@ -94,7 +81,7 @@ describe("runCli bootstrap", () => {
             const result = await sandbox.run(["--help"]);
             const logFileNames = await readdir(logDirectoryPath).catch(() => []);
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(logFileNames.length).toBeGreaterThan(0);
 
             const content = await readFile(
@@ -126,8 +113,14 @@ describe("runCli bootstrap", () => {
             const logFileNames = await readdir(logDirectoryPath);
             const logFilePath = join(logDirectoryPath, logFileNames.at(-1)!);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe(`${logFilePath}\n`);
+            expect(createCliSnapshot(result, {
+                replacements: [
+                    {
+                        placeholder: "<LOG_FILE_PATH>",
+                        value: logFilePath,
+                    },
+                ],
+            })).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -141,33 +134,10 @@ describe("runCli bootstrap", () => {
             const englishHelp = await sandbox.run(["--help"]);
             const chineseHelp = await sandbox.run(["--lang", "zh", "--help"]);
 
-            expect(englishHelp.exitCode).toBe(0);
-            expect(englishHelp.stdout).not.toContain("Usage:");
-            expect(englishHelp.stdout).toContain("auth");
-            expect(englishHelp.stdout).toContain("log");
-            expect(englishHelp.stdout).toContain(`${APP_NAME} is OOMOL's CLI toolkit.`);
-            expect(englishHelp.stdout).toContain("--debug");
-            expect(englishHelp.stdout).toContain("--lang <lang>");
-            expect(englishHelp.stdout).toContain(
-                "Log in with a browser flow (alias for auth login)",
-            );
-            expect(englishHelp.stdout).toContain(
-                "Log out the current account (alias for auth logout)",
-            );
-
-            expect(chineseHelp.exitCode).toBe(0);
-            expect(chineseHelp.stdout).not.toContain("用法：");
-            expect(chineseHelp.stdout).toContain("auth");
-            expect(chineseHelp.stdout).toContain("log");
-            expect(chineseHelp.stdout).toContain(`${APP_NAME} 是 OOMOL 的 CLI 工具集`);
-            expect(chineseHelp.stdout).toContain("--debug");
-            expect(chineseHelp.stdout).toContain("选项：");
-            expect(chineseHelp.stdout).toContain(
-                "通过浏览器登录（auth login 的别名）",
-            );
-            expect(chineseHelp.stdout).toContain(
-                "登出当前账号（auth logout 的别名）",
-            );
+            expect({
+                chinese: createCliSnapshot(chineseHelp),
+                english: createCliSnapshot(englishHelp),
+            }).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -188,7 +158,9 @@ describe("runCli bootstrap", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result, {
+                stripAnsi: true,
+            })).toMatchSnapshot();
             expect(result.stdout).toContain(
                 `${colors.magenta(APP_NAME)} is ${colors.cyan("OOMOL")}'s CLI toolkit.`,
             );
@@ -205,10 +177,12 @@ describe("runCli bootstrap", () => {
             const invalidLang = await sandbox.run(["--lang", "fr", "--help"]);
             const unknownCommand = await sandbox.run(["cnfig"]);
 
-            expect(invalidLang.exitCode).toBe(2);
+            expect({
+                invalidLang: createCliSnapshot(invalidLang),
+                unknownCommand: createCliSnapshot(unknownCommand),
+            }).toMatchSnapshot();
             expect(invalidLang.stderr).toContain("Invalid value for --lang");
 
-            expect(unknownCommand.exitCode).toBe(2);
             expect(unknownCommand.stderr).toContain("Unknown command");
         }
         finally {
@@ -246,7 +220,11 @@ describe("runCli bootstrap", () => {
             });
             const content = await readLatestLogContent(sandbox);
 
-            expect(exitCode).toBe(2);
+            expect(createCliSnapshot({
+                exitCode,
+                stderr: stderr.read(),
+                stdout: stdout.read(),
+            })).toMatchSnapshot();
             expect(stderr.read()).toContain("Invalid config key");
             expect(content).toContain(`"category":"user_error"`);
             expect(content).toContain(`"key":"errors.config.invalidKey"`);

--- a/src/application/commands/__snapshots__/check-update.cli.test.ts.snap
+++ b/src/application/commands/__snapshots__/check-update.cli.test.ts.snap
@@ -1,0 +1,121 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`checkUpdateCommand CLI writes update-check lifecycle logs when check-update finds a newer release 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"
+╭──────────────────────────────────────────────────────╮
+│                                                      │
+│            Update available 1.0.0 → 1.2.0            │
+│  Run pnpm add -g @oomol-lab/oo-cli@latest to update  │
+│                                                      │
+╰──────────────────────────────────────────────────────╯
+"
+,
+}
+`;
+
+exports[`checkUpdateCommand CLI does not automatically check for updates after unrelated commands 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"<XDG_CONFIG_HOME>/oo/settings.toml
+"
+,
+}
+`;
+
+exports[`checkUpdateCommand CLI retries once before printing a retry-later message 1`] = `
+{
+  "firstResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Unable to check for updates right now. Please try again later.
+"
+,
+  },
+  "secondResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Unable to check for updates right now. Please try again later.
+"
+,
+  },
+}
+`;
+
+exports[`checkUpdateCommand CLI does not cache failed update checks between check-update invocations 1`] = `
+{
+  "firstResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Unable to check for updates right now. Please try again later.
+"
+,
+  },
+  "secondResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"
+╭─────────────────────────────────────────────────────────╮
+│                                                         │
+│             Update available 1.0.0 → 1.2.0              │
+│  Run npm install -g @oomol-lab/oo-cli@latest to update  │
+│                                                         │
+╰─────────────────────────────────────────────────────────╯
+"
+,
+  },
+}
+`;
+
+exports[`checkUpdateCommand CLI fetches the latest registry version on every check-update invocation 1`] = `
+{
+  "firstResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"
+╭─────────────────────────────────────────────────────────╮
+│                                                         │
+│             Update available 1.0.0 → 1.2.0              │
+│  Run npm install -g @oomol-lab/oo-cli@latest to update  │
+│                                                         │
+╰─────────────────────────────────────────────────────────╯
+"
+,
+  },
+  "secondResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"
+╭─────────────────────────────────────────────────────────╮
+│                                                         │
+│             Update available 1.0.0 → 1.3.0              │
+│  Run npm install -g @oomol-lab/oo-cli@latest to update  │
+│                                                         │
+╰─────────────────────────────────────────────────────────╯
+"
+,
+  },
+}
+`;
+
+exports[`checkUpdateCommand CLI prints a friendly message when check-update receives an unsupported version 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Current version development does not support update checks.
+"
+,
+}
+`;

--- a/src/application/commands/__snapshots__/completion.cli.test.ts.snap
+++ b/src/application/commands/__snapshots__/completion.cli.test.ts.snap
@@ -1,0 +1,45 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`completionCommand CLI renders supported shells in completion help 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Output a shell completion script for a supported shell.
+
+Arguments:
+  shell          Target shell (choices: "bash", "zsh", "fish")
+
+Options:
+  -h, --help     Show help for command
+
+Global Options:
+  -V, --version  Show the current version
+  --debug        Print the current log file path when the CLI exits
+  --lang <lang>  Specify the display language
+"
+,
+}
+`;
+
+exports[`completionCommand CLI renders localized choices metadata in Chinese completion help 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"输出受支持 shell 的补全脚本。
+
+参数：
+  shell          目标 shell (可选值: "bash", "zsh", "fish")
+
+选项：
+  -h, --help     显示命令帮助
+
+全局选项：
+  -V, --version  显示当前版本
+  --debug        在 CLI 退出时打印当前日志文件路径
+  --lang <lang>  指定显示语言
+"
+,
+}
+`;

--- a/src/application/commands/__snapshots__/search.cli.test.ts.snap
+++ b/src/application/commands/__snapshots__/search.cli.test.ts.snap
@@ -1,0 +1,191 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`search CLI writes search request lifecycle logs 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"No matching packages were found.
+"
+,
+}
+`;
+
+exports[`search CLI writes sqlite cache adapter logs across repeated search invocations 1`] = `
+{
+  "firstResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"No matching packages were found.
+"
+,
+  },
+  "secondResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"No matching packages were found.
+"
+,
+  },
+}
+`;
+
+exports[`search CLI supports search command with text output 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Image Tools (@oomol/image-tools@1.2.3)
+Powerful image processing toolkit
+Blocks:
+- Image Processor (image-processor)
+  Process and transform image formats
+"
+,
+}
+`;
+
+exports[`search CLI adds the localized request language to search queries 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"未找到匹配的包。
+"
+,
+}
+`;
+
+exports[`search CLI reuses cached search responses across cli invocations 1`] = `
+{
+  "firstResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Image Tools (@oomol/image-tools@1.2.3)
+Powerful image processing toolkit
+"
+,
+  },
+  "secondResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Image Tools (@oomol/image-tools@1.2.3)
+Powerful image processing toolkit
+"
+,
+  },
+}
+`;
+
+exports[`search CLI renders search output with field-specific colors 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Image Tools (@oomol/image-tools@1.2.3)
+Powerful image processing toolkit
+Blocks:
+- Image Processor (image-processor)
+  Process and transform image formats
+"
+,
+}
+`;
+
+exports[`search CLI supports search command with only-package-id text output 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"@oomol/image-tools@1.2.3
+@oomol/vision-kit@2.0.0
+"
+,
+}
+`;
+
+exports[`search CLI supports search command with json array output and trims long text 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"[{"blocks":[{"title":"Image Processor"}],"displayName":"Image Tools","name":"@oomol/image-tools","version":"1.2.3"}]
+"
+,
+}
+`;
+
+exports[`search CLI supports search command with only-package-id json output 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"["@oomol/image-tools@1.2.3","@oomol/vision-kit@2.0.0"]
+"
+,
+}
+`;
+
+exports[`search CLI validates the search format option 1`] = `
+{
+  "exitCode": 2,
+  "stderr": 
+"Invalid format: yaml. Use json.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`search CLI renders search help when text argument is omitted 1`] = `
+{
+  "expectedHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Search packages with free-form text against the intent search API.
+
+Arguments:
+  text               Search text
+
+Options:
+  --format <format>  Specify output format (use json for structured output)
+  --json             Alias for --format=json
+  --only-package-id  Return only package ids
+  -h, --help         Show help for command
+
+Global Options:
+  -V, --version      Show the current version
+  --debug            Print the current log file path when the CLI exits
+  --lang <lang>      Specify the display language
+"
+,
+  },
+  "result": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Search packages with free-form text against the intent search API.
+
+Arguments:
+  text               Search text
+
+Options:
+  --format <format>  Specify output format (use json for structured output)
+  --json             Alias for --format=json
+  --only-package-id  Return only package ids
+  -h, --help         Show help for command
+
+Global Options:
+  -V, --version      Show the current version
+  --debug            Print the current log file path when the CLI exits
+  --lang <lang>      Specify the display language
+"
+,
+  },
+}
+`;

--- a/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
@@ -1,0 +1,221 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`auth CLI writes auth login callback logs without persisting api keys 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Open this URL in your browser to continue: <LOGIN_URL>
+Waiting for the browser login to complete...
+✓ Logged in to oomol.com account Alice
+  - Active account: true
+"
+,
+}
+`;
+
+exports[`auth CLI writes auth-store and auth status logs 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"✓ Logged in to oomol.com account Alice
+  - Active account: true
+  - API key status: Valid
+"
+,
+}
+`;
+
+exports[`auth CLI renders alias descriptions in login and logout help 1`] = `
+{
+  "loginHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Log in with an OOMOL account in the browser. Alias for auth login.
+
+Options:
+  -h, --help     Show help for command
+
+Global Options:
+  -V, --version  Show the current version
+  --debug        Print the current log file path when the CLI exits
+  --lang <lang>  Specify the display language
+"
+,
+  },
+  "logoutHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Remove the current account from persisted auth data. Alias for auth logout.
+
+Options:
+  -h, --help     Show help for command
+
+Global Options:
+  -V, --version  Show the current version
+  --debug        Print the current log file path when the CLI exits
+  --lang <lang>  Specify the display language
+"
+,
+  },
+}
+`;
+
+exports[`auth CLI supports auth login and updates the existing account without duplication 1`] = `
+{
+  "firstLogin": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Open this URL in your browser to continue: <LOGIN_URL>
+Waiting for the browser login to complete...
+✓ Logged in to oomol.com account Alice
+  - Active account: true
+"
+,
+  },
+  "secondLogin": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Open this URL in your browser to continue: <LOGIN_URL>
+Waiting for the browser login to complete...
+✓ Logged in to oomol.com account Alice
+  - Active account: true
+"
+,
+  },
+}
+`;
+
+exports[`auth CLI supports auth login with a custom OOMOL_ENDPOINT 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Open this URL in your browser to continue: <LOGIN_URL>
+Waiting for the browser login to complete...
+✓ Logged in to staging.oomol.test account Alice
+  - Active account: true
+"
+,
+}
+`;
+
+exports[`auth CLI supports login as an alias for auth login 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Open this URL in your browser to continue: <LOGIN_URL>
+Waiting for the browser login to complete...
+✓ Logged in to oomol.com account Alice
+  - Active account: true
+"
+,
+}
+`;
+
+exports[`auth CLI renders the auth login url and success block with color styling when stdout supports colors 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Open this URL in your browser to continue: <LOGIN_URL>
+Waiting for the browser login to complete...
+✓ Logged in to oomol.com account Alice
+  - Active account: true
+"
+,
+}
+`;
+
+exports[`auth CLI supports auth logout without falling back to another account 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Logged out the current account.
+"
+,
+}
+`;
+
+exports[`auth CLI supports logout as an alias for auth logout 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Logged out the current account.
+"
+,
+}
+`;
+
+exports[`auth CLI supports auth status for valid and invalid api keys 1`] = `
+{
+  "invalidStatus": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"X Logged in to oomol.com account Alice
+  - Active account: true
+  - API key status: Invalid
+"
+,
+  },
+  "validStatus": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"✓ Logged in to oomol.com account Alice
+  - Active account: true
+  - API key status: Valid
+"
+,
+  },
+}
+`;
+
+exports[`auth CLI supports auth switch by activating the next saved account 1`] = `
+{
+  "firstSwitch": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"✓ Switched active account for oomol.com to Bob
+"
+,
+  },
+  "secondSwitch": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"✓ Switched active account for oomol.com to Charlie
+"
+,
+  },
+  "thirdSwitch": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"✓ Switched active account for oomol.com to Alice
+"
+,
+  },
+}
+`;
+
+exports[`auth CLI renders the auth switch success block with gh-style emphasis when stdout supports colors 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"✓ Switched active account for oomol.com to Bob
+"
+,
+}
+`;

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
     createCliSandbox,
+    createCliSnapshot,
     defaultAuthEndpoint,
     findLoginUrl,
     readAuthLoginUrlPrefix,
@@ -27,7 +28,7 @@ describe("auth CLI", () => {
             const result = await runPrintedAuthLogin(sandbox, "secret-1");
             const content = await readLatestLogContent(sandbox);
 
-            expect(result.exitCode).toBe(0);
+            expect(createAuthLoginSnapshot(result)).toMatchSnapshot();
             expect(content).toContain(
                 `"msg":"Auth login callback server is listening."`,
             );
@@ -79,7 +80,7 @@ describe("auth CLI", () => {
             );
             const content = await readLatestLogContent(sandbox);
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(content).toContain(`"msg":"Auth store read completed."`);
             expect(content).toContain(`"msg":"Current auth account resolved."`);
             expect(content).toContain(`"msg":"Auth status request started."`);
@@ -97,26 +98,11 @@ describe("auth CLI", () => {
         try {
             const loginHelp = await sandbox.run(["login", "--help"]);
             const logoutHelp = await sandbox.run(["logout", "--help"]);
-            const loginDescriptionIndex = loginHelp.stdout.indexOf(
-                "Log in with an OOMOL account in the browser.",
-            );
-            const loginAliasIndex = loginHelp.stdout.indexOf(
-                "Alias for auth login.",
-            );
-            const logoutDescriptionIndex = logoutHelp.stdout.indexOf(
-                "Remove the current account from persisted auth data.",
-            );
-            const logoutAliasIndex = logoutHelp.stdout.indexOf(
-                "Alias for auth logout.",
-            );
 
-            expect(loginHelp.exitCode).toBe(0);
-            expect(loginDescriptionIndex).toBeGreaterThanOrEqual(0);
-            expect(loginAliasIndex).toBeGreaterThan(loginDescriptionIndex);
-
-            expect(logoutHelp.exitCode).toBe(0);
-            expect(logoutDescriptionIndex).toBeGreaterThanOrEqual(0);
-            expect(logoutAliasIndex).toBeGreaterThan(logoutDescriptionIndex);
+            expect({
+                loginHelp: createCliSnapshot(loginHelp),
+                logoutHelp: createCliSnapshot(logoutHelp),
+            }).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -135,17 +121,21 @@ describe("auth CLI", () => {
             const firstLogin = await runPrintedAuthLogin(sandbox, "secret-1");
             const secondLogin = await runPrintedAuthLogin(sandbox, "secret-2");
             const authFileContent = await readFile(authFilePath, "utf8");
+            const firstLoginUrl = findLoginUrl(firstLogin.stdout);
+            const secondLoginUrl = findLoginUrl(secondLogin.stdout);
 
             expect(firstLogin.exitCode).toBe(0);
-            expect(firstLogin.stdout).toContain(
-                "Open this URL in your browser to continue:",
-            );
-            expect(firstLogin.stdout).toContain(
+            expect(firstLoginUrl).toStartWith(
                 readAuthLoginUrlPrefix(defaultAuthEndpoint),
             );
-            expect(firstLogin.stdout).toContain("✓ Logged in to oomol.com account Alice");
-            expect(firstLogin.stdout).toContain("  - Active account: true");
             expect(secondLogin.exitCode).toBe(0);
+            expect(secondLoginUrl).toStartWith(
+                readAuthLoginUrlPrefix(defaultAuthEndpoint),
+            );
+            expect({
+                firstLogin: createAuthLoginSnapshot(firstLogin),
+                secondLogin: createAuthLoginSnapshot(secondLogin),
+            }).toMatchSnapshot();
             expect(authFileContent.split("[[auth]]").length - 1).toBe(1);
             expect(authFileContent).toContain("id = \"user-1\"");
             expect(authFileContent).toContain("api_key = \"secret-2\"");
@@ -164,14 +154,13 @@ describe("auth CLI", () => {
             const result = await runPrintedAuthLogin(sandbox, "secret-1", {
                 accountEndpoint: sandbox.env.OOMOL_ENDPOINT,
             });
+            const loginUrl = findLoginUrl(result.stdout);
 
             expect(result.exitCode).toBe(0);
-            expect(result.stdout).toContain(
+            expect(loginUrl).toStartWith(
                 readAuthLoginUrlPrefix("staging.oomol.test"),
             );
-            expect(result.stdout).toContain(
-                "✓ Logged in to staging.oomol.test account Alice",
-            );
+            expect(createAuthLoginSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -185,12 +174,13 @@ describe("auth CLI", () => {
             const result = await runPrintedAuthLogin(sandbox, "secret-1", {
                 argv: ["login"],
             });
+            const loginUrl = findLoginUrl(result.stdout);
 
             expect(result.exitCode).toBe(0);
-            expect(result.stdout).toContain(
-                "Open this URL in your browser to continue:",
+            expect(loginUrl).toStartWith(
+                readAuthLoginUrlPrefix(defaultAuthEndpoint),
             );
-            expect(result.stdout).toContain("✓ Logged in to oomol.com account Alice");
+            expect(createAuthLoginSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -209,6 +199,9 @@ describe("auth CLI", () => {
 
             expect(login.exitCode).toBe(0);
             expect(plainLoginUrl).toBeTruthy();
+            expect(createAuthLoginSnapshot(login, {
+                stripAnsi: true,
+            })).toMatchSnapshot();
             expect(login.stdout).toContain(
                 colors.hex(loginUrlColor)(plainLoginUrl!),
             );
@@ -256,7 +249,7 @@ describe("auth CLI", () => {
             const authFileContent = await readFile(authFilePath, "utf8");
 
             expect(result.exitCode).toBe(0);
-            expect(result.stdout).toContain("Logged out");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(authFileContent).toContain("id = \"\"");
             expect(authFileContent).not.toContain("id = \"user-1\"");
             expect(authFileContent).toContain("id = \"user-2\"");
@@ -294,7 +287,7 @@ describe("auth CLI", () => {
             const authFileContent = await readFile(authFilePath, "utf8");
 
             expect(result.exitCode).toBe(0);
-            expect(result.stdout).toContain("Logged out");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(authFileContent).toContain("id = \"\"");
             expect(authFileContent).not.toContain("id = \"user-1\"");
         }
@@ -349,17 +342,15 @@ describe("auth CLI", () => {
             );
 
             expect(validStatus.exitCode).toBe(0);
-            expect(validStatus.stdout).toContain("✓ Logged in to oomol.com account Alice");
-            expect(validStatus.stdout).toContain("  - Active account: true");
-            expect(validStatus.stdout).toContain("  - API key status: Valid");
-            expect(validStatus.stdout).not.toContain("saved_accounts=");
             expect(validRequests).toHaveLength(1);
             expect(validRequests[0]?.url).toBe("https://api.oomol.com/v1/users/profile");
             expect(validRequests[0]?.headers.get("Authorization")).toBe("secret-1");
 
             expect(invalidStatus.exitCode).toBe(0);
-            expect(invalidStatus.stdout).toContain("X Logged in to oomol.com account Alice");
-            expect(invalidStatus.stdout).toContain("  - API key status: Invalid");
+            expect({
+                invalidStatus: createCliSnapshot(invalidStatus),
+                validStatus: createCliSnapshot(validStatus),
+            }).toMatchSnapshot();
             expect(invalidRequests).toHaveLength(1);
             expect(invalidRequests[0]?.url).toBe("https://api.oomol.com/v1/users/profile");
             expect(invalidRequests[0]?.headers.get("Authorization")).toBe("secret-1");
@@ -409,25 +400,21 @@ describe("auth CLI", () => {
             const firstResult = await sandbox.run(["auth", "switch"]);
 
             expect(firstResult.exitCode).toBe(0);
-            expect(firstResult.stdout).toContain(
-                "✓ Switched active account for oomol.com to Bob",
-            );
             expect(await readFile(authFilePath, "utf8")).toContain("id = \"user-2\"");
 
             const secondResult = await sandbox.run(["auth", "switch"]);
 
             expect(secondResult.exitCode).toBe(0);
-            expect(secondResult.stdout).toContain(
-                "✓ Switched active account for oomol.com to Charlie",
-            );
             expect(await readFile(authFilePath, "utf8")).toContain("id = \"user-3\"");
 
             const thirdResult = await sandbox.run(["auth", "switch"]);
 
             expect(thirdResult.exitCode).toBe(0);
-            expect(thirdResult.stdout).toContain(
-                "✓ Switched active account for oomol.com to Alice",
-            );
+            expect({
+                firstSwitch: createCliSnapshot(firstResult),
+                secondSwitch: createCliSnapshot(secondResult),
+                thirdSwitch: createCliSnapshot(thirdResult),
+            }).toMatchSnapshot();
             expect(await readFile(authFilePath, "utf8")).toContain("id = \"user-1\"");
         }
         finally {
@@ -476,6 +463,9 @@ describe("auth CLI", () => {
             );
 
             expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result, {
+                stripAnsi: true,
+            })).toMatchSnapshot();
             expect(result.stdout).toContain(colors.green("✓"));
             expect(result.stdout).toContain(
                 "Switched active account for oomol.com to",
@@ -487,3 +477,28 @@ describe("auth CLI", () => {
         }
     });
 });
+
+function createAuthLoginSnapshot(
+    result: {
+        readonly exitCode: number;
+        readonly stdout: string;
+        readonly stderr: string;
+    },
+    options: {
+        readonly stripAnsi?: boolean;
+    } = {},
+) {
+    const loginUrl = findLoginUrl(result.stdout);
+
+    return createCliSnapshot(result, {
+        replacements: loginUrl === undefined
+            ? []
+            : [
+                    {
+                        placeholder: "<LOGIN_URL>",
+                        value: loginUrl,
+                    },
+                ],
+        stripAnsi: options.stripAnsi,
+    });
+}

--- a/src/application/commands/check-update.cli.test.ts
+++ b/src/application/commands/check-update.cli.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { createCliSandbox, readLatestLogContent } from "../../../__tests__/helpers.ts";
+import {
+    createCliSandbox,
+    createCliSnapshot,
+    readLatestLogContent,
+} from "../../../__tests__/helpers.ts";
 import packageManifest from "../../../package.json" with { type: "json" };
 
 const packageName = packageManifest.name;
@@ -29,7 +33,7 @@ describe("checkUpdateCommand CLI", () => {
             );
             const content = await readLatestLogContent(sandbox);
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(content).toContain(`"msg":"CLI update check started."`);
             expect(content).toContain(
                 `"msg":"CLI update latest-release request started."`,
@@ -61,7 +65,7 @@ describe("checkUpdateCommand CLI", () => {
             );
             const content = await readLatestLogContent(sandbox);
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             expect(fetchCount).toBe(0);
             expect(content).not.toContain(`"msg":"CLI update check started."`);
         }
@@ -94,16 +98,10 @@ describe("checkUpdateCommand CLI", () => {
                 },
             );
 
-            expect(firstResult.exitCode).toBe(0);
-            expect(firstResult.stdout).toContain(
-                "Unable to check for updates right now. Please try again later.",
-            );
-            expect(firstResult.stderr).toBe("");
-            expect(secondResult.exitCode).toBe(0);
-            expect(secondResult.stdout).toContain(
-                "Unable to check for updates right now. Please try again later.",
-            );
-            expect(secondResult.stderr).toBe("");
+            expect({
+                firstResult: createCliSnapshot(firstResult),
+                secondResult: createCliSnapshot(secondResult),
+            }).toMatchSnapshot();
             expect(fetchCount).toBe(4);
         }
         finally {
@@ -152,11 +150,11 @@ describe("checkUpdateCommand CLI", () => {
             );
 
             expect(firstResult.exitCode).toBe(0);
-            expect(firstResult.stdout).toContain(
-                "Unable to check for updates right now. Please try again later.",
-            );
             expect(secondResult.exitCode).toBe(0);
-            expect(secondResult.stdout).toContain("Update available 1.0.0");
+            expect({
+                firstResult: createCliSnapshot(firstResult),
+                secondResult: createCliSnapshot(secondResult),
+            }).toMatchSnapshot();
             expect(fetchCount).toBe(3);
         }
         finally {
@@ -193,12 +191,10 @@ describe("checkUpdateCommand CLI", () => {
                 },
             );
 
-            expect(firstResult.exitCode).toBe(0);
-            expect(firstResult.stdout).toContain("Update available 1.0.0");
-            expect(firstResult.stdout).toContain("1.2.0");
-            expect(secondResult.exitCode).toBe(0);
-            expect(secondResult.stdout).toContain("Update available 1.0.0");
-            expect(secondResult.stdout).toContain("1.3.0");
+            expect({
+                firstResult: createCliSnapshot(firstResult),
+                secondResult: createCliSnapshot(secondResult),
+            }).toMatchSnapshot();
             expect(fetchCount).toBe(2);
         }
         finally {
@@ -217,11 +213,7 @@ describe("checkUpdateCommand CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toContain(
-                "Current version development does not support update checks.",
-            );
-            expect(result.stderr).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/cloud-task/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/cloud-task/__snapshots__/index.cli.test.ts.snap
@@ -1,0 +1,188 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`cloudTaskCommand CLI writes package info and cloud-task request logs during task creation 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Task ID: task-1
+"
+,
+}
+`;
+
+exports[`cloudTaskCommand CLI supports cloud-task run with json output 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"{"taskID":"550e8400-e29b-41d4-a716-446655440017"}
+"
+,
+}
+`;
+
+exports[`cloudTaskCommand CLI supports cloud-task run dry-run with @file payloads 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Validation passed.
+"
+,
+}
+`;
+
+exports[`cloudTaskCommand CLI supports cloud-task result, log, and list json output 1`] = `
+{
+  "listResponse": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"{"nextToken":"eyJsYXN0SWQiOiIxMjMifQ==","tasks":[{"createdAt":1704067200000,"endTime":null,"failedMessage":null,"ownerID":"user-1","packageID":"foo","blockName":"main","progress":50,"resultURL":null,"schedulerPayload":{"type":"serverless"},"startTime":null,"status":"running","subscriptionID":null,"taskID":"550e8400-e29b-41d4-a716-446655440019","taskType":"user","updatedAt":1704067200000,"workload":"serverless","workloadID":"550e8400-e29b-41d4-a716-446655440020"}]}
+"
+,
+  },
+  "logResponse": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"{"logs":[{"level":"info","message":"running"}]}
+"
+,
+  },
+  "resultResponse": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"{"resultData":{"output":"ok"},"resultURL":"https://example.com/result.json","status":"success","traceID":"trace-1"}
+"
+,
+  },
+}
+`;
+
+exports[`cloudTaskCommand CLI supports cloud-task wait and its alias with timeout parsing 1`] = `
+{
+  "aliasResponse": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"✓ success
+  Task ID: task-2
+  Result data:
+    {
+      "output": "ok"
+    }
+"
+,
+  },
+  "waitResponse": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"✓ success
+  Task ID: task-1
+  Result data:
+    {
+      "output": "ok"
+    }
+"
+,
+  },
+}
+`;
+
+exports[`cloudTaskCommand CLI validates cloud-task wait timeout values 1`] = `
+{
+  "exitCode": 2,
+  "stderr": 
+"Invalid value for --timeout: 9s. Use 10s to 24h, with optional s, m, or h suffixes.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`cloudTaskCommand CLI treats omitted input handles with default values as optional in cloud-task run 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Validation passed.
+"
+,
+}
+`;
+
+exports[`cloudTaskCommand CLI accepts omitted and empty --data values by treating them as empty objects 1`] = `
+{
+  "emptyDataResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Validation passed.
+"
+,
+  },
+  "omittedDataResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Validation passed.
+"
+,
+  },
+}
+`;
+
+exports[`cloudTaskCommand CLI renders cloud-task result text output with colors and grouped details 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"✓ success
+  Task ID: task-1
+  Result URL: https://example.com/result.json
+  Result data:
+    {
+      "output": "ok"
+    }
+"
+,
+}
+`;
+
+exports[`cloudTaskCommand CLI renders cloud-task list text output with colors and summary blocks 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"▶ running
+  Task ID: task-1
+  Package/Block: foo / main
+  Workload: serverless
+  Progress: [=====-----] 50%
+  Created: 2024-01-01T00:00:00.000Z
+  Updated: 2024-01-01T00:00:00.000Z
+  Input values:
+    {
+      "foo": "bar"
+    }
+
+  Next token: next-token
+"
+,
+}
+`;
+
+exports[`cloudTaskCommand CLI requires a package filter when cloud-task list receives a block filter 1`] = `
+{
+  "exitCode": 2,
+  "stderr": 
+"You must provide --package-id (or --package-name) when using --block-id.
+"
+,
+  "stdout": "",
+}
+`;

--- a/src/application/commands/cloud-task/index.cli.test.ts
+++ b/src/application/commands/cloud-task/index.cli.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
     createCliSandbox,
+    createCliSnapshot,
     readLatestLogContent,
     toRequest,
 } from "../../../../__tests__/helpers.ts";
@@ -67,7 +68,7 @@ describe("cloudTaskCommand CLI", () => {
             );
             const content = await readLatestLogContent(sandbox);
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(content).toContain(`"msg":"Package info request started."`);
             expect(content).toContain(`"msg":"Package info request completed."`);
             expect(content).toContain(`"msg":"Cloud task request started."`);
@@ -156,8 +157,7 @@ describe("cloudTaskCommand CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(JSON.parse(result.stdout)).toEqual({
                 taskID: "550e8400-e29b-41d4-a716-446655440017",
             });
@@ -258,9 +258,7 @@ describe("cloudTaskCommand CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toBe("Validation passed.\n");
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             expect(requests).toHaveLength(1);
             expect(requests[0]?.url).toBe(
                 "https://registry.oomol.com/-/oomol/package-info/secret-tool/1.2.3?lang=en",
@@ -378,14 +376,17 @@ describe("cloudTaskCommand CLI", () => {
                 },
             );
 
-            expect(resultResponse.exitCode).toBe(0);
+            expect({
+                listResponse: createCliSnapshot(listResponse),
+                logResponse: createCliSnapshot(logResponse),
+                resultResponse: createCliSnapshot(resultResponse),
+            }).toMatchSnapshot();
             expect(JSON.parse(resultResponse.stdout)).toEqual({
                 resultData: { output: "ok" },
                 resultURL: "https://example.com/result.json",
                 status: "success",
                 traceID: "trace-1",
             });
-            expect(logResponse.exitCode).toBe(0);
             expect(JSON.parse(logResponse.stdout)).toEqual({
                 logs: [
                     {
@@ -394,7 +395,6 @@ describe("cloudTaskCommand CLI", () => {
                     },
                 ],
             });
-            expect(listResponse.exitCode).toBe(0);
             expect(JSON.parse(listResponse.stdout)).toEqual({
                 nextToken: "eyJsYXN0SWQiOiIxMjMifQ==",
                 tasks: [
@@ -483,32 +483,14 @@ describe("cloudTaskCommand CLI", () => {
                 },
             );
 
-            expect(waitResponse.exitCode).toBe(0);
-            expect(waitResponse.stderr).toBe("");
-            expect(createTerminalColors(true).strip(waitResponse.stdout)).toBe(
-                [
-                    "✓ success",
-                    "  Task ID: task-1",
-                    "  Result data:",
-                    "    {",
-                    "      \"output\": \"ok\"",
-                    "    }",
-                    "",
-                ].join("\n"),
-            );
-            expect(aliasResponse.exitCode).toBe(0);
-            expect(aliasResponse.stderr).toBe("");
-            expect(createTerminalColors(true).strip(aliasResponse.stdout)).toBe(
-                [
-                    "✓ success",
-                    "  Task ID: task-2",
-                    "  Result data:",
-                    "    {",
-                    "      \"output\": \"ok\"",
-                    "    }",
-                    "",
-                ].join("\n"),
-            );
+            expect({
+                aliasResponse: createCliSnapshot(aliasResponse, {
+                    stripAnsi: true,
+                }),
+                waitResponse: createCliSnapshot(waitResponse, {
+                    stripAnsi: true,
+                }),
+            }).toMatchSnapshot();
             expect(requests.map(request => request.url)).toEqual([
                 "https://cloud-task.oomol.com/v3/users/me/tasks/task-1/result",
                 "https://cloud-task.oomol.com/v3/users/me/tasks/task-2/result",
@@ -557,11 +539,7 @@ describe("cloudTaskCommand CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(2);
-            expect(result.stdout).toBe("");
-            expect(result.stderr).toBe(
-                "Invalid value for --timeout: 9s. Use 10s to 24h, with optional s, m, or h suffixes.\n",
-            );
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(fetchCount).toBe(0);
         }
         finally {
@@ -645,9 +623,7 @@ describe("cloudTaskCommand CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toBe("Validation passed.\n");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(requests).toHaveLength(1);
         }
         finally {
@@ -741,12 +717,10 @@ describe("cloudTaskCommand CLI", () => {
                 },
             );
 
-            expect(omittedDataResult.exitCode).toBe(0);
-            expect(omittedDataResult.stderr).toBe("");
-            expect(omittedDataResult.stdout).toBe("Validation passed.\n");
-            expect(emptyDataResult.exitCode).toBe(0);
-            expect(emptyDataResult.stderr).toBe("");
-            expect(emptyDataResult.stdout).toBe("Validation passed.\n");
+            expect({
+                emptyDataResult: createCliSnapshot(emptyDataResult),
+                omittedDataResult: createCliSnapshot(omittedDataResult),
+            }).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -794,20 +768,12 @@ describe("cloudTaskCommand CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(createTerminalColors(true).strip(result.stdout)).toBe(
-                [
-                    "✓ success",
-                    "  Task ID: task-1",
-                    "  Result URL: https://example.com/result.json",
-                    "  Result data:",
-                    "    {",
-                    "      \"output\": \"ok\"",
-                    "    }",
-                    "",
-                ].join("\n"),
-            );
+            expect(createCliSnapshot(
+                result,
+                {
+                    stripAnsi: true,
+                },
+            )).toMatchSnapshot();
             expect(result.stdout).toContain(colors.green("✓"));
             expect(result.stdout).toContain(colors.green.bold("success"));
             expect(result.stdout).toContain(colors.bold("task-1"));
@@ -880,26 +846,12 @@ describe("cloudTaskCommand CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(createTerminalColors(true).strip(result.stdout)).toBe(
-                [
-                    "▶ running",
-                    "  Task ID: task-1",
-                    "  Package/Block: foo / main",
-                    "  Workload: serverless",
-                    "  Progress: [=====-----] 50%",
-                    "  Created: 2024-01-01T00:00:00.000Z",
-                    "  Updated: 2024-01-01T00:00:00.000Z",
-                    "  Input values:",
-                    "    {",
-                    "      \"foo\": \"bar\"",
-                    "    }",
-                    "",
-                    "  Next token: next-token",
-                    "",
-                ].join("\n"),
-            );
+            expect(createCliSnapshot(
+                result,
+                {
+                    stripAnsi: true,
+                },
+            )).toMatchSnapshot();
             expect(result.stdout).toContain(colors.blue("▶"));
             expect(result.stdout).toContain(colors.blue.bold("running"));
             expect(result.stdout).toContain(colors.hex(searchDisplayNameColor)("foo"));
@@ -935,11 +887,7 @@ describe("cloudTaskCommand CLI", () => {
 
             const result = await sandbox.run(["cloud-task", "list", "--block-id=main"]);
 
-            expect(result.exitCode).toBe(2);
-            expect(result.stdout).toBe("");
-            expect(result.stderr).toBe(
-                "You must provide --package-id (or --package-name) when using --block-id.\n",
-            );
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/completion.cli.test.ts
+++ b/src/application/commands/completion.cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { createCliSandbox } from "../../../__tests__/helpers.ts";
+import { createCliSandbox, createCliSnapshot } from "../../../__tests__/helpers.ts";
 
 describe("completionCommand CLI", () => {
     test("renders supported shells in completion help", async () => {
@@ -9,11 +9,7 @@ describe("completionCommand CLI", () => {
         try {
             const result = await sandbox.run(["completion", "--help"]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toContain("Target shell");
-            expect(result.stdout).toContain("\"bash\"");
-            expect(result.stdout).toContain("\"zsh\"");
-            expect(result.stdout).toContain("\"fish\"");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -26,9 +22,7 @@ describe("completionCommand CLI", () => {
         try {
             const result = await sandbox.run(["--lang", "zh", "completion", "--help"]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toContain("目标 shell");
-            expect(result.stdout).toContain("(可选值: \"bash\", \"zsh\", \"fish\")");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -1,0 +1,404 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`config CLI writes settings-store and config mutation logs 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Set lang to zh.
+"
+,
+}
+`;
+
+exports[`config CLI persists the configured locale and allows explicit override 1`] = `
+{
+  "overriddenHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
+
+Options:
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
+
+Commands:
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  package                  Package utilities
+  search [options] <text>  Search packages by intent
+  help [command]           Show help for a command
+"
+,
+  },
+  "persistedHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"oo 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成
+
+选项：
+  -V, --version            显示当前版本
+  --debug                  在 CLI 退出时打印当前日志文件路径
+  --lang <lang>            指定显示语言
+  -h, --help               显示命令帮助
+
+命令：
+  auth                     管理 CLI 认证
+  check-update             检查 CLI 更新
+  cloud-task               管理云任务
+  file                     管理临时文件传输
+  login                    通过浏览器登录（auth login 的别名）
+  logout                   登出当前账号（auth logout 的别名）
+  completion <shell>       生成 shell 补全脚本
+  config                   管理持久化配置
+  skills                   管理 Codex skill
+  log                      管理持久化 debug 日志
+  package                  包相关工具
+  search [options] <text>  按意图搜索包
+  help [command]           显示命令帮助
+"
+,
+  },
+  "setResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Set lang to zh.
+"
+,
+  },
+}
+`;
+
+exports[`config CLI supports config path list get set and unset 1`] = `
+{
+  "configPath": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"<XDG_CONFIG_HOME>/oo/settings.toml
+"
+,
+  },
+  "get": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"zh
+"
+,
+  },
+  "getAfterUnset": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": "",
+  },
+  "listAfterSet": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"lang=zh
+"
+,
+  },
+  "listAfterUnset": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": "",
+  },
+  "listBeforeSet": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": "",
+  },
+  "set": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Set lang to zh.
+"
+,
+  },
+  "unset": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"已移除 lang。
+"
+,
+  },
+}
+`;
+
+exports[`config CLI supports the oo skill implicit invocation config key 1`] = `
+{
+  "get": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"false
+"
+,
+  },
+  "getAfterUnset": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": "",
+  },
+  "list": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"skills.oo.implicit_invocation=false
+"
+,
+  },
+  "set": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Set skills.oo.implicit_invocation to false.
+"
+,
+  },
+  "unset": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Removed skills.oo.implicit_invocation.
+"
+,
+  },
+}
+`;
+
+exports[`config CLI supports the file download output directory config key 1`] = `
+{
+  "get": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"~/Downloads/reports
+"
+,
+  },
+  "getAfterUnset": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": "",
+  },
+  "list": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"file.download.out_dir=~/Downloads/reports
+"
+,
+  },
+  "set": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Set file.download.out_dir to ~/Downloads/reports.
+"
+,
+  },
+  "unset": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Removed file.download.out_dir.
+"
+,
+  },
+}
+`;
+
+exports[`config CLI config set immediately synchronizes the installed managed skill policy 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Set skills.oo.implicit_invocation to false.
+"
+,
+}
+`;
+
+exports[`config CLI config unset immediately restores the installed managed skill policy default 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Removed skills.oo.implicit_invocation.
+"
+,
+}
+`;
+
+exports[`config CLI renders config list help with configured wording 1`] = `
+{
+  "chineseConfigHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"读取并更新持久化的用户配置。
+
+选项：
+  -h, --help         显示命令帮助
+
+全局选项：
+  -V, --version      显示当前版本
+  --debug            在 CLI 退出时打印当前日志文件路径
+  --lang <lang>      指定显示语言
+
+命令：
+  list               查看已配置的配置值
+  get <key>          读取配置值
+  path               显示配置文件路径
+  set <key> <value>  持久化配置值
+  unset <key>        移除配置值
+  help [command]     显示命令帮助
+"
+,
+  },
+  "chineseListHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"查看当前已配置的全部持久化配置值。
+
+选项：
+  -h, --help     显示命令帮助
+
+全局选项：
+  -V, --version  显示当前版本
+  --debug        在 CLI 退出时打印当前日志文件路径
+  --lang <lang>  指定显示语言
+"
+,
+  },
+  "englishConfigHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Read and update persisted user settings.
+
+Options:
+  -h, --help         Show help for command
+
+Global Options:
+  -V, --version      Show the current version
+  --debug            Print the current log file path when the CLI exits
+  --lang <lang>      Specify the display language
+
+Commands:
+  list               List configured values
+  get <key>          Read a configuration value
+  path               Show config file path
+  set <key> <value>  Persist a configuration value
+  unset <key>        Remove a configuration value
+  help [command]     Show help for a command
+"
+,
+  },
+  "englishListHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Print all persisted configuration values that are currently configured.
+
+Options:
+  -h, --help     Show help for command
+
+Global Options:
+  -V, --version  Show the current version
+  --debug        Print the current log file path when the CLI exits
+  --lang <lang>  Specify the display language
+"
+,
+  },
+}
+`;
+
+exports[`config CLI creates a default settings file on first read 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": "",
+}
+`;
+
+exports[`config CLI returns usage errors for invalid config inputs 1`] = `
+{
+  "invalidConfigValue": {
+    "exitCode": 2,
+    "stderr": 
+"Invalid lang value: fr. Use en or zh.
+"
+,
+    "stdout": "",
+  },
+  "invalidKey": {
+    "exitCode": 2,
+    "stderr": 
+"Invalid config key: update-notifier.
+"
+,
+    "stdout": "",
+  },
+  "invalidSkillPolicyValue": {
+    "exitCode": 2,
+    "stderr": 
+"Invalid skills.oo.implicit_invocation value: maybe. Use true or false.
+"
+,
+    "stdout": "",
+  },
+}
+`;
+
+exports[`config CLI returns runtime errors when the persisted store is corrupted 1`] = `
+{
+  "exitCode": 1,
+  "stderr": 
+"The settings file at <XDG_CONFIG_HOME>/oo/settings.toml is not valid TOML.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`config CLI reads TOML settings files 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"zh
+"
+,
+}
+`;
+
+exports[`config CLI ignores unknown persisted settings keys and logs a warning 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"zh
+"
+,
+}
+`;

--- a/src/application/commands/config/index.cli.test.ts
+++ b/src/application/commands/config/index.cli.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
     createCliSandbox,
+    createCliSnapshot,
     defaultSettingsFileContent,
     readLatestLogContent,
 } from "../../../../__tests__/helpers.ts";
@@ -22,7 +23,7 @@ describe("config CLI", () => {
             const result = await sandbox.run(["config", "set", "lang", "zh"]);
             const content = await readLatestLogContent(sandbox);
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(content).toContain(
                 `"msg":"Settings store file was missing. Initializing a default file."`,
             );
@@ -45,7 +46,11 @@ describe("config CLI", () => {
             const persistedHelp = await sandbox.run(["--help"]);
             const overriddenHelp = await sandbox.run(["--lang", "en", "--help"]);
 
-            expect(setResult.exitCode).toBe(0);
+            expect({
+                overriddenHelp: createCliSnapshot(overriddenHelp),
+                persistedHelp: createCliSnapshot(persistedHelp),
+                setResult: createCliSnapshot(setResult),
+            }).toMatchSnapshot();
             expect(setResult.stdout).toContain("Set lang to zh.");
             expect(persistedHelp.stdout).not.toContain("用法：");
             expect(overriddenHelp.stdout).not.toContain("Usage:");
@@ -68,20 +73,16 @@ describe("config CLI", () => {
             const listAfterUnsetResult = await sandbox.run(["config", "list"]);
             const getAfterUnsetResult = await sandbox.run(["config", "get", "lang"]);
 
-            expect(configPathResult.exitCode).toBe(0);
-            expect(configPathResult.stdout).toBe(
-                `${join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml")}\n`,
-            );
-            expect(listBeforeSetResult.exitCode).toBe(0);
-            expect(listBeforeSetResult.stdout).toBe("");
-            expect(setResult.exitCode).toBe(0);
-            expect(listAfterSetResult.exitCode).toBe(0);
-            expect(listAfterSetResult.stdout).toBe("lang=zh\n");
-            expect(getResult.stdout).toBe("zh\n");
-            expect(unsetResult.exitCode).toBe(0);
-            expect(listAfterUnsetResult.exitCode).toBe(0);
-            expect(listAfterUnsetResult.stdout).toBe("");
-            expect(getAfterUnsetResult.stdout).toBe("");
+            expect({
+                configPath: createCliSnapshot(configPathResult, { sandbox }),
+                get: createCliSnapshot(getResult, { sandbox }),
+                getAfterUnset: createCliSnapshot(getAfterUnsetResult, { sandbox }),
+                listAfterSet: createCliSnapshot(listAfterSetResult, { sandbox }),
+                listAfterUnset: createCliSnapshot(listAfterUnsetResult, { sandbox }),
+                listBeforeSet: createCliSnapshot(listBeforeSetResult, { sandbox }),
+                set: createCliSnapshot(setResult, { sandbox }),
+                unset: createCliSnapshot(unsetResult, { sandbox }),
+            }).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -115,16 +116,13 @@ describe("config CLI", () => {
                 "skills.oo.implicit_invocation",
             ]);
 
-            expect(setResult.exitCode).toBe(0);
-            expect(setResult.stdout).toBe(
-                "Set skills.oo.implicit_invocation to false.\n",
-            );
-            expect(listResult.stdout).toBe(
-                "skills.oo.implicit_invocation=false\n",
-            );
-            expect(getResult.stdout).toBe("false\n");
-            expect(unsetResult.exitCode).toBe(0);
-            expect(getAfterUnsetResult.stdout).toBe("");
+            expect({
+                get: createCliSnapshot(getResult),
+                getAfterUnset: createCliSnapshot(getAfterUnsetResult),
+                list: createCliSnapshot(listResult),
+                set: createCliSnapshot(setResult),
+                unset: createCliSnapshot(unsetResult),
+            }).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -158,16 +156,13 @@ describe("config CLI", () => {
                 "file.download.out_dir",
             ]);
 
-            expect(setResult.exitCode).toBe(0);
-            expect(setResult.stdout).toBe(
-                "Set file.download.out_dir to ~/Downloads/reports.\n",
-            );
-            expect(listResult.stdout).toBe(
-                "file.download.out_dir=~/Downloads/reports\n",
-            );
-            expect(getResult.stdout).toBe("~/Downloads/reports\n");
-            expect(unsetResult.exitCode).toBe(0);
-            expect(getAfterUnsetResult.stdout).toBe("");
+            expect({
+                get: createCliSnapshot(getResult),
+                getAfterUnset: createCliSnapshot(getAfterUnsetResult),
+                list: createCliSnapshot(listResult),
+                set: createCliSnapshot(setResult),
+                unset: createCliSnapshot(unsetResult),
+            }).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -200,7 +195,7 @@ describe("config CLI", () => {
                 version: "9.9.9",
             });
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(await readFile(ownershipFilePath, "utf8")).toContain(
                 "allow_implicit_invocation: false",
             );
@@ -257,7 +252,7 @@ describe("config CLI", () => {
                 version: "9.9.9",
             });
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(await readFile(ownershipFilePath, "utf8")).toContain(
                 "allow_implicit_invocation: true",
             );
@@ -276,7 +271,12 @@ describe("config CLI", () => {
             const chineseConfigHelp = await sandbox.run(["--lang", "zh", "config", "--help"]);
             const chineseListHelp = await sandbox.run(["--lang", "zh", "config", "list", "--help"]);
 
-            expect(englishConfigHelp.exitCode).toBe(0);
+            expect({
+                chineseConfigHelp: createCliSnapshot(chineseConfigHelp),
+                chineseListHelp: createCliSnapshot(chineseListHelp),
+                englishConfigHelp: createCliSnapshot(englishConfigHelp),
+                englishListHelp: createCliSnapshot(englishListHelp),
+            }).toMatchSnapshot();
             expect(englishConfigHelp.stdout).toContain("List configured values");
             expect(englishConfigHelp.stdout).toContain("Show config file path");
 
@@ -309,9 +309,7 @@ describe("config CLI", () => {
 
             const result = await sandbox.run(["config", "list"]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe("");
-            expect(result.stderr).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(await readFile(filePath, "utf8")).toBe(defaultSettingsFileContent);
         }
         finally {
@@ -332,14 +330,16 @@ describe("config CLI", () => {
                 "maybe",
             ]);
 
-            expect(invalidKey.exitCode).toBe(2);
+            expect({
+                invalidConfigValue: createCliSnapshot(invalidConfigValue),
+                invalidKey: createCliSnapshot(invalidKey),
+                invalidSkillPolicyValue: createCliSnapshot(invalidSkillPolicyValue),
+            }).toMatchSnapshot();
             expect(invalidKey.stderr).toContain("Invalid config key");
             expect(invalidKey.stderr).not.toContain("Supported keys");
 
-            expect(invalidConfigValue.exitCode).toBe(2);
             expect(invalidConfigValue.stderr).toContain("Invalid lang value");
 
-            expect(invalidSkillPolicyValue.exitCode).toBe(2);
             expect(invalidSkillPolicyValue.stderr).toContain(
                 "Invalid skills.oo.implicit_invocation value",
             );
@@ -364,7 +364,7 @@ describe("config CLI", () => {
             const result = await sandbox.run(["config", "get", "lang"]);
             const content = await readLatestLogContent(sandbox);
 
-            expect(result.exitCode).toBe(1);
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             expect(result.stderr).toContain("settings file");
             expect(content).toContain(`"category":"system_error"`);
             expect(content).toContain(`"key":"errors.store.invalidToml"`);
@@ -391,9 +391,7 @@ describe("config CLI", () => {
 
             const result = await sandbox.run(["config", "get", "lang"]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe("zh\n");
-            expect(result.stderr).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -418,9 +416,7 @@ describe("config CLI", () => {
             const result = await sandbox.run(["config", "get", "lang"]);
             const content = await readLatestLogContent(sandbox);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe("zh\n");
-            expect(result.stderr).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(content).toContain(`"level":"warn"`);
             expect(content).toContain(
                 `"msg":"Settings store file contained unknown keys that were ignored."`,

--- a/src/application/commands/file/__snapshots__/download-resume.cli.test.ts.snap
+++ b/src/application/commands/file/__snapshots__/download-resume.cli.test.ts.snap
@@ -1,0 +1,68 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`file download resume CLI preserves the temporary file and resume session when file download fails mid-download 1`] = `
+{
+  "exitCode": 1,
+  "stderr": 
+"Downloading 0 B
+
+Downloading 7 B
+Failed to download the file at <HOME>/downloads/broken.oodownload: Connection dropped.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`file download resume CLI cleans up download resume sessions older than 14 days when file download starts 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Saved to: <HOME>/downloads/fresh.txt
+"
+,
+}
+`;
+
+exports[`file download resume CLI resumes file download with HTTP Range after a mid-download failure 1`] = `
+{
+  "firstResult": {
+    "exitCode": 1,
+    "stderr": 
+"Failed to download the file at <HOME>/downloads/broken.oodownload: Connection dropped.
+"
+,
+    "stdout": "",
+  },
+  "secondResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Saved to: <HOME>/downloads/broken.txt
+"
+,
+  },
+}
+`;
+
+exports[`file download resume CLI restarts file download from the beginning when the server ignores Range 1`] = `
+{
+  "firstResult": {
+    "exitCode": 1,
+    "stderr": 
+"Failed to download the file at <HOME>/downloads/restart.oodownload: Connection dropped.
+"
+,
+    "stdout": "",
+  },
+  "secondResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Saved to: <HOME>/downloads/restart.txt
+"
+,
+  },
+}
+`;

--- a/src/application/commands/file/__snapshots__/download.cli.test.ts.snap
+++ b/src/application/commands/file/__snapshots__/download.cli.test.ts.snap
@@ -1,0 +1,189 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`file download CLI supports file download, creates missing directories, and prints the labeled saved path 1`] = `
+{
+  "exitCode": 0,
+  "stderr": 
+"Downloading 0 B / 11 B (0%)
+
+Downloaded 11 B / 11 B (100%)
+"
+,
+  "stdout": 
+"Saved to: <HOME>/downloads/reports/report.tar.gz
+"
+,
+}
+`;
+
+exports[`file download CLI renders file download progress with human-readable byte units 1`] = `
+{
+  "exitCode": 0,
+  "stderr": 
+"Downloading 0 B / 2 KB (0%)
+
+Downloaded 2 KB / 2 KB (100%)
+"
+,
+  "stdout": 
+"Saved to: <HOME>/downloads/reports/archive.bin
+"
+,
+}
+`;
+
+exports[`file download CLI keeps the cursor on the line below file download progress output 1`] = `
+{
+  "exitCode": 0,
+  "stderr": 
+"Downloading 0 B / 4 B (0%)
+\x1B[1A
+\x1B[2KDownloaded 4 B / 4 B (100%)
+"
+,
+  "stdout": 
+"Saved to: <HOME>/downloads/reports/chunked.bin
+"
+,
+}
+`;
+
+exports[`file download CLI uses the default downloads directory when file download output directory is omitted 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Saved to: <HOME>/Downloads/report.txt
+"
+,
+}
+`;
+
+exports[`file download CLI uses the configured file download output directory and expands a leading tilde 1`] = `
+{
+  "download": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Saved to: <HOME>/Downloads/reports/report.txt
+"
+,
+  },
+  "setConfig": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Set file.download.out_dir to ~/Downloads/reports.
+"
+,
+  },
+}
+`;
+
+exports[`file download CLI uses the current cli working directory when file.download.out_dir is dot 1`] = `
+{
+  "download": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Saved to: <CWD>/config-dot-target.txt
+"
+,
+  },
+  "setConfig": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Set file.download.out_dir to ..
+"
+,
+  },
+}
+`;
+
+exports[`file download CLI auto-renames conflicting targets and removes temporary files after file download 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Saved to: <HOME>/downloads/download_1.pdf
+"
+,
+}
+`;
+
+exports[`file download CLI fails file download when the output path already exists as a file 1`] = `
+{
+  "exitCode": 1,
+  "stderr": 
+"The output path <HOME>/not-a-directory exists but is not a directory.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`file download CLI fails file download before fetching when the url is invalid 1`] = `
+{
+  "exitCode": 2,
+  "stderr": 
+"Invalid URL: ftp://example.com/file.txt. Use an http or https URL.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`file download CLI fails file download before fetching when --name or --ext is invalid 1`] = `
+{
+  "invalidExt": {
+    "exitCode": 2,
+    "stderr": 
+"Invalid value for --ext: ..txt. Use a non-empty extension without path separators.
+"
+,
+    "stdout": "",
+  },
+  "invalidName": {
+    "exitCode": 2,
+    "stderr": 
+"Invalid value for --name: ... Use a non-empty file name without path separators.
+"
+,
+    "stdout": "",
+  },
+}
+`;
+
+exports[`file download CLI fails file download when the download request returns a non-success status 1`] = `
+{
+  "exitCode": 1,
+  "stderr": 
+"The download request returned HTTP 404.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`file download CLI fails file download when the output directory cannot be created 1`] = `
+{
+  "exitCode": 1,
+  "stderr": 
+"Failed to prepare the output directory <HOME>/occupied/nested: ENOTDIR: not a directory, stat '<HOME>/occupied/nested'
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`file download CLI uses the default download file name when the final response url has no file segment 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Saved to: <HOME>/downloads/download
+"
+,
+}
+`;

--- a/src/application/commands/file/__snapshots__/list-cleanup.cli.test.ts.snap
+++ b/src/application/commands/file/__snapshots__/list-cleanup.cli.test.ts.snap
@@ -1,0 +1,18 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`file list and cleanup CLI supports file list filters and cleanup json output 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"active.txt
+  - ID: 0195f5fe-ec28-7000-8000-000000000009
+  - File size: 11 B
+  - Uploaded at: 1970-01-01T00:00:03.000Z
+  - Expires at: 3000-01-01T00:00:00.000Z
+  - Status: active
+  - Download URL: https://download.example.com/active
+"
+,
+}
+`;

--- a/src/application/commands/file/__snapshots__/upload.cli.test.ts.snap
+++ b/src/application/commands/file/__snapshots__/upload.cli.test.ts.snap
@@ -1,0 +1,63 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`file upload CLI supports file upload and persists the uploaded record 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Uploaded sample.txt.
+  - ID: <UPLOAD_ID>
+  - File size: 11 B
+  - Uploaded at: <UPLOADED_AT>
+  - Expires at: 3026-03-27T00:00:00.000Z
+  - Status: active
+  - Download URL: https://download.example.com/file-1?signature=abc
+"
+,
+}
+`;
+
+exports[`file upload CLI supports file upload json output for both --json and --format=json 1`] = `
+{
+  "jsonAliasResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"{"downloadUrl":"https://download.example.com/file-1?signature=abc","expiresAt":"3026-03-27T00:00:00.000Z","fileName":"sample-json.txt","fileSize":11,"id":"<UPLOAD_ID>","status":"active","uploadedAt":"<UPLOADED_AT>"}
+"
+,
+  },
+  "jsonFormatResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"{"downloadUrl":"https://download.example.com/file-2?signature=abc","expiresAt":"3026-03-27T00:00:00.000Z","fileName":"sample-format.txt","fileSize":13,"id":"<UPLOAD_ID>","status":"active","uploadedAt":"<UPLOADED_AT>"}
+"
+,
+  },
+}
+`;
+
+exports[`file upload CLI supports file upload command help with the --json alias 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Upload a file and store the signed download URL locally.
+
+Arguments:
+  filePath           File path
+
+Options:
+  --format <format>  Specify output format (use json for structured output)
+  --json             Alias for --format=json
+  -h, --help         Show help for command
+
+Global Options:
+  -V, --version      Show the current version
+  --debug            Print the current log file path when the CLI exits
+  --lang <lang>      Specify the display language
+"
+,
+}
+`;

--- a/src/application/commands/file/download-resume.cli.test.ts
+++ b/src/application/commands/file/download-resume.cli.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test } from "bun:test";
 import {
     countDownloadResumeSessions,
     createCliSandbox,
-    readFileDownloadSuccessOutput,
+    createCliSnapshot,
 } from "../../../../__tests__/helpers.ts";
 import {
     SqliteFileDownloadSessionStore,
@@ -68,10 +68,13 @@ describe("file download resume CLI", () => {
             );
 
             expect(result.exitCode).toBe(1);
-            expect(result.stdout).toBe("");
-            expect(result.stderr).toContain("Downloading");
-            expect(result.stderr).not.toContain("Downloaded");
-            expect(result.stderr).toContain("Connection dropped.");
+            expect(createCliSnapshot(
+                result,
+                {
+                    sandbox,
+                    stripAnsi: true,
+                },
+            )).toMatchSnapshot();
             const outputEntries = await readdir(outputDirectoryPath);
 
             expect(outputEntries).toHaveLength(1);
@@ -133,7 +136,7 @@ describe("file download resume CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             expect(countDownloadResumeSessions(downloadSessionsFilePath)).toBe(0);
         }
         finally {
@@ -236,10 +239,11 @@ describe("file download resume CLI", () => {
             const downloadedFilePath = join(outputDirectoryPath, "broken.txt");
 
             expect(firstResult.exitCode).toBe(1);
-            expect(firstResult.stderr).toContain("Connection dropped.");
             expect(secondResult.exitCode).toBe(0);
-            expect(secondResult.stderr).toBe("");
-            expect(secondResult.stdout).toBe(readFileDownloadSuccessOutput(downloadedFilePath));
+            expect({
+                firstResult: createCliSnapshot(firstResult, { sandbox }),
+                secondResult: createCliSnapshot(secondResult, { sandbox }),
+            }).toMatchSnapshot();
             expect(requestCount).toBe(2);
             await expect(Bun.file(downloadedFilePath).text()).resolves.toBe("partial-payload");
             expect(await readdir(outputDirectoryPath)).toEqual([
@@ -345,8 +349,10 @@ describe("file download resume CLI", () => {
 
             expect(firstResult.exitCode).toBe(1);
             expect(secondResult.exitCode).toBe(0);
-            expect(secondResult.stderr).toBe("");
-            expect(secondResult.stdout).toBe(readFileDownloadSuccessOutput(downloadedFilePath));
+            expect({
+                firstResult: createCliSnapshot(firstResult, { sandbox }),
+                secondResult: createCliSnapshot(secondResult, { sandbox }),
+            }).toMatchSnapshot();
             expect(requestCount).toBe(2);
             await expect(Bun.file(downloadedFilePath).text()).resolves.toBe("stale-payload");
             expect(await readdir(outputDirectoryPath)).toEqual([

--- a/src/application/commands/file/download.cli.test.ts
+++ b/src/application/commands/file/download.cli.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
     createCliSandbox,
-    readFileDownloadSuccessOutput,
+    createCliSnapshot,
 } from "../../../../__tests__/helpers.ts";
 
 describe("file download CLI", () => {
@@ -46,10 +46,13 @@ describe("file download CLI", () => {
             );
             const downloadedFilePath = join(outputDirectoryPath, "report.tar.gz");
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(readFileDownloadSuccessOutput(downloadedFilePath));
-            expect(result.stderr).toContain("Downloaded");
-            expect(result.stderr).toContain("100%");
+            expect(createCliSnapshot(
+                result,
+                {
+                    sandbox,
+                    stripAnsi: true,
+                },
+            )).toMatchSnapshot();
             await expect(Bun.file(downloadedFilePath).text()).resolves.toBe("hello world");
         }
         finally {
@@ -86,8 +89,10 @@ describe("file download CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toContain("2 KB / 2 KB (100%)");
+            expect(createCliSnapshot(result, {
+                sandbox,
+                stripAnsi: true,
+            })).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -128,11 +133,7 @@ describe("file download CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe(
-                "Downloading 0 B / 4 B (0%)\n"
-                + "\u001B[1A\r\u001B[2KDownloaded 4 B / 4 B (100%)\n",
-            );
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -163,8 +164,7 @@ describe("file download CLI", () => {
             );
             const downloadedFilePath = join(outputDirectoryPath, "report.txt");
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(readFileDownloadSuccessOutput(downloadedFilePath));
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             await expect(Bun.file(downloadedFilePath).text()).resolves.toBe(
                 "default target",
             );
@@ -204,9 +204,10 @@ describe("file download CLI", () => {
             );
             const downloadedFilePath = join(outputDirectoryPath, "report.txt");
 
-            expect(setConfigResult.exitCode).toBe(0);
-            expect(downloadResult.exitCode).toBe(0);
-            expect(downloadResult.stdout).toBe(readFileDownloadSuccessOutput(downloadedFilePath));
+            expect({
+                download: createCliSnapshot(downloadResult, { sandbox }),
+                setConfig: createCliSnapshot(setConfigResult, { sandbox }),
+            }).toMatchSnapshot();
             await expect(Bun.file(downloadedFilePath).text()).resolves.toBe(
                 "configured target",
             );
@@ -246,9 +247,10 @@ describe("file download CLI", () => {
             );
             const downloadedFilePath = join(outputDirectoryPath, "config-dot-target.txt");
 
-            expect(setConfigResult.exitCode).toBe(0);
-            expect(downloadResult.exitCode).toBe(0);
-            expect(downloadResult.stdout).toBe(readFileDownloadSuccessOutput(downloadedFilePath));
+            expect({
+                download: createCliSnapshot(downloadResult, { sandbox }),
+                setConfig: createCliSnapshot(setConfigResult, { sandbox }),
+            }).toMatchSnapshot();
             await expect(Bun.file(downloadedFilePath).text()).resolves.toBe("cwd target");
         }
         finally {
@@ -283,11 +285,7 @@ describe("file download CLI", () => {
             );
             const outputEntries = await readdir(outputDirectoryPath);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toBe(
-                readFileDownloadSuccessOutput(join(outputDirectoryPath, "download_1.pdf")),
-            );
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             expect(outputEntries).toHaveLength(3);
             expect(outputEntries).toEqual(expect.arrayContaining([
                 "download.pdf",
@@ -326,8 +324,7 @@ describe("file download CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(1);
-            expect(result.stdout).toBe("");
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             expect(result.stderr).toContain("not a directory");
             expect(fetchCount).toBe(0);
         }
@@ -355,8 +352,7 @@ describe("file download CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(2);
-            expect(result.stdout).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(result.stderr).toContain("Invalid URL");
             expect(fetchCount).toBe(0);
         }
@@ -401,12 +397,12 @@ describe("file download CLI", () => {
                 },
             );
 
-            expect(invalidNameResult.exitCode).toBe(2);
-            expect(invalidNameResult.stdout).toBe("");
+            expect({
+                invalidExt: createCliSnapshot(invalidExtResult),
+                invalidName: createCliSnapshot(invalidNameResult),
+            }).toMatchSnapshot();
             expect(invalidNameResult.stderr).toContain("Invalid value for --name");
 
-            expect(invalidExtResult.exitCode).toBe(2);
-            expect(invalidExtResult.stdout).toBe("");
             expect(invalidExtResult.stderr).toContain("Invalid value for --ext");
             expect(fetchCount).toBe(0);
         }
@@ -436,8 +432,7 @@ describe("file download CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(1);
-            expect(result.stdout).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(result.stderr).toContain("HTTP 404");
             expect(await readdir(outputDirectoryPath)).toEqual([]);
         }
@@ -470,8 +465,7 @@ describe("file download CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(1);
-            expect(result.stdout).toBe("");
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             expect(result.stderr).toContain("Failed to prepare the output directory");
             expect(fetchCount).toBe(0);
         }
@@ -507,11 +501,7 @@ describe("file download CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toBe(
-                readFileDownloadSuccessOutput(join(outputDirectoryPath, "download")),
-            );
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             await expect(Bun.file(join(outputDirectoryPath, "download")).text()).resolves.toBe(
                 "payload",
             );

--- a/src/application/commands/file/list-cleanup.cli.test.ts
+++ b/src/application/commands/file/list-cleanup.cli.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 
-import { createCliSandbox } from "../../../../__tests__/helpers.ts";
+import { createCliSandbox, createCliSnapshot } from "../../../../__tests__/helpers.ts";
 import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 
@@ -75,9 +75,7 @@ describe("file list and cleanup CLI", () => {
             );
 
             expect(listTextResult.exitCode).toBe(0);
-            expect(listTextResult.stderr).toBe("");
-            expect(listTextResult.stdout).toContain("active.txt");
-            expect(listTextResult.stdout).toContain("https://download.example.com/active");
+            expect(createCliSnapshot(listTextResult)).toMatchSnapshot();
 
             expect(listJsonResult.exitCode).toBe(0);
             expect(JSON.parse(listJsonResult.stdout)).toEqual([

--- a/src/application/commands/file/upload.cli.test.ts
+++ b/src/application/commands/file/upload.cli.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
     createCliSandbox,
+    createCliSnapshot,
     toRequest,
     writeAuthFile,
 } from "../../../../__tests__/helpers.ts";
@@ -72,12 +73,7 @@ describe("file upload CLI", () => {
             });
 
             try {
-                expect(result.exitCode).toBe(0);
-                expect(result.stderr).toBe("");
-                expect(result.stdout).toContain("Uploaded sample.txt.");
-                expect(result.stdout).toContain(
-                    "https://download.example.com/file-1?signature=abc",
-                );
+                expect(createFileUploadSnapshot(result)).toMatchSnapshot();
                 expect(requests.map(request => request.url)).toEqual([
                     "https://llm.oomol.com/api/tasks/files/remote-cache/init",
                     "https://storage.example.com/upload/1",
@@ -181,8 +177,10 @@ describe("file upload CLI", () => {
                 },
             );
 
-            expect(jsonAliasResult.exitCode).toBe(0);
-            expect(jsonAliasResult.stderr).toBe("");
+            expect({
+                jsonAliasResult: createFileUploadJsonSnapshot(jsonAliasResult),
+                jsonFormatResult: createFileUploadJsonSnapshot(jsonFormatResult),
+            }).toMatchSnapshot();
             expect(JSON.parse(jsonAliasResult.stdout)).toMatchObject({
                 downloadUrl: "https://download.example.com/file-1?signature=abc",
                 expiresAt: "3026-03-27T00:00:00.000Z",
@@ -190,8 +188,6 @@ describe("file upload CLI", () => {
                 fileSize: 11,
                 status: "active",
             });
-            expect(jsonFormatResult.exitCode).toBe(0);
-            expect(jsonFormatResult.stderr).toBe("");
             expect(JSON.parse(jsonFormatResult.stdout)).toMatchObject({
                 downloadUrl: "https://download.example.com/file-2?signature=abc",
                 expiresAt: "3026-03-27T00:00:00.000Z",
@@ -213,13 +209,84 @@ describe("file upload CLI", () => {
         try {
             const result = await sandbox.run(["file", "upload", "--help"]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toContain("--json");
-            expect(result.stdout).toContain("Alias for --format=json");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
         }
     });
 });
+
+function createFileUploadSnapshot(
+    result: {
+        readonly exitCode: number;
+        readonly stdout: string;
+        readonly stderr: string;
+    },
+) {
+    return createCliSnapshot(result, {
+        replacements: [
+            createOutputLineReplacement(result.stdout, "  - ID: ", "<UPLOAD_ID>"),
+            createOutputLineReplacement(result.stdout, "  - Uploaded at: ", "<UPLOADED_AT>"),
+        ].filter((replacement): replacement is {
+            readonly placeholder: string;
+            readonly value: string;
+        } => replacement !== undefined),
+    });
+}
+
+function createFileUploadJsonSnapshot(
+    result: {
+        readonly exitCode: number;
+        readonly stdout: string;
+        readonly stderr: string;
+    },
+) {
+    const output = JSON.parse(result.stdout) as {
+        id?: string;
+        uploadedAt?: string;
+    };
+
+    return createCliSnapshot(result, {
+        replacements: [
+            createOptionalReplacement("<UPLOAD_ID>", output.id),
+            createOptionalReplacement("<UPLOADED_AT>", output.uploadedAt),
+        ].filter((replacement): replacement is {
+            readonly placeholder: string;
+            readonly value: string;
+        } => replacement !== undefined),
+    });
+}
+
+function createOutputLineReplacement(
+    output: string,
+    prefix: string,
+    placeholder: string,
+) {
+    const line = output
+        .split("\n")
+        .find(candidate => candidate.startsWith(prefix));
+
+    if (line === undefined) {
+        return undefined;
+    }
+
+    return {
+        placeholder,
+        value: line.slice(prefix.length),
+    };
+}
+
+function createOptionalReplacement(
+    placeholder: string,
+    value: string | undefined,
+) {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    return {
+        placeholder,
+        value,
+    };
+}

--- a/src/application/commands/log/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/log/__snapshots__/index.cli.test.ts.snap
@@ -1,0 +1,34 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`log CLI prints the resolved log directory path 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"<HOME>/Library/Logs/oo
+"
+,
+}
+`;
+
+exports[`log CLI prints the previous log file by default 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"second-log
+"
+,
+}
+`;
+
+exports[`log CLI prints a selected previous log file by index 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"second-log
+"
+,
+}
+`;

--- a/src/application/commands/log/index.cli.test.ts
+++ b/src/application/commands/log/index.cli.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
-import { createCliSandbox } from "../../../../__tests__/helpers.ts";
+import { createCliSandbox, createCliSnapshot } from "../../../../__tests__/helpers.ts";
 import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 
@@ -12,16 +12,9 @@ describe("log CLI", () => {
         const sandbox = await createCliSandbox();
 
         try {
-            const logDirectoryPath = resolveStorePaths({
-                appName: APP_NAME,
-                env: sandbox.env,
-                platform: process.platform,
-            }).logDirectoryPath;
             const result = await sandbox.run(["log", "path"]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(`${logDirectoryPath}\n`);
-            expect(result.stderr).toBe("");
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -44,9 +37,7 @@ describe("log CLI", () => {
 
             const result = await sandbox.run(["log", "print"]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe("second-log\n");
-            expect(result.stderr).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -70,9 +61,7 @@ describe("log CLI", () => {
 
             const result = await sandbox.run(["log", "print", "2"]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe("second-log\n");
-            expect(result.stderr).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/package/__snapshots__/info.cli.test.ts.snap
+++ b/src/application/commands/package/__snapshots__/info.cli.test.ts.snap
@@ -1,0 +1,166 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`packageInfoCommand CLI supports package info command with text output 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"QR Code (qrcode@1.0.4)
+The QR Code Toolkit.
+
+- Exist QR Code (Exist)
+  Checks whether an image contains a QR code.
+  Input:
+    - input  string (image)  [optional]  Image input
+    - tags   Array<string>   [required]  Tag list
+    - mode   string          [optional]  Scan mode
+    - count  integer         [optional]  Retry count
+  Output:
+    - output    boolean  Boolean result
+    - metadata  unknown  Unstructured metadata
+
+- Decode QR Code (Decode)
+  Reads the QR code payload from an image.
+  Input:
+    - image  string (image)  [required]  Image to decode
+  Output:
+    - text  string  Decoded text payload
+"
+,
+}
+`;
+
+exports[`packageInfoCommand CLI normalizes input ext metadata, applies input schema patches, and keeps output handle schema raw in package info json output 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"{"blocks":[{"blockName":"Exist","description":"Checks whether an image contains a QR code.","inputHandle":{"input":{"description":"Image input","ext":{"anyOf":[{"widget":"text"}]},"nullable":false,"schema":{"anyOf":[{"type":"string"}]},"value":"sample.png"},"placeholder":{"description":"Optional placeholder","nullable":true,"schema":{"type":"string"},"value":null},"fileInput":{"description":"Input file","ext":{"widget":"file"},"schema":{"type":"string","format":"uri"}},"excludes":{"description":"Excluded usernames","schema":{"type":"array","items":{"type":"string"}},"value":["alice","bob"]},"count":{"description":"Winner count","schema":{"type":"integer"},"value":3},"tags":{"description":"Tag list","schema":{"type":"array","items":{"type":"string"}}}},"outputHandle":{"output":{"description":"Boolean result","schema":{"type":"boolean","ui:widget":"switch","ui:tone":"success"}}},"title":"Exist QR Code"}],"description":"The QR Code Toolkit.","displayName":"QR Code","packageName":"qrcode","packageVersion":"1.0.4"}
+"
+,
+}
+`;
+
+exports[`packageInfoCommand CLI supports package info package specifier variants and json output 1`] = `
+[
+  {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"{"blocks":[],"description":"Inspect PDF files","displayName":"PDF Toolkit","packageName":"pdf","packageVersion":"1.0.0"}
+"
+,
+  },
+  {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"{"blocks":[],"description":"Inspect PDF files","displayName":"PDF Toolkit","packageName":"pdf","packageVersion":"1.0.0"}
+"
+,
+  },
+  {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"{"blocks":[],"description":"Read EPUB packages","displayName":"Scoped EPUB","packageName":"@foo/epub","packageVersion":"2.0.0"}
+"
+,
+  },
+  {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"{"blocks":[],"description":"Read EPUB packages","displayName":"Bar EPUB","packageName":"@bar/epub","packageVersion":"1.0.0"}
+"
+,
+  },
+  {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"{"blocks":[],"description":"Read Markdown packages","displayName":"Baz Markdown","packageName":"@baz@md","packageVersion":"3.2.1"}
+"
+,
+  },
+]
+`;
+
+exports[`packageInfoCommand CLI reuses cached package info responses for explicit versions 1`] = `
+{
+  "firstResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"QR Code (qrcode@1.0.4)
+The QR Code Toolkit.
+"
+,
+  },
+  "secondResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"QR Code (qrcode@1.0.4)
+The QR Code Toolkit.
+"
+,
+  },
+}
+`;
+
+exports[`packageInfoCommand CLI does not read latest package info lookups from cache and backfills the resolved version 1`] = `
+{
+  "explicitVersionResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"QR Code (qrcode@1.0.4)
+The QR Code Toolkit.
+"
+,
+  },
+  "latestAgainResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"QR Code (qrcode@1.0.4)
+The QR Code Toolkit.
+"
+,
+  },
+  "latestResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"QR Code (qrcode@1.0.4)
+The QR Code Toolkit.
+"
+,
+  },
+}
+`;
+
+exports[`packageInfoCommand CLI supports package info command help with the --json alias 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Show transformed package metadata for an explicit package specifier.
+
+Arguments:
+  packageSpecifier   Package specifier
+
+Options:
+  --format <format>  Specify output format (use json for structured output)
+  --json             Alias for --format=json
+  -h, --help         Show help for command
+
+Global Options:
+  -V, --version      Show the current version
+  --debug            Print the current log file path when the CLI exits
+  --lang <lang>      Specify the display language
+"
+,
+}
+`;

--- a/src/application/commands/package/info.cli.test.ts
+++ b/src/application/commands/package/info.cli.test.ts
@@ -2,7 +2,12 @@ import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
-import { createCliSandbox, toRequest } from "../../../../__tests__/helpers.ts";
+import {
+    createCliSandbox,
+    createCliSnapshot,
+    expectCliSnapshot,
+    toRequest,
+} from "../../../../__tests__/helpers.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 
 describe("packageInfoCommand CLI", () => {
@@ -143,33 +148,7 @@ describe("packageInfoCommand CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toBe(
-                [
-                    "QR Code (qrcode@1.0.4)",
-                    "The QR Code Toolkit.",
-                    "",
-                    "- Exist QR Code (Exist)",
-                    "  Checks whether an image contains a QR code.",
-                    "  Input:",
-                    "    - input  string (image)  [optional]  Image input",
-                    "    - tags   Array<string>   [required]  Tag list",
-                    "    - mode   string          [optional]  Scan mode",
-                    "    - count  integer         [optional]  Retry count",
-                    "  Output:",
-                    "    - output    boolean  Boolean result",
-                    "    - metadata  unknown  Unstructured metadata",
-                    "",
-                    "- Decode QR Code (Decode)",
-                    "  Reads the QR code payload from an image.",
-                    "  Input:",
-                    "    - image  string (image)  [required]  Image to decode",
-                    "  Output:",
-                    "    - text  string  Decoded text payload",
-                    "",
-                ].join("\n"),
-            );
+            expectCliSnapshot(result);
             expect(requests).toHaveLength(1);
             expect(requests[0]?.url).toBe(
                 "https://registry.oomol.com/-/oomol/package-info/qrcode/latest?lang=en",
@@ -302,8 +281,7 @@ describe("packageInfoCommand CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(JSON.parse(result.stdout)).toEqual({
                 blocks: [
                     {
@@ -423,6 +401,7 @@ describe("packageInfoCommand CLI", () => {
             );
 
             const requests: Request[] = [];
+            const snapshots = [];
             const cases = [
                 {
                     argv: ["package", "info", "pdf@1.0.0", "--format=json"],
@@ -498,8 +477,7 @@ describe("packageInfoCommand CLI", () => {
                     },
                 );
 
-                expect(result.exitCode).toBe(0);
-                expect(result.stderr).toBe("");
+                snapshots.push(createCliSnapshot(result));
                 expect(JSON.parse(result.stdout)).toEqual({
                     blocks: [],
                     description: testCase.response.description,
@@ -509,6 +487,7 @@ describe("packageInfoCommand CLI", () => {
                 });
             }
 
+            expect(snapshots).toMatchSnapshot();
             expect(requests.map(request => request.url)).toEqual(
                 cases.map(testCase => testCase.expectedUrl),
             );
@@ -566,7 +545,10 @@ describe("packageInfoCommand CLI", () => {
 
             expect(firstResult.exitCode).toBe(0);
             expect(secondResult.exitCode).toBe(0);
-            expect(firstResult.stdout).toBe(secondResult.stdout);
+            expect({
+                firstResult: createCliSnapshot(firstResult),
+                secondResult: createCliSnapshot(secondResult),
+            }).toMatchSnapshot();
             expect(requestCount).toBe(1);
         }
         finally {
@@ -624,9 +606,11 @@ describe("packageInfoCommand CLI", () => {
                 { fetcher },
             );
 
-            expect(latestResult.exitCode).toBe(0);
-            expect(latestAgainResult.exitCode).toBe(0);
-            expect(explicitVersionResult.exitCode).toBe(0);
+            expect({
+                explicitVersionResult: createCliSnapshot(explicitVersionResult),
+                latestAgainResult: createCliSnapshot(latestAgainResult),
+                latestResult: createCliSnapshot(latestResult),
+            }).toMatchSnapshot();
             expect(requestCount).toBe(2);
         }
         finally {
@@ -640,10 +624,7 @@ describe("packageInfoCommand CLI", () => {
         try {
             const result = await sandbox.run(["package", "info", "--help"]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toContain("--json");
-            expect(result.stdout).toContain("Alias for --format=json");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/search.cli.test.ts
+++ b/src/application/commands/search.cli.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, test } from "bun:test";
 
 import {
     createCliSandbox,
+    createCliSnapshot,
+    expectCliSnapshot,
     readLatestLogContent,
     toRequest,
 } from "../../../__tests__/helpers.ts";
@@ -48,7 +50,7 @@ describe("search CLI", () => {
             );
             const content = await readLatestLogContent(sandbox);
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(content).toContain(`"msg":"Search response cache miss."`);
             expect(content).toContain(`"msg":"Search request started."`);
             expect(content).toContain(`"msg":"Search request completed."`);
@@ -98,8 +100,10 @@ describe("search CLI", () => {
             const secondResult = await sandbox.run(["search", "cache me"], { fetcher });
             const secondContent = await readLatestLogContent(sandbox);
 
-            expect(firstResult.exitCode).toBe(0);
-            expect(secondResult.exitCode).toBe(0);
+            expect({
+                firstResult: createCliSnapshot(firstResult),
+                secondResult: createCliSnapshot(secondResult),
+            }).toMatchSnapshot();
             expect(requestCount).toBe(1);
             expect(firstContent).toContain(`"msg":"Sqlite cache namespace opened."`);
             expect(firstContent).toContain(`"msg":"Sqlite cache lookup missed."`);
@@ -165,18 +169,7 @@ describe("search CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toBe(
-                [
-                    "Image Tools (@oomol/image-tools@1.2.3)",
-                    "Powerful image processing toolkit",
-                    "Blocks:",
-                    "- Image Processor (image-processor)",
-                    "  Process and transform image formats",
-                    "",
-                ].join("\n"),
-            );
+            expectCliSnapshot(result);
             expect(requests).toHaveLength(1);
             expect(requests[0]?.url).toBe(
                 "https://search.oomol.com/v1/packages/-/intent-search?q=image+processing&lang=en",
@@ -226,7 +219,7 @@ describe("search CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(requests).toHaveLength(1);
             expect(
                 new URL(requests[0]!.url).searchParams.get("lang"),
@@ -287,7 +280,10 @@ describe("search CLI", () => {
 
             expect(firstResult.exitCode).toBe(0);
             expect(secondResult.exitCode).toBe(0);
-            expect(firstResult.stdout).toBe(secondResult.stdout);
+            expect({
+                firstResult: createCliSnapshot(firstResult),
+                secondResult: createCliSnapshot(secondResult),
+            }).toMatchSnapshot();
             expect(requestCount).toBe(1);
         }
         finally {
@@ -347,18 +343,9 @@ describe("search CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(createTerminalColors(true).strip(result.stdout)).toBe(
-                [
-                    "Image Tools (@oomol/image-tools@1.2.3)",
-                    "Powerful image processing toolkit",
-                    "Blocks:",
-                    "- Image Processor (image-processor)",
-                    "  Process and transform image formats",
-                    "",
-                ].join("\n"),
-            );
+            expect(createCliSnapshot(result, {
+                stripAnsi: true,
+            })).toMatchSnapshot();
             expect(result.stdout).toContain(
                 `${colors.hex(searchDisplayNameColor)("Image Tools")} (@oomol/image-tools@1.2.3)`,
             );
@@ -416,15 +403,7 @@ describe("search CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toBe(
-                [
-                    "@oomol/image-tools@1.2.3",
-                    "@oomol/vision-kit@2.0.0",
-                    "",
-                ].join("\n"),
-            );
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -484,20 +463,7 @@ describe("search CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(`${JSON.stringify([
-                {
-                    blocks: [
-                        {
-                            title: "Image Processor",
-                        },
-                    ],
-                    displayName: "Image Tools",
-                    name: "@oomol/image-tools",
-                    version: "1.2.3",
-                },
-            ])}\n`);
-            expect(result.stderr).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(requests).toHaveLength(1);
             expect(
                 new URL(requests[0]!.url).searchParams.get("q"),
@@ -551,12 +517,7 @@ describe("search CLI", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toBe(`${JSON.stringify([
-                "@oomol/image-tools@1.2.3",
-                "@oomol/vision-kit@2.0.0",
-            ])}\n`);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -569,8 +530,7 @@ describe("search CLI", () => {
         try {
             const result = await sandbox.run(["search", "image", "--format=yaml"]);
 
-            expect(result.exitCode).toBe(2);
-            expect(result.stdout).toBe("");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(result.stderr).toContain("Invalid format: yaml. Use json.");
         }
         finally {
@@ -584,10 +544,14 @@ describe("search CLI", () => {
         try {
             const expectedHelp = await sandbox.run(["search", "--help"]);
             const result = await sandbox.run(["search"]);
+            const expectedHelpSnapshot = createCliSnapshot(expectedHelp);
+            const resultSnapshot = createCliSnapshot(result);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toBe(expectedHelp.stdout);
+            expect({
+                expectedHelp: expectedHelpSnapshot,
+                result: resultSnapshot,
+            }).toMatchSnapshot();
+            expect(resultSnapshot).toEqual(expectedHelpSnapshot);
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -1,0 +1,151 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`skills CLI rejects unsupported skill names for skills install 1`] = `
+{
+  "exitCode": 2,
+  "stderr": 
+"Unsupported skill: unknown. Use oo.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`skills CLI treats the removed allow-implicit-invocation subcommand as unknown 1`] = `
+{
+  "exitCode": 2,
+  "stderr": 
+"Unknown command: allow-implicit-invocation.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`skills CLI silently installs the managed Codex skill on the first run 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
+
+Options:
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
+
+Commands:
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  package                  Package utilities
+  search [options] <text>  Search packages by intent
+  help [command]           Show help for a command
+"
+,
+}
+`;
+
+exports[`skills CLI does not auto-install the managed Codex skill during local development runs 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
+
+Options:
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
+
+Commands:
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  package                  Package utilities
+  search [options] <text>  Search packages by intent
+  help [command]           Show help for a command
+"
+,
+}
+`;
+
+exports[`skills CLI does not auto-install the managed Codex skill for skills subcommands 1`] = `
+{
+  "exitCode": 1,
+  "stderr": 
+"Codex skill oo is not installed at <HOME>/.codex/skills/oo.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`skills CLI synchronizes the managed Codex skill policy from persisted settings 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
+
+Options:
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
+
+Commands:
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  package                  Package utilities
+  search [options] <text>  Search packages by intent
+  help [command]           Show help for a command
+"
+,
+}
+`;
+
+exports[`skills CLI writes explicit skills install and uninstall logs 1`] = `
+{
+  "installResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Installed Codex skill oo to <HOME>/.codex/skills/oo.
+"
+,
+  },
+  "uninstallResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Removed Codex skill oo from <HOME>/.codex/skills/oo.
+"
+,
+  },
+}
+`;

--- a/src/application/commands/skills/config/__snapshots__/get.cli.test.ts.snap
+++ b/src/application/commands/skills/config/__snapshots__/get.cli.test.ts.snap
@@ -1,0 +1,44 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`skills config get CLI reads the effective oo skill config value for a key 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"true
+"
+,
+}
+`;
+
+exports[`skills config get CLI lists all known effective values when the key is omitted 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"allow-implicit-invocation=true
+"
+,
+}
+`;
+
+exports[`skills config get CLI validates skills config get input 1`] = `
+{
+  "invalidKey": {
+    "exitCode": 2,
+    "stderr": 
+"Invalid config key for skill oo: missing. Use allow-implicit-invocation.
+"
+,
+    "stdout": "",
+  },
+  "invalidSkill": {
+    "exitCode": 2,
+    "stderr": 
+"Unsupported skill: missing. Use oo.
+"
+,
+    "stdout": "",
+  },
+}
+`;

--- a/src/application/commands/skills/config/__snapshots__/set.cli.test.ts.snap
+++ b/src/application/commands/skills/config/__snapshots__/set.cli.test.ts.snap
@@ -1,0 +1,41 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`skills config set CLI supports skills config set for the oo skill implicit invocation policy 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Set Codex skill oo allow-implicit-invocation to false.
+"
+,
+}
+`;
+
+exports[`skills config set CLI validates skills config set input 1`] = `
+{
+  "invalidKey": {
+    "exitCode": 2,
+    "stderr": 
+"Invalid config key for skill oo: missing. Use allow-implicit-invocation.
+"
+,
+    "stdout": "",
+  },
+  "invalidSkill": {
+    "exitCode": 2,
+    "stderr": 
+"Unsupported skill: missing. Use oo.
+"
+,
+    "stdout": "",
+  },
+  "invalidValue": {
+    "exitCode": 2,
+    "stderr": 
+"Invalid allow-implicit-invocation value for skill oo: disabled. Use true or false.
+"
+,
+    "stdout": "",
+  },
+}
+`;

--- a/src/application/commands/skills/config/get.cli.test.ts
+++ b/src/application/commands/skills/config/get.cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { createCliSandbox } from "../../../../../__tests__/helpers.ts";
+import { createCliSandbox, createCliSnapshot } from "../../../../../__tests__/helpers.ts";
 
 describe("skills config get CLI", () => {
     test("reads the effective oo skill config value for a key", async () => {
@@ -15,8 +15,7 @@ describe("skills config get CLI", () => {
                 "allow-implicit-invocation",
             ]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe("true\n");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -34,8 +33,7 @@ describe("skills config get CLI", () => {
                 "oo",
             ]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe("allow-implicit-invocation=true\n");
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -60,11 +58,10 @@ describe("skills config get CLI", () => {
                 "missing",
             ]);
 
-            expect(invalidSkill.exitCode).toBe(2);
-            expect(invalidSkill.stderr).toContain("Unsupported skill");
-
-            expect(invalidKey.exitCode).toBe(2);
-            expect(invalidKey.stderr).toContain("Invalid config key for skill oo");
+            expect({
+                invalidKey: createCliSnapshot(invalidKey),
+                invalidSkill: createCliSnapshot(invalidSkill),
+            }).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/config/set.cli.test.ts
+++ b/src/application/commands/skills/config/set.cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { createCliSandbox } from "../../../../../__tests__/helpers.ts";
+import { createCliSandbox, createCliSnapshot } from "../../../../../__tests__/helpers.ts";
 
 describe("skills config set CLI", () => {
     test("supports skills config set for the oo skill implicit invocation policy", async () => {
@@ -16,10 +16,7 @@ describe("skills config set CLI", () => {
                 "false",
             ]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(
-                "Set Codex skill oo allow-implicit-invocation to false.\n",
-            );
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -55,16 +52,11 @@ describe("skills config set CLI", () => {
                 "disabled",
             ]);
 
-            expect(invalidSkill.exitCode).toBe(2);
-            expect(invalidSkill.stderr).toContain("Unsupported skill");
-
-            expect(invalidKey.exitCode).toBe(2);
-            expect(invalidKey.stderr).toContain("Invalid config key for skill oo");
-
-            expect(invalidValue.exitCode).toBe(2);
-            expect(invalidValue.stderr).toContain(
-                "Invalid allow-implicit-invocation value for skill oo",
-            );
+            expect({
+                invalidKey: createCliSnapshot(invalidKey),
+                invalidSkill: createCliSnapshot(invalidSkill),
+                invalidValue: createCliSnapshot(invalidValue),
+            }).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -3,7 +3,11 @@ import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
-import { createCliSandbox, readLatestLogContent } from "../../../../__tests__/helpers.ts";
+import {
+    createCliSandbox,
+    createCliSnapshot,
+    readLatestLogContent,
+} from "../../../../__tests__/helpers.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import {
     resolveBundledSkillVersionFilePath,
@@ -17,11 +21,7 @@ describe("skills CLI", () => {
         try {
             const result = await sandbox.run(["skills", "install", "unknown"]);
 
-            expect(result.exitCode).toBe(2);
-            expect(result.stdout).toBe("");
-            expect(result.stderr).toBe(
-                "Unsupported skill: unknown. Use oo.\n",
-            );
+            expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
             await sandbox.cleanup();
@@ -38,7 +38,7 @@ describe("skills CLI", () => {
                 "false",
             ]);
 
-            expect(result.exitCode).toBe(2);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(result.stderr).toContain("Unknown command");
         }
         finally {
@@ -61,9 +61,8 @@ describe("skills CLI", () => {
             });
             const content = await readLatestLogContent(sandbox);
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(result.stdout).not.toContain("Installed Codex skill");
-            expect(result.stderr).toBe("");
             await expect(stat(join(skillDirectoryPath, "SKILL.md"))).resolves.toMatchObject({
                 isFile: expect.any(Function),
             });
@@ -94,9 +93,8 @@ describe("skills CLI", () => {
             const result = await sandbox.run(["--help"]);
             const content = await readLatestLogContent(sandbox);
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(result.stdout).not.toContain("Installed Codex skill");
-            expect(result.stderr).toBe("");
             await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
@@ -123,10 +121,7 @@ describe("skills CLI", () => {
             const result = await sandbox.run(["skills", "uninstall"]);
 
             expect(result.exitCode).toBe(1);
-            expect(result.stdout).toBe("");
-            expect(result.stderr).toBe(
-                `Codex skill oo is not installed at ${skillDirectoryPath}.\n`,
-            );
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
@@ -170,7 +165,7 @@ describe("skills CLI", () => {
                 version: "9.9.9",
             });
 
-            expect(result.exitCode).toBe(0);
+            expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(await readFile(ownershipFilePath, "utf8")).toContain(
                 "allow_implicit_invocation: false",
             );
@@ -195,7 +190,10 @@ describe("skills CLI", () => {
             const uninstallResult = await sandbox.run(["skills", "uninstall"]);
             const uninstallContent = await readLatestLogContent(sandbox);
 
-            expect(installResult.exitCode).toBe(0);
+            expect({
+                installResult: createCliSnapshot(installResult, { sandbox }),
+                uninstallResult: createCliSnapshot(uninstallResult, { sandbox }),
+            }).toMatchSnapshot();
             expect(installContent).toContain(
                 `"msg":"Bundled Codex skill installed explicitly."`,
             );
@@ -203,7 +201,6 @@ describe("skills CLI", () => {
             expect(installContent).toContain(`"path":"${skillDirectoryPath}"`);
             expect(installContent).toContain(`"version":"9.9.9"`);
 
-            expect(uninstallResult.exitCode).toBe(0);
             expect(uninstallContent).toContain(
                 `"msg":"Bundled Codex skill removed explicitly."`,
             );


### PR DESCRIPTION
Add createCliSnapshot/expectCliSnapshot helpers that normalize platform-specific paths, strip ANSI codes, and apply custom replacements before matching against snapshots. Migrate all command CLI tests to use snapshot assertions for consistent, maintainable output verification.