### PR TITLE
refactor(skills): replace version file with structured metadata JSON

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -169,8 +169,8 @@ Install one bundled skill into the local Codex skills directory.
   as `oo skills install oo`.
 - Supported skill names: currently `oo`.
 - Target directory: `${CODEX_HOME:-~/.codex}/skills/oo`.
-- Metadata: the installation writes the current `oo` version into a hidden
-  version file inside the skill directory.
+- Metadata: the installation writes a hidden `.oo-metadata.json` file inside
+  the skill directory with a `version` field for the current `oo` version.
 - Metadata: `agents/openai.yaml` uses the persisted
   `skills.oo.implicit_invocation` value when configured, otherwise the
   bundled default is used.
@@ -183,8 +183,8 @@ Install one bundled skill into the local Codex skills directory.
   data yet, `oo` silently installs the managed skill automatically if the
   Codex home directory already exists.
 - Notes: when a bundled skill is already installed, every `oo` startup checks
-  whether its recorded version matches the current CLI version and silently
-  refreshes the installed files when needed.
+  whether the recorded metadata `version` matches the current CLI version and
+  silently refreshes the installed files when needed.
 
 ### `oo skills uninstall`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -152,7 +152,8 @@
 - 参数：`[skill]` 可选。未提供时，该命令等价于 `oo skills install oo`。
 - 支持的 skill 名称：当前仅 `oo`。
 - 目标目录：`${CODEX_HOME:-~/.codex}/skills/oo`。
-- 元数据：安装时会在 skill 目录内写入一个隐藏的 `oo` 版本记录文件。
+- 元数据：安装时会在 skill 目录内写入一个隐藏的 `.oo-metadata.json`
+  文件，并在其中记录 `version` 字段。
 - 元数据：当存在持久化的 `skills.oo.implicit_invocation` 配置时，
   `agents/openai.yaml` 会使用该值；否则使用内置默认值。
 - 说明：当 Codex 根目录不存在时，命令会直接报错退出，这表示当前机器上没有
@@ -163,7 +164,8 @@
   数据，那么只要 Codex 根目录已经存在，`oo` 就会静默自动安装这个受管
   skill。
 - 说明：如果内置 skill 已经安装，`oo` 每次启动都会检查其记录版本是否与当前
-  CLI 版本一致；不一致时会静默刷新已安装的文件。
+  CLI 版本一致；这里的版本来自元数据文件中的 `version` 字段。不一致时会
+  静默刷新已安装的文件。
 
 ### `oo skills uninstall`
 

--- a/src/application/commands/config/index.cli.test.ts
+++ b/src/application/commands/config/index.cli.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../__tests__/helpers.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import {
-    resolveBundledSkillVersionFilePath,
+    resolveBundledSkillMetadataFilePath,
     resolveCodexHomeDirectory,
 } from "../skills/shared.ts";
 
@@ -174,11 +174,14 @@ describe("config CLI", () => {
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
-        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
 
         try {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
-            await Bun.write(versionFilePath, "9.9.9\n");
+            await Bun.write(
+                metadataFilePath,
+                formatBundledSkillMetadataContent("9.9.9"),
+            );
             await Bun.write(
                 ownershipFilePath,
                 await Bun.file(
@@ -210,7 +213,7 @@ describe("config CLI", () => {
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
-        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
         const settingsFilePath = join(
             sandbox.env.XDG_CONFIG_HOME!,
             APP_NAME,
@@ -219,7 +222,10 @@ describe("config CLI", () => {
 
         try {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
-            await Bun.write(versionFilePath, "9.9.9\n");
+            await Bun.write(
+                metadataFilePath,
+                formatBundledSkillMetadataContent("9.9.9"),
+            );
             await Bun.write(
                 ownershipFilePath,
                 [
@@ -428,3 +434,7 @@ describe("config CLI", () => {
         }
     });
 });
+
+function formatBundledSkillMetadataContent(version: string): string {
+    return `${JSON.stringify({ version }, null, 2)}\n`;
+}

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../../__tests__/helpers.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import {
-    resolveBundledSkillVersionFilePath,
+    resolveBundledSkillMetadataFilePath,
     resolveCodexHomeDirectory,
 } from "./shared.ts";
 
@@ -51,7 +51,7 @@ describe("skills CLI", () => {
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
-        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -69,7 +69,9 @@ describe("skills CLI", () => {
             expect(await readFile(ownershipFilePath, "utf8")).toContain(
                 "allow_implicit_invocation: true",
             );
-            expect(await readFile(versionFilePath, "utf8")).toBe("9.9.9\n");
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                formatBundledSkillMetadataContent("9.9.9"),
+            );
             expect(content).toContain(`"msg":"CLI first-run detection completed."`);
             expect(content).toContain(`"isFirstRun":true`);
             expect(content).toContain(`"shouldInstallMissingBundledSkills":true`);
@@ -135,7 +137,7 @@ describe("skills CLI", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
-        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
         const settingsFilePath = join(
             sandbox.env.XDG_CONFIG_HOME!,
@@ -145,7 +147,10 @@ describe("skills CLI", () => {
 
         try {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
-            await Bun.write(versionFilePath, "9.9.9\n");
+            await Bun.write(
+                metadataFilePath,
+                formatBundledSkillMetadataContent("9.9.9"),
+            );
             await Bun.write(
                 ownershipFilePath,
                 await Bun.file(
@@ -212,3 +217,7 @@ describe("skills CLI", () => {
         }
     });
 });
+
+function formatBundledSkillMetadataContent(version: string): string {
+    return `${JSON.stringify({ version }, null, 2)}\n`;
+}

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -8,7 +8,7 @@ import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import { getBundledSkillFiles } from "./embedded-assets.ts";
 import {
-    resolveBundledSkillVersionFilePath,
+    resolveBundledSkillMetadataFilePath,
     resolveCodexHomeDirectory,
 } from "./shared.ts";
 
@@ -18,7 +18,7 @@ describe("skills commands", () => {
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
-        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
         const resultVersion = "9.9.9";
 
         try {
@@ -42,8 +42,8 @@ describe("skills commands", () => {
             expect(await readFile(ownershipFilePath, "utf8")).toContain(
                 "allow_implicit_invocation: true",
             );
-            expect(await readFile(versionFilePath, "utf8")).toBe(
-                `${resultVersion}\n`,
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                formatBundledSkillMetadataContent(resultVersion),
             );
         }
         finally {
@@ -55,7 +55,7 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
-        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
         const resultVersion = "9.9.9";
 
         try {
@@ -70,8 +70,8 @@ describe("skills commands", () => {
                 `Installed Codex skill oo to ${skillDirectoryPath}.\n`,
             );
             expect(result.stderr).toBe("");
-            expect(await readFile(versionFilePath, "utf8")).toBe(
-                `${resultVersion}\n`,
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                formatBundledSkillMetadataContent(resultVersion),
             );
         }
         finally {
@@ -230,7 +230,53 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
-        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const managedSkillPath = join(skillDirectoryPath, "SKILL.md");
+        const managedOwnershipPath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const obsoleteFilePath = join(skillDirectoryPath, "legacy.txt");
+        const expectedSkillContent = await Bun.file(
+            getBundledSkillFiles("oo")[0]!.sourcePath,
+        ).text();
+        const expectedOwnershipContent = await Bun.file(
+            getBundledSkillFiles("oo").find(file => file.relativePath === "agents/openai.yaml")!.sourcePath,
+        ).text();
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(
+                metadataFilePath,
+                formatBundledSkillMetadataContent("0.0.1"),
+            );
+            await Bun.write(managedSkillPath, "stale\n");
+            await Bun.write(managedOwnershipPath, expectedOwnershipContent);
+            await Bun.write(obsoleteFilePath, "obsolete\n");
+
+            const result = await sandbox.run(["--help"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                formatBundledSkillMetadataContent("9.9.9"),
+            );
+            expect(await readFile(managedSkillPath, "utf8")).toBe(
+                expectedSkillContent,
+            );
+            await expect(stat(obsoleteFilePath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rebuilds managed skills that do not have the metadata file yet", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
         const managedSkillPath = join(skillDirectoryPath, "SKILL.md");
         const managedOwnershipPath = join(skillDirectoryPath, "agents", "openai.yaml");
         const expectedSkillContent = await Bun.file(
@@ -242,7 +288,6 @@ describe("skills commands", () => {
 
         try {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
-            await Bun.write(versionFilePath, "0.0.1\n");
             await Bun.write(managedSkillPath, "stale\n");
             await Bun.write(managedOwnershipPath, expectedOwnershipContent);
 
@@ -252,7 +297,9 @@ describe("skills commands", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
-            expect(await readFile(versionFilePath, "utf8")).toBe("9.9.9\n");
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                formatBundledSkillMetadataContent("9.9.9"),
+            );
             expect(await readFile(managedSkillPath, "utf8")).toBe(
                 expectedSkillContent,
             );
@@ -266,7 +313,7 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
-        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
         const managedSkillPath = join(skillDirectoryPath, "SKILL.md");
         const managedOwnershipPath = join(skillDirectoryPath, "agents", "openai.yaml");
         const expectedOwnershipContent = await Bun.file(
@@ -275,7 +322,10 @@ describe("skills commands", () => {
 
         try {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
-            await Bun.write(versionFilePath, "0.0.1\n");
+            await Bun.write(
+                metadataFilePath,
+                formatBundledSkillMetadataContent("0.0.1"),
+            );
             await Bun.write(managedSkillPath, "stale\n");
             await Bun.write(managedOwnershipPath, expectedOwnershipContent);
 
@@ -283,7 +333,9 @@ describe("skills commands", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
-            expect(await readFile(versionFilePath, "utf8")).toBe("0.0.1\n");
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                formatBundledSkillMetadataContent("0.0.1"),
+            );
             expect(await readFile(managedSkillPath, "utf8")).toBe("stale\n");
         }
         finally {
@@ -323,12 +375,15 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
-        const versionFilePath = resolveBundledSkillVersionFilePath(skillDirectoryPath);
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
 
         try {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
-            await Bun.write(versionFilePath, "0.0.1\n");
+            await Bun.write(
+                metadataFilePath,
+                formatBundledSkillMetadataContent("0.0.1"),
+            );
             await Bun.write(
                 ownershipFilePath,
                 [
@@ -344,7 +399,9 @@ describe("skills commands", () => {
             });
 
             expect(result.exitCode).toBe(0);
-            expect(await readFile(versionFilePath, "utf8")).toBe("0.0.1\n");
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                formatBundledSkillMetadataContent("0.0.1"),
+            );
             expect(await readFile(ownershipFilePath, "utf8")).not.toContain("OOMOL");
         }
         finally {
@@ -352,3 +409,7 @@ describe("skills commands", () => {
         }
     });
 });
+
+function formatBundledSkillMetadataContent(version: string): string {
+    return `${JSON.stringify({ version }, null, 2)}\n`;
+}

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -17,10 +17,14 @@ import {
 
 const codexDirectoryName = ".codex";
 const codexSkillsDirectoryName = "skills";
-const bundledSkillVersionFileName = ".oo-version";
+const bundledSkillMetadataFileName = ".oo-metadata.json";
 const bundledSkillOwnershipMarker = "OOMOL";
 const bundledSkillOwnershipFileRelativePath = "agents/openai.yaml";
 const bundledSkillImplicitInvocationKey = "allow_implicit_invocation";
+
+interface BundledSkillMetadata {
+    version: string;
+}
 
 export function resolveCodexHomeDirectory(
     env: Record<string, string | undefined>,
@@ -41,10 +45,10 @@ export function resolveBundledSkillDirectoryPath(
     return join(codexHomeDirectory, codexSkillsDirectoryName, skillName);
 }
 
-export function resolveBundledSkillVersionFilePath(
+export function resolveBundledSkillMetadataFilePath(
     skillDirectoryPath: string,
 ): string {
-    return join(skillDirectoryPath, bundledSkillVersionFileName);
+    return join(skillDirectoryPath, bundledSkillMetadataFileName);
 }
 
 export async function installBundledSkill(
@@ -326,6 +330,7 @@ async function writeBundledSkillInstallation(options: {
         options.skillName,
     );
 
+    await rm(skillDirectoryPath, { force: true, recursive: true });
     await mkdir(skillDirectoryPath, { recursive: true });
 
     for (const file of getBundledSkillFiles(options.skillName)) {
@@ -343,9 +348,11 @@ async function writeBundledSkillInstallation(options: {
         );
     }
 
-    await Bun.write(
-        resolveBundledSkillVersionFilePath(skillDirectoryPath),
-        `${options.version}\n`,
+    await writeInstalledBundledSkillMetadata(
+        skillDirectoryPath,
+        {
+            version: options.version,
+        },
     );
 
     return skillDirectoryPath;
@@ -480,9 +487,11 @@ async function isBundledSkillInstallationCurrent(
         return false;
     }
 
-    const installedVersion = await readInstalledBundledSkillVersion(
-        skillDirectoryPath,
-    );
+    if (!(await fileExists(resolveBundledSkillMetadataFilePath(skillDirectoryPath)))) {
+        return false;
+    }
+
+    const installedVersion = await readInstalledBundledSkillVersion(skillDirectoryPath);
 
     if (installedVersion !== version) {
         return false;
@@ -523,15 +532,23 @@ async function isManagedBundledSkillInstallation(
 async function readInstalledBundledSkillVersion(
     skillDirectoryPath: string,
 ): Promise<string | undefined> {
-    try {
-        const version = (
-            await readFile(
-                resolveBundledSkillVersionFilePath(skillDirectoryPath),
-                "utf8",
-            )
-        ).trim();
+    const metadata = await readInstalledBundledSkillMetadata(
+        skillDirectoryPath,
+    );
 
-        return version === "" ? undefined : version;
+    return metadata?.version;
+}
+
+async function readInstalledBundledSkillMetadata(
+    skillDirectoryPath: string,
+): Promise<BundledSkillMetadata | undefined> {
+    try {
+        const content = await readFile(
+            resolveBundledSkillMetadataFilePath(skillDirectoryPath),
+            "utf8",
+        );
+
+        return parseBundledSkillMetadataContent(content);
     }
     catch (error) {
         if (isNodeNotFoundError(error)) {
@@ -540,6 +557,59 @@ async function readInstalledBundledSkillVersion(
 
         throw error;
     }
+}
+
+async function writeInstalledBundledSkillMetadata(
+    skillDirectoryPath: string,
+    metadata: BundledSkillMetadata,
+): Promise<void> {
+    await Bun.write(
+        resolveBundledSkillMetadataFilePath(skillDirectoryPath),
+        renderBundledSkillMetadataContent(metadata),
+    );
+}
+
+function parseBundledSkillMetadataContent(
+    content: string,
+): BundledSkillMetadata | undefined {
+    let parsedContent: unknown;
+
+    try {
+        parsedContent = JSON.parse(content);
+    }
+    catch {
+        return undefined;
+    }
+
+    if (
+        typeof parsedContent !== "object"
+        || parsedContent === null
+        || Array.isArray(parsedContent)
+    ) {
+        return undefined;
+    }
+
+    const rawVersion = (parsedContent as Record<string, unknown>).version;
+
+    if (typeof rawVersion !== "string") {
+        return undefined;
+    }
+
+    const version = rawVersion.trim();
+
+    if (version === "") {
+        return undefined;
+    }
+
+    return {
+        version,
+    };
+}
+
+function renderBundledSkillMetadataContent(
+    metadata: BundledSkillMetadata,
+): string {
+    return `${JSON.stringify(metadata, null, 2)}\n`;
 }
 
 async function requireCodexHomeDirectory(


### PR DESCRIPTION
Switch bundled skill version tracking from a plain-text `.oo-version` file to a JSON-based `.oo-metadata.json` file with a `version` field. This makes the metadata format extensible for future fields.

Clean the skill directory before reinstalling so obsolete files from prior installations are removed. Treat a missing metadata file as outdated to handle migration from the old format gracefully.