### PR TITLE
refactor: extract helpers and replace boolean flags with unions

### DIFF
--- a/src/adapters/cache/sqlite-cache.test.ts
+++ b/src/adapters/cache/sqlite-cache.test.ts
@@ -214,6 +214,7 @@ describe("SqliteCacheStore", () => {
 
     test("truncates wal sidecar files on close", async () => {
         const root = await createTemporaryDirectory("sqlite-cache-close");
+        const logCapture = createLogCapture();
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: {
@@ -222,26 +223,39 @@ describe("SqliteCacheStore", () => {
             },
             platform: "linux",
         });
-        const cacheStore = new SqliteCacheStore(storePaths.cacheFilePath);
+        const cacheStore = new SqliteCacheStore(
+            storePaths.cacheFilePath,
+            logCapture.logger,
+        );
         const cache = cacheStore.getCache<string>({
             id: "search",
         });
         const walFilePath = `${cacheStore.getFilePath()}-wal`;
         const shmFilePath = `${cacheStore.getFilePath()}-shm`;
 
-        cache.set("query:image", "cached");
+        try {
+            cache.set("query:image", "cached");
 
-        await expect(stat(walFilePath)).resolves.toMatchObject({
-            isFile: expect.any(Function),
-        });
-        await expect(stat(shmFilePath)).resolves.toMatchObject({
-            isFile: expect.any(Function),
-        });
+            await expect(stat(walFilePath)).resolves.toMatchObject({
+                isFile: expect.any(Function),
+            });
+            await expect(stat(shmFilePath)).resolves.toMatchObject({
+                isFile: expect.any(Function),
+            });
 
-        cacheStore.close();
+            cacheStore.close();
 
-        await expect(stat(walFilePath)).rejects.toBeDefined();
-        await expect(stat(shmFilePath)).rejects.toBeDefined();
+            await expect(stat(walFilePath)).rejects.toBeDefined();
+            await expect(stat(shmFilePath)).rejects.toBeDefined();
+
+            const logs = logCapture.read();
+
+            expect(logs).toContain(`"msg":"Sqlite cache store closed."`);
+            expect(logs).not.toContain(`"storePathExists"`);
+        }
+        finally {
+            logCapture.close();
+        }
     });
 
     test("falls back to a no-op cache when sqlite namespace initialization is locked", async () => {
@@ -402,6 +416,7 @@ describe("SqliteCacheStore", () => {
 
             expect(logs).toContain(`"level":"warn"`);
             expect(logs).toContain(`"category":"recoverable_cache"`);
+            expect(logs).not.toContain(`"storePathExists"`);
             expect(logs).toContain(
                 `"msg":"Sqlite cache touch update was skipped because the database is locked."`,
             );

--- a/src/adapters/cache/sqlite-cache.ts
+++ b/src/adapters/cache/sqlite-cache.ts
@@ -51,6 +51,19 @@ interface StorePathDiagnostics {
     storePathKind: "directory" | "file" | "missing" | "other";
 }
 
+type RecoverableSqliteStorePathDiagnosticsPolicy
+    = | "always"
+        | "except-lock"
+        | "never";
+
+interface RecoverableSqliteErrorContext {
+    description: string;
+    error: Error & {
+        code: string;
+    };
+    includeStorePathDiagnostics: boolean;
+}
+
 const recoverableSqliteLockCodes = new Set([
     "SQLITE_BUSY",
     "SQLITE_LOCKED",
@@ -85,7 +98,12 @@ export class SqliteCacheStore implements CacheStore {
             );
         }
         catch (error) {
-            if (!isRecoverableSqliteCacheError(error)) {
+            const recoverableError = resolveRecoverableSqliteErrorContext(
+                error,
+                "always",
+            );
+
+            if (recoverableError === undefined) {
                 throw error;
             }
 
@@ -95,10 +113,10 @@ export class SqliteCacheStore implements CacheStore {
                     ...withCategory(logCategory.recoverableCache),
                     err: error,
                     ...readStorePathDiagnostics(this.filePath),
-                    sqliteErrorCode: error.code,
+                    sqliteErrorCode: recoverableError.error.code,
                     ...withStorePath(this.filePath),
                 },
-                `Sqlite cache store open was deferred because ${describeRecoverableSqliteCacheError(error)}.`,
+                `Sqlite cache store open was deferred because ${recoverableError.description}.`,
             );
         }
     }
@@ -130,7 +148,12 @@ export class SqliteCacheStore implements CacheStore {
             });
         }
         catch (error) {
-            if (!isRecoverableSqliteCacheError(error)) {
+            const recoverableError = resolveRecoverableSqliteErrorContext(
+                error,
+                "always",
+            );
+
+            if (recoverableError === undefined) {
                 throw error;
             }
 
@@ -140,10 +163,10 @@ export class SqliteCacheStore implements CacheStore {
                     ...withCategory(logCategory.recoverableCache),
                     err: error,
                     ...readStorePathDiagnostics(this.filePath),
-                    sqliteErrorCode: error.code,
+                    sqliteErrorCode: recoverableError.error.code,
                     ...withStorePath(this.filePath),
                 },
-                `Sqlite cache namespace is temporarily unavailable because ${describeRecoverableSqliteCacheError(error)}.`,
+                `Sqlite cache namespace is temporarily unavailable because ${recoverableError.description}.`,
             );
 
             return new UnavailableSqliteCache<Value>();
@@ -165,7 +188,12 @@ export class SqliteCacheStore implements CacheStore {
                 database.run("PRAGMA wal_checkpoint(TRUNCATE);");
             }
             catch (error) {
-                if (!isRecoverableSqliteCacheError(error)) {
+                const recoverableError = resolveRecoverableSqliteErrorContext(
+                    error,
+                    "never",
+                );
+
+                if (recoverableError === undefined) {
                     throw error;
                 }
 
@@ -173,10 +201,10 @@ export class SqliteCacheStore implements CacheStore {
                     {
                         ...withCategory(logCategory.recoverableCache),
                         err: error,
-                        sqliteErrorCode: error.code,
+                        sqliteErrorCode: recoverableError.error.code,
                         ...withStorePath(this.filePath),
                     },
-                    `Sqlite cache store close skipped WAL checkpoint because ${describeRecoverableSqliteCacheError(error)}.`,
+                    `Sqlite cache store close skipped WAL checkpoint because ${recoverableError.description}.`,
                 );
             }
         }
@@ -474,7 +502,12 @@ export class SqliteCache<Value> implements Cache<Value> {
             };
         }
         catch (error) {
-            if (!isRecoverableSqliteCacheError(error)) {
+            const recoverableError = resolveRecoverableSqliteErrorContext(
+                error,
+                "except-lock",
+            );
+
+            if (recoverableError === undefined) {
                 throw error;
             }
 
@@ -484,16 +517,16 @@ export class SqliteCache<Value> implements Cache<Value> {
                     ...withCategory(logCategory.recoverableCache),
                     err: error,
                     operation: options.operation,
-                    ...(recoverableSqliteLockCodes.has(error.code)
-                        ? {}
-                        : readStorePathDiagnostics(this.options.filePath)),
-                    sqliteErrorCode: error.code,
+                    ...(recoverableError.includeStorePathDiagnostics
+                        ? readStorePathDiagnostics(this.options.filePath)
+                        : {}),
+                    sqliteErrorCode: recoverableError.error.code,
                     ...withStorePath(this.options.filePath),
                     ...(options.key === undefined
                         ? {}
                         : withKeyFingerprint(createCacheKeyFingerprint(options.key))),
                 },
-                `${options.messagePrefix} because ${describeRecoverableSqliteCacheError(error)}.`,
+                `${options.messagePrefix} because ${recoverableError.description}.`,
             );
 
             return {
@@ -640,6 +673,24 @@ function isRecoverableSqliteCacheError(
         && isRecoverableSqliteCacheErrorCode(error.code);
 }
 
+function resolveRecoverableSqliteErrorContext(
+    error: unknown,
+    storePathDiagnosticsPolicy: RecoverableSqliteStorePathDiagnosticsPolicy,
+): RecoverableSqliteErrorContext | undefined {
+    if (!isRecoverableSqliteCacheError(error)) {
+        return undefined;
+    }
+
+    return {
+        description: describeRecoverableSqliteCacheError(error),
+        error,
+        includeStorePathDiagnostics: resolveRecoverableSqliteStorePathDiagnosticsPolicy(
+            error,
+            storePathDiagnosticsPolicy,
+        ),
+    };
+}
+
 function describeRecoverableSqliteCacheError(
     error: Error & {
         code: string;
@@ -665,6 +716,24 @@ function describeRecoverableSqliteCacheError(
         default:
             return "the database is unavailable";
     }
+}
+
+function resolveRecoverableSqliteStorePathDiagnosticsPolicy(
+    error: Error & {
+        code: string;
+    },
+    policy: RecoverableSqliteStorePathDiagnosticsPolicy,
+): boolean {
+    switch (policy) {
+        case "always":
+            return true;
+        case "except-lock":
+            return !isRecoverableSqliteLockCode(error.code);
+        case "never":
+            return false;
+    }
+
+    return false;
 }
 
 export function isRecoverableSqliteCacheErrorCode(code: string): boolean {

--- a/src/adapters/commander/commander-cli-adapter.test.ts
+++ b/src/adapters/commander/commander-cli-adapter.test.ts
@@ -1,0 +1,120 @@
+import type { CliCatalog, CliExecutionContext } from "../../application/contracts/cli.ts";
+
+import { describe, expect, test } from "bun:test";
+import {
+    createNoopFileDownloadSessionStore,
+    createNoopFileUploadStore,
+    createTextBuffer,
+} from "../../../__tests__/helpers.ts";
+import { createTranslator } from "../../i18n/translator.ts";
+import { CommanderCliAdapter } from "./commander-cli-adapter.ts";
+
+describe("CommanderCliAdapter", () => {
+    test("requires inputSchema when a command defines a handler", async () => {
+        const adapter = new CommanderCliAdapter();
+        const stdout = createTextBuffer();
+        const stderr = createTextBuffer();
+        const catalog: CliCatalog = {
+            commands: [
+                {
+                    handler: async () => {},
+                    name: "demo",
+                    summaryKey: "commands.help.summary",
+                },
+            ],
+            descriptionKey: "app.description",
+            globalOptions: [],
+            name: "oo",
+        };
+
+        const exitCode = await adapter.run({
+            argv: ["demo"],
+            catalog,
+            context: createCommanderContext(catalog, stdout.writer, stderr.writer),
+        });
+
+        expect(exitCode).toBe(1);
+        expect(stderr.read()).toBe(
+            "Unexpected error: Command \"demo\" must define inputSchema when handler is provided.\n",
+        );
+    });
+});
+
+function createCommanderContext(
+    catalog: CliCatalog,
+    stdout: CliExecutionContext["stdout"],
+    stderr: CliExecutionContext["stderr"],
+): CliExecutionContext {
+    return {
+        authStore: {
+            getFilePath() {
+                return "";
+            },
+            read: async () => ({
+                auth: [],
+                id: "",
+            }),
+            update: async updater => updater({
+                auth: [],
+                id: "",
+            }),
+            write: async auth => auth,
+        },
+        cacheStore: {
+            close() {},
+            getCache() {
+                return {
+                    clear() {},
+                    delete() {
+                        return false;
+                    },
+                    get() {
+                        return null;
+                    },
+                    has() {
+                        return false;
+                    },
+                    set() {},
+                };
+            },
+            getFilePath() {
+                return "";
+            },
+        },
+        catalog,
+        completionRenderer: {
+            render() {
+                return "";
+            },
+        },
+        currentLogFilePath: "",
+        cwd: "/tmp",
+        env: {},
+        fetcher: async () => new Response(""),
+        fileDownloadSessionStore: createNoopFileDownloadSessionStore(),
+        fileUploadStore: createNoopFileUploadStore(),
+        logger: {} as CliExecutionContext["logger"],
+        packageName: "oo",
+        settingsStore: {
+            getFilePath() {
+                return "";
+            },
+            read: async () => ({
+                lang: "en",
+            }),
+            update: async updater => updater({
+                lang: "en",
+            }),
+            write: async settings => settings,
+        },
+        stdin: {
+            isTTY: false,
+            off() {},
+            on() {},
+        },
+        stdout,
+        stderr,
+        translator: createTranslator("en"),
+        version: "0.0.0-development",
+    };
+}

--- a/src/adapters/commander/commander-cli-adapter.ts
+++ b/src/adapters/commander/commander-cli-adapter.ts
@@ -1,5 +1,5 @@
 import type { OptionValues } from "commander";
-import type { ZodError } from "zod";
+import type { ZodError, ZodType } from "zod";
 
 import type { CliCatalog, CliCommandDefinition, CliExecutionContext } from "../../application/contracts/cli.ts";
 import type { Translator } from "../../application/contracts/translator.ts";
@@ -40,9 +40,9 @@ class LocalizedCommand extends Command {
 
 export class CommanderCliAdapter {
     async run(request: CommanderCliRunRequest): Promise<number> {
-        const program = this.buildProgram(request.catalog, request.context);
-
         try {
+            const program = this.buildProgram(request.catalog, request.context);
+
             await program.parseAsync(request.argv, { from: "user" });
             return 0;
         }
@@ -141,19 +141,29 @@ export class CommanderCliAdapter {
             this.addCommand(command, child, context);
         }
 
-        if (definition.handler && definition.inputSchema) {
-            command.action(async (...actionArguments) => {
-                const commandInstance = actionArguments.at(-1) as Command;
-                const rawInput = collectRawInput(
-                    definition,
-                    actionArguments,
-                    commandInstance.optsWithGlobals<OptionValues>(),
-                );
-                const parsedInput = parseInput(definition, rawInput);
+        const handler = definition.handler;
 
-                await definition.handler?.(parsedInput, context);
-            });
+        if (!handler) {
+            return;
         }
+
+        const inputSchema = ensureCommandInputSchema(definition);
+
+        command.action(async (...actionArguments) => {
+            const commandInstance = actionArguments.at(-1) as Command;
+            const rawInput = collectRawInput(
+                definition,
+                actionArguments,
+                commandInstance.optsWithGlobals<OptionValues>(),
+            );
+            const parsedInput = parseInput(
+                definition,
+                inputSchema,
+                rawInput,
+            );
+
+            await handler(parsedInput, context);
+        });
     }
 
     private handleError(
@@ -306,19 +316,28 @@ function collectRawInput(
 
 function parseInput<TInput>(
     definition: CliCommandDefinition<TInput>,
+    inputSchema: ZodType<TInput>,
     rawInput: Record<string, unknown>,
 ): TInput {
-    const result = definition.inputSchema?.safeParse(rawInput);
-
-    if (!result) {
-        return rawInput as TInput;
-    }
+    const result = inputSchema.safeParse(rawInput);
 
     if (result.success) {
         return result.data as TInput;
     }
 
     throw mapInputError(definition, result.error, rawInput);
+}
+
+function ensureCommandInputSchema<TInput>(
+    definition: CliCommandDefinition<TInput>,
+): ZodType<TInput> {
+    if (!definition.inputSchema) {
+        throw new Error(
+            `Command "${definition.name}" must define inputSchema when handler is provided.`,
+        );
+    }
+
+    return definition.inputSchema as ZodType<TInput>;
 }
 
 function mapInputError(

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -1,8 +1,11 @@
+import type { CacheStore } from "../contracts/cache.ts";
+import type { FileDownloadSessionStore } from "../contracts/file-download-session-store.ts";
+
+import type { FileUploadRecordStore } from "../contracts/file-upload-store.ts";
+
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
-
 import { describe, expect, test } from "bun:test";
-
 import {
     createCliSandbox,
     createCliSnapshot,
@@ -233,4 +236,245 @@ describe("runCli bootstrap", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("reports cache store cleanup failures and keeps closing the remaining stores", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await runCleanupFailureScenario(sandbox, ["cache"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.closeOrder).toEqual([
+                "cache",
+                "fileUpload",
+                "fileDownloadSession",
+            ]);
+            expect(result.stderr).toBe(
+                "Unexpected error: cache store close failed\n",
+            );
+            expect(result.logContent).toContain(
+                "Failed to close the cache store cleanly.",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports file upload store cleanup failures and keeps closing the remaining stores", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await runCleanupFailureScenario(sandbox, [
+                "fileUpload",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.closeOrder).toEqual([
+                "cache",
+                "fileUpload",
+                "fileDownloadSession",
+            ]);
+            expect(result.stderr).toBe(
+                "Unexpected error: file upload store close failed\n",
+            );
+            expect(result.logContent).toContain(
+                "Failed to close the file upload store cleanly.",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports file download session store cleanup failures and keeps closing the remaining stores", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await runCleanupFailureScenario(sandbox, [
+                "fileDownloadSession",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.closeOrder).toEqual([
+                "cache",
+                "fileUpload",
+                "fileDownloadSession",
+            ]);
+            expect(result.stderr).toBe(
+                "Unexpected error: file download session store close failed\n",
+            );
+            expect(result.logContent).toContain(
+                "Failed to close the file download session store cleanly.",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("continues cleanup when multiple stores fail to close", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await runCleanupFailureScenario(sandbox, [
+                "cache",
+                "fileUpload",
+                "fileDownloadSession",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.closeOrder).toEqual([
+                "cache",
+                "fileUpload",
+                "fileDownloadSession",
+            ]);
+            expect(result.stderr).toBe([
+                "Unexpected error: cache store close failed",
+                "Unexpected error: file upload store close failed",
+                "Unexpected error: file download session store close failed",
+                "",
+            ].join("\n"));
+            expect(result.logContent).toContain(
+                "Failed to close the cache store cleanly.",
+            );
+            expect(result.logContent).toContain(
+                "Failed to close the file upload store cleanly.",
+            );
+            expect(result.logContent).toContain(
+                "Failed to close the file download session store cleanly.",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });
+
+type CleanupResourceName
+    = | "cache"
+        | "fileUpload"
+        | "fileDownloadSession";
+
+async function runCleanupFailureScenario(
+    sandbox: Awaited<ReturnType<typeof createCliSandbox>>,
+    failingResources: readonly CleanupResourceName[],
+): Promise<{
+    closeOrder: CleanupResourceName[];
+    exitCode: number;
+    logContent: string;
+    stderr: string;
+}> {
+    const stdout = createTextBuffer();
+    const stderr = createTextBuffer();
+    const closeOrder: CleanupResourceName[] = [];
+    const resourceSet = new Set(failingResources);
+    const exitCode = await executeCli({
+        argv: ["--help"],
+        cacheStore: createCleanupCacheStore(closeOrder, resourceSet),
+        cwd: sandbox.cwd,
+        env: sandbox.env,
+        fileDownloadSessionStore: createCleanupFileDownloadSessionStore(
+            closeOrder,
+            resourceSet,
+        ),
+        fileUploadStore: createCleanupFileUploadStore(closeOrder, resourceSet),
+        stdout: stdout.writer,
+        stderr: stderr.writer,
+        systemLocale: "en-US",
+        version: packageManifest.version,
+    });
+
+    return {
+        closeOrder,
+        exitCode,
+        logContent: await readLatestLogContent(sandbox),
+        stderr: stderr.read(),
+    };
+}
+
+function createCleanupCacheStore(
+    closeOrder: CleanupResourceName[],
+    resourceSet: Set<CleanupResourceName>,
+): CacheStore {
+    return {
+        close() {
+            closeOrder.push("cache");
+
+            if (resourceSet.has("cache")) {
+                throw new Error("cache store close failed");
+            }
+        },
+        getCache() {
+            return {
+                clear() {},
+                delete() {
+                    return false;
+                },
+                get() {
+                    return null;
+                },
+                has() {
+                    return false;
+                },
+                set() {},
+            };
+        },
+        getFilePath() {
+            return "";
+        },
+    };
+}
+
+function createCleanupFileUploadStore(
+    closeOrder: CleanupResourceName[],
+    resourceSet: Set<CleanupResourceName>,
+): FileUploadRecordStore {
+    return {
+        close() {
+            closeOrder.push("fileUpload");
+
+            if (resourceSet.has("fileUpload")) {
+                throw new Error("file upload store close failed");
+            }
+        },
+        deleteExpired() {
+            return 0;
+        },
+        getFilePath() {
+            return "";
+        },
+        list() {
+            return [];
+        },
+        save() {},
+    };
+}
+
+function createCleanupFileDownloadSessionStore(
+    closeOrder: CleanupResourceName[],
+    resourceSet: Set<CleanupResourceName>,
+): FileDownloadSessionStore {
+    return {
+        close() {
+            closeOrder.push("fileDownloadSession");
+
+            if (resourceSet.has("fileDownloadSession")) {
+                throw new Error("file download session store close failed");
+            }
+        },
+        deleteDownloadSession() {
+            return false;
+        },
+        deleteDownloadSessionsUpdatedBefore() {
+            return 0;
+        },
+        findDownloadSession() {
+            return undefined;
+        },
+        getFilePath() {
+            return "";
+        },
+        saveDownloadSession() {},
+    };
+}

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -1,12 +1,13 @@
+import type { Logger } from "pino";
 import type { AuthStore } from "../contracts/auth-store.ts";
 import type { CacheStore } from "../contracts/cache.ts";
+
 import type {
     CliExecutionContext,
     Fetcher,
     InteractiveInput,
     Writer,
 } from "../contracts/cli.ts";
-
 import type { FileDownloadSessionStore } from "../contracts/file-download-session-store.ts";
 import type { FileUploadRecordStore } from "../contracts/file-upload-store.ts";
 import type { SettingsStore } from "../contracts/settings-store.ts";
@@ -265,70 +266,42 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
         exitCode = writeBootstrapError(error, translator, invocation.stderr);
     }
     finally {
-        if (cacheStore) {
-            try {
-                cacheStore.close();
-            }
-            catch (error) {
-                logger.error(
-                    {
-                        ...withCategory(logCategory.systemError),
-                        err: error,
-                    },
-                    "Failed to close the cache store cleanly.",
-                );
-                invocation.stderr.write(
-                    `${translator.t("errors.unexpected", {
-                        message: error instanceof Error ? error.message : String(error),
-                    })}\n`,
-                );
+        const cleanupCacheStore = cacheStore;
+        const cleanupFileUploadStore = fileUploadStore;
+        const cleanupFileDownloadSessionStore = fileDownloadSessionStore;
 
-                exitCode = 1;
-            }
+        if (cleanupCacheStore) {
+            exitCode = closeCleanupResource({
+                close: () => cleanupCacheStore.close(),
+                exitCode,
+                failureMessage: "Failed to close the cache store cleanly.",
+                logger,
+                stderr: invocation.stderr,
+                translator,
+            });
         }
 
-        if (fileUploadStore) {
-            try {
-                fileUploadStore.close();
-            }
-            catch (error) {
-                logger.error(
-                    {
-                        ...withCategory(logCategory.systemError),
-                        err: error,
-                    },
-                    "Failed to close the file upload store cleanly.",
-                );
-                invocation.stderr.write(
-                    `${translator.t("errors.unexpected", {
-                        message: error instanceof Error ? error.message : String(error),
-                    })}\n`,
-                );
-
-                exitCode = 1;
-            }
+        if (cleanupFileUploadStore) {
+            exitCode = closeCleanupResource({
+                close: () => cleanupFileUploadStore.close(),
+                exitCode,
+                failureMessage: "Failed to close the file upload store cleanly.",
+                logger,
+                stderr: invocation.stderr,
+                translator,
+            });
         }
 
-        if (fileDownloadSessionStore) {
-            try {
-                fileDownloadSessionStore.close();
-            }
-            catch (error) {
-                logger.error(
-                    {
-                        ...withCategory(logCategory.systemError),
-                        err: error,
-                    },
+        if (cleanupFileDownloadSessionStore) {
+            exitCode = closeCleanupResource({
+                close: () => cleanupFileDownloadSessionStore.close(),
+                exitCode,
+                failureMessage:
                     "Failed to close the file download session store cleanly.",
-                );
-                invocation.stderr.write(
-                    `${translator.t("errors.unexpected", {
-                        message: error instanceof Error ? error.message : String(error),
-                    })}\n`,
-                );
-
-                exitCode = 1;
-            }
+                logger,
+                stderr: invocation.stderr,
+                translator,
+            });
         }
 
         logger.debug(
@@ -463,6 +436,36 @@ function writeBootstrapError(
     );
 
     return 1;
+}
+
+function closeCleanupResource(options: {
+    close: () => void;
+    exitCode: number;
+    failureMessage: string;
+    logger: Logger;
+    stderr: Writer;
+    translator: ReturnType<typeof createTranslator>;
+}): number {
+    try {
+        options.close();
+        return options.exitCode;
+    }
+    catch (error) {
+        options.logger.error(
+            {
+                ...withCategory(logCategory.systemError),
+                err: error,
+            },
+            options.failureMessage,
+        );
+        options.stderr.write(
+            `${options.translator.t("errors.unexpected", {
+                message: error instanceof Error ? error.message : String(error),
+            })}\n`,
+        );
+
+        return 1;
+    }
 }
 
 function createDetachedStdin(): InteractiveInput {

--- a/src/application/commands/package/shared.test.ts
+++ b/src/application/commands/package/shared.test.ts
@@ -61,6 +61,125 @@ describe("loadPackageInfo", () => {
         expect(fetchCount).toBe(1);
     });
 
+    test("preserves array ext placeholders and omits empty ext objects in input schemas", async () => {
+        const cacheValues = new Map<string, string>();
+        const cache = createCache<string>({
+            delete(key) {
+                return cacheValues.delete(key);
+            },
+            get(key) {
+                return cacheValues.get(key) ?? null;
+            },
+            set(key, value) {
+                cacheValues.set(key, value);
+            },
+        });
+        const context = createPackageInfoContext(
+            cache,
+            (async () => new Response(JSON.stringify({
+                packageName: "schema-lab",
+                packageVersion: "2.0.0",
+                title: "Schema Lab",
+                description: "Schema edge cases",
+                blocks: [
+                    {
+                        blockName: "Normalize",
+                        title: "Normalize",
+                        description: "Covers schema edge cases.",
+                        inputHandleDefs: [
+                            {
+                                handle: "choiceInput",
+                                description: "Choice input",
+                                json_schema: {
+                                    anyOf: [
+                                        {
+                                            "type": "string",
+                                            "ui:widget": "text",
+                                        },
+                                        {
+                                            type: "number",
+                                        },
+                                    ],
+                                },
+                            },
+                            {
+                                handle: "plainObjectInput",
+                                description: "Plain object input",
+                                json_schema: {
+                                    type: "object",
+                                    properties: {
+                                        name: {
+                                            "type": "string",
+                                            "ui:help": "ignored",
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                        outputHandleDefs: [],
+                    },
+                ],
+            }))) satisfies Fetcher,
+        );
+
+        const response = await loadPackageInfo(
+            parsePackageSpecifier("schema-lab@2.0.0"),
+            packageInfoAccount,
+            packageInfoRequestLanguage,
+            context,
+        );
+
+        expect(response).toEqual({
+            blocks: [
+                {
+                    blockName: "Normalize",
+                    description: "Covers schema edge cases.",
+                    inputHandle: {
+                        choiceInput: {
+                            description: "Choice input",
+                            ext: {
+                                anyOf: [
+                                    {
+                                        widget: "text",
+                                    },
+                                    null,
+                                ],
+                            },
+                            schema: {
+                                anyOf: [
+                                    {
+                                        type: "string",
+                                    },
+                                    {
+                                        type: "number",
+                                    },
+                                ],
+                            },
+                        },
+                        plainObjectInput: {
+                            description: "Plain object input",
+                            schema: {
+                                properties: {
+                                    name: {
+                                        type: "string",
+                                    },
+                                },
+                                type: "object",
+                            },
+                        },
+                    },
+                    outputHandle: {},
+                    title: "Normalize",
+                },
+            ],
+            description: "Schema edge cases",
+            displayName: "Schema Lab",
+            packageName: "schema-lab",
+            packageVersion: "2.0.0",
+        });
+        expect(response.blocks[0]?.inputHandle.plainObjectInput).not.toHaveProperty("ext");
+    });
+
     test("deserializes preloaded cached normalized responses without fetching", async () => {
         const cacheValues = new Map<string, string>();
         let fetchCount = 0;

--- a/src/application/commands/skills/shared.test.ts
+++ b/src/application/commands/skills/shared.test.ts
@@ -111,6 +111,36 @@ describe("bundled skill publication", () => {
         }
     });
 
+    test("returns false when symlink creation throws", async () => {
+        const result = await createBundledSkillDirectorySymlink(
+            "/tmp/canonical/skills/oo",
+            "/tmp/agent/skills/oo",
+            {
+                lstat: async () => {
+                    const error = new Error("missing") as NodeJS.ErrnoException;
+
+                    error.code = "ENOENT";
+
+                    throw error;
+                },
+                mkdir: async () => undefined,
+                readlink: async () => {
+                    throw new Error("readlink should not run when the link is missing");
+                },
+                realpath: async path => path,
+                removePath: async () => {
+                    throw new Error("removePath should not run when the link is missing");
+                },
+                resolveParentSymlinks: async path => path,
+                symlink: async () => {
+                    throw new Error("boom");
+                },
+            },
+        );
+
+        expect(result).toBeFalse();
+    });
+
     test("replaces an existing directory at the installed path before creating a symlink", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
         const canonicalSkillDirectoryPath = join(

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -50,6 +50,16 @@ interface BundledSkillPublicationDependencies {
     ) => Promise<boolean>;
 }
 
+type BundledSkillDirectorySymlinkAttempt
+    = | {
+        kind: "reuse";
+    }
+    | {
+        kind: "create";
+        resolvedLinkPath: string;
+        resolvedTargetPath: string;
+    };
+
 export interface CreateBundledSkillDirectorySymlinkDependencies {
     lstat?: (path: string) => Promise<{
         isSymbolicLink: () => boolean;
@@ -789,71 +799,36 @@ export async function createBundledSkillDirectorySymlink(
     const symlinkFn = dependencies.symlink ?? symlink;
 
     try {
-        const resolvedTargetPath = resolve(targetPath);
-        const resolvedLinkPath = resolve(linkPath);
-        const [realTargetPath, realLinkPath] = await Promise.all([
-            realpathFn(resolvedTargetPath).catch(() => resolvedTargetPath),
-            realpathFn(resolvedLinkPath).catch(() => resolvedLinkPath),
-        ]);
+        const attempt = await resolveBundledSkillDirectorySymlinkAttempt(
+            targetPath,
+            linkPath,
+            {
+                lstat: lstatFn,
+                readlink: readlinkFn,
+                realpath: realpathFn,
+                removePath: removePathFn,
+                resolveParentSymlinks: resolveParentSymlinksFn,
+            },
+        );
 
-        if (realTargetPath === realLinkPath) {
+        if (attempt.kind === "reuse") {
             return true;
         }
 
-        const [realTargetPathWithParents, realLinkPathWithParents]
-            = await Promise.all([
-                resolveParentSymlinksFn(resolvedTargetPath),
-                resolveParentSymlinksFn(resolvedLinkPath),
-            ]);
-
-        if (realTargetPathWithParents === realLinkPathWithParents) {
-            return true;
-        }
-
-        try {
-            const existingStats = await lstatFn(resolvedLinkPath);
-
-            if (existingStats.isSymbolicLink()) {
-                const existingTarget = await readlinkFn(resolvedLinkPath);
-
-                if (
-                    resolveSymlinkTarget(resolvedLinkPath, existingTarget)
-                    === resolvedTargetPath
-                ) {
-                    return true;
-                }
-            }
-
-            await removePathFn(resolvedLinkPath);
-        }
-        catch (error) {
-            if (isSymlinkLoopError(error)) {
-                try {
-                    await removePathFn(resolvedLinkPath);
-                }
-                catch {
-                    // Let symlink creation determine whether copy fallback is needed.
-                }
-            }
-            else if (!isNodeNotFoundError(error)) {
-                throw error;
-            }
-        }
-
-        const linkDirectoryPath = dirname(resolvedLinkPath);
+        const linkDirectoryPath = dirname(attempt.resolvedLinkPath);
 
         await mkdirFn(linkDirectoryPath, { recursive: true });
 
         const symlinkTargetPath = process.platform === "win32"
-            ? resolvedTargetPath
+            ? attempt.resolvedTargetPath
             : relative(
                     await resolveParentSymlinksFn(linkDirectoryPath),
-                    resolvedTargetPath,
+                    attempt.resolvedTargetPath,
                 );
 
         await symlinkFn(
             symlinkTargetPath,
-            resolvedLinkPath,
+            attempt.resolvedLinkPath,
             process.platform === "win32" ? "junction" : "dir",
         );
 
@@ -862,6 +837,84 @@ export async function createBundledSkillDirectorySymlink(
     catch {
         return false;
     }
+}
+
+async function resolveBundledSkillDirectorySymlinkAttempt(
+    targetPath: string,
+    linkPath: string,
+    dependencies: Pick<
+        CreateBundledSkillDirectorySymlinkDependencies,
+        "lstat" | "readlink" | "realpath" | "removePath" | "resolveParentSymlinks"
+    >,
+): Promise<BundledSkillDirectorySymlinkAttempt> {
+    const resolvedTargetPath = resolve(targetPath);
+    const resolvedLinkPath = resolve(linkPath);
+    const realpathFn = dependencies.realpath ?? realpath;
+    const [realTargetPath, realLinkPath] = await Promise.all([
+        realpathFn(resolvedTargetPath).catch(() => resolvedTargetPath),
+        realpathFn(resolvedLinkPath).catch(() => resolvedLinkPath),
+    ]);
+
+    if (realTargetPath === realLinkPath) {
+        return {
+            kind: "reuse",
+        };
+    }
+
+    const resolveParentSymlinksFn
+        = dependencies.resolveParentSymlinks ?? resolveParentSymlinks;
+    const [realTargetPathWithParents, realLinkPathWithParents] = await Promise.all([
+        resolveParentSymlinksFn(resolvedTargetPath),
+        resolveParentSymlinksFn(resolvedLinkPath),
+    ]);
+
+    if (realTargetPathWithParents === realLinkPathWithParents) {
+        return {
+            kind: "reuse",
+        };
+    }
+
+    const lstatFn = dependencies.lstat ?? lstat;
+    const readlinkFn = dependencies.readlink ?? readlink;
+    const removePathFn = dependencies.removePath ?? removePath;
+
+    try {
+        const existingStats = await lstatFn(resolvedLinkPath);
+
+        if (existingStats.isSymbolicLink()) {
+            const existingTarget = await readlinkFn(resolvedLinkPath);
+
+            if (
+                resolveSymlinkTarget(resolvedLinkPath, existingTarget)
+                === resolvedTargetPath
+            ) {
+                return {
+                    kind: "reuse",
+                };
+            }
+        }
+
+        await removePathFn(resolvedLinkPath);
+    }
+    catch (error) {
+        if (isSymlinkLoopError(error)) {
+            try {
+                await removePathFn(resolvedLinkPath);
+            }
+            catch {
+                // Let symlink creation determine whether copy fallback is needed.
+            }
+        }
+        else if (!isNodeNotFoundError(error)) {
+            throw error;
+        }
+    }
+
+    return {
+        kind: "create",
+        resolvedLinkPath,
+        resolvedTargetPath,
+    };
 }
 
 async function copyBundledSkillDirectory(

--- a/src/application/update/update-notifier.test.ts
+++ b/src/application/update/update-notifier.test.ts
@@ -166,6 +166,108 @@ describe("update notifier", () => {
         }
     });
 
+    test("returns latest-version-unavailable for a non-2xx registry response", async () => {
+        let fetchCount = 0;
+        const notifier = createUpdateNotifierHarness({
+            fetcher: async () => {
+                fetchCount += 1;
+
+                return new Response("{}", {
+                    status: 503,
+                });
+            },
+        });
+
+        try {
+            const result = await checkForCliUpdate(notifier.context);
+
+            expect(result).toEqual({
+                reason: "latest-version-unavailable",
+                status: "failed",
+            });
+            expect(fetchCount).toBe(1);
+        }
+        finally {
+            notifier.close();
+        }
+    });
+
+    test("returns latest-version-unavailable when registry JSON parsing fails", async () => {
+        let fetchCount = 0;
+        const notifier = createUpdateNotifierHarness({
+            fetcher: async () => {
+                fetchCount += 1;
+
+                return new Response("not-json");
+            },
+        });
+
+        try {
+            const result = await checkForCliUpdate(notifier.context);
+
+            expect(result).toEqual({
+                reason: "latest-version-unavailable",
+                status: "failed",
+            });
+            expect(fetchCount).toBe(1);
+        }
+        finally {
+            notifier.close();
+        }
+    });
+
+    test("returns latest-version-unavailable when dist-tags is missing", async () => {
+        let fetchCount = 0;
+        const notifier = createUpdateNotifierHarness({
+            fetcher: async () => {
+                fetchCount += 1;
+
+                return new Response(JSON.stringify({
+                    name: packageName,
+                }));
+            },
+        });
+
+        try {
+            const result = await checkForCliUpdate(notifier.context);
+
+            expect(result).toEqual({
+                reason: "latest-version-unavailable",
+                status: "failed",
+            });
+            expect(fetchCount).toBe(1);
+        }
+        finally {
+            notifier.close();
+        }
+    });
+
+    test("returns latest-version-unavailable when latest is missing", async () => {
+        let fetchCount = 0;
+        const notifier = createUpdateNotifierHarness({
+            fetcher: async () => {
+                fetchCount += 1;
+
+                return new Response(JSON.stringify({
+                    "dist-tags": {},
+                }));
+            },
+        });
+
+        try {
+            const result = await checkForCliUpdate(notifier.context);
+
+            expect(result).toEqual({
+                reason: "latest-version-unavailable",
+                status: "failed",
+            });
+            expect(fetchCount).toBe(1);
+        }
+        finally {
+            notifier.close();
+        }
+    });
+
     test("retries once within the same update check after a transient failure", async () => {
         let fetchCount = 0;
         const notifier = createUpdateNotifierHarness({

--- a/src/application/update/update-notifier.ts
+++ b/src/application/update/update-notifier.ts
@@ -8,15 +8,23 @@ const defaultRegistryUrl = "https://registry.npmjs.org/";
 const updateRequestTimeoutMs = 2000;
 const updateRequestMaxAttempts = 2;
 
-interface LatestReleaseRequestFailure {
-    retryable: boolean;
-    status: "failed";
-}
-
 interface LatestReleaseRequestSuccess {
     latestVersion: string;
     status: "success";
 }
+
+interface LatestReleaseRequestRetryableFailure {
+    status: "retryable-failure";
+}
+
+interface LatestReleaseRequestTerminalFailure {
+    status: "terminal-failure";
+}
+
+type LatestReleaseRequestAttemptResult
+    = LatestReleaseRequestSuccess
+        | LatestReleaseRequestRetryableFailure
+        | LatestReleaseRequestTerminalFailure;
 
 interface ParsedReleaseVersion {
     core: readonly [number, number, number];
@@ -252,22 +260,26 @@ async function fetchLatestReleaseVersion(options: {
             packageName: options.packageName,
         });
 
-        if (result.status === "success") {
-            return result.latestVersion;
-        }
+        switch (result.status) {
+            case "success":
+                return result.latestVersion;
+            case "terminal-failure":
+                return null;
+            case "retryable-failure":
+                if (attempt >= updateRequestMaxAttempts) {
+                    return null;
+                }
 
-        if (!result.retryable || attempt >= updateRequestMaxAttempts) {
-            return null;
+                options.logger.debug(
+                    {
+                        attempt,
+                        maxAttempts: updateRequestMaxAttempts,
+                        packageName: options.packageName,
+                    },
+                    "CLI update latest-release request retry scheduled.",
+                );
+                break;
         }
-
-        options.logger.debug(
-            {
-                attempt,
-                maxAttempts: updateRequestMaxAttempts,
-                packageName: options.packageName,
-            },
-            "CLI update latest-release request retry scheduled.",
-        );
     }
 
     return null;
@@ -281,7 +293,7 @@ async function fetchLatestReleaseVersionAttempt(options: {
     logger: CliExecutionContext["logger"];
     maxAttempts: number;
     packageName: string;
-}): Promise<LatestReleaseRequestFailure | LatestReleaseRequestSuccess> {
+}): Promise<LatestReleaseRequestAttemptResult> {
     const requestUrl = resolveRegistryPackageMetadataUrl(
         options.env,
         options.packageName,
@@ -324,8 +336,7 @@ async function fetchLatestReleaseVersionAttempt(options: {
             "CLI update latest-release request timed out or failed.",
         );
         return {
-            retryable: true,
-            status: "failed",
+            status: "retryable-failure",
         };
     }
 
@@ -342,8 +353,7 @@ async function fetchLatestReleaseVersionAttempt(options: {
             "CLI update latest-release request returned a non-success status.",
         );
         return {
-            retryable: false,
-            status: "failed",
+            status: "terminal-failure",
         };
     }
 
@@ -354,15 +364,13 @@ async function fetchLatestReleaseVersionAttempt(options: {
     }
     catch {
         return {
-            retryable: false,
-            status: "failed",
+            status: "terminal-failure",
         };
     }
 
     if (!payload || typeof payload !== "object") {
         return {
-            retryable: false,
-            status: "failed",
+            status: "terminal-failure",
         };
     }
 
@@ -370,8 +378,7 @@ async function fetchLatestReleaseVersionAttempt(options: {
 
     if (!distTags || typeof distTags !== "object") {
         return {
-            retryable: false,
-            status: "failed",
+            status: "terminal-failure",
         };
     }
 
@@ -379,8 +386,7 @@ async function fetchLatestReleaseVersionAttempt(options: {
 
     if (typeof latestVersion !== "string" || latestVersion === "") {
         return {
-            retryable: false,
-            status: "failed",
+            status: "terminal-failure",
         };
     }
 


### PR DESCRIPTION
Consolidate repeated patterns across multiple modules:

- sqlite-cache: unify recoverable error handling into resolveRecoverableSqliteErrorContext with a diagnostics policy that controls when store-path metadata appears in logs
- commander-cli-adapter: enforce inputSchema requirement via ensureCommandInputSchema, move buildProgram inside try block
- run-cli: deduplicate three identical try/catch cleanup blocks into closeCleanupResource
- skills/shared: separate symlink reuse-vs-create decision into resolveBundledSkillDirectorySymlinkAttempt with a discriminated union return type
- update-notifier: replace { retryable: boolean; status: "failed" } with explicit "retryable-failure" and "terminal-failure" statuses

Add comprehensive tests covering error paths for each refactored module.