### PR TITLE
refactor(package): move search command under package subcommand group

### DIFF
--- a/contrib/skills/oo/SKILL.md
+++ b/contrib/skills/oo/SKILL.md
@@ -26,7 +26,7 @@ media processing.
 
 If the request is to use a ready-made capability over a local file or archive,
 stay on the `oo` path first. Do not switch to ad hoc local Python, OCR, or
-shell processing before you have at least tried `oo search ... --json` and
+shell processing before you have at least tried `oo package search ... --json` and
 inspected plausible packages with `oo package info ... --json`.
 
 Do not use this skill for ordinary local coding, shell scripting, glue code,
@@ -60,7 +60,7 @@ Before doing anything substantial:
 ## Non-negotiable rules
 
 - Always use `--json` with:
-    - `search`
+    - `package search`
     - `package info`
     - `cloud-task run`
     - `file upload`
@@ -81,7 +81,7 @@ Before doing anything substantial:
   retry.
 - `cloud-task run` must use `PACKAGE_NAME@SEMVER`.
 - `cloud-task run` must include a real `--block-id`.
-- If `search` returns zero packages, stop and tell the user that `oo` does not
+- If `package search` returns zero packages, stop and tell the user that `oo` does not
   currently have a matching capability.
 - Ask follow-up questions only when required inputs are missing or too risky to
   infer.
@@ -138,7 +138,7 @@ Combine the keywords into one concise English search query.
 Run:
 
 ```bash
-oo search "<english query>" --json
+oo package search "<english query>" --json
 ```
 
 Then:
@@ -178,7 +178,7 @@ Prefer a block that:
 Use `blocks[].blockName` as the block identifier for execution. Do not use the
 human-facing block title as `--block-id`.
 
-If search does not provide a version, inspect the package by name first and use
+If package search does not provide a version, inspect the package by name first and use
 the resolved `packageVersion` for any later `cloud-task run`.
 
 If a candidate does not expose a usable package name, do not select it.
@@ -383,5 +383,5 @@ https://console.oomol.com/billing/recharge before retrying anything.
 - Be decisive.
 - Prefer the most specific block over a generic block.
 - Prefer recoverable progress over fragile one-shot waiting.
-- Never claim a capability that was not proven by `search`, `package info`, or
+- Never claim a capability that was not proven by `package search`, `package info`, or
   command output.

--- a/contrib/skills/oo/references/oo-cli-contract.md
+++ b/contrib/skills/oo/references/oo-cli-contract.md
@@ -14,7 +14,7 @@ oo ...
 
 ## Authentication
 
-- `search`, `package info`, `file upload`, `cloud-task run`,
+- `package search`, `package info`, `file upload`, `cloud-task run`,
   `cloud-task result`, and `cloud-task wait` all require a current
   authenticated account.
 - Do not run `auth status` as a routine precheck.
@@ -42,12 +42,12 @@ oo auth login
 - Direct them to recharge before retrying at
   https://console.oomol.com/billing/recharge.
 
-## `search`
+## `package search`
 
 Canonical form:
 
 ```bash
-oo search "<text>" --json
+oo package search "<text>" --json
 ```
 
 Facts:
@@ -363,7 +363,7 @@ Skill policy:
 Use this order:
 
 1. Convert the user request into `2` to `6` English keywords.
-2. Run `search --json`.
+2. Run `package search --json`.
 3. Run `package info --json` for the serious candidates.
 4. Choose one primary package and optionally one fallback.
 5. Ask focused follow-up questions only for missing required inputs.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -271,7 +271,7 @@ Delete expired upload records from the local sqlite store.
 
 ## Package Discovery
 
-### `oo search <text>`
+### `oo package search <text>`
 
 Search packages with free-form intent text.
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -240,7 +240,7 @@
 
 ## Package 检索
 
-### `oo search <text>`
+### `oo package search <text>`
 
 使用自由文本按意图搜索 package。
 

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -34,25 +34,24 @@ exports[`runCli bootstrap creates the sqlite cache file during cli startup 1`] =
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version       Show the current version
+  --debug             Print the current log file path when the CLI exits
+  --lang <lang>       Specify the display language
+  -h, --help          Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  package                  Package utilities
-  search [options] <text>  Search packages by intent
-  help [command]           Show help for a command
+  auth                Manage CLI authentication
+  check-update        Check for CLI updates
+  cloud-task          Manage cloud tasks
+  file                Manage temporary file transfers
+  login               Log in with a browser flow (alias for auth login)
+  logout              Log out the current account (alias for auth logout)
+  completion <shell>  Generate shell completion scripts
+  config              Manage persisted configuration
+  skills              Manage Codex skills
+  log                 Manage persisted debug logs
+  package             Package utilities
+  help [command]      Show help for a command
 "
 ,
 }
@@ -66,25 +65,24 @@ exports[`runCli bootstrap writes debug logs to the log directory during cli star
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version       Show the current version
+  --debug             Print the current log file path when the CLI exits
+  --lang <lang>       Specify the display language
+  -h, --help          Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  package                  Package utilities
-  search [options] <text>  Search packages by intent
-  help [command]           Show help for a command
+  auth                Manage CLI authentication
+  check-update        Check for CLI updates
+  cloud-task          Manage cloud tasks
+  file                Manage temporary file transfers
+  login               Log in with a browser flow (alias for auth login)
+  logout              Log out the current account (alias for auth logout)
+  completion <shell>  Generate shell completion scripts
+  config              Manage persisted configuration
+  skills              Manage Codex skills
+  log                 Manage persisted debug logs
+  package             Package utilities
+  help [command]      Show help for a command
 "
 ,
 }
@@ -101,25 +99,24 @@ exports[`runCli bootstrap prints the current log file path to stderr when --debu
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version       Show the current version
+  --debug             Print the current log file path when the CLI exits
+  --lang <lang>       Specify the display language
+  -h, --help          Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  package                  Package utilities
-  search [options] <text>  Search packages by intent
-  help [command]           Show help for a command
+  auth                Manage CLI authentication
+  check-update        Check for CLI updates
+  cloud-task          Manage cloud tasks
+  file                Manage temporary file transfers
+  login               Log in with a browser flow (alias for auth login)
+  logout              Log out the current account (alias for auth logout)
+  completion <shell>  Generate shell completion scripts
+  config              Manage persisted configuration
+  skills              Manage Codex skills
+  log                 Manage persisted debug logs
+  package             Package utilities
+  help [command]      Show help for a command
 "
 ,
 }
@@ -134,25 +131,24 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
 "oo 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成
 
 选项：
-  -V, --version            显示当前版本
-  --debug                  在 CLI 退出时打印当前日志文件路径
-  --lang <lang>            指定显示语言
-  -h, --help               显示命令帮助
+  -V, --version       显示当前版本
+  --debug             在 CLI 退出时打印当前日志文件路径
+  --lang <lang>       指定显示语言
+  -h, --help          显示命令帮助
 
 命令：
-  auth                     管理 CLI 认证
-  check-update             检查 CLI 更新
-  cloud-task               管理云任务
-  file                     管理临时文件传输
-  login                    通过浏览器登录（auth login 的别名）
-  logout                   登出当前账号（auth logout 的别名）
-  completion <shell>       生成 shell 补全脚本
-  config                   管理持久化配置
-  skills                   管理 Codex skill
-  log                      管理持久化 debug 日志
-  package                  包相关工具
-  search [options] <text>  按意图搜索包
-  help [command]           显示命令帮助
+  auth                管理 CLI 认证
+  check-update        检查 CLI 更新
+  cloud-task          管理云任务
+  file                管理临时文件传输
+  login               通过浏览器登录（auth login 的别名）
+  logout              登出当前账号（auth logout 的别名）
+  completion <shell>  生成 shell 补全脚本
+  config              管理持久化配置
+  skills              管理 Codex skill
+  log                 管理持久化 debug 日志
+  package             包相关工具
+  help [command]      显示命令帮助
 "
 ,
   },
@@ -163,25 +159,24 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version       Show the current version
+  --debug             Print the current log file path when the CLI exits
+  --lang <lang>       Specify the display language
+  -h, --help          Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  package                  Package utilities
-  search [options] <text>  Search packages by intent
-  help [command]           Show help for a command
+  auth                Manage CLI authentication
+  check-update        Check for CLI updates
+  cloud-task          Manage cloud tasks
+  file                Manage temporary file transfers
+  login               Log in with a browser flow (alias for auth login)
+  logout              Log out the current account (alias for auth logout)
+  completion <shell>  Generate shell completion scripts
+  config              Manage persisted configuration
+  skills              Manage Codex skills
+  log                 Manage persisted debug logs
+  package             Package utilities
+  help [command]      Show help for a command
 "
 ,
   },
@@ -196,25 +191,24 @@ exports[`runCli bootstrap renders branded colors in help when stdout supports co
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version       Show the current version
+  --debug             Print the current log file path when the CLI exits
+  --lang <lang>       Specify the display language
+  -h, --help          Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  package                  Package utilities
-  search [options] <text>  Search packages by intent
-  help [command]           Show help for a command
+  auth                Manage CLI authentication
+  check-update        Check for CLI updates
+  cloud-task          Manage cloud tasks
+  file                Manage temporary file transfers
+  login               Log in with a browser flow (alias for auth login)
+  logout              Log out the current account (alias for auth logout)
+  completion <shell>  Generate shell completion scripts
+  config              Manage persisted configuration
+  skills              Manage Codex skills
+  log                 Manage persisted debug logs
+  package             Package utilities
+  help [command]      Show help for a command
 "
 ,
 }

--- a/src/application/commands/catalog.ts
+++ b/src/application/commands/catalog.ts
@@ -11,7 +11,6 @@ import { logCommand } from "./log/index.ts";
 import { loginCommand } from "./login.ts";
 import { logoutCommand } from "./logout.ts";
 import { packageCommand } from "./package/index.ts";
-import { searchCommand } from "./search.ts";
 import { skillsCommand } from "./skills/index.ts";
 
 const globalOptions = [
@@ -47,7 +46,6 @@ export function createCliCatalog(): CliCatalog {
             skillsCommand,
             logCommand,
             packageCommand,
-            searchCommand,
         ],
     };
 }

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -20,25 +20,24 @@ exports[`config CLI persists the configured locale and allows explicit override 
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version       Show the current version
+  --debug             Print the current log file path when the CLI exits
+  --lang <lang>       Specify the display language
+  -h, --help          Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  package                  Package utilities
-  search [options] <text>  Search packages by intent
-  help [command]           Show help for a command
+  auth                Manage CLI authentication
+  check-update        Check for CLI updates
+  cloud-task          Manage cloud tasks
+  file                Manage temporary file transfers
+  login               Log in with a browser flow (alias for auth login)
+  logout              Log out the current account (alias for auth logout)
+  completion <shell>  Generate shell completion scripts
+  config              Manage persisted configuration
+  skills              Manage Codex skills
+  log                 Manage persisted debug logs
+  package             Package utilities
+  help [command]      Show help for a command
 "
 ,
   },
@@ -49,25 +48,24 @@ Commands:
 "oo 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成
 
 选项：
-  -V, --version            显示当前版本
-  --debug                  在 CLI 退出时打印当前日志文件路径
-  --lang <lang>            指定显示语言
-  -h, --help               显示命令帮助
+  -V, --version       显示当前版本
+  --debug             在 CLI 退出时打印当前日志文件路径
+  --lang <lang>       指定显示语言
+  -h, --help          显示命令帮助
 
 命令：
-  auth                     管理 CLI 认证
-  check-update             检查 CLI 更新
-  cloud-task               管理云任务
-  file                     管理临时文件传输
-  login                    通过浏览器登录（auth login 的别名）
-  logout                   登出当前账号（auth logout 的别名）
-  completion <shell>       生成 shell 补全脚本
-  config                   管理持久化配置
-  skills                   管理 Codex skill
-  log                      管理持久化 debug 日志
-  package                  包相关工具
-  search [options] <text>  按意图搜索包
-  help [command]           显示命令帮助
+  auth                管理 CLI 认证
+  check-update        检查 CLI 更新
+  cloud-task          管理云任务
+  file                管理临时文件传输
+  login               通过浏览器登录（auth login 的别名）
+  logout              登出当前账号（auth logout 的别名）
+  completion <shell>  生成 shell 补全脚本
+  config              管理持久化配置
+  skills              管理 Codex skill
+  log                 管理持久化 debug 日志
+  package             包相关工具
+  help [command]      显示命令帮助
 "
 ,
   },

--- a/src/application/commands/file/__snapshots__/download.cli.test.ts.snap
+++ b/src/application/commands/file/__snapshots__/download.cli.test.ts.snap
@@ -166,17 +166,6 @@ exports[`file download CLI fails file download when the download request returns
 }
 `;
 
-exports[`file download CLI fails file download when the output directory cannot be created 1`] = `
-{
-  "exitCode": 1,
-  "stderr": 
-"Failed to prepare the output directory <HOME>/occupied/nested: ENOTDIR: not a directory, stat '<HOME>/occupied/nested'
-"
-,
-  "stdout": "",
-}
-`;
-
 exports[`file download CLI uses the default download file name when the final response url has no file segment 1`] = `
 {
   "exitCode": 0,

--- a/src/application/commands/file/download.cli.test.ts
+++ b/src/application/commands/file/download.cli.test.ts
@@ -465,8 +465,11 @@ describe("file download CLI", () => {
                 },
             );
 
-            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
             expect(result.stderr).toContain("Failed to prepare the output directory");
+            expect(result.stderr).toContain(nestedOutputDirectory);
+            expect(result.stderr).toContain("ENOTDIR");
             expect(fetchCount).toBe(0);
         }
         finally {

--- a/src/application/commands/log/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/log/__snapshots__/index.cli.test.ts.snap
@@ -1,16 +1,5 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`log CLI prints the resolved log directory path 1`] = `
-{
-  "exitCode": 0,
-  "stderr": "",
-  "stdout": 
-"<HOME>/Library/Logs/oo
-"
-,
-}
-`;
-
 exports[`log CLI prints the previous log file by default 1`] = `
 {
   "exitCode": 0,

--- a/src/application/commands/log/index.cli.test.ts
+++ b/src/application/commands/log/index.cli.test.ts
@@ -12,9 +12,18 @@ describe("log CLI", () => {
         const sandbox = await createCliSandbox();
 
         try {
+            const logDirectoryPath = resolveStorePaths({
+                appName: APP_NAME,
+                env: sandbox.env,
+                platform: process.platform,
+            }).logDirectoryPath;
             const result = await sandbox.run(["log", "path"]);
 
-            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
+            expect(result).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: `${logDirectoryPath}\n`,
+            });
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/package/__snapshots__/search.cli.test.ts.snap
+++ b/src/application/commands/package/__snapshots__/search.cli.test.ts.snap
@@ -1,6 +1,6 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`search CLI writes search request lifecycle logs 1`] = `
+exports[`packageSearchCommand CLI writes search request lifecycle logs 1`] = `
 {
   "exitCode": 0,
   "stderr": "",
@@ -11,7 +11,7 @@ exports[`search CLI writes search request lifecycle logs 1`] = `
 }
 `;
 
-exports[`search CLI writes sqlite cache adapter logs across repeated search invocations 1`] = `
+exports[`packageSearchCommand CLI writes sqlite cache adapter logs across repeated search invocations 1`] = `
 {
   "firstResult": {
     "exitCode": 0,
@@ -32,7 +32,7 @@ exports[`search CLI writes sqlite cache adapter logs across repeated search invo
 }
 `;
 
-exports[`search CLI supports search command with text output 1`] = `
+exports[`packageSearchCommand CLI supports package search command with text output 1`] = `
 {
   "exitCode": 0,
   "stderr": "",
@@ -47,7 +47,7 @@ Blocks:
 }
 `;
 
-exports[`search CLI adds the localized request language to search queries 1`] = `
+exports[`packageSearchCommand CLI adds the localized request language to package search queries 1`] = `
 {
   "exitCode": 0,
   "stderr": "",
@@ -58,7 +58,7 @@ exports[`search CLI adds the localized request language to search queries 1`] = 
 }
 `;
 
-exports[`search CLI reuses cached search responses across cli invocations 1`] = `
+exports[`packageSearchCommand CLI reuses cached search responses across cli invocations 1`] = `
 {
   "firstResult": {
     "exitCode": 0,
@@ -81,7 +81,7 @@ Powerful image processing toolkit
 }
 `;
 
-exports[`search CLI renders search output with field-specific colors 1`] = `
+exports[`packageSearchCommand CLI renders search output with field-specific colors 1`] = `
 {
   "exitCode": 0,
   "stderr": "",
@@ -96,7 +96,7 @@ Blocks:
 }
 `;
 
-exports[`search CLI supports search command with only-package-id text output 1`] = `
+exports[`packageSearchCommand CLI supports package search command with only-package-id text output 1`] = `
 {
   "exitCode": 0,
   "stderr": "",
@@ -108,7 +108,7 @@ exports[`search CLI supports search command with only-package-id text output 1`]
 }
 `;
 
-exports[`search CLI supports search command with json array output and trims long text 1`] = `
+exports[`packageSearchCommand CLI supports package search command with json array output and trims long text 1`] = `
 {
   "exitCode": 0,
   "stderr": "",
@@ -119,7 +119,7 @@ exports[`search CLI supports search command with json array output and trims lon
 }
 `;
 
-exports[`search CLI supports search command with only-package-id json output 1`] = `
+exports[`packageSearchCommand CLI supports package search command with only-package-id json output 1`] = `
 {
   "exitCode": 0,
   "stderr": "",
@@ -130,7 +130,7 @@ exports[`search CLI supports search command with only-package-id json output 1`]
 }
 `;
 
-exports[`search CLI validates the search format option 1`] = `
+exports[`packageSearchCommand CLI validates the search format option 1`] = `
 {
   "exitCode": 2,
   "stderr": 
@@ -141,7 +141,7 @@ exports[`search CLI validates the search format option 1`] = `
 }
 `;
 
-exports[`search CLI renders search help when text argument is omitted 1`] = `
+exports[`packageSearchCommand CLI renders package search help when text argument is omitted 1`] = `
 {
   "expectedHelp": {
     "exitCode": 0,

--- a/src/application/commands/package/index.ts
+++ b/src/application/commands/package/index.ts
@@ -1,12 +1,14 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { packageInfoCommand } from "./info.ts";
+import { packageSearchCommand } from "./search.ts";
 
 export const packageCommand: CliCommandDefinition = {
     name: "package",
     summaryKey: "commands.package.summary",
     descriptionKey: "commands.package.description",
     children: [
+        packageSearchCommand,
         packageInfoCommand,
     ],
 };

--- a/src/application/commands/package/search.cli.test.ts
+++ b/src/application/commands/package/search.cli.test.ts
@@ -8,14 +8,14 @@ import {
     expectCliSnapshot,
     readLatestLogContent,
     toRequest,
-} from "../../../__tests__/helpers.ts";
-import { APP_NAME } from "../config/app-config.ts";
-import { createTerminalColors } from "../terminal-colors.ts";
+} from "../../../../__tests__/helpers.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import { createTerminalColors } from "../../terminal-colors.ts";
 
 const searchBlockTitleColor = "#CAA8FA";
 const searchDisplayNameColor = "#59F78D";
 
-describe("search CLI", () => {
+describe("packageSearchCommand CLI", () => {
     test("writes search request lifecycle logs", async () => {
         const sandbox = await createCliSandbox();
 
@@ -41,7 +41,7 @@ describe("search CLI", () => {
             );
 
             const result = await sandbox.run(
-                ["search", "image processing"],
+                ["package", "search", "image processing"],
                 {
                     fetcher: async () => new Response(JSON.stringify({
                         packages: [],
@@ -95,9 +95,9 @@ describe("search CLI", () => {
                 }));
             };
 
-            const firstResult = await sandbox.run(["search", "cache me"], { fetcher });
+            const firstResult = await sandbox.run(["package", "search", "cache me"], { fetcher });
             const firstContent = await readLatestLogContent(sandbox);
-            const secondResult = await sandbox.run(["search", "cache me"], { fetcher });
+            const secondResult = await sandbox.run(["package", "search", "cache me"], { fetcher });
             const secondContent = await readLatestLogContent(sandbox);
 
             expect({
@@ -116,7 +116,7 @@ describe("search CLI", () => {
         }
     });
 
-    test("supports search command with text output", async () => {
+    test("supports package search command with text output", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -142,7 +142,7 @@ describe("search CLI", () => {
 
             const requests: Request[] = [];
             const result = await sandbox.run(
-                ["search", "image processing"],
+                ["package", "search", "image processing"],
                 {
                     fetcher: async (input, init) => {
                         requests.push(toRequest(input, init));
@@ -181,7 +181,7 @@ describe("search CLI", () => {
         }
     });
 
-    test("adds the localized request language to search queries", async () => {
+    test("adds the localized request language to package search queries", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -207,7 +207,7 @@ describe("search CLI", () => {
 
             const requests: Request[] = [];
             const result = await sandbox.run(
-                ["--lang", "zh", "search", "image processing"],
+                ["--lang", "zh", "package", "search", "image processing"],
                 {
                     fetcher: async (input, init) => {
                         requests.push(toRequest(input, init));
@@ -270,11 +270,11 @@ describe("search CLI", () => {
                 }));
             };
             const firstResult = await sandbox.run(
-                ["search", "image processing"],
+                ["package", "search", "image processing"],
                 { fetcher },
             );
             const secondResult = await sandbox.run(
-                ["search", "image processing"],
+                ["package", "search", "image processing"],
                 { fetcher },
             );
 
@@ -317,7 +317,7 @@ describe("search CLI", () => {
             );
 
             const result = await sandbox.run(
-                ["search", "image processing"],
+                ["package", "search", "image processing"],
                 {
                     fetcher: async () => new Response(JSON.stringify({
                         packages: [
@@ -358,7 +358,7 @@ describe("search CLI", () => {
         }
     });
 
-    test("supports search command with only-package-id text output", async () => {
+    test("supports package search command with only-package-id text output", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -383,7 +383,7 @@ describe("search CLI", () => {
             );
 
             const result = await sandbox.run(
-                ["search", "image processing", "--only-package-id"],
+                ["package", "search", "image processing", "--only-package-id"],
                 {
                     fetcher: async () => new Response(JSON.stringify({
                         packages: [
@@ -410,7 +410,7 @@ describe("search CLI", () => {
         }
     });
 
-    test("supports search command with json array output and trims long text", async () => {
+    test("supports package search command with json array output and trims long text", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -453,7 +453,7 @@ describe("search CLI", () => {
             const searchText = "x".repeat(210);
             const expectedQuery = "x".repeat(200);
             const result = await sandbox.run(
-                ["search", searchText, "--json"],
+                ["package", "search", searchText, "--json"],
                 {
                     fetcher: async (input, init) => {
                         requests.push(toRequest(input, init));
@@ -474,7 +474,7 @@ describe("search CLI", () => {
         }
     });
 
-    test("supports search command with only-package-id json output", async () => {
+    test("supports package search command with only-package-id json output", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -499,7 +499,7 @@ describe("search CLI", () => {
             );
 
             const result = await sandbox.run(
-                ["search", "image processing", "--format=json", "--only-package-id"],
+                ["package", "search", "image processing", "--format=json", "--only-package-id"],
                 {
                     fetcher: async () => new Response(JSON.stringify({
                         packages: [
@@ -528,7 +528,7 @@ describe("search CLI", () => {
         const sandbox = await createCliSandbox();
 
         try {
-            const result = await sandbox.run(["search", "image", "--format=yaml"]);
+            const result = await sandbox.run(["package", "search", "image", "--format=yaml"]);
 
             expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(result.stderr).toContain("Invalid format: yaml. Use json.");
@@ -538,12 +538,12 @@ describe("search CLI", () => {
         }
     });
 
-    test("renders search help when text argument is omitted", async () => {
+    test("renders package search help when text argument is omitted", async () => {
         const sandbox = await createCliSandbox();
 
         try {
-            const expectedHelp = await sandbox.run(["search", "--help"]);
-            const result = await sandbox.run(["search"]);
+            const expectedHelp = await sandbox.run(["package", "search", "--help"]);
+            const result = await sandbox.run(["package", "search"]);
             const expectedHelpSnapshot = createCliSnapshot(expectedHelp);
             const resultSnapshot = createCliSnapshot(result);
 

--- a/src/application/commands/package/search.test.ts
+++ b/src/application/commands/package/search.test.ts
@@ -1,19 +1,19 @@
-import type { AuthStore } from "../contracts/auth-store.ts";
+import type { AuthStore } from "../../contracts/auth-store.ts";
 import type {
     Cache,
     CacheOptions,
     CacheStore,
-} from "../contracts/cache.ts";
+} from "../../contracts/cache.ts";
 import type {
     CliCatalog,
     CliExecutionContext,
     Fetcher,
     InteractiveInput,
-} from "../contracts/cli.ts";
-import type { SettingsStore } from "../contracts/settings-store.ts";
-import type { Translator } from "../contracts/translator.ts";
-import type { AuthFile } from "../schemas/auth.ts";
-import type { AppSettings } from "../schemas/settings.ts";
+} from "../../contracts/cli.ts";
+import type { SettingsStore } from "../../contracts/settings-store.ts";
+import type { Translator } from "../../contracts/translator.ts";
+import type { AuthFile } from "../../schemas/auth.ts";
+import type { AppSettings } from "../../schemas/settings.ts";
 
 import { describe, expect, test } from "bun:test";
 import pino from "pino";
@@ -22,10 +22,10 @@ import {
     createNoopFileDownloadSessionStore,
     createNoopFileUploadStore,
     createTextBuffer,
-} from "../../../__tests__/helpers.ts";
-import { searchCommand } from "./search.ts";
+} from "../../../../__tests__/helpers.ts";
+import { packageSearchCommand } from "./search.ts";
 
-const searchHandler = searchCommand.handler!;
+const searchHandler = packageSearchCommand.handler!;
 const activeAuthFile: AuthFile = {
     id: "user-1",
     auth: [
@@ -53,7 +53,7 @@ const stdin: InteractiveInput = {
     off() {},
 };
 
-describe("searchCommand", () => {
+describe("packageSearchCommand", () => {
     test("reuses cached responses with the configured sqlite cache policy", async () => {
         const cacheOptions: CacheOptions[] = [];
         const cacheValues = new Map<string, string>();

--- a/src/application/commands/package/search.ts
+++ b/src/application/commands/package/search.ts
@@ -1,18 +1,18 @@
-import type { CliCommandDefinition, CliExecutionContext } from "../contracts/cli.ts";
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 
-import type { AuthAccount } from "../schemas/auth.ts";
-import type { TerminalColors } from "../terminal-colors.ts";
+import type { AuthAccount } from "../../schemas/auth.ts";
+import type { TerminalColors } from "../../terminal-colors.ts";
 import { z } from "zod";
-import { resolveRequestLanguage } from "../../i18n/locale.ts";
-import { CliUserError } from "../contracts/cli.ts";
+import { resolveRequestLanguage } from "../../../i18n/locale.ts";
+import { CliUserError } from "../../contracts/cli.ts";
 import {
     withAccountIdentity,
     withPath,
     withRequestTarget,
-} from "../logging/log-fields.ts";
-import { createWriterColors } from "../terminal-colors.ts";
-import { readCurrentAuth } from "./auth/shared.ts";
-import { jsonOutputOptions, writeJsonOutput } from "./json-output.ts";
+} from "../../logging/log-fields.ts";
+import { createWriterColors } from "../../terminal-colors.ts";
+import { readCurrentAuth } from "../auth/shared.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 
 const MAX_SEARCH_TEXT_LENGTH = 200;
 const SEARCH_CACHE_ID = "search.intent-response";
@@ -59,7 +59,7 @@ interface SearchInput {
     onlyPackageId?: boolean;
 }
 
-export const searchCommand: CliCommandDefinition<SearchInput> = {
+export const packageSearchCommand: CliCommandDefinition<SearchInput> = {
     name: "search",
     summaryKey: "commands.search.summary",
     descriptionKey: "commands.search.description",

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -30,25 +30,24 @@ exports[`skills CLI silently installs the managed Codex skill on the first run 1
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version       Show the current version
+  --debug             Print the current log file path when the CLI exits
+  --lang <lang>       Specify the display language
+  -h, --help          Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  package                  Package utilities
-  search [options] <text>  Search packages by intent
-  help [command]           Show help for a command
+  auth                Manage CLI authentication
+  check-update        Check for CLI updates
+  cloud-task          Manage cloud tasks
+  file                Manage temporary file transfers
+  login               Log in with a browser flow (alias for auth login)
+  logout              Log out the current account (alias for auth logout)
+  completion <shell>  Generate shell completion scripts
+  config              Manage persisted configuration
+  skills              Manage Codex skills
+  log                 Manage persisted debug logs
+  package             Package utilities
+  help [command]      Show help for a command
 "
 ,
 }
@@ -62,25 +61,24 @@ exports[`skills CLI does not auto-install the managed Codex skill during local d
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version       Show the current version
+  --debug             Print the current log file path when the CLI exits
+  --lang <lang>       Specify the display language
+  -h, --help          Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  package                  Package utilities
-  search [options] <text>  Search packages by intent
-  help [command]           Show help for a command
+  auth                Manage CLI authentication
+  check-update        Check for CLI updates
+  cloud-task          Manage cloud tasks
+  file                Manage temporary file transfers
+  login               Log in with a browser flow (alias for auth login)
+  logout              Log out the current account (alias for auth logout)
+  completion <shell>  Generate shell completion scripts
+  config              Manage persisted configuration
+  skills              Manage Codex skills
+  log                 Manage persisted debug logs
+  package             Package utilities
+  help [command]      Show help for a command
 "
 ,
 }
@@ -105,25 +103,24 @@ exports[`skills CLI synchronizes the managed Codex skill policy from persisted s
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version       Show the current version
+  --debug             Print the current log file path when the CLI exits
+  --lang <lang>       Specify the display language
+  -h, --help          Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  package                  Package utilities
-  search [options] <text>  Search packages by intent
-  help [command]           Show help for a command
+  auth                Manage CLI authentication
+  check-update        Check for CLI updates
+  cloud-task          Manage cloud tasks
+  file                Manage temporary file transfers
+  login               Log in with a browser flow (alias for auth login)
+  logout              Log out the current account (alias for auth logout)
+  completion <shell>  Generate shell completion scripts
+  config              Manage persisted configuration
+  skills              Manage Codex skills
+  log                 Manage persisted debug logs
+  package             Package utilities
+  help [command]      Show help for a command
 "
 ,
 }


### PR DESCRIPTION
Search is inherently a package discovery operation. Nesting it under the package command group makes the CLI taxonomy more consistent and keeps all package-related actions in one place.