### PR TITLE
ci: split pr-check into quality and cross-platform test jobs

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -11,7 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-check:
+  quality:
+    name: Quality
     runs-on: ubuntu-latest
 
     steps:
@@ -31,6 +32,29 @@ jobs:
 
       - name: TypeScript Check
         run: bun run ts-check
+
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install
+        run: bun install --frozen-lockfile
 
       - name: Test
         run: bun run test

--- a/__tests__/helpers.test.ts
+++ b/__tests__/helpers.test.ts
@@ -23,7 +23,7 @@ describe("test helpers", () => {
             {
                 exitCode: 0,
                 stdout: [
-                    "C:/Users/Tester/.config/oo-cli/settings.toml",
+                    "C:\\Users\\Tester\\.config\\oo-cli\\settings.toml",
                     outputFilePath,
                 ].join("\r\n"),
                 stderr: `${colors.green("ok")} ${outputFilePath}\r`,

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -487,7 +487,7 @@ function normalizeSnapshotText(
         }
     }
 
-    return normalized;
+    return normalized.split("\\").join("/");
 }
 
 function replaceSnapshotValue(

--- a/src/adapters/cache/sqlite-cache.test.ts
+++ b/src/adapters/cache/sqlite-cache.test.ts
@@ -325,7 +325,7 @@ describe("SqliteCacheStore", () => {
 
             expect(logs).toContain(`"level":"warn"`);
             expect(logs).toContain(`"category":"recoverable_cache"`);
-            expect(logs).toContain(`"sqliteErrorCode":"SQLITE_CANTOPEN"`);
+            expect(logs).toContain(`"sqliteErrorCode":"SQLITE_CANTOPEN`);
             expect(logs).toContain(`"storePathKind":"directory"`);
             expect(logs).toContain(`"storePathExists":true`);
             expect(logs).toContain(`"parentDirectoryExists":true`);

--- a/src/adapters/cache/sqlite-cache.test.ts
+++ b/src/adapters/cache/sqlite-cache.test.ts
@@ -11,11 +11,20 @@ import {
 import { APP_NAME } from "../../application/config/app-config.ts";
 import { resolveStorePaths } from "../store/store-path.ts";
 import {
+    isRecoverableSqliteCacheErrorCode,
     resolveSqliteCacheTableName,
     SqliteCacheStore,
 } from "./sqlite-cache.ts";
 
 describe("SqliteCacheStore", () => {
+    test("treats sqlite extended recoverable error codes as recoverable", () => {
+        expect(isRecoverableSqliteCacheErrorCode("SQLITE_BUSY_SNAPSHOT")).toBeTrue();
+        expect(isRecoverableSqliteCacheErrorCode("SQLITE_CANTOPEN_ISDIR")).toBeTrue();
+        expect(isRecoverableSqliteCacheErrorCode("SQLITE_IOERR_ACCESS")).toBeTrue();
+        expect(isRecoverableSqliteCacheErrorCode("SQLITE_READONLY_DIRECTORY")).toBeTrue();
+        expect(isRecoverableSqliteCacheErrorCode("SQLITE_MISUSE")).toBeFalse();
+    });
+
     test("creates the sqlite file in the data directory and shares tables by id", async () => {
         const root = await createTemporaryDirectory("sqlite-cache");
         const storePaths = resolveStorePaths({

--- a/src/adapters/cache/sqlite-cache.ts
+++ b/src/adapters/cache/sqlite-cache.ts
@@ -637,7 +637,7 @@ function isRecoverableSqliteCacheError(
     return error instanceof Error
         && "code" in error
         && typeof error.code === "string"
-        && recoverableSqliteCacheErrorCodes.has(error.code);
+        && isRecoverableSqliteCacheErrorCode(error.code);
 }
 
 function describeRecoverableSqliteCacheError(
@@ -645,11 +645,11 @@ function describeRecoverableSqliteCacheError(
         code: string;
     },
 ): string {
-    if (recoverableSqliteLockCodes.has(error.code)) {
+    if (isRecoverableSqliteLockCode(error.code)) {
         return "the database is locked";
     }
 
-    switch (error.code) {
+    switch (resolveRecoverableSqliteErrorCodeFamily(error.code)) {
         case "SQLITE_CANTOPEN":
             return "the database file cannot be opened";
         case "SQLITE_CORRUPT":
@@ -665,6 +665,37 @@ function describeRecoverableSqliteCacheError(
         default:
             return "the database is unavailable";
     }
+}
+
+export function isRecoverableSqliteCacheErrorCode(code: string): boolean {
+    return resolveRecoverableSqliteErrorCodeFamily(code) !== undefined;
+}
+
+function isRecoverableSqliteLockCode(code: string): boolean {
+    for (const recoverableCode of recoverableSqliteLockCodes) {
+        if (matchesSqliteErrorCodeFamily(code, recoverableCode)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function resolveRecoverableSqliteErrorCodeFamily(code: string): string | undefined {
+    for (const recoverableCode of recoverableSqliteCacheErrorCodes) {
+        if (matchesSqliteErrorCodeFamily(code, recoverableCode)) {
+            return recoverableCode;
+        }
+    }
+
+    return undefined;
+}
+
+function matchesSqliteErrorCodeFamily(
+    code: string,
+    recoverableCode: string,
+): boolean {
+    return code === recoverableCode || code.startsWith(`${recoverableCode}_`);
 }
 
 function readStorePathDiagnostics(filePath: string): StorePathDiagnostics {

--- a/src/adapters/store/store-path.test.ts
+++ b/src/adapters/store/store-path.test.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import { describe, expect, test } from "bun:test";
 
 import { APP_NAME } from "../../application/config/app-config.ts";
@@ -16,14 +18,19 @@ describe("resolveStorePaths", () => {
         });
 
         expect(storePaths).toEqual({
-            authFilePath: `/tmp/xdg/${APP_NAME}/auth.toml`,
-            cacheFilePath: `/tmp/xdg/${APP_NAME}/data/cache.sqlite`,
-            dataDirectory: `/tmp/xdg/${APP_NAME}/data`,
-            downloadSessionsFilePath: `/tmp/xdg/${APP_NAME}/data/download-sessions.sqlite`,
-            logDirectoryPath: `/tmp/xdg-state/${APP_NAME}/logs`,
-            rootDirectory: `/tmp/xdg/${APP_NAME}`,
-            settingsFilePath: `/tmp/xdg/${APP_NAME}/settings.toml`,
-            uploadsFilePath: `/tmp/xdg/${APP_NAME}/data/uploads.sqlite`,
+            authFilePath: join("/tmp/xdg", APP_NAME, "auth.toml"),
+            cacheFilePath: join("/tmp/xdg", APP_NAME, "data", "cache.sqlite"),
+            dataDirectory: join("/tmp/xdg", APP_NAME, "data"),
+            downloadSessionsFilePath: join(
+                "/tmp/xdg",
+                APP_NAME,
+                "data",
+                "download-sessions.sqlite",
+            ),
+            logDirectoryPath: join("/tmp/xdg-state", APP_NAME, "logs"),
+            rootDirectory: join("/tmp/xdg", APP_NAME),
+            settingsFilePath: join("/tmp/xdg", APP_NAME, "settings.toml"),
+            uploadsFilePath: join("/tmp/xdg", APP_NAME, "data", "uploads.sqlite"),
         });
     });
 
@@ -37,7 +44,7 @@ describe("resolveStorePaths", () => {
         });
 
         expect(storePaths.logDirectoryPath).toBe(
-            `/tmp/home/.local/state/${APP_NAME}/logs`,
+            join("/tmp/home", ".local", "state", APP_NAME, "logs"),
         );
     });
 
@@ -51,7 +58,7 @@ describe("resolveStorePaths", () => {
         });
 
         expect(storePaths.logDirectoryPath).toBe(
-            `/tmp/home/Library/Logs/${APP_NAME}`,
+            join("/tmp/home", "Library", "Logs", APP_NAME),
         );
     });
 
@@ -68,7 +75,7 @@ describe("resolveStorePaths", () => {
         });
 
         expect(storePaths.logDirectoryPath).toBe(
-            "C:\\Users\\kevin\\AppData\\Local/oo/Logs",
+            join("C:\\Users\\kevin\\AppData\\Local", APP_NAME, "Logs"),
         );
     });
 });

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -192,6 +192,7 @@ describe("skills CLI", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const serializedSkillDirectoryPath = JSON.stringify(skillDirectoryPath);
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -211,14 +212,14 @@ describe("skills CLI", () => {
                 `"msg":"Bundled Codex skill installed explicitly."`,
             );
             expect(installContent).toContain(`"skillName":"oo"`);
-            expect(installContent).toContain(`"path":"${skillDirectoryPath}"`);
+            expect(installContent).toContain(`"path":${serializedSkillDirectoryPath}`);
             expect(installContent).toContain(`"version":"9.9.9"`);
 
             expect(uninstallContent).toContain(
                 `"msg":"Bundled Codex skill removed explicitly."`,
             );
             expect(uninstallContent).toContain(`"skillName":"oo"`);
-            expect(uninstallContent).toContain(`"path":"${skillDirectoryPath}"`);
+            expect(uninstallContent).toContain(`"path":${serializedSkillDirectoryPath}`);
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/shared.test.ts
+++ b/src/application/commands/skills/shared.test.ts
@@ -1,10 +1,13 @@
-import { mkdir, readFile, realpath, rm } from "node:fs/promises";
+import { mkdir, readFile, realpath, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
 import { createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
-import { publishBundledSkillInstallation } from "./shared.ts";
+import {
+    createBundledSkillDirectorySymlink,
+    publishBundledSkillInstallation,
+} from "./shared.ts";
 
 describe("bundled skill publication", () => {
     test("publishes the bundled skill through a symlink-compatible path", async () => {
@@ -102,5 +105,183 @@ describe("bundled skill publication", () => {
         finally {
             await rm(rootDirectory, { force: true, recursive: true });
         }
+    });
+
+    test("replaces an existing directory at the installed path before creating a symlink", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const canonicalSkillDirectoryPath = join(
+            rootDirectory,
+            "config",
+            "skills",
+            "oo",
+        );
+        const installedSkillDirectoryPath = join(
+            rootDirectory,
+            ".codex",
+            "skills",
+            "oo",
+        );
+
+        try {
+            await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
+                recursive: true,
+            });
+            await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "skill\n");
+            await Bun.write(
+                join(canonicalSkillDirectoryPath, "agents", "openai.yaml"),
+                "OOMOL\n",
+            );
+            await mkdir(installedSkillDirectoryPath, { recursive: true });
+            await Bun.write(join(installedSkillDirectoryPath, "stale.txt"), "stale\n");
+
+            const result = await publishBundledSkillInstallation({
+                canonicalSkillDirectoryPath,
+                installedSkillDirectoryPath,
+            });
+
+            expect(result).toEqual({
+                mode: "symlink",
+                path: installedSkillDirectoryPath,
+            });
+            expect(await realpath(installedSkillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            await expect(stat(join(installedSkillDirectoryPath, "stale.txt"))).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("reuses an existing symlink when it already points to the target", async () => {
+        const createdSymlinks: Array<{
+            linkPath: string;
+            targetPath: string;
+            type: string | null | undefined;
+        }> = [];
+
+        const result = await createBundledSkillDirectorySymlink(
+            "/tmp/canonical/skills/oo",
+            "/tmp/agent/skills/oo",
+            {
+                lstat: async () => ({
+                    isSymbolicLink: () => true,
+                }),
+                mkdir: async () => undefined,
+                readlink: async () => "../../canonical/skills/oo",
+                realpath: async path => path,
+                removePath: async () => {
+                    throw new Error("expected the existing symlink to be reused");
+                },
+                resolveParentSymlinks: async path => path,
+                symlink: async (targetPath, linkPath, type) => {
+                    createdSymlinks.push({ linkPath, targetPath, type });
+                },
+            },
+        );
+
+        expect(result).toBeTrue();
+        expect(createdSymlinks).toHaveLength(0);
+    });
+
+    test("replaces an existing directory before creating a symlink", async () => {
+        const removedPaths: string[] = [];
+        const createdSymlinks: Array<{
+            linkPath: string;
+            targetPath: string;
+            type: string | null | undefined;
+        }> = [];
+        const targetPath = "/tmp/canonical/skills/oo";
+        const linkPath = "/tmp/agent/skills/oo";
+
+        const result = await createBundledSkillDirectorySymlink(
+            targetPath,
+            linkPath,
+            {
+                lstat: async () => ({
+                    isSymbolicLink: () => false,
+                }) as Awaited<ReturnType<typeof stat>>,
+                mkdir: async () => undefined,
+                readlink: async () => {
+                    throw new Error("readlink should not run for directories");
+                },
+                realpath: async path => path,
+                removePath: async (path) => {
+                    removedPaths.push(path);
+                },
+                resolveParentSymlinks: async path => path,
+                symlink: async (createdTargetPath, createdLinkPath, type) => {
+                    createdSymlinks.push({
+                        linkPath: createdLinkPath,
+                        targetPath: createdTargetPath,
+                        type,
+                    });
+                },
+            },
+        );
+
+        expect(result).toBeTrue();
+        expect(removedPaths).toEqual([linkPath]);
+        expect(createdSymlinks).toEqual([
+            {
+                linkPath,
+                targetPath: "../../canonical/skills/oo",
+                type: "dir",
+            },
+        ]);
+    });
+
+    test("cleans a broken symlink loop before creating a junction in win32 mode", async () => {
+        const removedPaths: string[] = [];
+        const createdSymlinks: Array<{
+            linkPath: string;
+            targetPath: string;
+            type: string | null | undefined;
+        }> = [];
+        const targetPath = "/windows/canonical/oo";
+        const linkPath = "/windows/agent/oo";
+
+        const result = await createBundledSkillDirectorySymlink(
+            targetPath,
+            linkPath,
+            {
+                lstat: async () => {
+                    const error = new Error("loop") as NodeJS.ErrnoException;
+
+                    error.code = "ELOOP";
+
+                    throw error;
+                },
+                mkdir: async () => undefined,
+                readlink: async () => {
+                    throw new Error("readlink should not run when lstat fails");
+                },
+                realpath: async path => path,
+                removePath: async (path) => {
+                    removedPaths.push(path);
+                },
+                resolveParentSymlinks: async path => path,
+                symlink: async (createdTargetPath, createdLinkPath, type) => {
+                    createdSymlinks.push({
+                        linkPath: createdLinkPath,
+                        targetPath: createdTargetPath,
+                        type,
+                    });
+                },
+                platform: "win32",
+            },
+        );
+
+        expect(result).toBeTrue();
+        expect(removedPaths).toEqual([linkPath]);
+        expect(createdSymlinks).toEqual([
+            {
+                linkPath,
+                targetPath,
+                type: "junction",
+            },
+        ]);
     });
 });

--- a/src/application/commands/skills/shared.test.ts
+++ b/src/application/commands/skills/shared.test.ts
@@ -214,6 +214,7 @@ describe("bundled skill publication", () => {
                 removePath: async (path) => {
                     removedPaths.push(path);
                 },
+                platform: "linux",
                 resolveParentSymlinks: async path => path,
                 symlink: async (createdTargetPath, createdLinkPath, type) => {
                     createdSymlinks.push({

--- a/src/application/commands/skills/shared.test.ts
+++ b/src/application/commands/skills/shared.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, realpath, rm, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
@@ -7,6 +7,7 @@ import { createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
 import {
     createBundledSkillDirectorySymlink,
     publishBundledSkillInstallation,
+    removeBundledSkillSymbolicPath,
 } from "./shared.ts";
 
 describe("bundled skill publication", () => {
@@ -195,6 +196,8 @@ describe("bundled skill publication", () => {
         }> = [];
         const targetPath = "/tmp/canonical/skills/oo";
         const linkPath = "/tmp/agent/skills/oo";
+        const resolvedTargetPath = resolve(targetPath);
+        const resolvedLinkPath = resolve(linkPath);
 
         const result = await createBundledSkillDirectorySymlink(
             targetPath,
@@ -223,11 +226,11 @@ describe("bundled skill publication", () => {
         );
 
         expect(result).toBeTrue();
-        expect(removedPaths).toEqual([linkPath]);
+        expect(removedPaths).toEqual([resolvedLinkPath]);
         expect(createdSymlinks).toEqual([
             {
-                linkPath,
-                targetPath: "../../canonical/skills/oo",
+                linkPath: resolvedLinkPath,
+                targetPath: relative(dirname(resolvedLinkPath), resolvedTargetPath),
                 type: "dir",
             },
         ]);
@@ -242,6 +245,8 @@ describe("bundled skill publication", () => {
         }> = [];
         const targetPath = "/windows/canonical/oo";
         const linkPath = "/windows/agent/oo";
+        const resolvedTargetPath = resolve(targetPath);
+        const resolvedLinkPath = resolve(linkPath);
 
         const result = await createBundledSkillDirectorySymlink(
             targetPath,
@@ -275,13 +280,34 @@ describe("bundled skill publication", () => {
         );
 
         expect(result).toBeTrue();
-        expect(removedPaths).toEqual([linkPath]);
+        expect(removedPaths).toEqual([resolvedLinkPath]);
         expect(createdSymlinks).toEqual([
             {
-                linkPath,
-                targetPath,
+                linkPath: resolvedLinkPath,
+                targetPath: resolvedTargetPath,
                 type: "junction",
             },
         ]);
+    });
+
+    test("falls back to rmdir when removing a junction hits EFAULT on win32", async () => {
+        const removedWithRmdir: string[] = [];
+        const junctionPath = "C:\\Users\\Tester\\.codex\\skills\\oo";
+
+        await removeBundledSkillSymbolicPath(junctionPath, {
+            platform: "win32",
+            rm: async () => {
+                const error = new Error("bad address") as NodeJS.ErrnoException;
+
+                error.code = "EFAULT";
+
+                throw error;
+            },
+            rmdir: async (path) => {
+                removedWithRmdir.push(path);
+            },
+        });
+
+        expect(removedWithRmdir).toEqual([junctionPath]);
     });
 });

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -72,6 +72,17 @@ export interface CreateBundledSkillDirectorySymlinkDependencies {
     platform?: NodeJS.Platform;
 }
 
+export interface RemoveBundledSkillSymbolicPathDependencies {
+    platform?: NodeJS.Platform;
+    rm?: (
+        path: string,
+        options: {
+            force: true;
+        },
+    ) => Promise<void>;
+    rmdir?: (path: string) => Promise<void>;
+}
+
 export function resolveCodexHomeDirectory(
     env: Record<string, string | undefined>,
 ): string {
@@ -874,7 +885,7 @@ async function removePath(path: string): Promise<void> {
         const pathStats = await lstat(path);
 
         if (pathStats.isSymbolicLink()) {
-            await removeSymbolicPath(path);
+            await removeBundledSkillSymbolicPath(path);
             return;
         }
 
@@ -889,13 +900,20 @@ async function removePath(path: string): Promise<void> {
     }
 }
 
-async function removeSymbolicPath(path: string): Promise<void> {
+export async function removeBundledSkillSymbolicPath(
+    path: string,
+    dependencies: RemoveBundledSkillSymbolicPathDependencies = {},
+): Promise<void> {
+    const rmFn = dependencies.rm ?? rm;
+    const rmdirFn = dependencies.rmdir ?? rmdir;
+    const runtimePlatform = dependencies.platform ?? process.platform;
+
     try {
-        await rm(path, { force: true });
+        await rmFn(path, { force: true });
     }
     catch (error) {
-        if (process.platform === "win32" && isWindowsBadAddressError(error)) {
-            await rmdir(path);
+        if (runtimePlatform === "win32" && isWindowsBadAddressError(error)) {
+            await rmdirFn(path);
             return;
         }
 

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -50,6 +50,28 @@ interface BundledSkillPublicationDependencies {
     ) => Promise<boolean>;
 }
 
+export interface CreateBundledSkillDirectorySymlinkDependencies {
+    lstat?: (path: string) => Promise<{
+        isSymbolicLink: () => boolean;
+    }>;
+    mkdir?: (
+        path: string,
+        options: {
+            recursive: true;
+        },
+    ) => Promise<void>;
+    readlink?: (path: string) => Promise<string>;
+    realpath?: (path: string) => Promise<string>;
+    removePath?: (path: string) => Promise<void>;
+    resolveParentSymlinks?: (path: string) => Promise<string>;
+    symlink?: (
+        targetPath: string,
+        linkPath: string,
+        type: "dir" | "junction",
+    ) => Promise<void>;
+    platform?: NodeJS.Platform;
+}
+
 export function resolveCodexHomeDirectory(
     env: Record<string, string | undefined>,
 ): string {
@@ -685,7 +707,7 @@ export async function publishBundledSkillInstallation(
     dependencies: BundledSkillPublicationDependencies = {},
 ): Promise<BundledSkillPublicationResult> {
     const createDirectoryLink
-        = dependencies.createDirectorySymlink ?? createDirectorySymlink;
+        = dependencies.createDirectorySymlink ?? createBundledSkillDirectorySymlink;
     const symlinkCreated = await createDirectoryLink(
         options.canonicalSkillDirectoryPath,
         options.installedSkillDirectoryPath,
@@ -739,16 +761,31 @@ function isNodeNotFoundError(error: unknown): error is NodeJS.ErrnoException {
     return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
-async function createDirectorySymlink(
+function isSymlinkLoopError(error: unknown): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "ELOOP";
+}
+
+export async function createBundledSkillDirectorySymlink(
     targetPath: string,
     linkPath: string,
+    dependencies: CreateBundledSkillDirectorySymlinkDependencies = {},
 ): Promise<boolean> {
+    const lstatFn = dependencies.lstat ?? lstat;
+    const mkdirFn = dependencies.mkdir ?? mkdir;
+    const readlinkFn = dependencies.readlink ?? readlink;
+    const realpathFn = dependencies.realpath ?? realpath;
+    const removePathFn = dependencies.removePath ?? removePath;
+    const resolveParentSymlinksFn
+        = dependencies.resolveParentSymlinks ?? resolveParentSymlinks;
+    const symlinkFn = dependencies.symlink ?? symlink;
+    const runtimePlatform = dependencies.platform ?? process.platform;
+
     try {
         const resolvedTargetPath = resolve(targetPath);
         const resolvedLinkPath = resolve(linkPath);
         const [realTargetPath, realLinkPath] = await Promise.all([
-            realpath(resolvedTargetPath).catch(() => resolvedTargetPath),
-            realpath(resolvedLinkPath).catch(() => resolvedLinkPath),
+            realpathFn(resolvedTargetPath).catch(() => resolvedTargetPath),
+            realpathFn(resolvedLinkPath).catch(() => resolvedLinkPath),
         ]);
 
         if (realTargetPath === realLinkPath) {
@@ -757,8 +794,8 @@ async function createDirectorySymlink(
 
         const [realTargetPathWithParents, realLinkPathWithParents]
             = await Promise.all([
-                resolveParentSymlinks(resolvedTargetPath),
-                resolveParentSymlinks(resolvedLinkPath),
+                resolveParentSymlinksFn(resolvedTargetPath),
+                resolveParentSymlinksFn(resolvedLinkPath),
             ]);
 
         if (realTargetPathWithParents === realLinkPathWithParents) {
@@ -766,10 +803,10 @@ async function createDirectorySymlink(
         }
 
         try {
-            const existingStats = await lstat(resolvedLinkPath);
+            const existingStats = await lstatFn(resolvedLinkPath);
 
             if (existingStats.isSymbolicLink()) {
-                const existingTarget = await readlink(resolvedLinkPath);
+                const existingTarget = await readlinkFn(resolvedLinkPath);
 
                 if (
                     resolveSymlinkTarget(resolvedLinkPath, existingTarget)
@@ -779,29 +816,37 @@ async function createDirectorySymlink(
                 }
             }
 
-            await removePath(resolvedLinkPath);
+            await removePathFn(resolvedLinkPath);
         }
         catch (error) {
-            if (!isNodeNotFoundError(error)) {
+            if (isSymlinkLoopError(error)) {
+                try {
+                    await removePathFn(resolvedLinkPath);
+                }
+                catch {
+                    // Let symlink creation determine whether copy fallback is needed.
+                }
+            }
+            else if (!isNodeNotFoundError(error)) {
                 throw error;
             }
         }
 
         const linkDirectoryPath = dirname(resolvedLinkPath);
 
-        await mkdir(linkDirectoryPath, { recursive: true });
+        await mkdirFn(linkDirectoryPath, { recursive: true });
 
-        const symlinkTargetPath = process.platform === "win32"
+        const symlinkTargetPath = runtimePlatform === "win32"
             ? resolvedTargetPath
             : relative(
-                    await resolveParentSymlinks(linkDirectoryPath),
+                    await resolveParentSymlinksFn(linkDirectoryPath),
                     resolvedTargetPath,
                 );
 
-        await symlink(
+        await symlinkFn(
             symlinkTargetPath,
             resolvedLinkPath,
-            process.platform === "win32" ? "junction" : "dir",
+            runtimePlatform === "win32" ? "junction" : "dir",
         );
 
         return true;

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -10,6 +10,7 @@ import {
     readlink,
     realpath,
     rm,
+    rmdir,
     stat,
     symlink,
 } from "node:fs/promises";
@@ -501,7 +502,8 @@ function writeImplicitInvocationValue(
     content: string,
     value: boolean,
 ): string {
-    const lines = content.split("\n");
+    const lineSeparator = content.includes("\r\n") ? "\r\n" : "\n";
+    const lines = content.split(lineSeparator);
 
     for (const [index, line] of lines.entries()) {
         const trimmedLine = line.trim();
@@ -519,7 +521,7 @@ function writeImplicitInvocationValue(
             value ? "true" : "false",
         ].join("");
 
-        return lines.join("\n");
+        return lines.join(lineSeparator);
     }
 
     throw new Error(
@@ -827,7 +829,7 @@ async function removePath(path: string): Promise<void> {
         const pathStats = await lstat(path);
 
         if (pathStats.isSymbolicLink()) {
-            await rm(path, { force: true });
+            await removeSymbolicPath(path);
             return;
         }
 
@@ -840,6 +842,24 @@ async function removePath(path: string): Promise<void> {
 
         throw error;
     }
+}
+
+async function removeSymbolicPath(path: string): Promise<void> {
+    try {
+        await rm(path, { force: true });
+    }
+    catch (error) {
+        if (process.platform === "win32" && isWindowsBadAddressError(error)) {
+            await rmdir(path);
+            return;
+        }
+
+        throw error;
+    }
+}
+
+function isWindowsBadAddressError(error: unknown): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "EFAULT";
 }
 
 async function resolveParentSymlinks(path: string): Promise<string> {

--- a/src/application/path/home-directory.test.ts
+++ b/src/application/path/home-directory.test.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import { describe, expect, test } from "bun:test";
 
 import {
@@ -29,7 +31,7 @@ describe("expandHomeDirectoryPath", () => {
             expandHomeDirectoryPath("~/Downloads/reports", {
                 HOME: "/env-home",
             }),
-        ).toBe("/env-home/Downloads/reports");
+        ).toBe(join("/env-home", "Downloads", "reports"));
     });
 
     test("leaves non-tilde values untouched", () => {


### PR DESCRIPTION
Separate the monolithic pr-check job into two independent jobs:
- quality: runs lint and TypeScript checks on ubuntu
- test: runs tests across ubuntu, windows, and macos using a matrix strategy with fail-fast enabled

This enables cross-platform test coverage and allows quality checks to complete independently of test runs.