### PR TITLE
refactor(package): rename "package" command to "packages"

### DIFF
--- a/contrib/skills/oo/SKILL.md
+++ b/contrib/skills/oo/SKILL.md
@@ -26,8 +26,8 @@ media processing.
 
 If the request is to use a ready-made capability over a local file or archive,
 stay on the `oo` path first. Do not switch to ad hoc local Python, OCR, or
-shell processing before you have at least tried `oo package search ... --json` and
-inspected plausible packages with `oo package info ... --json`.
+shell processing before you have at least tried `oo packages search ... --json` and
+inspected plausible packages with `oo packages info ... --json`.
 
 Do not use this skill for ordinary local coding, shell scripting, glue code,
 or for requests that explicitly ask for a local implementation instead of
@@ -60,8 +60,8 @@ Before doing anything substantial:
 ## Non-negotiable rules
 
 - Always use `--json` with:
-    - `package search`
-    - `package info`
+    - `packages search`
+    - `packages info`
     - `cloud-task run`
     - `file upload`
 - Never add `--json` to `cloud-task wait`.
@@ -81,7 +81,7 @@ Before doing anything substantial:
   retry.
 - `cloud-task run` must use `PACKAGE_NAME@SEMVER`.
 - `cloud-task run` must include a real `--block-id`.
-- If `package search` returns zero packages, stop and tell the user that `oo` does not
+- If `packages search` returns zero packages, stop and tell the user that `oo` does not
   currently have a matching capability.
 - Ask follow-up questions only when required inputs are missing or too risky to
   infer.
@@ -138,7 +138,7 @@ Combine the keywords into one concise English search query.
 Run:
 
 ```bash
-oo package search "<english query>" --json
+oo packages search "<english query>" --json
 ```
 
 Then:
@@ -159,11 +159,11 @@ If the result is empty, stop.
 For each serious candidate, inspect it with one of these forms:
 
 ```bash
-oo package info "<packageName>@<version>" --json
+oo packages info "<packageName>@<version>" --json
 ```
 
 ```bash
-oo package info "<packageName>" --json
+oo packages info "<packageName>" --json
 ```
 
 Then choose the best block using only returned metadata.
@@ -178,7 +178,7 @@ Prefer a block that:
 Use `blocks[].blockName` as the block identifier for execution. Do not use the
 human-facing block title as `--block-id`.
 
-If package search does not provide a version, inspect the package by name first and use
+If `packages search` does not provide a version, inspect the package by name first and use
 the resolved `packageVersion` for any later `cloud-task run`.
 
 If a candidate does not expose a usable package name, do not select it.
@@ -383,5 +383,5 @@ https://console.oomol.com/billing/recharge before retrying anything.
 - Be decisive.
 - Prefer the most specific block over a generic block.
 - Prefer recoverable progress over fragile one-shot waiting.
-- Never claim a capability that was not proven by `package search`, `package info`, or
+- Never claim a capability that was not proven by `packages search`, `packages info`, or
   command output.

--- a/contrib/skills/oo/references/oo-cli-contract.md
+++ b/contrib/skills/oo/references/oo-cli-contract.md
@@ -14,7 +14,7 @@ oo ...
 
 ## Authentication
 
-- `package search`, `package info`, `file upload`, `cloud-task run`,
+- `packages search`, `packages info`, `file upload`, `cloud-task run`,
   `cloud-task result`, and `cloud-task wait` all require a current
   authenticated account.
 - Do not run `auth status` as a routine precheck.
@@ -42,12 +42,12 @@ oo auth login
 - Direct them to recharge before retrying at
   https://console.oomol.com/billing/recharge.
 
-## `package search`
+## `packages search`
 
 Canonical form:
 
 ```bash
-oo package search "<text>" --json
+oo packages search "<text>" --json
 ```
 
 Facts:
@@ -85,12 +85,12 @@ Stop condition:
 - If the array is empty, stop and tell the user that `oo` does not currently
   have a matching capability.
 
-## `package info`
+## `packages info`
 
 Canonical form:
 
 ```bash
-oo package info "<packageSpecifier>" --json
+oo packages info "<packageSpecifier>" --json
 ```
 
 Supported package specifier examples:
@@ -103,7 +103,7 @@ Supported package specifier examples:
 Facts:
 
 - If no version is provided, the CLI resolves the latest version.
-- `@latest` is valid for `package info`, but not for `cloud-task run`.
+- `@latest` is valid for `packages info`, but not for `cloud-task run`.
 - For execution later, always use the resolved `packageVersion`.
 - Use `blocks[].blockName` for `--block-id`.
 - Do not confuse block `title` with `blockName`.
@@ -363,8 +363,8 @@ Skill policy:
 Use this order:
 
 1. Convert the user request into `2` to `6` English keywords.
-2. Run `package search --json`.
-3. Run `package info --json` for the serious candidates.
+2. Run `packages search --json`.
+3. Run `packages info --json` for the serious candidates.
 4. Choose one primary package and optionally one fallback.
 5. Ask focused follow-up questions only for missing required inputs.
 6. Upload local files with `file upload --json` when a selected handle needs a

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -271,7 +271,7 @@ Delete expired upload records from the local sqlite store.
 
 ## Package Discovery
 
-### `oo package search <text>`
+### `oo packages search <text>`
 
 Search packages with free-form intent text.
 
@@ -283,7 +283,7 @@ Search packages with free-form intent text.
 - Notes: queries longer than 200 characters are truncated before the request is
   sent.
 
-### `oo package info <packageSpecifier>`
+### `oo packages info <packageSpecifier>`
 
 Show package metadata for one package.
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -240,7 +240,7 @@
 
 ## Package 检索
 
-### `oo package search <text>`
+### `oo packages search <text>`
 
 使用自由文本按意图搜索 package。
 
@@ -250,7 +250,7 @@
 - 选项：`--only-package-id` 仅返回 package id。
 - 说明：搜索文本超过 200 个字符时，会在发送请求前被截断。
 
-### `oo package info <packageSpecifier>`
+### `oo packages info <packageSpecifier>`
 
 查看单个 package 的元数据。
 

--- a/src/adapters/completion/static-completion-renderer.test.ts
+++ b/src/adapters/completion/static-completion-renderer.test.ts
@@ -15,6 +15,7 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain("config");
         expect(output).toContain("login");
         expect(output).toContain("logout");
+        expect(output).toContain("packages");
         expect(output).toContain("--lang");
         expect(output).toContain("en zh");
     });
@@ -26,6 +27,7 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain(`#compdef ${APP_NAME}`);
         expect(output).toContain("auth switch");
         expect(output).toContain("config set");
+        expect(output).toContain("packages search");
         expect(output).toContain(`compdef _${APP_NAME} ${APP_NAME}`);
     });
 
@@ -40,6 +42,7 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain("config");
         expect(output).toContain("login");
         expect(output).toContain("logout");
+        expect(output).toContain("__fish_seen_subcommand_from packages");
         expect(output).toContain("en zh");
     });
 });

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -50,7 +50,7 @@ Commands:
   config              Manage persisted configuration
   skills              Manage Codex skills
   log                 Manage persisted debug logs
-  package             Package utilities
+  packages            Package utilities
   help [command]      Show help for a command
 "
 ,
@@ -81,7 +81,7 @@ Commands:
   config              Manage persisted configuration
   skills              Manage Codex skills
   log                 Manage persisted debug logs
-  package             Package utilities
+  packages            Package utilities
   help [command]      Show help for a command
 "
 ,
@@ -115,7 +115,7 @@ Commands:
   config              Manage persisted configuration
   skills              Manage Codex skills
   log                 Manage persisted debug logs
-  package             Package utilities
+  packages            Package utilities
   help [command]      Show help for a command
 "
 ,
@@ -147,7 +147,7 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
   config              管理持久化配置
   skills              管理 Codex skill
   log                 管理持久化 debug 日志
-  package             包相关工具
+  packages            包相关工具
   help [command]      显示命令帮助
 "
 ,
@@ -175,7 +175,7 @@ Commands:
   config              Manage persisted configuration
   skills              Manage Codex skills
   log                 Manage persisted debug logs
-  package             Package utilities
+  packages            Package utilities
   help [command]      Show help for a command
 "
 ,
@@ -207,7 +207,7 @@ Commands:
   config              Manage persisted configuration
   skills              Manage Codex skills
   log                 Manage persisted debug logs
-  package             Package utilities
+  packages            Package utilities
   help [command]      Show help for a command
 "
 ,

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -36,7 +36,7 @@ Commands:
   config              Manage persisted configuration
   skills              Manage Codex skills
   log                 Manage persisted debug logs
-  package             Package utilities
+  packages            Package utilities
   help [command]      Show help for a command
 "
 ,
@@ -64,7 +64,7 @@ Commands:
   config              管理持久化配置
   skills              管理 Codex skill
   log                 管理持久化 debug 日志
-  package             包相关工具
+  packages            包相关工具
   help [command]      显示命令帮助
 "
 ,

--- a/src/application/commands/package/index.ts
+++ b/src/application/commands/package/index.ts
@@ -4,7 +4,7 @@ import { packageInfoCommand } from "./info.ts";
 import { packageSearchCommand } from "./search.ts";
 
 export const packageCommand: CliCommandDefinition = {
-    name: "package",
+    name: "packages",
     summaryKey: "commands.package.summary",
     descriptionKey: "commands.package.description",
     children: [

--- a/src/application/commands/package/info.cli.test.ts
+++ b/src/application/commands/package/info.cli.test.ts
@@ -37,7 +37,7 @@ describe("packageInfoCommand CLI", () => {
 
             const requests: Request[] = [];
             const result = await sandbox.run(
-                ["package", "info", "qrcode"],
+                ["packages", "info", "qrcode"],
                 {
                     fetcher: async (input, init) => {
                         requests.push(toRequest(input, init));
@@ -185,7 +185,7 @@ describe("packageInfoCommand CLI", () => {
             );
 
             const result = await sandbox.run(
-                ["package", "info", "qrcode@1.0.4", "--json"],
+                ["packages", "info", "qrcode@1.0.4", "--json"],
                 {
                     fetcher: async () => new Response(JSON.stringify({
                         packageName: "qrcode",
@@ -404,7 +404,7 @@ describe("packageInfoCommand CLI", () => {
             const snapshots = [];
             const cases = [
                 {
-                    argv: ["package", "info", "pdf@1.0.0", "--format=json"],
+                    argv: ["packages", "info", "pdf@1.0.0", "--format=json"],
                     expectedUrl:
                         "https://registry.oomol.com/-/oomol/package-info/pdf/1.0.0?lang=en",
                     response: {
@@ -416,7 +416,7 @@ describe("packageInfoCommand CLI", () => {
                     },
                 },
                 {
-                    argv: ["package", "info", "pdf", "--format=json"],
+                    argv: ["packages", "info", "pdf", "--format=json"],
                     expectedUrl:
                         "https://registry.oomol.com/-/oomol/package-info/pdf/latest?lang=en",
                     response: {
@@ -428,7 +428,7 @@ describe("packageInfoCommand CLI", () => {
                     },
                 },
                 {
-                    argv: ["package", "info", "@foo/epub", "--format=json"],
+                    argv: ["packages", "info", "@foo/epub", "--format=json"],
                     expectedUrl:
                         "https://registry.oomol.com/-/oomol/package-info/%40foo%2Fepub/latest?lang=en",
                     response: {
@@ -440,7 +440,7 @@ describe("packageInfoCommand CLI", () => {
                     },
                 },
                 {
-                    argv: ["package", "info", "@bar/epub@1.0.0", "--format=json"],
+                    argv: ["packages", "info", "@bar/epub@1.0.0", "--format=json"],
                     expectedUrl:
                         "https://registry.oomol.com/-/oomol/package-info/%40bar%2Fepub/1.0.0?lang=en",
                     response: {
@@ -452,7 +452,7 @@ describe("packageInfoCommand CLI", () => {
                     },
                 },
                 {
-                    argv: ["package", "info", "@baz@md@latest", "--format=json"],
+                    argv: ["packages", "info", "@baz@md@latest", "--format=json"],
                     expectedUrl:
                         "https://registry.oomol.com/-/oomol/package-info/%40baz%40md/latest?lang=en",
                     response: {
@@ -535,11 +535,11 @@ describe("packageInfoCommand CLI", () => {
             };
 
             const firstResult = await sandbox.run(
-                ["package", "info", "qrcode@1.0.4"],
+                ["packages", "info", "qrcode@1.0.4"],
                 { fetcher },
             );
             const secondResult = await sandbox.run(
-                ["package", "info", "qrcode@1.0.4"],
+                ["packages", "info", "qrcode@1.0.4"],
                 { fetcher },
             );
 
@@ -594,15 +594,15 @@ describe("packageInfoCommand CLI", () => {
             };
 
             const latestResult = await sandbox.run(
-                ["package", "info", "qrcode"],
+                ["packages", "info", "qrcode"],
                 { fetcher },
             );
             const latestAgainResult = await sandbox.run(
-                ["package", "info", "qrcode"],
+                ["packages", "info", "qrcode"],
                 { fetcher },
             );
             const explicitVersionResult = await sandbox.run(
-                ["package", "info", "qrcode@1.0.4"],
+                ["packages", "info", "qrcode@1.0.4"],
                 { fetcher },
             );
 
@@ -622,7 +622,7 @@ describe("packageInfoCommand CLI", () => {
         const sandbox = await createCliSandbox();
 
         try {
-            const result = await sandbox.run(["package", "info", "--help"]);
+            const result = await sandbox.run(["packages", "info", "--help"]);
 
             expect(createCliSnapshot(result)).toMatchSnapshot();
         }

--- a/src/application/commands/package/search.cli.test.ts
+++ b/src/application/commands/package/search.cli.test.ts
@@ -41,7 +41,7 @@ describe("packageSearchCommand CLI", () => {
             );
 
             const result = await sandbox.run(
-                ["package", "search", "image processing"],
+                ["packages", "search", "image processing"],
                 {
                     fetcher: async () => new Response(JSON.stringify({
                         packages: [],
@@ -95,9 +95,9 @@ describe("packageSearchCommand CLI", () => {
                 }));
             };
 
-            const firstResult = await sandbox.run(["package", "search", "cache me"], { fetcher });
+            const firstResult = await sandbox.run(["packages", "search", "cache me"], { fetcher });
             const firstContent = await readLatestLogContent(sandbox);
-            const secondResult = await sandbox.run(["package", "search", "cache me"], { fetcher });
+            const secondResult = await sandbox.run(["packages", "search", "cache me"], { fetcher });
             const secondContent = await readLatestLogContent(sandbox);
 
             expect({
@@ -142,7 +142,7 @@ describe("packageSearchCommand CLI", () => {
 
             const requests: Request[] = [];
             const result = await sandbox.run(
-                ["package", "search", "image processing"],
+                ["packages", "search", "image processing"],
                 {
                     fetcher: async (input, init) => {
                         requests.push(toRequest(input, init));
@@ -207,7 +207,7 @@ describe("packageSearchCommand CLI", () => {
 
             const requests: Request[] = [];
             const result = await sandbox.run(
-                ["--lang", "zh", "package", "search", "image processing"],
+                ["--lang", "zh", "packages", "search", "image processing"],
                 {
                     fetcher: async (input, init) => {
                         requests.push(toRequest(input, init));
@@ -270,11 +270,11 @@ describe("packageSearchCommand CLI", () => {
                 }));
             };
             const firstResult = await sandbox.run(
-                ["package", "search", "image processing"],
+                ["packages", "search", "image processing"],
                 { fetcher },
             );
             const secondResult = await sandbox.run(
-                ["package", "search", "image processing"],
+                ["packages", "search", "image processing"],
                 { fetcher },
             );
 
@@ -317,7 +317,7 @@ describe("packageSearchCommand CLI", () => {
             );
 
             const result = await sandbox.run(
-                ["package", "search", "image processing"],
+                ["packages", "search", "image processing"],
                 {
                     fetcher: async () => new Response(JSON.stringify({
                         packages: [
@@ -383,7 +383,7 @@ describe("packageSearchCommand CLI", () => {
             );
 
             const result = await sandbox.run(
-                ["package", "search", "image processing", "--only-package-id"],
+                ["packages", "search", "image processing", "--only-package-id"],
                 {
                     fetcher: async () => new Response(JSON.stringify({
                         packages: [
@@ -453,7 +453,7 @@ describe("packageSearchCommand CLI", () => {
             const searchText = "x".repeat(210);
             const expectedQuery = "x".repeat(200);
             const result = await sandbox.run(
-                ["package", "search", searchText, "--json"],
+                ["packages", "search", searchText, "--json"],
                 {
                     fetcher: async (input, init) => {
                         requests.push(toRequest(input, init));
@@ -499,7 +499,7 @@ describe("packageSearchCommand CLI", () => {
             );
 
             const result = await sandbox.run(
-                ["package", "search", "image processing", "--format=json", "--only-package-id"],
+                ["packages", "search", "image processing", "--format=json", "--only-package-id"],
                 {
                     fetcher: async () => new Response(JSON.stringify({
                         packages: [
@@ -528,7 +528,7 @@ describe("packageSearchCommand CLI", () => {
         const sandbox = await createCliSandbox();
 
         try {
-            const result = await sandbox.run(["package", "search", "image", "--format=yaml"]);
+            const result = await sandbox.run(["packages", "search", "image", "--format=yaml"]);
 
             expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(result.stderr).toContain("Invalid format: yaml. Use json.");
@@ -542,8 +542,8 @@ describe("packageSearchCommand CLI", () => {
         const sandbox = await createCliSandbox();
 
         try {
-            const expectedHelp = await sandbox.run(["package", "search", "--help"]);
-            const result = await sandbox.run(["package", "search"]);
+            const expectedHelp = await sandbox.run(["packages", "search", "--help"]);
+            const result = await sandbox.run(["packages", "search"]);
             const expectedHelpSnapshot = createCliSnapshot(expectedHelp);
             const resultSnapshot = createCliSnapshot(result);
 

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -46,7 +46,7 @@ Commands:
   config              Manage persisted configuration
   skills              Manage Codex skills
   log                 Manage persisted debug logs
-  package             Package utilities
+  packages            Package utilities
   help [command]      Show help for a command
 "
 ,
@@ -77,7 +77,7 @@ Commands:
   config              Manage persisted configuration
   skills              Manage Codex skills
   log                 Manage persisted debug logs
-  package             Package utilities
+  packages            Package utilities
   help [command]      Show help for a command
 "
 ,
@@ -119,7 +119,7 @@ Commands:
   config              Manage persisted configuration
   skills              Manage Codex skills
   log                 Manage persisted debug logs
-  package             Package utilities
+  packages            Package utilities
   help [command]      Show help for a command
 "
 ,

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -264,7 +264,7 @@ export const enMessages = {
     "errors.search.activeAccountMissing":
         "The active auth account is missing from the auth store.",
     "errors.search.authRequired":
-        "You must log in before using the search command.",
+        "You must log in before using the packages search command.",
     "errors.search.invalidFormat":
         "Invalid format: {value}. Use json.",
     "errors.search.invalidResponse":
@@ -276,7 +276,7 @@ export const enMessages = {
     "errors.packageInfo.activeAccountMissing":
         "The active auth account is missing from the auth store.",
     "errors.packageInfo.authRequired":
-        "You must log in before using the package info command.",
+        "You must log in before using the packages info command.",
     "errors.packageInfo.invalidFormat":
         "Invalid format: {value}. Use json.",
     "errors.packageInfo.invalidPackageSpecifier":
@@ -655,7 +655,7 @@ export const zhMessages = {
     "errors.search.activeAccountMissing":
         "当前激活账号不存在于认证数据中。",
     "errors.search.authRequired":
-        "使用 search 命令前请先登录。",
+        "使用 packages search 命令前请先登录。",
     "errors.search.invalidFormat":
         "无效的 format：{value}。请使用 json。",
     "errors.search.invalidResponse":
@@ -667,7 +667,7 @@ export const zhMessages = {
     "errors.packageInfo.activeAccountMissing":
         "当前激活账号不存在于认证数据中。",
     "errors.packageInfo.authRequired":
-        "使用 package info 命令前请先登录。",
+        "使用 packages info 命令前请先登录。",
     "errors.packageInfo.invalidFormat":
         "无效的 format：{value}。请使用 json。",
     "errors.packageInfo.invalidPackageSpecifier":


### PR DESCRIPTION
Use plural noun for the subcommand group name so that it reads naturally as a resource-collection noun (e.g. `oo packages search`). Updates command definition, tests, snapshots, docs, shell-completion assertions, and skill references.