### PR TITLE
ci: split pr-check into quality and cross-platform test jobs

### DIFF
--- a/__tests__/helpers.test.ts
+++ b/__tests__/helpers.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import { createTerminalColors } from "../src/application/terminal-colors.ts";
-import { createCliSnapshot } from "./helpers.ts";
+import {
+    createCliSnapshot,
+    createPlatformScope,
+    platformDescribe,
+    platformTest,
+} from "./helpers.ts";
 
 describe("test helpers", () => {
     test("normalizes cli snapshots for paths, ansi output, and replacement precedence", () => {
@@ -46,5 +51,29 @@ describe("test helpers", () => {
             ].join("\n"),
             stderr: "ok <OUTPUT_FILE>\n",
         });
+    });
+
+    test("creates platform-scoped conditional modifiers", () => {
+        const scope = createPlatformScope(
+            {
+                if(condition: boolean) {
+                    return { condition };
+                },
+            },
+            "darwin",
+        );
+
+        expect(scope).toEqual({
+            darwin: { condition: true },
+            linux: { condition: false },
+            win32: { condition: false },
+        });
+    });
+
+    test("exports platform shorthands for test and describe", () => {
+        expect(Object.keys(platformTest).sort()).toEqual(["darwin", "linux", "win32"]);
+        expect(Object.keys(platformDescribe).sort()).toEqual(["darwin", "linux", "win32"]);
+        expect(typeof platformTest.darwin).toBe("function");
+        expect(typeof platformDescribe.win32).toBe("function");
     });
 });

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -10,7 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { Database } from "bun:sqlite";
-import { expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import pino from "pino";
 import {
     downloadResumeSessionsTableName,
@@ -84,6 +84,12 @@ export interface LogCapture {
     read: () => string;
 }
 
+export interface PlatformScope<T> {
+    readonly darwin: T;
+    readonly linux: T;
+    readonly win32: T;
+}
+
 export interface AuthAccountFixture {
     readonly id: string;
     readonly name: string;
@@ -98,6 +104,23 @@ export interface PrintedAuthLoginOptions {
 }
 
 export const defaultAuthEndpoint = "oomol.com";
+
+export function createPlatformScope<T>(
+    conditional: {
+        if: (condition: boolean) => T;
+    },
+    currentPlatform: NodeJS.Platform = process.platform,
+): PlatformScope<T> {
+    return {
+        darwin: conditional.if(currentPlatform === "darwin"),
+        linux: conditional.if(currentPlatform === "linux"),
+        win32: conditional.if(currentPlatform === "win32"),
+    };
+}
+
+export const platformTest = createPlatformScope(test);
+
+export const platformDescribe = createPlatformScope(describe);
 
 export const defaultSettingsFileContent = [
     "# lang controls the CLI display language for help text, messages, and errors.",

--- a/src/application/commands/skills/shared.test.ts
+++ b/src/application/commands/skills/shared.test.ts
@@ -3,7 +3,10 @@ import { dirname, join, relative, resolve } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
-import { createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
+import {
+    createTemporaryDirectory,
+    platformDescribe,
+} from "../../../../__tests__/helpers.ts";
 import {
     createBundledSkillDirectorySymlink,
     publishBundledSkillInstallation,
@@ -186,57 +189,12 @@ describe("bundled skill publication", () => {
         expect(result).toBeTrue();
         expect(createdSymlinks).toHaveLength(0);
     });
+});
 
-    test("replaces an existing directory before creating a symlink", async () => {
-        const removedPaths: string[] = [];
-        const createdSymlinks: Array<{
-            linkPath: string;
-            targetPath: string;
-            type: string | null | undefined;
-        }> = [];
-        const targetPath = "/tmp/canonical/skills/oo";
-        const linkPath = "/tmp/agent/skills/oo";
-        const resolvedTargetPath = resolve(targetPath);
-        const resolvedLinkPath = resolve(linkPath);
+registerPosixBundledSkillPublicationTests("darwin");
+registerPosixBundledSkillPublicationTests("linux");
 
-        const result = await createBundledSkillDirectorySymlink(
-            targetPath,
-            linkPath,
-            {
-                lstat: async () => ({
-                    isSymbolicLink: () => false,
-                }) as Awaited<ReturnType<typeof stat>>,
-                mkdir: async () => undefined,
-                readlink: async () => {
-                    throw new Error("readlink should not run for directories");
-                },
-                realpath: async path => path,
-                removePath: async (path) => {
-                    removedPaths.push(path);
-                },
-                platform: "linux",
-                resolveParentSymlinks: async path => path,
-                symlink: async (createdTargetPath, createdLinkPath, type) => {
-                    createdSymlinks.push({
-                        linkPath: createdLinkPath,
-                        targetPath: createdTargetPath,
-                        type,
-                    });
-                },
-            },
-        );
-
-        expect(result).toBeTrue();
-        expect(removedPaths).toEqual([resolvedLinkPath]);
-        expect(createdSymlinks).toEqual([
-            {
-                linkPath: resolvedLinkPath,
-                targetPath: relative(dirname(resolvedLinkPath), resolvedTargetPath),
-                type: "dir",
-            },
-        ]);
-    });
-
+platformDescribe.win32("bundled skill publication on win32", () => {
     test("cleans a broken symlink loop before creating a junction in win32 mode", async () => {
         const removedPaths: string[] = [];
         const createdSymlinks: Array<{
@@ -276,7 +234,6 @@ describe("bundled skill publication", () => {
                         type,
                     });
                 },
-                platform: "win32",
             },
         );
 
@@ -296,7 +253,6 @@ describe("bundled skill publication", () => {
         const junctionPath = "C:\\Users\\Tester\\.codex\\skills\\oo";
 
         await removeBundledSkillSymbolicPath(junctionPath, {
-            platform: "win32",
             rm: async () => {
                 const error = new Error("bad address") as NodeJS.ErrnoException;
 
@@ -312,3 +268,81 @@ describe("bundled skill publication", () => {
         expect(removedWithRmdir).toEqual([junctionPath]);
     });
 });
+
+function registerPosixBundledSkillPublicationTests(
+    platform: "darwin" | "linux",
+): void {
+    const scopedDescribe = platform === "darwin"
+        ? platformDescribe.darwin
+        : platformDescribe.linux;
+
+    scopedDescribe(`bundled skill publication on ${platform}`, () => {
+        test("replaces an existing directory before creating a symlink", async () => {
+            const removedPaths: string[] = [];
+            const createdSymlinks: Array<{
+                linkPath: string;
+                targetPath: string;
+                type: string | null | undefined;
+            }> = [];
+            const targetPath = "/tmp/canonical/skills/oo";
+            const linkPath = "/tmp/agent/skills/oo";
+            const resolvedTargetPath = resolve(targetPath);
+            const resolvedLinkPath = resolve(linkPath);
+
+            const result = await createBundledSkillDirectorySymlink(
+                targetPath,
+                linkPath,
+                {
+                    lstat: async () => ({
+                        isSymbolicLink: () => false,
+                    }) as Awaited<ReturnType<typeof stat>>,
+                    mkdir: async () => undefined,
+                    readlink: async () => {
+                        throw new Error("readlink should not run for directories");
+                    },
+                    realpath: async path => path,
+                    removePath: async (path) => {
+                        removedPaths.push(path);
+                    },
+                    resolveParentSymlinks: async path => path,
+                    symlink: async (createdTargetPath, createdLinkPath, type) => {
+                        createdSymlinks.push({
+                            linkPath: createdLinkPath,
+                            targetPath: createdTargetPath,
+                            type,
+                        });
+                    },
+                },
+            );
+
+            expect(result).toBeTrue();
+            expect(removedPaths).toEqual([resolvedLinkPath]);
+            expect(createdSymlinks).toEqual([
+                {
+                    linkPath: resolvedLinkPath,
+                    targetPath: relative(dirname(resolvedLinkPath), resolvedTargetPath),
+                    type: "dir",
+                },
+            ]);
+        });
+
+        test("rethrows EFAULT when removing a symbolic path on POSIX", async () => {
+            const symlinkPath = "/tmp/.codex/skills/oo";
+
+            await expect(removeBundledSkillSymbolicPath(symlinkPath, {
+                rm: async () => {
+                    const error = new Error("bad address") as NodeJS.ErrnoException;
+
+                    error.code = "EFAULT";
+
+                    throw error;
+                },
+                rmdir: async () => {
+                    throw new Error("rmdir should not run on POSIX");
+                },
+            })).rejects.toMatchObject({
+                code: "EFAULT",
+            });
+        });
+    });
+}

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -69,11 +69,9 @@ export interface CreateBundledSkillDirectorySymlinkDependencies {
         linkPath: string,
         type: "dir" | "junction",
     ) => Promise<void>;
-    platform?: NodeJS.Platform;
 }
 
 export interface RemoveBundledSkillSymbolicPathDependencies {
-    platform?: NodeJS.Platform;
     rm?: (
         path: string,
         options: {
@@ -789,7 +787,6 @@ export async function createBundledSkillDirectorySymlink(
     const resolveParentSymlinksFn
         = dependencies.resolveParentSymlinks ?? resolveParentSymlinks;
     const symlinkFn = dependencies.symlink ?? symlink;
-    const runtimePlatform = dependencies.platform ?? process.platform;
 
     try {
         const resolvedTargetPath = resolve(targetPath);
@@ -847,7 +844,7 @@ export async function createBundledSkillDirectorySymlink(
 
         await mkdirFn(linkDirectoryPath, { recursive: true });
 
-        const symlinkTargetPath = runtimePlatform === "win32"
+        const symlinkTargetPath = process.platform === "win32"
             ? resolvedTargetPath
             : relative(
                     await resolveParentSymlinksFn(linkDirectoryPath),
@@ -857,7 +854,7 @@ export async function createBundledSkillDirectorySymlink(
         await symlinkFn(
             symlinkTargetPath,
             resolvedLinkPath,
-            runtimePlatform === "win32" ? "junction" : "dir",
+            process.platform === "win32" ? "junction" : "dir",
         );
 
         return true;
@@ -906,13 +903,12 @@ export async function removeBundledSkillSymbolicPath(
 ): Promise<void> {
     const rmFn = dependencies.rm ?? rm;
     const rmdirFn = dependencies.rmdir ?? rmdir;
-    const runtimePlatform = dependencies.platform ?? process.platform;
 
     try {
         await rmFn(path, { force: true });
     }
     catch (error) {
-        if (runtimePlatform === "win32" && isWindowsBadAddressError(error)) {
+        if (process.platform === "win32" && isWindowsBadAddressError(error)) {
             await rmdirFn(path);
             return;
         }


### PR DESCRIPTION
Separate the monolithic pr-check job into two independent jobs:
- quality: runs lint and TypeScript checks on ubuntu
- test: runs tests across ubuntu, windows, and macos
  using a matrix strategy with fail-fast enabled

This enables cross-platform test coverage and allows
quality checks to complete independently of test runs.

Signed-off-by: Kevin Cui <bh@bugs.cc>