### PR TITLE
feat(skills): publish bundled skill installation via symlink

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -168,7 +168,14 @@ Install one bundled skill into the local Codex skills directory.
 - Arguments: `[skill]` is optional. When omitted, the command behaves the same
   as `oo skills install oo`.
 - Supported skill names: currently `oo`.
+- Canonical directory: the bundled files are materialized to
+  `<config-dir>/skills/oo`, where `<config-dir>` is the directory that
+  contains `settings.toml`.
 - Target directory: `${CODEX_HOME:-~/.codex}/skills/oo`.
+- Installation mode: `oo` publishes the target directory as a symlink to the
+  canonical directory when the current platform and environment allow it. When
+  symlink creation fails, `oo` falls back to copying the canonical files into
+  the Codex skills directory.
 - Metadata: the installation writes a hidden `.oo-metadata.json` file inside
   the skill directory with a `version` field for the current `oo` version.
 - Metadata: `agents/openai.yaml` uses the persisted
@@ -191,6 +198,8 @@ Install one bundled skill into the local Codex skills directory.
 Remove one bundled skill from the local Codex skills directory.
 
 - Managed skill: `oo`.
+- Canonical directory removed: `<config-dir>/skills/oo`, where
+  `<config-dir>` is the directory that contains `settings.toml`.
 - Target directory: `${CODEX_HOME:-~/.codex}/skills/oo`.
 
 ## Logs

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -151,7 +151,12 @@
 
 - 参数：`[skill]` 可选。未提供时，该命令等价于 `oo skills install oo`。
 - 支持的 skill 名称：当前仅 `oo`。
+- canonical 目录：内置文件会先释放到 `<config-dir>/skills/oo`，
+  其中 `<config-dir>` 是 `settings.toml` 所在目录。
 - 目标目录：`${CODEX_HOME:-~/.codex}/skills/oo`。
+- 安装方式：`oo` 会优先将目标目录发布为指向 canonical 目录的软连接。
+  如果当前平台或环境下创建软连接失败，则会回退为把 canonical 目录内容复制
+  到 Codex skills 目录。
 - 元数据：安装时会在 skill 目录内写入一个隐藏的 `.oo-metadata.json`
   文件，并在其中记录 `version` 字段。
 - 元数据：当存在持久化的 `skills.oo.implicit_invocation` 配置时，
@@ -172,6 +177,8 @@
 从本地 Codex skills 目录移除一个内置 skill。
 
 - 内置 skill：`oo`。
+- 会同时移除 canonical 目录：`<config-dir>/skills/oo`，其中
+  `<config-dir>` 是 `settings.toml` 所在目录。
 - 目标目录：`${CODEX_HOME:-~/.codex}/skills/oo`。
 
 ## 日志

--- a/src/adapters/commander/commander-cli-adapter.ts
+++ b/src/adapters/commander/commander-cli-adapter.ts
@@ -3,6 +3,7 @@ import type { ZodError } from "zod";
 
 import type { CliCatalog, CliCommandDefinition, CliExecutionContext } from "../../application/contracts/cli.ts";
 import type { Translator } from "../../application/contracts/translator.ts";
+import process from "node:process";
 import {
     Argument,
     Command,
@@ -54,8 +55,13 @@ export class CommanderCliAdapter {
         catalog: CliCatalog,
         context: CliExecutionContext,
     ): Command {
+        const defaultHelpWidth = 80;
         const program = new LocalizedCommand(context.translator, catalog.name);
         const outputConfiguration = {
+            getErrHelpWidth: () =>
+                context.stderr.isTTY ? process.stderr.columns : defaultHelpWidth,
+            getOutHelpWidth: () =>
+                context.stdout.isTTY ? process.stdout.columns : defaultHelpWidth,
             writeOut: (value: string) => context.stdout.write(value),
             writeErr: (value: string) => context.stderr.write(value),
             outputError: () => {},

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, stat } from "node:fs/promises";
+import { mkdir, readFile, realpath, stat } from "node:fs/promises";
 import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
@@ -10,6 +10,7 @@ import {
 } from "../../../../__tests__/helpers.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import {
+    resolveBundledSkillCanonicalDirectoryPath,
     resolveBundledSkillMetadataFilePath,
     resolveCodexHomeDirectory,
 } from "./shared.ts";
@@ -50,6 +51,10 @@ describe("skills CLI", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
+            "oo",
+        );
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
         const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
 
@@ -63,6 +68,9 @@ describe("skills CLI", () => {
 
             expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(result.stdout).not.toContain("Installed Codex skill");
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
             await expect(stat(join(skillDirectoryPath, "SKILL.md"))).resolves.toMatchObject({
                 isFile: expect.any(Function),
             });

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, stat } from "node:fs/promises";
+import { mkdir, readFile, realpath, stat } from "node:fs/promises";
 import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
@@ -8,6 +8,7 @@ import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import { getBundledSkillFiles } from "./embedded-assets.ts";
 import {
+    resolveBundledSkillCanonicalDirectoryPath,
     resolveBundledSkillMetadataFilePath,
     resolveCodexHomeDirectory,
 } from "./shared.ts";
@@ -17,6 +18,15 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+        );
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
         const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
         const resultVersion = "9.9.9";
@@ -33,6 +43,9 @@ describe("skills commands", () => {
                 `Installed Codex skill oo to ${skillDirectoryPath}.\n`,
             );
             expect(result.stderr).toBe("");
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
 
             for (const file of getBundledSkillFiles("oo")) {
                 expect(
@@ -55,6 +68,15 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+        );
         const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
         const resultVersion = "9.9.9";
 
@@ -70,6 +92,9 @@ describe("skills commands", () => {
                 `Installed Codex skill oo to ${skillDirectoryPath}.\n`,
             );
             expect(result.stderr).toBe("");
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 formatBundledSkillMetadataContent(resultVersion),
             );
@@ -169,6 +194,15 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+        );
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -184,6 +218,9 @@ describe("skills commands", () => {
             );
             expect(result.stderr).toBe("");
             await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(canonicalSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
         }

--- a/src/application/commands/skills/shared.test.ts
+++ b/src/application/commands/skills/shared.test.ts
@@ -1,0 +1,106 @@
+import { mkdir, readFile, realpath, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
+import { publishBundledSkillInstallation } from "./shared.ts";
+
+describe("bundled skill publication", () => {
+    test("publishes the bundled skill through a symlink-compatible path", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const canonicalSkillDirectoryPath = join(
+            rootDirectory,
+            "config",
+            "skills",
+            "oo",
+        );
+        const installedSkillDirectoryPath = join(
+            rootDirectory,
+            ".codex",
+            "skills",
+            "oo",
+        );
+
+        try {
+            await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
+                recursive: true,
+            });
+            await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "skill\n");
+            await Bun.write(
+                join(canonicalSkillDirectoryPath, "agents", "openai.yaml"),
+                "OOMOL\n",
+            );
+
+            const result = await publishBundledSkillInstallation({
+                canonicalSkillDirectoryPath,
+                installedSkillDirectoryPath,
+            });
+
+            expect(result).toEqual({
+                mode: "symlink",
+                path: installedSkillDirectoryPath,
+            });
+            expect(await readFile(join(installedSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
+                "skill\n",
+            );
+            expect(await realpath(installedSkillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("falls back to copying when symlink creation fails", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const canonicalSkillDirectoryPath = join(
+            rootDirectory,
+            "config",
+            "skills",
+            "oo",
+        );
+        const installedSkillDirectoryPath = join(
+            rootDirectory,
+            ".codex",
+            "skills",
+            "oo",
+        );
+
+        try {
+            await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
+                recursive: true,
+            });
+            await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "skill\n");
+            await Bun.write(
+                join(canonicalSkillDirectoryPath, "agents", "openai.yaml"),
+                "OOMOL\n",
+            );
+
+            const result = await publishBundledSkillInstallation(
+                {
+                    canonicalSkillDirectoryPath,
+                    installedSkillDirectoryPath,
+                },
+                {
+                    createDirectorySymlink: async () => false,
+                },
+            );
+
+            expect(result).toEqual({
+                mode: "copy",
+                path: installedSkillDirectoryPath,
+            });
+            expect(await readFile(join(installedSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
+                "skill\n",
+            );
+            expect(await realpath(installedSkillDirectoryPath)).not.toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+});

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -2,8 +2,19 @@ import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { AppSettings } from "../../schemas/settings.ts";
 
 import type { BundledSkillName } from "./embedded-assets.ts";
-import { mkdir, readFile, rm, stat } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import {
+    cp,
+    lstat,
+    mkdir,
+    readFile,
+    readlink,
+    realpath,
+    rm,
+    stat,
+    symlink,
+} from "node:fs/promises";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import process from "node:process";
 import { CliUserError } from "../../contracts/cli.ts";
 import { resolveHomeDirectory } from "../../path/home-directory.ts";
 import {
@@ -26,6 +37,18 @@ interface BundledSkillMetadata {
     version: string;
 }
 
+export interface BundledSkillPublicationResult {
+    mode: "copy" | "symlink";
+    path: string;
+}
+
+interface BundledSkillPublicationDependencies {
+    createDirectorySymlink?: (
+        targetPath: string,
+        linkPath: string,
+    ) => Promise<boolean>;
+}
+
 export function resolveCodexHomeDirectory(
     env: Record<string, string | undefined>,
 ): string {
@@ -45,6 +68,13 @@ export function resolveBundledSkillDirectoryPath(
     return join(codexHomeDirectory, codexSkillsDirectoryName, skillName);
 }
 
+export function resolveBundledSkillCanonicalDirectoryPath(
+    settingsFilePath: string,
+    skillName: BundledSkillName,
+): string {
+    return join(dirname(settingsFilePath), codexSkillsDirectoryName, skillName);
+}
+
 export function resolveBundledSkillMetadataFilePath(
     skillDirectoryPath: string,
 ): string {
@@ -57,8 +87,13 @@ export async function installBundledSkill(
 ): Promise<void> {
     const codexHomeDirectory = await requireCodexHomeDirectory(context);
     const settings = await context.settingsStore.read();
+    const settingsFilePath = context.settingsStore.getFilePath();
     const installedSkillDirectoryPath = resolveBundledSkillDirectoryPath(
         codexHomeDirectory,
+        skillName,
+    );
+    const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+        settingsFilePath,
         skillName,
     );
 
@@ -79,9 +114,27 @@ export async function installBundledSkill(
         });
     }
 
-    const skillDirectoryPath = await writeBundledSkillInstallation({
+    if (
+        await directoryExists(canonicalSkillDirectoryPath)
+        && !(await isManagedBundledSkillInstallation(canonicalSkillDirectoryPath))
+    ) {
+        context.logger.warn(
+            {
+                path: canonicalSkillDirectoryPath,
+                skillName,
+            },
+            "Bundled Codex skill install was blocked by an unmanaged canonical directory.",
+        );
+        throw new CliUserError("errors.skills.storageConflict", 1, {
+            name: skillName,
+            path: canonicalSkillDirectoryPath,
+        });
+    }
+
+    const installation = await writeBundledSkillInstallation({
         codexHomeDirectory,
         settings,
+        settingsFilePath,
         skillName,
         version: context.version,
     });
@@ -90,12 +143,14 @@ export async function installBundledSkill(
         context,
         context.translator.t("skills.install.success", {
             name: skillName,
-            path: skillDirectoryPath,
+            path: installation.path,
         }),
     );
     context.logger.info(
         {
-            path: skillDirectoryPath,
+            canonicalPath: canonicalSkillDirectoryPath,
+            installMode: installation.mode,
+            path: installation.path,
             skillName,
             version: context.version,
         },
@@ -104,7 +159,7 @@ export async function installBundledSkill(
 }
 
 export async function maybeSynchronizeInstalledBundledSkills(
-    context: Pick<CliExecutionContext, "env" | "logger" | "version">,
+    context: Pick<CliExecutionContext, "env" | "logger" | "settingsStore" | "version">,
     options: {
         installMissing?: boolean;
         settings?: AppSettings;
@@ -112,6 +167,7 @@ export async function maybeSynchronizeInstalledBundledSkills(
 ): Promise<void> {
     const codexHomeDirectory = resolveCodexHomeDirectory(context.env);
     const settings = options.settings ?? defaultSettings;
+    const settingsFilePath = context.settingsStore.getFilePath();
 
     if (!(await directoryExists(codexHomeDirectory))) {
         context.logger.debug(
@@ -126,6 +182,10 @@ export async function maybeSynchronizeInstalledBundledSkills(
     for (const skillName of availableBundledSkillNames) {
         const skillDirectoryPath = resolveBundledSkillDirectoryPath(
             codexHomeDirectory,
+            skillName,
+        );
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            settingsFilePath,
             skillName,
         );
 
@@ -143,15 +203,18 @@ export async function maybeSynchronizeInstalledBundledSkills(
                     continue;
                 }
 
-                await writeBundledSkillInstallation({
+                const installation = await writeBundledSkillInstallation({
                     codexHomeDirectory,
                     settings,
+                    settingsFilePath,
                     skillName,
                     version: context.version,
                 });
                 context.logger.info(
                     {
-                        path: skillDirectoryPath,
+                        canonicalPath: canonicalSkillDirectoryPath,
+                        installMode: installation.mode,
+                        path: installation.path,
                         skillName,
                         version: context.version,
                     },
@@ -180,16 +243,19 @@ export async function maybeSynchronizeInstalledBundledSkills(
             ) {
                 const previousVersion
                     = await readInstalledBundledSkillVersion(skillDirectoryPath);
-
-                await writeBundledSkillInstallation({
+                const installation = await writeBundledSkillInstallation({
                     codexHomeDirectory,
                     settings,
+                    settingsFilePath,
                     skillName,
                     version: context.version,
                 });
+
                 context.logger.info(
                     {
-                        path: skillDirectoryPath,
+                        canonicalPath: canonicalSkillDirectoryPath,
+                        installMode: installation.mode,
+                        path: installation.path,
                         previousVersion: previousVersion ?? "unknown",
                         skillName,
                         version: context.version,
@@ -199,11 +265,10 @@ export async function maybeSynchronizeInstalledBundledSkills(
                 continue;
             }
 
-            const desiredImplicitInvocation
-                = resolveBundledSkillImplicitInvocation(
-                    skillName,
-                    settings,
-                );
+            const desiredImplicitInvocation = resolveBundledSkillImplicitInvocation(
+                skillName,
+                settings,
+            );
             const installedImplicitInvocation
                 = await readInstalledBundledSkillImplicitInvocation(
                     skillDirectoryPath,
@@ -221,36 +286,19 @@ export async function maybeSynchronizeInstalledBundledSkills(
                 continue;
             }
 
-            if (installedImplicitInvocation === undefined) {
-                const previousVersion
-                    = await readInstalledBundledSkillVersion(skillDirectoryPath);
-
-                await writeBundledSkillInstallation({
-                    codexHomeDirectory,
-                    settings,
-                    skillName,
-                    version: context.version,
-                });
-                context.logger.info(
-                    {
-                        path: skillDirectoryPath,
-                        previousVersion: previousVersion ?? "unknown",
-                        skillName,
-                        version: context.version,
-                    },
-                    "Bundled Codex skill synchronized.",
-                );
-                continue;
-            }
-
-            await writeInstalledBundledSkillImplicitInvocation(
-                skillDirectoryPath,
-                desiredImplicitInvocation,
-            );
+            const installation = await writeBundledSkillInstallation({
+                codexHomeDirectory,
+                settings,
+                settingsFilePath,
+                skillName,
+                version: context.version,
+            });
             context.logger.info(
                 {
+                    canonicalPath: canonicalSkillDirectoryPath,
                     implicitInvocation: desiredImplicitInvocation,
-                    path: skillDirectoryPath,
+                    installMode: installation.mode,
+                    path: installation.path,
                     skillName,
                     version: context.version,
                 },
@@ -280,6 +328,10 @@ export async function uninstallBundledSkill(
         codexHomeDirectory,
         skillName,
     );
+    const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+        context.settingsStore.getFilePath(),
+        skillName,
+    );
 
     if (
         !(await directoryExists(skillDirectoryPath))
@@ -300,7 +352,8 @@ export async function uninstallBundledSkill(
 
     const previousVersion = await readInstalledBundledSkillVersion(skillDirectoryPath);
 
-    await rm(skillDirectoryPath, { force: true, recursive: true });
+    await removePath(skillDirectoryPath);
+    await removePath(canonicalSkillDirectoryPath);
 
     writeLine(
         context,
@@ -311,6 +364,7 @@ export async function uninstallBundledSkill(
     );
     context.logger.info(
         {
+            canonicalPath: canonicalSkillDirectoryPath,
             path: skillDirectoryPath,
             previousVersion: previousVersion ?? "unknown",
             skillName,
@@ -322,19 +376,27 @@ export async function uninstallBundledSkill(
 async function writeBundledSkillInstallation(options: {
     codexHomeDirectory: string;
     settings: AppSettings;
+    settingsFilePath: string;
     skillName: BundledSkillName;
     version: string;
-}): Promise<string> {
-    const skillDirectoryPath = resolveBundledSkillDirectoryPath(
+}): Promise<BundledSkillPublicationResult> {
+    const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+        options.settingsFilePath,
+        options.skillName,
+    );
+    const installedSkillDirectoryPath = resolveBundledSkillDirectoryPath(
         options.codexHomeDirectory,
         options.skillName,
     );
 
-    await rm(skillDirectoryPath, { force: true, recursive: true });
-    await mkdir(skillDirectoryPath, { recursive: true });
+    await removePath(canonicalSkillDirectoryPath);
+    await mkdir(canonicalSkillDirectoryPath, { recursive: true });
 
     for (const file of getBundledSkillFiles(options.skillName)) {
-        const destinationPath = join(skillDirectoryPath, file.relativePath);
+        const destinationPath = join(
+            canonicalSkillDirectoryPath,
+            file.relativePath,
+        );
 
         await mkdir(dirname(destinationPath), { recursive: true });
         await Bun.write(
@@ -349,13 +411,16 @@ async function writeBundledSkillInstallation(options: {
     }
 
     await writeInstalledBundledSkillMetadata(
-        skillDirectoryPath,
+        canonicalSkillDirectoryPath,
         {
             version: options.version,
         },
     );
 
-    return skillDirectoryPath;
+    return publishBundledSkillInstallation({
+        canonicalSkillDirectoryPath,
+        installedSkillDirectoryPath,
+    });
 }
 
 function renderBundledSkillFileContent(
@@ -402,22 +467,6 @@ async function readInstalledBundledSkillImplicitInvocation(
 
         throw error;
     }
-}
-
-async function writeInstalledBundledSkillImplicitInvocation(
-    skillDirectoryPath: string,
-    value: boolean,
-): Promise<void> {
-    const ownershipFilePath = join(
-        skillDirectoryPath,
-        bundledSkillOwnershipFileRelativePath,
-    );
-    const content = await readFile(ownershipFilePath, "utf8");
-
-    await Bun.write(
-        ownershipFilePath,
-        writeImplicitInvocationValue(content, value),
-    );
 }
 
 function readImplicitInvocationValue(
@@ -626,6 +675,38 @@ async function requireCodexHomeDirectory(
     return codexHomeDirectory;
 }
 
+export async function publishBundledSkillInstallation(
+    options: {
+        canonicalSkillDirectoryPath: string;
+        installedSkillDirectoryPath: string;
+    },
+    dependencies: BundledSkillPublicationDependencies = {},
+): Promise<BundledSkillPublicationResult> {
+    const createDirectoryLink
+        = dependencies.createDirectorySymlink ?? createDirectorySymlink;
+    const symlinkCreated = await createDirectoryLink(
+        options.canonicalSkillDirectoryPath,
+        options.installedSkillDirectoryPath,
+    );
+
+    if (symlinkCreated) {
+        return {
+            mode: "symlink",
+            path: options.installedSkillDirectoryPath,
+        };
+    }
+
+    await copyBundledSkillDirectory(
+        options.canonicalSkillDirectoryPath,
+        options.installedSkillDirectoryPath,
+    );
+
+    return {
+        mode: "copy",
+        path: options.installedSkillDirectoryPath,
+    };
+}
+
 async function directoryExists(path: string): Promise<boolean> {
     try {
         return (await stat(path)).isDirectory();
@@ -654,6 +735,133 @@ async function fileExists(path: string): Promise<boolean> {
 
 function isNodeNotFoundError(error: unknown): error is NodeJS.ErrnoException {
     return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+async function createDirectorySymlink(
+    targetPath: string,
+    linkPath: string,
+): Promise<boolean> {
+    try {
+        const resolvedTargetPath = resolve(targetPath);
+        const resolvedLinkPath = resolve(linkPath);
+        const [realTargetPath, realLinkPath] = await Promise.all([
+            realpath(resolvedTargetPath).catch(() => resolvedTargetPath),
+            realpath(resolvedLinkPath).catch(() => resolvedLinkPath),
+        ]);
+
+        if (realTargetPath === realLinkPath) {
+            return true;
+        }
+
+        const [realTargetPathWithParents, realLinkPathWithParents]
+            = await Promise.all([
+                resolveParentSymlinks(resolvedTargetPath),
+                resolveParentSymlinks(resolvedLinkPath),
+            ]);
+
+        if (realTargetPathWithParents === realLinkPathWithParents) {
+            return true;
+        }
+
+        try {
+            const existingStats = await lstat(resolvedLinkPath);
+
+            if (existingStats.isSymbolicLink()) {
+                const existingTarget = await readlink(resolvedLinkPath);
+
+                if (
+                    resolveSymlinkTarget(resolvedLinkPath, existingTarget)
+                    === resolvedTargetPath
+                ) {
+                    return true;
+                }
+            }
+
+            await removePath(resolvedLinkPath);
+        }
+        catch (error) {
+            if (!isNodeNotFoundError(error)) {
+                throw error;
+            }
+        }
+
+        const linkDirectoryPath = dirname(resolvedLinkPath);
+
+        await mkdir(linkDirectoryPath, { recursive: true });
+
+        const symlinkTargetPath = process.platform === "win32"
+            ? resolvedTargetPath
+            : relative(
+                    await resolveParentSymlinks(linkDirectoryPath),
+                    resolvedTargetPath,
+                );
+
+        await symlink(
+            symlinkTargetPath,
+            resolvedLinkPath,
+            process.platform === "win32" ? "junction" : "dir",
+        );
+
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+
+async function copyBundledSkillDirectory(
+    sourcePath: string,
+    destinationPath: string,
+): Promise<void> {
+    await removePath(destinationPath);
+    await mkdir(dirname(destinationPath), { recursive: true });
+    await cp(sourcePath, destinationPath, {
+        dereference: true,
+        force: true,
+        recursive: true,
+    });
+}
+
+async function removePath(path: string): Promise<void> {
+    try {
+        const pathStats = await lstat(path);
+
+        if (pathStats.isSymbolicLink()) {
+            await rm(path, { force: true });
+            return;
+        }
+
+        await rm(path, { force: true, recursive: true });
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return;
+        }
+
+        throw error;
+    }
+}
+
+async function resolveParentSymlinks(path: string): Promise<string> {
+    const resolvedPath = resolve(path);
+    const parentPath = dirname(resolvedPath);
+    const baseName = basename(resolvedPath);
+
+    try {
+        const realParentPath = await realpath(parentPath);
+
+        return join(realParentPath, baseName);
+    }
+    catch {
+        return resolvedPath;
+    }
+}
+
+function resolveSymlinkTarget(
+    linkPath: string,
+    linkTargetPath: string,
+): string {
+    return resolve(dirname(linkPath), linkTargetPath);
 }
 
 function writeLine(context: CliExecutionContext, message: string): void {

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -307,6 +307,8 @@ export const enMessages = {
         "Codex is not installed. Expected the Codex home directory at {path}.",
     "errors.skills.nameConflict":
         "Skill name {name} is already used by a non-OOMOL Codex skill at {path}.",
+    "errors.skills.storageConflict":
+        "Bundled skill storage for {name} is already occupied by non-OOMOL content at {path}.",
     "errors.skills.notInstalled":
         "Codex skill {name} is not installed at {path}.",
     "errors.store.invalidToml":
@@ -719,6 +721,8 @@ export const zhMessages = {
         "未检测到 Codex 安装。期望的 Codex 根目录为 {path}。",
     "errors.skills.nameConflict":
         "Skill 名称 {name} 已被 {path} 中的非 OOMOL Codex skill 占用。",
+    "errors.skills.storageConflict":
+        "{path} 中用于 {name} 的内置 skill 存储目录已被非 OOMOL 内容占用。",
     "errors.skills.notInstalled":
         "Codex skill {name} 未安装在 {path}。",
     "errors.store.invalidToml": "配置文件 {path} 不是有效的 TOML。",


### PR DESCRIPTION
Introduce a canonical directory under the config directory where bundled skill files are materialized first. The Codex skills target directory is then published as a symlink pointing to the canonical directory. When symlink creation fails (e.g. platform restrictions), the installer falls back to copying files.

Uninstall now removes both the canonical and target directories.

Also fix commander help output width to respect terminal columns when connected to a TTY, falling back to 80 columns otherwise.