### PR TITLE
feat(skills): add search command for published skills

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,20 @@ Check whether a newer CLI release is available.
 
 ## Codex Skills
 
+### `oo skills search <text>`
+
+Search published skills with free-form text.
+
+- Alias: `oo skills find <text>`.
+- Arguments: `<text>` is the search text sent to the skills search service.
+- Options: `--keywords <keywords>` sends a comma-separated keyword list as
+  repeated `keywords` query parameters after trimming empty entries.
+- Options: `--format=json` and `--json` print a JSON array of matching skill
+  entries.
+- Output: text output prints one block per skill with its title or name,
+  optional description, and source package reference when available.
+- Notes: every invocation requests at most `5` results.
+
 ### `oo skills config get <skill> [key]`
 
 Read skill configuration values.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -108,6 +108,19 @@
 
 ## Codex Skill
 
+### `oo skills search <text>`
+
+使用自由文本搜索已发布的 skill。
+
+- 别名：`oo skills find <text>`。
+- 参数：`<text>` 会作为搜索文本发送到 skills search 服务。
+- 选项：`--keywords <keywords>` 接收逗号分隔的关键词列表，去掉空项后以
+  重复的 `keywords` 查询参数发送。
+- 选项：`--format=json` 和 `--json` 会输出匹配 skill 条目的 JSON 数组。
+- 输出：文本输出会为每个 skill 打印一个块，包含标题或名称、可选描述，以及
+  在可用时显示来源包标识。
+- 说明：每次调用最多请求 `5` 条结果。
+
 ### `oo skills config get <skill> [key]`
 
 读取 skill 配置值。

--- a/src/application/commands/skills/__snapshots__/search.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/search.cli.test.ts.snap
@@ -1,0 +1,87 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`skills search CLI supports skills search command with text output 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Text Generation (text-generation)
+Generate text using AI models
+Package: @oomol/ai-tools@1.0.0
+"
+,
+}
+`;
+
+exports[`skills search CLI supports skills find alias with json output and keywords 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"[{"description":"Generate text using AI models","icon":"https://example.com/text-generation.png","name":"text-generation","packageName":"@oomol/ai-tools","packageVersion":"1.0.0","title":"Text Generation"}]
+"
+,
+}
+`;
+
+exports[`skills search CLI validates the skills search format option 1`] = `
+{
+  "exitCode": 2,
+  "stderr": 
+"Invalid format: yaml. Use json.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`skills search CLI renders skills search help when text argument is omitted 1`] = `
+{
+  "expectedHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Search published skills against the skills search API.
+
+Arguments:
+  text                   Search text
+
+Options:
+  --format <format>      Specify output format (use json for structured output)
+  --json                 Alias for --format=json
+  --keywords <keywords>  Specify comma-separated keywords to refine the skill
+                         search
+  -h, --help             Show help for command
+
+Global Options:
+  -V, --version          Show the current version
+  --debug                Print the current log file path when the CLI exits
+  --lang <lang>          Specify the display language
+"
+,
+  },
+  "result": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Search published skills against the skills search API.
+
+Arguments:
+  text                   Search text
+
+Options:
+  --format <format>      Specify output format (use json for structured output)
+  --json                 Alias for --format=json
+  --keywords <keywords>  Specify comma-separated keywords to refine the skill
+                         search
+  -h, --help             Show help for command
+
+Global Options:
+  -V, --version          Show the current version
+  --debug                Print the current log file path when the CLI exits
+  --lang <lang>          Specify the display language
+"
+,
+  },
+}
+`;

--- a/src/application/commands/skills/__snapshots__/search.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/search.cli.test.ts.snap
@@ -85,3 +85,16 @@ Global Options:
   },
 }
 `;
+
+exports[`skills search CLI renders skills search output with field-specific colors 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Text Generation (text-generation)
+Generate text using AI models
+Package: @oomol/ai-tools@1.0.0
+"
+,
+}
+`;

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -2,6 +2,7 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { skillsConfigCommand } from "./config/index.ts";
 import { skillsInstallCommand } from "./install.ts";
+import { skillsSearchCommand } from "./search.ts";
 import { skillsUninstallCommand } from "./uninstall.ts";
 
 export const skillsCommand: CliCommandDefinition = {
@@ -9,6 +10,7 @@ export const skillsCommand: CliCommandDefinition = {
     summaryKey: "commands.skills.summary",
     descriptionKey: "commands.skills.description",
     children: [
+        skillsSearchCommand,
         skillsConfigCommand,
         skillsInstallCommand,
         skillsUninstallCommand,

--- a/src/application/commands/skills/search.cli.test.ts
+++ b/src/application/commands/skills/search.cli.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    createCliSandbox,
+    createCliSnapshot,
+    toRequest,
+    writeAuthFile,
+} from "../../../../__tests__/helpers.ts";
+
+describe("skills search CLI", () => {
+    test("supports skills search command with text output", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["skills", "search", "text generation"],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            data: [
+                                {
+                                    description: "Generate text using AI models",
+                                    icon: "https://example.com/text-generation.png",
+                                    name: "text-generation",
+                                    owner: "0195f082-f87a-7772-80a9-9a2e4245d4d5",
+                                    packageName: "@oomol/ai-tools",
+                                    packageVersion: "1.0.0",
+                                    title: "Text Generation",
+                                    when: "Use this when the user asks for text generation.",
+                                },
+                            ],
+                        }));
+                    },
+                },
+            );
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    "Text Generation (text-generation)",
+                    "Generate text using AI models",
+                    "Package: @oomol/ai-tools@1.0.0",
+                    "",
+                ].join("\n"),
+            );
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.url).toBe(
+                "https://search.oomol.com/v1/packages/-/skills-search?text=text+generation&size=5",
+            );
+            expect(requests[0]?.headers.get("Authorization")).toBe("secret-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports skills find alias with json output and keywords", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["skills", "find", "text generation", "--format=json", "--keywords=bar,baz"],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            data: [
+                                {
+                                    description: "Generate text using AI models",
+                                    icon: "https://example.com/text-generation.png",
+                                    name: "text-generation",
+                                    packageName: "@oomol/ai-tools",
+                                    packageVersion: "1.0.0",
+                                    title: "Text Generation",
+                                },
+                            ],
+                        }));
+                    },
+                },
+            );
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(JSON.parse(result.stdout)).toEqual([
+                {
+                    description: "Generate text using AI models",
+                    icon: "https://example.com/text-generation.png",
+                    name: "text-generation",
+                    packageName: "@oomol/ai-tools",
+                    packageVersion: "1.0.0",
+                    title: "Text Generation",
+                },
+            ]);
+            expect(result.stdout).not.toContain("\"owner\"");
+            expect(result.stdout).not.toContain("\"when\"");
+            expect(requests).toHaveLength(1);
+            expect(new URL(requests[0]!.url).searchParams.get("text")).toBe(
+                "text generation",
+            );
+            expect(
+                new URL(requests[0]!.url).searchParams.getAll("keywords"),
+            ).toEqual(["bar", "baz"]);
+            expect(new URL(requests[0]!.url).searchParams.get("size")).toBe("5");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("validates the skills search format option", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["skills", "search", "text", "--format=yaml"]);
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+            expect(result.exitCode).toBe(2);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe("Invalid format: yaml. Use json.\n");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders skills search help when text argument is omitted", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const expectedHelp = await sandbox.run(["skills", "search", "--help"]);
+            const result = await sandbox.run(["skills", "search"]);
+
+            expect({
+                expectedHelp: createCliSnapshot(expectedHelp),
+                result: createCliSnapshot(result),
+            }).toMatchSnapshot();
+            expect(result).toEqual(expectedHelp);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/search.cli.test.ts
+++ b/src/application/commands/skills/search.cli.test.ts
@@ -6,6 +6,10 @@ import {
     toRequest,
     writeAuthFile,
 } from "../../../../__tests__/helpers.ts";
+import { createTerminalColors } from "../../terminal-colors.ts";
+
+const skillSearchTitleColor = "#59F78D";
+const skillSearchPackageColor = "#CAA8FA";
 
 describe("skills search CLI", () => {
     test("supports skills search command with text output", async () => {
@@ -113,6 +117,48 @@ describe("skills search CLI", () => {
                 new URL(requests[0]!.url).searchParams.getAll("keywords"),
             ).toEqual(["bar", "baz"]);
             expect(new URL(requests[0]!.url).searchParams.get("size")).toBe("5");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders skills search output with field-specific colors", async () => {
+        const sandbox = await createCliSandbox();
+        const colors = createTerminalColors(true);
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "search", "text generation"],
+                {
+                    fetcher: async () => new Response(JSON.stringify({
+                        data: [
+                            {
+                                description: "Generate text using AI models",
+                                name: "text-generation",
+                                packageName: "@oomol/ai-tools",
+                                packageVersion: "1.0.0",
+                                title: "Text Generation",
+                            },
+                        ],
+                    })),
+                    stdout: {
+                        hasColors: true,
+                    },
+                },
+            );
+
+            expect(createCliSnapshot(result, {
+                stripAnsi: true,
+            })).toMatchSnapshot();
+            expect(result.stdout).toContain(
+                `${colors.hex(skillSearchTitleColor)("Text Generation")} (text-generation)`,
+            );
+            expect(result.stdout).toContain(
+                `Package: ${colors.hex(skillSearchPackageColor)("@oomol/ai-tools@1.0.0")}`,
+            );
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/search.test.ts
+++ b/src/application/commands/skills/search.test.ts
@@ -1,0 +1,204 @@
+import type { AuthStore } from "../../contracts/auth-store.ts";
+import type {
+    CliCatalog,
+    CliExecutionContext,
+    Fetcher,
+    InteractiveInput,
+} from "../../contracts/cli.ts";
+import type { SettingsStore } from "../../contracts/settings-store.ts";
+import type { Translator } from "../../contracts/translator.ts";
+import type { AuthFile } from "../../schemas/auth.ts";
+import type { AppSettings } from "../../schemas/settings.ts";
+
+import { describe, expect, test } from "bun:test";
+import pino from "pino";
+
+import {
+    createNoopFileDownloadSessionStore,
+    createNoopFileUploadStore,
+    createTextBuffer,
+    toRequest,
+} from "../../../../__tests__/helpers.ts";
+import { skillsSearchCommand } from "./search.ts";
+
+const searchHandler = skillsSearchCommand.handler!;
+const activeAuthFile: AuthFile = {
+    id: "user-1",
+    auth: [
+        {
+            id: "user-1",
+            name: "Alice",
+            apiKey: "secret-1",
+            endpoint: "oomol.com",
+        },
+    ],
+};
+const emptyCatalog: CliCatalog = {
+    name: "oo",
+    descriptionKey: "catalog.description",
+    globalOptions: [],
+    commands: [],
+};
+const translator: Translator = {
+    locale: "en",
+    t: (key) => {
+        switch (key) {
+            case "skills.search.text.noResults":
+                return "No matching skills were found.";
+            case "skills.search.text.package":
+                return "Package";
+            case "skills.search.text.unnamedSkill":
+                return "unnamed-skill";
+            default:
+                return key;
+        }
+    },
+    resolveLocale: () => "en",
+};
+const stdin: InteractiveInput = {
+    on() {},
+    off() {},
+};
+
+describe("skillsSearchCommand", () => {
+    test("trims and deduplicates keywords before sending the request", async () => {
+        const requests: Request[] = [];
+        const context = createSearchContext({
+            fetcher: async (input, init) => {
+                requests.push(toRequest(input, init));
+
+                return new Response(JSON.stringify({
+                    data: [],
+                }));
+            },
+        });
+
+        await searchHandler(
+            {
+                text: "text generation",
+                keywords: "  bar, baz , ,bar,qux  ",
+            },
+            context,
+        );
+
+        expect(requests).toHaveLength(1);
+        expect(new URL(requests[0]!.url).searchParams.getAll("keywords")).toEqual([
+            "bar",
+            "baz",
+            "qux",
+        ]);
+    });
+
+    test("writes the no-results message when no skills are returned", async () => {
+        const context = createSearchContext({
+            fetcher: async () => new Response(JSON.stringify({
+                data: [],
+            })),
+        });
+
+        await searchHandler(
+            {
+                text: "text generation",
+            },
+            context,
+        );
+
+        expect(context.stdoutBuffer.read()).toBe("No matching skills were found.\n");
+    });
+
+    test("rejects unsupported skills search responses", async () => {
+        const context = createSearchContext({
+            fetcher: async () => new Response("not-json"),
+        });
+
+        await expect(
+            searchHandler(
+                {
+                    text: "text generation",
+                },
+                context,
+            ),
+        ).rejects.toMatchObject({
+            key: "errors.skillsSearch.invalidResponse",
+        });
+    });
+});
+
+function createSearchContext(options: {
+    fetcher: Fetcher;
+}): CliExecutionContext & {
+    stdoutBuffer: ReturnType<typeof createTextBuffer>;
+} {
+    const stdoutBuffer = createTextBuffer();
+    const stderr = createTextBuffer();
+
+    return {
+        authStore: createAuthStore(activeAuthFile),
+        cacheStore: {
+            close() {},
+            getCache() {
+                throw new Error("Unexpected cache access.");
+            },
+            getFilePath: () => "",
+        },
+        currentLogFilePath: "",
+        fetcher: options.fetcher,
+        cwd: process.cwd(),
+        env: {},
+        fileDownloadSessionStore: createNoopFileDownloadSessionStore(),
+        fileUploadStore: createNoopFileUploadStore(),
+        stdin,
+        logger: pino({
+            enabled: false,
+        }),
+        packageName: "@oomol-lab/oo-cli",
+        settingsStore: createSettingsStore({}),
+        stdout: stdoutBuffer.writer,
+        stdoutBuffer,
+        stderr: stderr.writer,
+        translator,
+        completionRenderer: {
+            render: () => "",
+        },
+        catalog: emptyCatalog,
+        version: "0.1.0",
+    };
+}
+
+function createAuthStore(authFile: AuthFile): AuthStore {
+    let currentAuthFile = authFile;
+
+    return {
+        getFilePath: () => "",
+        read: async () => currentAuthFile,
+        write: async (nextAuthFile) => {
+            currentAuthFile = nextAuthFile;
+
+            return currentAuthFile;
+        },
+        update: async (updater) => {
+            currentAuthFile = updater(currentAuthFile);
+
+            return currentAuthFile;
+        },
+    };
+}
+
+function createSettingsStore(settings: AppSettings): SettingsStore {
+    let currentSettings = settings;
+
+    return {
+        getFilePath: () => "",
+        read: async () => currentSettings,
+        write: async (nextSettings) => {
+            currentSettings = nextSettings;
+
+            return currentSettings;
+        },
+        update: async (updater) => {
+            currentSettings = updater(currentSettings);
+
+            return currentSettings;
+        },
+    };
+}

--- a/src/application/commands/skills/search.ts
+++ b/src/application/commands/skills/search.ts
@@ -1,0 +1,313 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+
+import type { AuthAccount } from "../../schemas/auth.ts";
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import {
+    withRequestTarget,
+} from "../../logging/log-fields.ts";
+import { readCurrentAuth } from "../auth/shared.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+
+const searchFormatValues = ["json"] as const;
+const skillSearchResultLimit = 5;
+
+const skillSearchItemSchema = z.object({
+    description: z.string().optional().default(""),
+    icon: z.string().optional().default(""),
+    name: z.string().optional().default(""),
+    packageName: z.string().optional().default(""),
+    packageVersion: z.string().optional().default(""),
+    title: z.string().optional().default(""),
+});
+
+const skillSearchJsonResponseSchema = z.object({
+    data: z.array(skillSearchItemSchema).optional().default([]),
+}).passthrough();
+
+const skillSearchResponseSchema = z.object({
+    data: z.array(skillSearchItemSchema).optional().default([]),
+}).passthrough();
+
+type SkillSearchJsonResponse = z.output<typeof skillSearchJsonResponseSchema>;
+type SkillSearchResponse = z.output<typeof skillSearchResponseSchema>;
+type SkillSearchTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
+
+interface SkillsSearchInput {
+    text: string;
+    format?: (typeof searchFormatValues)[number];
+    keywords?: string;
+}
+
+export const skillsSearchCommand: CliCommandDefinition<SkillsSearchInput> = {
+    name: "search",
+    aliases: ["find"],
+    summaryKey: "commands.skills.search.summary",
+    descriptionKey: "commands.skills.search.description",
+    missingArgumentBehavior: "showHelp",
+    arguments: [
+        {
+            name: "text",
+            descriptionKey: "arguments.text",
+            required: true,
+        },
+    ],
+    options: [
+        ...jsonOutputOptions,
+        {
+            name: "keywords",
+            longFlag: "--keywords",
+            valueName: "keywords",
+            descriptionKey: "options.keywords",
+        },
+    ],
+    inputSchema: z.object({
+        text: z.string(),
+        format: z.enum(searchFormatValues).optional(),
+        keywords: z.string().optional(),
+    }),
+    mapInputError: (_, rawInput) => createSkillsSearchInputError(rawInput),
+    handler: async (input, context) => {
+        const account = await requireCurrentSkillsSearchAccount(context);
+        const requestUrl = createSkillsSearchRequestUrl(
+            account.endpoint,
+            input.text,
+            parseSkillSearchKeywords(input.keywords),
+        );
+        const response = parseSkillsSearchResponse(
+            await requestSkillsSearch(requestUrl, account.apiKey, context),
+        );
+
+        if (input.format === "json") {
+            writeJsonOutput(context.stdout, response.json.data);
+            return;
+        }
+
+        const output = formatSkillsSearchResponseAsText(response.text, context);
+
+        context.stdout.write(
+            output === ""
+                ? `${context.translator.t("skills.search.text.noResults")}\n`
+                : `${output}\n`,
+        );
+    },
+};
+
+function createSkillsSearchInputError(
+    rawInput: Record<string, unknown>,
+): CliUserError {
+    return new CliUserError("errors.skillsSearch.invalidFormat", 2, {
+        value: String(rawInput.format ?? ""),
+    });
+}
+
+async function requireCurrentSkillsSearchAccount(
+    context: CliExecutionContext,
+): Promise<AuthAccount> {
+    const { authFile, currentAccount } = await readCurrentAuth(context);
+
+    if (currentAccount !== undefined) {
+        return currentAccount;
+    }
+
+    throw new CliUserError(
+        authFile.id === ""
+            ? "errors.skillsSearch.authRequired"
+            : "errors.skillsSearch.activeAccountMissing",
+        1,
+    );
+}
+
+function createSkillsSearchRequestUrl(
+    endpoint: string,
+    text: string,
+    keywords: readonly string[],
+): URL {
+    const requestUrl = new URL(
+        `https://search.${endpoint}/v1/packages/-/skills-search`,
+    );
+
+    requestUrl.searchParams.set("text", text);
+
+    for (const keyword of keywords) {
+        requestUrl.searchParams.append("keywords", keyword);
+    }
+
+    requestUrl.searchParams.set("size", String(skillSearchResultLimit));
+
+    return requestUrl;
+}
+
+function parseSkillSearchKeywords(value: string | undefined): string[] {
+    if (value === undefined) {
+        return [];
+    }
+
+    const keywords: string[] = [];
+    const seen = new Set<string>();
+
+    for (const segment of value.split(",")) {
+        const keyword = segment.trim();
+
+        if (keyword === "" || seen.has(keyword)) {
+            continue;
+        }
+
+        seen.add(keyword);
+        keywords.push(keyword);
+    }
+
+    return keywords;
+}
+
+async function requestSkillsSearch(
+    requestUrl: URL,
+    apiKey: string,
+    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+): Promise<string> {
+    const requestStartedAt = Date.now();
+    const keywordCount = requestUrl.searchParams.getAll("keywords").length;
+
+    context.logger.debug(
+        {
+            keywordCount,
+            textLength: requestUrl.searchParams.get("text")?.length ?? 0,
+            ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+        },
+        "Skills search request started.",
+    );
+
+    try {
+        const response = await context.fetcher(requestUrl, {
+            headers: {
+                Authorization: apiKey,
+            },
+        });
+        const durationMs = Date.now() - requestStartedAt;
+
+        if (!response.ok) {
+            context.logger.warn(
+                {
+                    durationMs,
+                    keywordCount,
+                    status: response.status,
+                    ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+                },
+                "Skills search request returned a non-success status.",
+            );
+            throw new CliUserError("errors.skillsSearch.requestFailed", 1, {
+                status: response.status,
+            });
+        }
+
+        context.logger.debug(
+            {
+                durationMs,
+                keywordCount,
+                status: response.status,
+                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+            },
+            "Skills search request completed.",
+        );
+
+        return await response.text();
+    }
+    catch (error) {
+        if (error instanceof CliUserError) {
+            throw error;
+        }
+
+        context.logger.warn(
+            {
+                durationMs: Date.now() - requestStartedAt,
+                err: error,
+                keywordCount,
+                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+            },
+            "Skills search request failed unexpectedly.",
+        );
+        throw new CliUserError("errors.skillsSearch.requestError", 1, {
+            message: error instanceof Error ? error.message : String(error),
+        });
+    }
+}
+
+function parseSkillsSearchResponse(rawResponse: string): {
+    json: SkillSearchJsonResponse;
+    text: SkillSearchResponse;
+} {
+    try {
+        const parsed = JSON.parse(rawResponse) as unknown;
+
+        return {
+            json: skillSearchJsonResponseSchema.parse(parsed),
+            text: skillSearchResponseSchema.parse(parsed),
+        };
+    }
+    catch {
+        throw new CliUserError("errors.skillsSearch.invalidResponse", 1);
+    }
+}
+
+function formatSkillsSearchResponseAsText(
+    response: SkillSearchResponse,
+    context: SkillSearchTextContext,
+): string {
+    return response.data
+        .map(item => formatSkillsSearchItem(item, context))
+        .join("\n\n");
+}
+
+function formatSkillsSearchItem(
+    item: SkillSearchResponse["data"][number],
+    context: SkillSearchTextContext,
+): string {
+    const lines = [readSkillsSearchItemLabel(item, context)];
+
+    if (item.description !== "") {
+        lines.push(item.description);
+    }
+
+    const packageLabel = readSkillsSearchPackageLabel(item);
+
+    if (packageLabel !== "") {
+        lines.push(
+            `${context.translator.t("skills.search.text.package")}: ${packageLabel}`,
+        );
+    }
+
+    return lines.join("\n");
+}
+
+function readSkillsSearchItemLabel(
+    item: SkillSearchResponse["data"][number],
+    context: SkillSearchTextContext,
+): string {
+    if (item.title !== "") {
+        if (item.name !== "" && item.title !== item.name) {
+            return `${item.title} (${item.name})`;
+        }
+
+        return item.title;
+    }
+
+    if (item.name !== "") {
+        return item.name;
+    }
+
+    return context.translator.t("skills.search.text.unnamedSkill");
+}
+
+function readSkillsSearchPackageLabel(
+    item: SkillSearchResponse["data"][number],
+): string {
+    if (item.packageName === "") {
+        return "";
+    }
+
+    if (item.packageVersion === "") {
+        return item.packageName;
+    }
+
+    return `${item.packageName}@${item.packageVersion}`;
+}

--- a/src/application/commands/skills/search.ts
+++ b/src/application/commands/skills/search.ts
@@ -1,16 +1,20 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 
 import type { AuthAccount } from "../../schemas/auth.ts";
+import type { TerminalColors } from "../../terminal-colors.ts";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import {
     withRequestTarget,
 } from "../../logging/log-fields.ts";
+import { createWriterColors } from "../../terminal-colors.ts";
 import { readCurrentAuth } from "../auth/shared.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 
 const searchFormatValues = ["json"] as const;
 const skillSearchResultLimit = 5;
+const skillSearchTitleColor = "#59F78D";
+const skillSearchPackageColor = "#CAA8FA";
 
 const skillSearchItemSchema = z.object({
     description: z.string().optional().default(""),
@@ -253,16 +257,19 @@ function formatSkillsSearchResponseAsText(
     response: SkillSearchResponse,
     context: SkillSearchTextContext,
 ): string {
+    const colors = createSkillsSearchColors(context);
+
     return response.data
-        .map(item => formatSkillsSearchItem(item, context))
+        .map(item => formatSkillsSearchItem(item, context, colors))
         .join("\n\n");
 }
 
 function formatSkillsSearchItem(
     item: SkillSearchResponse["data"][number],
     context: SkillSearchTextContext,
+    colors: TerminalColors,
 ): string {
-    const lines = [readSkillsSearchItemLabel(item, context)];
+    const lines = [readSkillsSearchItemLabel(item, context, colors)];
 
     if (item.description !== "") {
         lines.push(item.description);
@@ -272,7 +279,7 @@ function formatSkillsSearchItem(
 
     if (packageLabel !== "") {
         lines.push(
-            `${context.translator.t("skills.search.text.package")}: ${packageLabel}`,
+            `${context.translator.t("skills.search.text.package")}: ${colors.hex(skillSearchPackageColor)(packageLabel)}`,
         );
     }
 
@@ -282,17 +289,20 @@ function formatSkillsSearchItem(
 function readSkillsSearchItemLabel(
     item: SkillSearchResponse["data"][number],
     context: SkillSearchTextContext,
+    colors: TerminalColors,
 ): string {
     if (item.title !== "") {
+        const title = colors.hex(skillSearchTitleColor)(item.title);
+
         if (item.name !== "" && item.title !== item.name) {
-            return `${item.title} (${item.name})`;
+            return `${title} (${item.name})`;
         }
 
-        return item.title;
+        return title;
     }
 
     if (item.name !== "") {
-        return item.name;
+        return colors.hex(skillSearchTitleColor)(item.name);
     }
 
     return context.translator.t("skills.search.text.unnamedSkill");
@@ -310,4 +320,10 @@ function readSkillsSearchPackageLabel(
     }
 
     return `${item.packageName}@${item.packageVersion}`;
+}
+
+function createSkillsSearchColors(
+    context: Pick<CliExecutionContext, "stdout">,
+): TerminalColors {
+    return createWriterColors(context.stdout);
 }

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -117,6 +117,10 @@ export const enMessages = {
         "Persist one skill configuration value and synchronize the installed managed skill when present.",
     "commands.skills.config.set.summary":
         "Set a skill configuration value",
+    "commands.skills.search.description":
+        "Search published skills against the skills search API.",
+    "commands.skills.search.summary":
+        "Search published skills",
     "commands.skills.install.description":
         "Install one bundled Codex skill into the local Codex skills directory.",
     "commands.skills.install.summary": "Install a bundled Codex skill",
@@ -273,6 +277,18 @@ export const enMessages = {
         "The search request failed: {message}",
     "errors.search.requestFailed":
         "The search request returned HTTP {status}.",
+    "errors.skillsSearch.activeAccountMissing":
+        "The active auth account is missing from the auth store.",
+    "errors.skillsSearch.authRequired":
+        "You must log in before using the skills search command.",
+    "errors.skillsSearch.invalidFormat":
+        "Invalid format: {value}. Use json.",
+    "errors.skillsSearch.invalidResponse":
+        "The skills search service returned an unsupported response body.",
+    "errors.skillsSearch.requestError":
+        "The skills search request failed: {message}",
+    "errors.skillsSearch.requestFailed":
+        "The skills search request returned HTTP {status}.",
     "errors.packageInfo.activeAccountMissing":
         "The active auth account is missing from the auth store.",
     "errors.packageInfo.authRequired":
@@ -337,6 +353,8 @@ export const enMessages = {
     "options.limit": "Specify the maximum number of items to return",
     "options.format": "Specify output format (use json for structured output)",
     "options.json": "Alias for --format=json",
+    "options.keywords":
+        "Specify comma-separated keywords to refine the skill search",
     "options.onlyPackageId": "Return only package ids",
     "options.nextToken": "Specify the pagination token for the next page",
     "options.packageId": "Filter by package id",
@@ -411,6 +429,9 @@ export const enMessages = {
     "search.text.noResults": "No matching packages were found.",
     "search.text.unnamedBlock": "unnamed-block",
     "search.text.unnamedPackage": "unnamed-package",
+    "skills.search.text.noResults": "No matching skills were found.",
+    "skills.search.text.package": "Package",
+    "skills.search.text.unnamedSkill": "unnamed-skill",
     "packageInfo.text.blocks": "Blocks:",
     "packageInfo.text.inputHandle": "Input:",
     "packageInfo.text.outputHandle": "Output:",
@@ -517,6 +538,10 @@ export const zhMessages = {
         "持久化一个 skill 配置值，并在本地存在受管安装时同步对应文件。",
     "commands.skills.config.set.summary":
         "设置一个 skill 配置值",
+    "commands.skills.search.description":
+        "使用自由文本通过 skills search API 搜索已发布的 skill。",
+    "commands.skills.search.summary":
+        "搜索已发布的 skill",
     "commands.skills.install.description": "将一个内置 Codex skill 安装到本地 Codex skills 目录。",
     "commands.skills.install.summary": "安装一个内置 Codex skill",
     "commands.skills.uninstall.description": "从本地 Codex skills 目录移除一个内置 Codex skill。",
@@ -664,6 +689,18 @@ export const zhMessages = {
         "搜索请求失败：{message}",
     "errors.search.requestFailed":
         "搜索请求返回了 HTTP {status}。",
+    "errors.skillsSearch.activeAccountMissing":
+        "当前激活账号不存在于认证数据中。",
+    "errors.skillsSearch.authRequired":
+        "使用 skills search 命令前请先登录。",
+    "errors.skillsSearch.invalidFormat":
+        "无效的 format：{value}。请使用 json。",
+    "errors.skillsSearch.invalidResponse":
+        "skills 搜索服务返回了不受支持的响应内容。",
+    "errors.skillsSearch.requestError":
+        "skills 搜索请求失败：{message}",
+    "errors.skillsSearch.requestFailed":
+        "skills 搜索请求返回了 HTTP {status}。",
     "errors.packageInfo.activeAccountMissing":
         "当前激活账号不存在于认证数据中。",
     "errors.packageInfo.authRequired":
@@ -723,6 +760,8 @@ export const zhMessages = {
     "options.limit": "指定最多返回多少条记录",
     "options.format": "指定输出格式（使用 json 返回结构化内容）",
     "options.json": "--format=json 的别名",
+    "options.keywords":
+        "指定用于细化 skill 搜索的逗号分隔关键词",
     "options.onlyPackageId": "仅返回 package id",
     "options.nextToken": "指定下一页分页令牌",
     "options.packageId": "按 package id 过滤",
@@ -793,6 +832,9 @@ export const zhMessages = {
     "search.text.noResults": "未找到匹配的包。",
     "search.text.unnamedBlock": "未命名功能块",
     "search.text.unnamedPackage": "未命名包",
+    "skills.search.text.noResults": "未找到匹配的 skill。",
+    "skills.search.text.package": "包",
+    "skills.search.text.unnamedSkill": "未命名 skill",
     "packageInfo.text.blocks": "功能块：",
     "packageInfo.text.inputHandle": "输入：",
     "packageInfo.text.outputHandle": "输出：",


### PR DESCRIPTION
Introduce `oo skills search <text>` (aliased as `find`) to query the skills search API with free-form text. Supports `--keywords` for comma-separated keyword filtering and `--format=json`/`--json` for structured output. Text output renders title, description, and source package reference per skill entry. Each invocation requests at most 5 results.