### PR TITLE
refactor: extract shared request, semver, and schema utilities

### DIFF
--- a/src/adapters/commander/commander-cli-adapter.test.ts
+++ b/src/adapters/commander/commander-cli-adapter.test.ts
@@ -1,6 +1,7 @@
 import type { CliCatalog, CliExecutionContext } from "../../application/contracts/cli.ts";
 
 import { describe, expect, test } from "bun:test";
+import { z } from "zod";
 import {
     createNoopFileDownloadSessionStore,
     createNoopFileUploadStore,
@@ -37,6 +38,99 @@ describe("CommanderCliAdapter", () => {
         expect(stderr.read()).toBe(
             "Unexpected error: Command \"demo\" must define inputSchema when handler is provided.\n",
         );
+    });
+
+    test("shows help instead of a usage error when missing arguments are configured to do so", async () => {
+        const adapter = new CommanderCliAdapter();
+        const stdout = createTextBuffer();
+        const stderr = createTextBuffer();
+        const catalog: CliCatalog = {
+            commands: [
+                {
+                    arguments: [
+                        {
+                            descriptionKey: "arguments.text",
+                            name: "text",
+                            required: true,
+                        },
+                    ],
+                    inputSchema: z.object({
+                        text: z.string(),
+                    }),
+                    handler: async () => {},
+                    missingArgumentBehavior: "showHelp",
+                    name: "demo",
+                    summaryKey: "commands.help.summary",
+                },
+            ],
+            descriptionKey: "app.description",
+            globalOptions: [],
+            name: "oo",
+        };
+
+        const exitCode = await adapter.run({
+            argv: ["demo"],
+            catalog,
+            context: createCommanderContext(catalog, stdout.writer, stderr.writer),
+        });
+
+        expect(exitCode).toBe(0);
+        expect(stdout.read()).toContain("Arguments:");
+        expect(stdout.read()).toContain("text");
+        expect(stderr.read()).toBe("");
+    });
+
+    test("passes collected arguments and options to the handler", async () => {
+        const adapter = new CommanderCliAdapter();
+        const stdout = createTextBuffer();
+        const stderr = createTextBuffer();
+        const handledInputs: Array<{ text: string; upper?: boolean }> = [];
+        const catalog: CliCatalog = {
+            commands: [
+                {
+                    arguments: [
+                        {
+                            descriptionKey: "arguments.text",
+                            name: "text",
+                            required: true,
+                        },
+                    ],
+                    handler: async (input) => {
+                        handledInputs.push(input as { text: string; upper?: boolean });
+                    },
+                    inputSchema: z.object({
+                        text: z.string(),
+                        upper: z.boolean().optional(),
+                    }),
+                    name: "demo",
+                    options: [
+                        {
+                            descriptionKey: "options.help",
+                            longFlag: "--upper",
+                            name: "upper",
+                        },
+                    ],
+                    summaryKey: "commands.help.summary",
+                },
+            ],
+            descriptionKey: "app.description",
+            globalOptions: [],
+            name: "oo",
+        };
+
+        const exitCode = await adapter.run({
+            argv: ["demo", "hello", "--upper"],
+            catalog,
+            context: createCommanderContext(catalog, stdout.writer, stderr.writer),
+        });
+
+        expect(exitCode).toBe(0);
+        expect(handledInputs).toEqual([
+            {
+                text: "hello",
+                upper: true,
+            },
+        ]);
     });
 });
 

--- a/src/adapters/commander/commander-cli-adapter.ts
+++ b/src/adapters/commander/commander-cli-adapter.ts
@@ -21,6 +21,16 @@ interface CommanderCliRunRequest {
     context: CliExecutionContext;
 }
 
+interface CommandOutputConfiguration {
+    getErrHasColors: () => boolean;
+    getErrHelpWidth: () => number;
+    getOutHasColors: () => boolean;
+    getOutHelpWidth: () => number;
+    outputError: () => void;
+    writeErr: (value: string) => void;
+    writeOut: (value: string) => void;
+}
+
 class LocalizedCommand extends Command {
     constructor(
         private readonly translator: Translator,
@@ -55,19 +65,7 @@ export class CommanderCliAdapter {
         catalog: CliCatalog,
         context: CliExecutionContext,
     ): Command {
-        const defaultHelpWidth = 80;
         const program = new LocalizedCommand(context.translator, catalog.name);
-        const outputConfiguration = {
-            getErrHelpWidth: () =>
-                context.stderr.isTTY ? process.stderr.columns : defaultHelpWidth,
-            getOutHelpWidth: () =>
-                context.stdout.isTTY ? process.stdout.columns : defaultHelpWidth,
-            writeOut: (value: string) => context.stdout.write(value),
-            writeErr: (value: string) => context.stderr.write(value),
-            outputError: () => {},
-            getOutHasColors: () => context.stdout.hasColors?.() ?? false,
-            getErrHasColors: () => context.stderr.hasColors?.() ?? false,
-        };
 
         program
             .name(catalog.name)
@@ -85,7 +83,7 @@ export class CommanderCliAdapter {
             .configureHelp({
                 showGlobalOptions: true,
             })
-            .configureOutput(outputConfiguration)
+            .configureOutput(createOutputConfiguration(context))
             .exitOverride();
 
         for (const option of catalog.globalOptions) {
@@ -105,37 +103,7 @@ export class CommanderCliAdapter {
         context: CliExecutionContext,
     ): void {
         const command = parent.command(definition.name);
-        const descriptionKey = definition.descriptionKey ?? definition.summaryKey;
-
-        command
-            .summary(context.translator.t(definition.summaryKey))
-            .description(context.translator.t(descriptionKey))
-            .helpOption("-h, --help", context.translator.t("options.help"));
-
-        for (const alias of definition.aliases ?? []) {
-            command.alias(alias);
-        }
-
-        if (definition.children?.length) {
-            command.helpCommand(
-                "help [command]",
-                context.translator.t("commands.help.summary"),
-            );
-        }
-
-        for (const option of definition.options ?? []) {
-            command.addOption(createOption(option, context.translator));
-        }
-
-        for (const argument of definition.arguments ?? []) {
-            command.addArgument(
-                createArgument(argument, context.translator),
-            );
-        }
-
-        if (definition.missingArgumentBehavior === "showHelp") {
-            configureMissingArgumentHelp(command);
-        }
+        configureCommand(command, definition, context.translator);
 
         for (const child of definition.children ?? []) {
             this.addCommand(command, child, context);
@@ -149,21 +117,7 @@ export class CommanderCliAdapter {
 
         const inputSchema = ensureCommandInputSchema(definition);
 
-        command.action(async (...actionArguments) => {
-            const commandInstance = actionArguments.at(-1) as Command;
-            const rawInput = collectRawInput(
-                definition,
-                actionArguments,
-                commandInstance.optsWithGlobals<OptionValues>(),
-            );
-            const parsedInput = parseInput(
-                definition,
-                inputSchema,
-                rawInput,
-            );
-
-            await handler(parsedInput, context);
-        });
+        bindCommandHandler(command, definition, inputSchema, context);
     }
 
     private handleError(
@@ -205,6 +159,91 @@ export class CommanderCliAdapter {
 
         return 1;
     }
+}
+
+function createOutputConfiguration(
+    context: CliExecutionContext,
+): CommandOutputConfiguration {
+    const defaultHelpWidth = 80;
+
+    return {
+        getErrHelpWidth: () =>
+            context.stderr.isTTY ? process.stderr.columns : defaultHelpWidth,
+        getOutHelpWidth: () =>
+            context.stdout.isTTY ? process.stdout.columns : defaultHelpWidth,
+        writeOut: (value: string) => context.stdout.write(value),
+        writeErr: (value: string) => context.stderr.write(value),
+        outputError: () => {},
+        getOutHasColors: () => context.stdout.hasColors?.() ?? false,
+        getErrHasColors: () => context.stderr.hasColors?.() ?? false,
+    };
+}
+
+function configureCommand(
+    command: Command,
+    definition: CliCommandDefinition,
+    translator: Translator,
+): void {
+    const descriptionKey = definition.descriptionKey ?? definition.summaryKey;
+
+    command
+        .summary(translator.t(definition.summaryKey))
+        .description(translator.t(descriptionKey))
+        .helpOption("-h, --help", translator.t("options.help"));
+
+    for (const alias of definition.aliases ?? []) {
+        command.alias(alias);
+    }
+
+    if (definition.children?.length) {
+        command.helpCommand(
+            "help [command]",
+            translator.t("commands.help.summary"),
+        );
+    }
+
+    for (const option of definition.options ?? []) {
+        command.addOption(createOption(option, translator));
+    }
+
+    for (const argument of definition.arguments ?? []) {
+        command.addArgument(
+            createArgument(argument, translator),
+        );
+    }
+
+    if (definition.missingArgumentBehavior === "showHelp") {
+        configureMissingArgumentHelp(command);
+    }
+}
+
+function bindCommandHandler<TInput>(
+    command: Command,
+    definition: CliCommandDefinition<TInput>,
+    inputSchema: ZodType<TInput>,
+    context: CliExecutionContext,
+): void {
+    const handler = definition.handler;
+
+    if (!handler) {
+        return;
+    }
+
+    command.action(async (...actionArguments) => {
+        const commandInstance = actionArguments.at(-1) as Command;
+        const rawInput = collectRawInput(
+            definition,
+            actionArguments,
+            commandInstance.optsWithGlobals<OptionValues>(),
+        );
+        const parsedInput = parseInput(
+            definition,
+            inputSchema,
+            rawInput,
+        );
+
+        await handler(parsedInput, context);
+    });
 }
 
 function formatOptionFlags(option: {
@@ -292,8 +331,8 @@ function configureMissingArgumentHelp(command: Command): void {
     };
 }
 
-function collectRawInput(
-    definition: CliCommandDefinition,
+function collectRawInput<TInput>(
+    definition: CliCommandDefinition<TInput>,
     actionArguments: unknown[],
     optionValues: OptionValues,
 ): Record<string, unknown> {

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -1,7 +1,7 @@
 import type { CacheStore } from "../contracts/cache.ts";
 import type { FileDownloadSessionStore } from "../contracts/file-download-session-store.ts";
-
 import type { FileUploadRecordStore } from "../contracts/file-upload-store.ts";
+import type { SettingsStore } from "../contracts/settings-store.ts";
 
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
@@ -231,6 +231,49 @@ describe("runCli bootstrap", () => {
             expect(stderr.read()).toContain("Invalid config key");
             expect(content).toContain(`"category":"user_error"`);
             expect(content).toContain(`"key":"errors.config.invalidKey"`);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("closes initialized stores when bootstrap setup fails", async () => {
+        const sandbox = await createCliSandbox();
+        const stdout = createTextBuffer();
+        const stderr = createTextBuffer();
+        const closeOrder: CleanupResourceName[] = [];
+
+        try {
+            const exitCode = await executeCli({
+                argv: ["config", "get", "lang"],
+                cacheStore: createCleanupCacheStore(closeOrder, new Set()),
+                cwd: sandbox.cwd,
+                env: sandbox.env,
+                fileDownloadSessionStore: createCleanupFileDownloadSessionStore(
+                    closeOrder,
+                    new Set(),
+                ),
+                fileUploadStore: createCleanupFileUploadStore(
+                    closeOrder,
+                    new Set(),
+                ),
+                settingsStore: createFailingSettingsStore(
+                    new Error("settings read failed"),
+                ),
+                stderr: stderr.writer,
+                stdout: stdout.writer,
+                systemLocale: "en-US",
+            });
+
+            expect(exitCode).toBe(1);
+            expect(closeOrder).toEqual([
+                "cache",
+                "fileUpload",
+                "fileDownloadSession",
+            ]);
+            expect(stderr.read()).toBe(
+                "Unexpected error: settings read failed\n",
+            );
         }
         finally {
             await sandbox.cleanup();
@@ -476,5 +519,22 @@ function createCleanupFileDownloadSessionStore(
             return "";
         },
         saveDownloadSession() {},
+    };
+}
+
+function createFailingSettingsStore(error: Error): SettingsStore {
+    return {
+        getFilePath() {
+            return "";
+        },
+        async read() {
+            throw error;
+        },
+        async update() {
+            throw new Error("update should not be called");
+        },
+        async write() {
+            throw new Error("write should not be called");
+        },
     };
 }

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -59,6 +59,38 @@ export interface CliInvocation {
     version?: string;
 }
 
+interface InitializedCliStores {
+    authStore: AuthStore;
+    cacheStore: CacheStore;
+    fileDownloadSessionStore: FileDownloadSessionStore;
+    fileUploadStore: FileUploadRecordStore;
+    settings: Awaited<ReturnType<SettingsStore["read"]>>;
+    settingsStore: SettingsStore;
+}
+
+interface CleanupResource {
+    close: () => void;
+    failureMessage: string;
+}
+
+interface CreateCliExecutionContextOptions {
+    authStore: AuthStore;
+    buildInfo: ReturnType<typeof resolveCliBuildInfo>;
+    cacheStore: CacheStore;
+    catalog: ReturnType<typeof createCliCatalog>;
+    completionRenderer: StaticCompletionRenderer;
+    fetcher: Fetcher;
+    fileDownloadSessionStore: FileDownloadSessionStore;
+    fileUploadStore: FileUploadRecordStore;
+    invocation: CliInvocation;
+    logger: Logger;
+    logFilePath: string;
+    packageName: string;
+    settingsStore: SettingsStore;
+    translator: ReturnType<typeof createTranslator>;
+    version: string;
+}
+
 export async function runCli(argv: string[]): Promise<number> {
     return executeCli({
         argv,
@@ -121,43 +153,24 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
         }
 
         cacheStore
-            = invocation.cacheStore
-                ?? new SqliteCacheStore(storePaths.cacheFilePath, logger);
-        fileUploadStore = invocation.fileUploadStore;
-        fileDownloadSessionStore = invocation.fileDownloadSessionStore;
+            = undefined;
+        fileUploadStore = undefined;
+        fileDownloadSessionStore = undefined;
 
-        if (fileUploadStore === undefined) {
-            fileUploadStore = new SqliteFileUploadStore(
-                storePaths.uploadsFilePath,
-                logger,
-            );
-        }
+        const initializedStores = await initializeCliStores(
+            invocation,
+            logger,
+            storePaths,
+        );
 
-        if (fileDownloadSessionStore === undefined) {
-            fileDownloadSessionStore = new SqliteFileDownloadSessionStore(
-                storePaths.downloadSessionsFilePath,
-                logger,
-            );
-        }
-
-        const settingsStore
-            = invocation.settingsStore
-                ?? new FileSettingsStore({
-                    filePath: storePaths.settingsFilePath,
-                    logger,
-                });
-        const authStore
-            = invocation.authStore
-                ?? new FileAuthStore({
-                    filePath: storePaths.authFilePath,
-                    logger,
-                });
-        const settings = await settingsStore.read();
+        cacheStore = initializedStores.cacheStore;
+        fileUploadStore = initializedStores.fileUploadStore;
+        fileDownloadSessionStore = initializedStores.fileDownloadSessionStore;
 
         translator = createTranslator(
             resolvePreferredLocale({
                 cliFlag: parsedCliLanguage,
-                storedLocale: settings.lang,
+                storedLocale: initializedStores.settings.lang,
                 env: invocation.env,
                 systemLocale: invocation.systemLocale,
             }),
@@ -196,39 +209,29 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
             "CLI first-run detection completed.",
         );
 
-        const context: CliExecutionContext = {
-            authStore,
+        const context = createCliExecutionContext({
+            authStore: initializedStores.authStore,
+            buildInfo,
             cacheStore,
-            currentLogFilePath: logFilePath,
+            catalog,
+            completionRenderer,
             fetcher: invocation.fetcher ?? fetch,
-            cwd: invocation.cwd,
-            env: invocation.env,
             fileDownloadSessionStore,
             fileUploadStore,
-            stdin: invocation.stdin ?? createDetachedStdin(),
+            invocation,
             logger,
+            logFilePath,
             packageName,
-            settingsStore,
-            stdout: invocation.stdout,
-            stderr: invocation.stderr,
+            settingsStore: initializedStores.settingsStore,
             translator,
-            completionRenderer,
-            catalog,
             version,
-            versionText: formatCliVersionText(
-                {
-                    ...buildInfo,
-                    version,
-                },
-                translator,
-            ),
-        };
+        });
         if (shouldSynchronizeBundledSkills) {
             await maybeSynchronizeInstalledBundledSkills(
                 context,
                 {
                     installMissing: shouldInstallMissingBundledSkills,
-                    settings,
+                    settings: initializedStores.settings,
                 },
             );
         }
@@ -270,39 +273,26 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
         const cleanupFileUploadStore = fileUploadStore;
         const cleanupFileDownloadSessionStore = fileDownloadSessionStore;
 
-        if (cleanupCacheStore) {
-            exitCode = closeCleanupResource({
-                close: () => cleanupCacheStore.close(),
-                exitCode,
-                failureMessage: "Failed to close the cache store cleanly.",
-                logger,
-                stderr: invocation.stderr,
-                translator,
-            });
-        }
-
-        if (cleanupFileUploadStore) {
-            exitCode = closeCleanupResource({
-                close: () => cleanupFileUploadStore.close(),
-                exitCode,
-                failureMessage: "Failed to close the file upload store cleanly.",
-                logger,
-                stderr: invocation.stderr,
-                translator,
-            });
-        }
-
-        if (cleanupFileDownloadSessionStore) {
-            exitCode = closeCleanupResource({
-                close: () => cleanupFileDownloadSessionStore.close(),
-                exitCode,
-                failureMessage:
+        exitCode = closeCleanupResources(
+            [
+                createCleanupResource(
+                    cleanupCacheStore,
+                    "Failed to close the cache store cleanly.",
+                ),
+                createCleanupResource(
+                    cleanupFileUploadStore,
+                    "Failed to close the file upload store cleanly.",
+                ),
+                createCleanupResource(
+                    cleanupFileDownloadSessionStore,
                     "Failed to close the file download session store cleanly.",
-                logger,
-                stderr: invocation.stderr,
-                translator,
-            });
-        }
+                ),
+            ],
+            exitCode,
+            logger,
+            invocation.stderr,
+            translator,
+        );
 
         logger.debug(
             {
@@ -318,6 +308,81 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
     }
 
     return exitCode;
+}
+
+async function initializeCliStores(
+    invocation: CliInvocation,
+    logger: Logger,
+    storePaths: ReturnType<typeof resolveStorePaths>,
+): Promise<InitializedCliStores> {
+    const cacheStore
+        = invocation.cacheStore
+            ?? new SqliteCacheStore(storePaths.cacheFilePath, logger);
+    const fileUploadStore
+        = invocation.fileUploadStore
+            ?? new SqliteFileUploadStore(
+                storePaths.uploadsFilePath,
+                logger,
+            );
+    const fileDownloadSessionStore
+        = invocation.fileDownloadSessionStore
+            ?? new SqliteFileDownloadSessionStore(
+                storePaths.downloadSessionsFilePath,
+                logger,
+            );
+    const settingsStore
+        = invocation.settingsStore
+            ?? new FileSettingsStore({
+                filePath: storePaths.settingsFilePath,
+                logger,
+            });
+    const authStore
+        = invocation.authStore
+            ?? new FileAuthStore({
+                filePath: storePaths.authFilePath,
+                logger,
+            });
+
+    return {
+        authStore,
+        cacheStore,
+        fileDownloadSessionStore,
+        fileUploadStore,
+        settings: await settingsStore.read(),
+        settingsStore,
+    };
+}
+
+function createCliExecutionContext(
+    options: CreateCliExecutionContextOptions,
+): CliExecutionContext {
+    return {
+        authStore: options.authStore,
+        cacheStore: options.cacheStore,
+        currentLogFilePath: options.logFilePath,
+        fetcher: options.fetcher,
+        cwd: options.invocation.cwd,
+        env: options.invocation.env,
+        fileDownloadSessionStore: options.fileDownloadSessionStore,
+        fileUploadStore: options.fileUploadStore,
+        stdin: options.invocation.stdin ?? createDetachedStdin(),
+        logger: options.logger,
+        packageName: options.packageName,
+        settingsStore: options.settingsStore,
+        stdout: options.invocation.stdout,
+        stderr: options.invocation.stderr,
+        translator: options.translator,
+        completionRenderer: options.completionRenderer,
+        catalog: options.catalog,
+        version: options.version,
+        versionText: formatCliVersionText(
+            {
+                ...options.buildInfo,
+                version: options.version,
+            },
+            options.translator,
+        ),
+    };
 }
 
 function hasCliDebugFlag(argv: readonly string[]): boolean {
@@ -466,6 +531,47 @@ function closeCleanupResource(options: {
 
         return 1;
     }
+}
+
+function closeCleanupResources(
+    resources: Array<CleanupResource | undefined>,
+    exitCode: number,
+    logger: Logger,
+    stderr: Writer,
+    translator: ReturnType<typeof createTranslator>,
+): number {
+    let nextExitCode = exitCode;
+
+    for (const resource of resources) {
+        if (!resource) {
+            continue;
+        }
+
+        nextExitCode = closeCleanupResource({
+            close: resource.close,
+            exitCode: nextExitCode,
+            failureMessage: resource.failureMessage,
+            logger,
+            stderr,
+            translator,
+        });
+    }
+
+    return nextExitCode;
+}
+
+function createCleanupResource(
+    resource: CacheStore | FileDownloadSessionStore | FileUploadRecordStore | undefined,
+    failureMessage: string,
+): CleanupResource | undefined {
+    if (!resource) {
+        return undefined;
+    }
+
+    return {
+        close: () => resource.close(),
+        failureMessage,
+    };
 }
 
 function createDetachedStdin(): InteractiveInput {

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -64,7 +64,6 @@ interface InitializedCliStores {
     cacheStore: CacheStore;
     fileDownloadSessionStore: FileDownloadSessionStore;
     fileUploadStore: FileUploadRecordStore;
-    settings: Awaited<ReturnType<SettingsStore["read"]>>;
     settingsStore: SettingsStore;
 }
 
@@ -166,11 +165,12 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
         cacheStore = initializedStores.cacheStore;
         fileUploadStore = initializedStores.fileUploadStore;
         fileDownloadSessionStore = initializedStores.fileDownloadSessionStore;
+        const settings = await initializedStores.settingsStore.read();
 
         translator = createTranslator(
             resolvePreferredLocale({
                 cliFlag: parsedCliLanguage,
-                storedLocale: initializedStores.settings.lang,
+                storedLocale: settings.lang,
                 env: invocation.env,
                 systemLocale: invocation.systemLocale,
             }),
@@ -231,7 +231,7 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
                 context,
                 {
                     installMissing: shouldInstallMissingBundledSkills,
-                    settings: initializedStores.settings,
+                    settings,
                 },
             );
         }
@@ -348,7 +348,6 @@ async function initializeCliStores(
         cacheStore,
         fileDownloadSessionStore,
         fileUploadStore,
-        settings: await settingsStore.read(),
         settingsStore,
     };
 }

--- a/src/application/commands/cloud-task/shared.ts
+++ b/src/application/commands/cloud-task/shared.ts
@@ -3,8 +3,8 @@ import type { AuthAccount } from "../../schemas/auth.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import { withRequestTarget } from "../../logging/log-fields.ts";
 import { readCurrentAuth } from "../auth/shared.ts";
+import { requestText } from "../shared/request.ts";
 
 export const cloudTaskFormatValues = ["json"] as const;
 export const cloudTaskStatusValues = [
@@ -262,81 +262,53 @@ export async function requestCloudTask(
         method?: string;
     } = {},
 ): Promise<string> {
-    const requestStartedAt = Date.now();
     const method = options.method ?? "GET";
+    const headers: Record<string, string> = {
+        Authorization: apiKey,
+    };
 
-    context.logger.debug(
-        {
-            bodyBytes: options.body?.length ?? 0,
-            hasBody: options.body !== undefined,
-            method,
-            ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-            query: requestUrl.searchParams.toString(),
+    if (options.body !== undefined) {
+        headers["Content-Type"] = "application/json";
+    }
+
+    return await requestText({
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.cloudTask.requestFailed",
+            1,
+            {
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.cloudTask.requestError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            error: {
+                method,
+            },
+            response: {
+                method,
+            },
+            start: {
+                bodyBytes: options.body?.length ?? 0,
+                hasBody: options.body !== undefined,
+                method,
+                query: requestUrl.searchParams.toString(),
+            },
         },
-        "Cloud task request started.",
-    );
-
-    try {
-        const headers: Record<string, string> = {
-            Authorization: apiKey,
-        };
-
-        if (options.body !== undefined) {
-            headers["Content-Type"] = "application/json";
-        }
-
-        const response = await context.fetcher(requestUrl, {
+        init: {
             body: options.body,
             headers,
             method,
-        });
-        const durationMs = Date.now() - requestStartedAt;
-
-        if (!response.ok) {
-            context.logger.warn(
-                {
-                    durationMs,
-                    method,
-                    ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                    status: response.status,
-                },
-                "Cloud task request returned a non-success status.",
-            );
-            throw new CliUserError("errors.cloudTask.requestFailed", 1, {
-                status: response.status,
-            });
-        }
-
-        context.logger.debug(
-            {
-                durationMs,
-                method,
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                status: response.status,
-            },
-            "Cloud task request completed.",
-        );
-
-        return await response.text();
-    }
-    catch (error) {
-        if (error instanceof CliUserError) {
-            throw error;
-        }
-
-        context.logger.warn(
-            {
-                durationMs: Date.now() - requestStartedAt,
-                err: error,
-                method,
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-            },
-            "Cloud task request failed unexpectedly.",
-        );
-        throw new CliUserError("errors.cloudTask.requestError", 1, {
-            message: error instanceof Error ? error.message : String(error),
-        });
-    }
+        },
+        requestLabel: "Cloud task",
+        requestUrl,
+    });
 }
 
 export function parseCloudTaskCreateResponse(

--- a/src/application/commands/cloud-task/validation.ts
+++ b/src/application/commands/cloud-task/validation.ts
@@ -9,6 +9,7 @@ import ajvZH from "ajv-i18n/localize/zh/index.js";
 import { CliUserError } from "../../contracts/cli.ts";
 import { isPackageInfoInputHandleOptional } from "../package/shared.ts";
 import { patchHandleSchema } from "../shared/handle-schema.ts";
+import { isPlainObject, readWidgetName } from "../shared/schema-utils.ts";
 
 const ajv = createAjv();
 const oomolStoragePathPrefix = "/oomol-driver/oomol-storage/";
@@ -67,18 +68,6 @@ interface WidgetValidationRule {
         value: unknown,
         translator: ValidationTranslator,
     ) => string | undefined;
-}
-
-interface JsonSchemaObject {
-    [key: string]: unknown;
-    anyOf?: unknown;
-    oneOf?: unknown;
-    allOf?: unknown;
-    contentMediaType?: unknown;
-    enum?: unknown;
-    format?: unknown;
-    type?: unknown;
-    uniqueItems?: unknown;
 }
 
 const storagePathWidgetRule: WidgetValidationRule = {
@@ -405,14 +394,6 @@ function typeOfSchema(schema: unknown): WidgetType {
     }
 }
 
-function readWidgetName(ext: unknown): string | undefined {
-    if (!isPlainObject(ext) || typeof ext.widget !== "string") {
-        return undefined;
-    }
-
-    return ext.widget;
-}
-
 function asPrimitiveType(type: WidgetType): PrimitiveType | undefined {
     switch (type) {
         case "string":
@@ -482,14 +463,4 @@ function isOomolStoragePath(value: string): boolean {
     }
 
     return !value.includes("\\");
-}
-
-function isPlainObject(value: unknown): value is JsonSchemaObject {
-    if (value === null || typeof value !== "object") {
-        return false;
-    }
-
-    const prototype = Object.getPrototypeOf(value);
-
-    return prototype === Object.prototype || prototype === null;
 }

--- a/src/application/commands/config/set.ts
+++ b/src/application/commands/config/set.ts
@@ -1,19 +1,26 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import type { AppSettings } from "../../schemas/settings.ts";
 
-import type { ConfigSetInput } from "./shared.ts";
+import type { ConfigKey } from "./shared.ts";
 import { z } from "zod";
 import { maybeSynchronizeInstalledBundledSkills } from "../skills/shared.ts";
 import {
     configKeyChoices,
     configKeySchema,
     createInvalidConfigKeyError,
-    fileDownloadOutDirConfigKey,
     getConfigDefinition,
     getConfigDefinitionByRawKey,
     ooSkillImplicitInvocationConfigKey,
     writeLine,
 } from "./shared.ts";
+
+interface ResolvedConfigSetInput {
+    definition: {
+        setValue: (settings: AppSettings, value: string) => AppSettings;
+    };
+    key: ConfigKey;
+    value: string;
+}
 
 const configSetInputSchema = z.object({
     key: configKeySchema,
@@ -33,12 +40,13 @@ const configSetInputSchema = z.object({
     }
 
     return {
+        definition,
         key: input.key,
         value: valueResult.data,
-    } as ConfigSetInput;
+    } as ResolvedConfigSetInput;
 });
 
-export const configSetCommand: CliCommandDefinition<ConfigSetInput> = {
+export const configSetCommand: CliCommandDefinition<ResolvedConfigSetInput> = {
     name: "set",
     summaryKey: "commands.config.set.summary",
     descriptionKey: "commands.config.set.description",
@@ -67,7 +75,7 @@ export const configSetCommand: CliCommandDefinition<ConfigSetInput> = {
     },
     handler: async (input, context) => {
         const nextSettings = await context.settingsStore.update(
-            settings => setConfigValue(settings, input),
+            settings => input.definition.setValue(settings, input.value),
         );
 
         if (input.key === ooSkillImplicitInvocationConfigKey) {
@@ -92,22 +100,3 @@ export const configSetCommand: CliCommandDefinition<ConfigSetInput> = {
         );
     },
 };
-
-function setConfigValue(
-    settings: AppSettings,
-    input: ConfigSetInput,
-): AppSettings {
-    switch (input.key) {
-        case "lang":
-            return getConfigDefinition("lang").setValue(settings, input.value);
-        case fileDownloadOutDirConfigKey:
-            return getConfigDefinition(fileDownloadOutDirConfigKey).setValue(
-                settings,
-                input.value,
-            );
-        case ooSkillImplicitInvocationConfigKey:
-            return getConfigDefinition(
-                ooSkillImplicitInvocationConfigKey,
-            ).setValue(settings, input.value);
-    }
-}

--- a/src/application/commands/file/download/request.ts
+++ b/src/application/commands/file/download/request.ts
@@ -2,7 +2,7 @@ import type { CliExecutionContext } from "../../../contracts/cli.ts";
 import type { FileDownloadSessionRecord } from "../../../contracts/file-download-session-store.ts";
 
 import { CliUserError } from "../../../contracts/cli.ts";
-import { withRequestTarget } from "../../../logging/log-fields.ts";
+import { performLoggedRequest } from "../../shared/request.ts";
 
 type DownloadRequestContext = Pick<CliExecutionContext, "fetcher" | "logger">;
 
@@ -37,71 +37,45 @@ async function requestFileDownload(
     init?: RequestInit,
     allowedStatuses: readonly number[] = [],
 ): Promise<Response> {
-    const requestStartedAt = Date.now();
-
-    context.logger.debug(
-        {
-            method: "GET",
-            ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-            query: requestUrl.searchParams.toString(),
-            url: requestUrl.toString(),
-        },
-        "File download request started.",
-    );
-
-    try {
-        const response = await context.fetcher(requestUrl, init);
-        const durationMs = Date.now() - requestStartedAt;
-
-        if (!response.ok && !allowedStatuses.includes(response.status)) {
-            context.logger.warn(
-                {
-                    durationMs,
-                    method: "GET",
-                    ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                    status: response.status,
-                    url: requestUrl.toString(),
-                },
-                "File download request returned a non-success status.",
-            );
-            throw new CliUserError("errors.fileDownload.requestFailed", 1, {
-                status: response.status,
-            });
-        }
-
-        context.logger.debug(
+    return await performLoggedRequest({
+        allowedStatuses,
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.fileDownload.requestFailed",
+            1,
             {
-                durationMs,
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.fileDownload.requestError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            error: {
                 method: "GET",
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+                url: requestUrl.toString(),
+            },
+            response: {
+                method: "GET",
+                url: requestUrl.toString(),
+            },
+            start: {
+                method: "GET",
+                query: requestUrl.searchParams.toString(),
+                url: requestUrl.toString(),
+            },
+            success: response => ({
                 finalUrl: response.url === "" ? requestUrl.toString() : response.url,
-                status: response.status,
-                url: requestUrl.toString(),
-            },
-            "File download request completed.",
-        );
-
-        return response;
-    }
-    catch (error) {
-        if (error instanceof CliUserError) {
-            throw error;
-        }
-
-        context.logger.warn(
-            {
-                durationMs: Date.now() - requestStartedAt,
-                err: error,
-                method: "GET",
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                url: requestUrl.toString(),
-            },
-            "File download request failed unexpectedly.",
-        );
-        throw new CliUserError("errors.fileDownload.requestError", 1, {
-            message: error instanceof Error ? error.message : String(error),
-        });
-    }
+            }),
+        },
+        init,
+        requestLabel: "File download",
+        requestUrl,
+    });
 }
 
 function buildRequestHeaders(): Headers {

--- a/src/application/commands/file/shared.test.ts
+++ b/src/application/commands/file/shared.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import { createLogCapture } from "../../../../__tests__/helpers.ts";
+import { uploadFileParts } from "./shared.ts";
+
+describe("uploadFileParts", () => {
+    test("keeps the request method in unexpected error logs", async () => {
+        const logCapture = createLogCapture();
+        const originalSetTimeout = globalThis.setTimeout;
+
+        try {
+            globalThis.setTimeout = ((handler: unknown, _timeout?: number, ...args: unknown[]) => {
+                if (typeof handler === "function") {
+                    (handler as (...callbackArgs: unknown[]) => void)(...args);
+                }
+
+                return 0 as unknown as ReturnType<typeof setTimeout>;
+            }) as typeof setTimeout;
+
+            await expect(uploadFileParts(
+                {
+                    size: 1,
+                    slice: () => new Blob(["a"]),
+                },
+                {
+                    partSize: 1,
+                    presignedUrls: {
+                        1: "https://storage.example.com/upload/1",
+                    },
+                    totalParts: 1,
+                    uploadId: "upload-1",
+                },
+                {
+                    fetcher: async () => {
+                        throw new Error("network down");
+                    },
+                    logger: logCapture.logger,
+                },
+            )).rejects.toMatchObject({
+                key: "errors.fileUpload.requestError",
+            });
+
+            const logs = logCapture.read();
+
+            expect(logs).toContain(
+                "\"msg\":\"File upload part request failed unexpectedly.\"",
+            );
+            expect(logs).toContain("\"method\":\"PUT\"");
+        }
+        finally {
+            globalThis.setTimeout = originalSetTimeout;
+            logCapture.close();
+        }
+    });
+});

--- a/src/application/commands/file/shared.ts
+++ b/src/application/commands/file/shared.ts
@@ -7,8 +7,8 @@ import type { AuthAccount } from "../../schemas/auth.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import { withRequestTarget } from "../../logging/log-fields.ts";
 import { readCurrentAuth } from "../auth/shared.ts";
+import { performLoggedRequest, requestText } from "../shared/request.ts";
 
 export const fileFormatValues = ["json"] as const;
 export const maxFileUploadSizeBytes = 512 * 1024 * 1024;
@@ -271,81 +271,53 @@ async function requestFileUpload(
         method?: string;
     } = {},
 ): Promise<string> {
-    const requestStartedAt = Date.now();
     const method = options.method ?? "GET";
+    const headers: Record<string, string> = {
+        Authorization: apiKey,
+    };
 
-    context.logger.debug(
-        {
-            bodyBytes: options.body?.length ?? 0,
-            hasBody: options.body !== undefined,
-            method,
-            ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-            query: requestUrl.searchParams.toString(),
+    if (options.body !== undefined) {
+        headers["Content-Type"] = "application/json";
+    }
+
+    return await requestText({
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.fileUpload.requestFailed",
+            1,
+            {
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.fileUpload.requestError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            error: {
+                method,
+            },
+            response: {
+                method,
+            },
+            start: {
+                bodyBytes: options.body?.length ?? 0,
+                hasBody: options.body !== undefined,
+                method,
+                query: requestUrl.searchParams.toString(),
+            },
         },
-        "File upload request started.",
-    );
-
-    try {
-        const headers: Record<string, string> = {
-            Authorization: apiKey,
-        };
-
-        if (options.body !== undefined) {
-            headers["Content-Type"] = "application/json";
-        }
-
-        const response = await context.fetcher(requestUrl, {
+        init: {
             body: options.body,
             headers,
             method,
-        });
-        const durationMs = Date.now() - requestStartedAt;
-
-        if (!response.ok) {
-            context.logger.warn(
-                {
-                    durationMs,
-                    method,
-                    ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                    status: response.status,
-                },
-                "File upload request returned a non-success status.",
-            );
-            throw new CliUserError("errors.fileUpload.requestFailed", 1, {
-                status: response.status,
-            });
-        }
-
-        context.logger.debug(
-            {
-                durationMs,
-                method,
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                status: response.status,
-            },
-            "File upload request completed.",
-        );
-
-        return await response.text();
-    }
-    catch (error) {
-        if (error instanceof CliUserError) {
-            throw error;
-        }
-
-        context.logger.warn(
-            {
-                durationMs: Date.now() - requestStartedAt,
-                err: error,
-                method,
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-            },
-            "File upload request failed unexpectedly.",
-        );
-        throw new CliUserError("errors.fileUpload.requestError", 1, {
-            message: error instanceof Error ? error.message : String(error),
-        });
-    }
+        },
+        requestLabel: "File upload",
+        requestUrl,
+    });
 }
 
 async function uploadFilePart(
@@ -358,90 +330,61 @@ async function uploadFilePart(
 
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
         const requestUrl = new URL(presignedUrl);
-        const requestStartedAt = Date.now();
-
-        context.logger.debug(
-            {
-                attempt,
-                bodyBytes: partData.size,
-                method: "PUT",
-                partNumber,
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-            },
-            "File upload part request started.",
-        );
 
         try {
-            const response = await context.fetcher(requestUrl, {
-                body: partData,
-                headers: {
-                    "Content-Type": "application/octet-stream",
-                },
-                method: "PUT",
-            });
-            const durationMs = Date.now() - requestStartedAt;
-
-            if (!response.ok) {
-                context.logger.warn(
+            await performLoggedRequest({
+                context,
+                createRequestFailedError: status => new CliUserError(
+                    "errors.fileUpload.requestFailed",
+                    1,
                     {
-                        attempt,
-                        durationMs,
-                        method: "PUT",
-                        partNumber,
-                        ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                        status: response.status,
+                        status,
                     },
-                    "File upload part request returned a non-success status.",
-                );
-
-                if (attempt === maxAttempts) {
-                    throw new CliUserError("errors.fileUpload.requestFailed", 1, {
-                        status: response.status,
-                    });
-                }
-
+                ),
+                createUnexpectedError: error => new CliUserError(
+                    "errors.fileUpload.requestError",
+                    1,
+                    {
+                        message: error instanceof Error ? error.message : String(error),
+                    },
+                ),
+                fields: {
+                    common: {
+                        attempt,
+                        partNumber,
+                    },
+                    error: {
+                        method: "PUT",
+                    },
+                    response: {
+                        method: "PUT",
+                    },
+                    start: {
+                        bodyBytes: partData.size,
+                        method: "PUT",
+                    },
+                },
+                init: {
+                    body: partData,
+                    headers: {
+                        "Content-Type": "application/octet-stream",
+                    },
+                    method: "PUT",
+                },
+                requestLabel: "File upload part",
+                requestUrl,
+            });
+            return;
+        }
+        catch (error) {
+            if (error instanceof CliUserError && attempt < maxAttempts) {
                 await delayRetry(attempt);
                 continue;
             }
 
-            context.logger.debug(
-                {
-                    attempt,
-                    durationMs,
-                    method: "PUT",
-                    partNumber,
-                    ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                    status: response.status,
-                },
-                "File upload part request completed.",
-            );
-
-            return;
-        }
-        catch (error) {
             if (error instanceof CliUserError) {
                 throw error;
             }
-
-            context.logger.warn(
-                {
-                    attempt,
-                    durationMs: Date.now() - requestStartedAt,
-                    err: error,
-                    method: "PUT",
-                    partNumber,
-                    ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                },
-                "File upload part request failed unexpectedly.",
-            );
-
-            if (attempt === maxAttempts) {
-                throw new CliUserError("errors.fileUpload.requestError", 1, {
-                    message: error instanceof Error ? error.message : String(error),
-                });
-            }
-
-            await delayRetry(attempt);
         }
     }
 }

--- a/src/application/commands/package/search.ts
+++ b/src/application/commands/package/search.ts
@@ -8,11 +8,11 @@ import { CliUserError } from "../../contracts/cli.ts";
 import {
     withAccountIdentity,
     withPath,
-    withRequestTarget,
 } from "../../logging/log-fields.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { readCurrentAuth } from "../auth/shared.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { requestText } from "../shared/request.ts";
 
 const MAX_SEARCH_TEXT_LENGTH = 200;
 const SEARCH_CACHE_ID = "search.intent-response";
@@ -173,67 +173,36 @@ async function requestSearch(
     apiKey: string,
     context: Pick<CliExecutionContext, "fetcher" | "logger">,
 ): Promise<string> {
-    const requestStartedAt = Date.now();
-
-    context.logger.debug(
-        {
-            ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-            queryLength: requestUrl.searchParams.get("q")?.length ?? 0,
-            requestLanguage: requestUrl.searchParams.get("lang") ?? "",
+    return await requestText({
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.search.requestFailed",
+            1,
+            {
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.search.requestError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            start: {
+                queryLength: requestUrl.searchParams.get("q")?.length ?? 0,
+                requestLanguage: requestUrl.searchParams.get("lang") ?? "",
+            },
         },
-        "Search request started.",
-    );
-
-    try {
-        const response = await context.fetcher(requestUrl, {
+        init: {
             headers: {
                 Authorization: apiKey,
             },
-        });
-        const durationMs = Date.now() - requestStartedAt;
-
-        if (!response.ok) {
-            context.logger.warn(
-                {
-                    durationMs,
-                    ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                    status: response.status,
-                },
-                "Search request returned a non-success status.",
-            );
-            throw new CliUserError("errors.search.requestFailed", 1, {
-                status: response.status,
-            });
-        }
-
-        context.logger.debug(
-            {
-                durationMs,
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                status: response.status,
-            },
-            "Search request completed.",
-        );
-
-        return await response.text();
-    }
-    catch (error) {
-        if (error instanceof CliUserError) {
-            throw error;
-        }
-
-        context.logger.warn(
-            {
-                durationMs: Date.now() - requestStartedAt,
-                err: error,
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-            },
-            "Search request failed unexpectedly.",
-        );
-        throw new CliUserError("errors.search.requestError", 1, {
-            message: error instanceof Error ? error.message : String(error),
-        });
-    }
+        },
+        requestLabel: "Search",
+        requestUrl,
+    });
 }
 
 async function loadSearchResponse(

--- a/src/application/commands/package/shared.test.ts
+++ b/src/application/commands/package/shared.test.ts
@@ -225,6 +225,35 @@ describe("loadPackageInfo", () => {
     });
 });
 
+describe("parsePackageSpecifier", () => {
+    test("accepts semver prerelease and build metadata when semver is required", () => {
+        expect(parsePackageSpecifier("pkg@1.2.3-beta.1+build.01", {
+            requireSemver: true,
+        })).toEqual({
+            packageName: "pkg",
+            packageVersion: "1.2.3-beta.1+build.01",
+            shouldReadCache: true,
+        });
+    });
+
+    test("rejects invalid semver when semver is required", () => {
+        expect(() => parsePackageSpecifier("pkg@1.2.3-01", {
+            requireSemver: true,
+            requireVersion: true,
+        })).toThrow("errors.packageInfo.invalidPackageSpecifier");
+    });
+
+    test("keeps invalid semver suffixes as latest when version is optional", () => {
+        expect(parsePackageSpecifier("pkg@1.2.3-01", {
+            requireSemver: true,
+        })).toEqual({
+            packageName: "pkg@1.2.3-01",
+            packageVersion: "latest",
+            shouldReadCache: false,
+        });
+    });
+});
+
 function createRawPackageInfoResponse() {
     return {
         packageName: "qrcode",

--- a/src/application/commands/package/shared.ts
+++ b/src/application/commands/package/shared.ts
@@ -7,9 +7,10 @@ import { CliUserError } from "../../contracts/cli.ts";
 import {
     withAccountIdentity,
     withPackageIdentity,
-    withRequestTarget,
 } from "../../logging/log-fields.ts";
+import { isSemver as isValidSemver } from "../../semver.ts";
 import { patchHandleSchema } from "../shared/handle-schema.ts";
+import { requestText } from "../shared/request.ts";
 
 const PACKAGE_INFO_CACHE_ID = "package.info.v5";
 const PACKAGE_INFO_CACHE_MAX_ENTRIES = 300;
@@ -132,7 +133,7 @@ export function parsePackageSpecifier(
 
     const versionSeparatorIndex = resolveVersionSeparatorIndex(
         trimmedPackageSpecifier,
-        options.requireSemver === true ? isSemverVersion : looksLikePackageVersion,
+        options.requireSemver === true ? isValidSemver : looksLikePackageVersion,
     );
 
     if (versionSeparatorIndex < 0) {
@@ -155,7 +156,7 @@ export function parsePackageSpecifier(
     if (
         packageName === ""
         || packageVersion === ""
-        || (options.requireSemver === true && !isSemverVersion(packageVersion))
+        || (options.requireSemver === true && !isValidSemver(packageVersion))
     ) {
         throw new CliUserError(errorKey, 2, {
             value: packageSpecifier,
@@ -319,124 +320,8 @@ function looksLikePackageVersion(version: string): boolean {
     return Array.from(version).some(character => isAsciiDigit(character));
 }
 
-function isSemverVersion(version: string): boolean {
-    if (version === "") {
-        return false;
-    }
-
-    const [versionWithPrerelease, buildMetadata] = splitVersionSection(version, "+");
-    const [coreVersion, prerelease] = splitVersionSection(versionWithPrerelease, "-");
-
-    if (!isSemverCore(coreVersion)) {
-        return false;
-    }
-
-    if (
-        prerelease !== undefined
-        && !isSemverIdentifiers(prerelease, false)
-    ) {
-        return false;
-    }
-
-    if (
-        buildMetadata !== undefined
-        && !isSemverIdentifiers(buildMetadata, true)
-    ) {
-        return false;
-    }
-
-    return true;
-}
-
-function splitVersionSection(
-    value: string,
-    separator: string,
-): [string, string | undefined] {
-    const separatorIndex = value.indexOf(separator);
-
-    if (separatorIndex < 0) {
-        return [value, undefined];
-    }
-
-    return [
-        value.slice(0, separatorIndex),
-        value.slice(separatorIndex + separator.length),
-    ];
-}
-
-function isSemverCore(version: string): boolean {
-    const segments = version.split(".");
-
-    if (segments.length !== 3) {
-        return false;
-    }
-
-    return segments.every(segment => isNumericIdentifier(segment));
-}
-
-function isSemverIdentifiers(
-    value: string,
-    allowLeadingZeroNumeric: boolean,
-): boolean {
-    if (value === "") {
-        return false;
-    }
-
-    return value.split(".").every((identifier) => {
-        if (!isSemverIdentifier(identifier)) {
-            return false;
-        }
-
-        if (
-            !allowLeadingZeroNumeric
-            && isDigits(identifier)
-            && identifier.length > 1
-            && identifier[0] === "0"
-        ) {
-            return false;
-        }
-
-        return true;
-    });
-}
-
-function isNumericIdentifier(value: string): boolean {
-    if (!isDigits(value)) {
-        return false;
-    }
-
-    return value.length === 1 || value[0] !== "0";
-}
-
-function isDigits(value: string): boolean {
-    if (value === "") {
-        return false;
-    }
-
-    return Array.from(value).every(character => isAsciiDigit(character));
-}
-
-function isSemverIdentifier(value: string): boolean {
-    if (value === "") {
-        return false;
-    }
-
-    return Array.from(value).every(character =>
-        isAsciiDigit(character)
-        || isAsciiLetter(character)
-        || character === "-",
-    );
-}
-
 function isAsciiDigit(character: string): boolean {
     return character >= "0" && character <= "9";
-}
-
-function isAsciiLetter(character: string): boolean {
-    return (
-        (character >= "a" && character <= "z")
-        || (character >= "A" && character <= "Z")
-    );
 }
 
 function createPackageInfoCacheKey(
@@ -473,73 +358,40 @@ async function requestPackageInfo(
     apiKey: string,
     context: Pick<CliExecutionContext, "fetcher" | "logger">,
 ): Promise<string> {
-    const requestStartedAt = Date.now();
     const pathSegments = requestUrl.pathname.split("/");
     const packageName = decodeURIComponent(pathSegments.at(-2) ?? "");
     const packageVersion = decodeURIComponent(pathSegments.at(-1) ?? "");
 
-    context.logger.debug(
-        {
-            ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-            ...withPackageIdentity(packageName, packageVersion),
-            requestLanguage: requestUrl.searchParams.get("lang") ?? "",
+    return await requestText({
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.packageInfo.requestFailed",
+            1,
+            {
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.packageInfo.requestError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            common: withPackageIdentity(packageName, packageVersion),
+            start: {
+                requestLanguage: requestUrl.searchParams.get("lang") ?? "",
+            },
         },
-        "Package info request started.",
-    );
-
-    try {
-        const response = await context.fetcher(requestUrl, {
+        init: {
             headers: {
                 Authorization: apiKey,
             },
-        });
-        const durationMs = Date.now() - requestStartedAt;
-
-        if (!response.ok) {
-            context.logger.warn(
-                {
-                    durationMs,
-                    ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                    ...withPackageIdentity(packageName, packageVersion),
-                    status: response.status,
-                },
-                "Package info request returned a non-success status.",
-            );
-            throw new CliUserError("errors.packageInfo.requestFailed", 1, {
-                status: response.status,
-            });
-        }
-
-        context.logger.debug(
-            {
-                durationMs,
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                ...withPackageIdentity(packageName, packageVersion),
-                status: response.status,
-            },
-            "Package info request completed.",
-        );
-
-        return await response.text();
-    }
-    catch (error) {
-        if (error instanceof CliUserError) {
-            throw error;
-        }
-
-        context.logger.warn(
-            {
-                durationMs: Date.now() - requestStartedAt,
-                err: error,
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                ...withPackageIdentity(packageName, packageVersion),
-            },
-            "Package info request failed unexpectedly.",
-        );
-        throw new CliUserError("errors.packageInfo.requestError", 1, {
-            message: error instanceof Error ? error.message : String(error),
-        });
-    }
+        },
+        requestLabel: "Package info",
+        requestUrl,
+    });
 }
 
 function parseCachedPackageInfoResponse(rawResponse: string): PackageInfoResponse {

--- a/src/application/commands/shared/handle-schema.ts
+++ b/src/application/commands/shared/handle-schema.ts
@@ -1,3 +1,5 @@
+import { isPlainObject, readWidgetName } from "./schema-utils.ts";
+
 interface JsonSchemaObject {
     [key: string]: unknown;
     allOf?: unknown;
@@ -99,22 +101,4 @@ function canMergeConstraint(
     return Object.entries(constraint).every(([key, value]) =>
         !Object.hasOwn(schema, key) || Object.is(schema[key], value),
     );
-}
-
-function readWidgetName(ext: unknown): string | undefined {
-    if (!isPlainObject(ext) || typeof ext.widget !== "string") {
-        return undefined;
-    }
-
-    return ext.widget;
-}
-
-function isPlainObject(value: unknown): value is JsonSchemaObject {
-    if (value === null || typeof value !== "object") {
-        return false;
-    }
-
-    const prototype = Object.getPrototypeOf(value);
-
-    return prototype === Object.prototype || prototype === null;
 }

--- a/src/application/commands/shared/request.test.ts
+++ b/src/application/commands/shared/request.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+
+import { createLogCapture } from "../../../../__tests__/helpers.ts";
+import { CliUserError } from "../../contracts/cli.ts";
+import { executeCliRequest, executeCliTextRequest } from "./request.ts";
+
+describe("executeCliRequest", () => {
+    test("logs request lifecycle and returns the response", async () => {
+        const logCapture = createLogCapture();
+        const requestUrl = new URL("https://example.com/items/1");
+
+        try {
+            const response = await executeCliRequest({
+                context: {
+                    fetcher: async () => new Response("ok", {
+                        status: 200,
+                    }),
+                    logger: logCapture.logger,
+                },
+                createRequestError: error => new CliUserError(
+                    "errors.shared.requestError",
+                    1,
+                    {
+                        message: error instanceof Error ? error.message : String(error),
+                    },
+                ),
+                createRequestFailedError: status => new CliUserError(
+                    "errors.shared.requestFailed",
+                    1,
+                    {
+                        status,
+                    },
+                ),
+                includeMethod: true,
+                label: "Shared",
+                requestUrl,
+                startLogFields: {
+                    traceId: "trace-1",
+                },
+            });
+
+            expect(response.status).toBe(200);
+            const logs = logCapture.read();
+
+            expect(logs).toContain("\"msg\":\"Shared request started.\"");
+            expect(logs).toContain("\"msg\":\"Shared request completed.\"");
+            expect(logs).toContain("\"traceId\":\"trace-1\"");
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("accepts configured non-success status codes", async () => {
+        const logCapture = createLogCapture();
+
+        try {
+            const response = await executeCliRequest({
+                allowedStatusCodes: [416],
+                context: {
+                    fetcher: async () => new Response(null, {
+                        status: 416,
+                    }),
+                    logger: logCapture.logger,
+                },
+                createRequestError: error => new CliUserError(
+                    "errors.shared.requestError",
+                    1,
+                    {
+                        message: error instanceof Error ? error.message : String(error),
+                    },
+                ),
+                createRequestFailedError: status => new CliUserError(
+                    "errors.shared.requestFailed",
+                    1,
+                    {
+                        status,
+                    },
+                ),
+                label: "Shared",
+                requestUrl: new URL("https://example.com/items/1"),
+            });
+
+            expect(response.status).toBe(416);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("wraps non-success statuses with the caller-provided error", async () => {
+        const logCapture = createLogCapture();
+
+        try {
+            await expect(executeCliRequest({
+                context: {
+                    fetcher: async () => new Response("missing", {
+                        status: 404,
+                    }),
+                    logger: logCapture.logger,
+                },
+                createRequestError: error => new CliUserError(
+                    "errors.shared.requestError",
+                    1,
+                    {
+                        message: error instanceof Error ? error.message : String(error),
+                    },
+                ),
+                createRequestFailedError: status => new CliUserError(
+                    "errors.shared.requestFailed",
+                    1,
+                    {
+                        status,
+                    },
+                ),
+                label: "Shared",
+                requestUrl: new URL("https://example.com/items/1"),
+            })).rejects.toMatchObject({
+                key: "errors.shared.requestFailed",
+                params: {
+                    status: 404,
+                },
+            });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("wraps unexpected fetcher errors with the caller-provided error", async () => {
+        const logCapture = createLogCapture();
+
+        try {
+            await expect(executeCliTextRequest({
+                context: {
+                    fetcher: async () => {
+                        throw new Error("network down");
+                    },
+                    logger: logCapture.logger,
+                },
+                createRequestError: error => new CliUserError(
+                    "errors.shared.requestError",
+                    1,
+                    {
+                        message: error instanceof Error ? error.message : String(error),
+                    },
+                ),
+                createRequestFailedError: status => new CliUserError(
+                    "errors.shared.requestFailed",
+                    1,
+                    {
+                        status,
+                    },
+                ),
+                label: "Shared",
+                requestUrl: new URL("https://example.com/items/1"),
+            })).rejects.toMatchObject({
+                key: "errors.shared.requestError",
+                params: {
+                    message: "network down",
+                },
+            });
+
+            expect(logCapture.read()).toContain(
+                "\"msg\":\"Shared request failed unexpectedly.\"",
+            );
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+});

--- a/src/application/commands/shared/request.ts
+++ b/src/application/commands/shared/request.ts
@@ -1,0 +1,179 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+
+import { CliUserError } from "../../contracts/cli.ts";
+import { withRequestTarget } from "../../logging/log-fields.ts";
+
+type RequestContext = Pick<CliExecutionContext, "fetcher" | "logger">;
+type LogFields = Record<string, unknown>;
+type LogFieldsResolver<TValue> = LogFields | ((input: TValue) => LogFields);
+
+export interface ExecuteCliRequestOptions {
+    allowedStatusCodes?: readonly number[];
+    context: RequestContext;
+    createRequestError: (error: unknown) => CliUserError;
+    createRequestFailedError: (status: number) => CliUserError;
+    includeMethod?: boolean;
+    includeRequestTarget?: boolean;
+    init?: RequestInit;
+    label: string;
+    nonSuccessLogFields?: LogFieldsResolver<Response>;
+    requestUrl: URL;
+    startLogFields?: LogFields;
+    successLogFields?: LogFieldsResolver<Response>;
+    unexpectedLogFields?: LogFieldsResolver<unknown>;
+}
+
+export interface PerformLoggedRequestOptions {
+    allowedStatuses?: readonly number[];
+    context: RequestContext;
+    createRequestFailedError: (status: number) => CliUserError;
+    createUnexpectedError: (error: unknown) => CliUserError;
+    fields?: {
+        common?: LogFields;
+        error?: LogFieldsResolver<unknown>;
+        response?: LogFieldsResolver<Response>;
+        start?: LogFields;
+        success?: LogFieldsResolver<Response>;
+    };
+    init?: RequestInit;
+    requestLabel: string;
+    requestUrl: URL;
+}
+
+export async function executeCliRequest(
+    options: ExecuteCliRequestOptions,
+): Promise<Response> {
+    const requestStartedAt = Date.now();
+    const method = options.init?.method ?? "GET";
+
+    options.context.logger.debug(
+        {
+            ...createBaseLogFields(options.requestUrl, method, options),
+            ...options.startLogFields,
+        },
+        `${options.label} request started.`,
+    );
+
+    try {
+        const response = await options.context.fetcher(
+            options.requestUrl,
+            options.init,
+        );
+        const durationMs = Date.now() - requestStartedAt;
+
+        if (
+            !response.ok
+            && !(options.allowedStatusCodes ?? []).includes(response.status)
+        ) {
+            options.context.logger.warn(
+                {
+                    durationMs,
+                    ...createBaseLogFields(options.requestUrl, method, options),
+                    ...resolveLogFields(options.nonSuccessLogFields, response),
+                    status: response.status,
+                },
+                `${options.label} request returned a non-success status.`,
+            );
+            throw options.createRequestFailedError(response.status);
+        }
+
+        options.context.logger.debug(
+            {
+                durationMs,
+                ...createBaseLogFields(options.requestUrl, method, options),
+                ...resolveLogFields(options.successLogFields, response),
+                status: response.status,
+            },
+            `${options.label} request completed.`,
+        );
+
+        return response;
+    }
+    catch (error) {
+        if (error instanceof CliUserError) {
+            throw error;
+        }
+
+        options.context.logger.warn(
+            {
+                durationMs: Date.now() - requestStartedAt,
+                err: error,
+                ...createBaseLogFields(options.requestUrl, method, options),
+                ...resolveLogFields(options.unexpectedLogFields, error),
+            },
+            `${options.label} request failed unexpectedly.`,
+        );
+        throw options.createRequestError(error);
+    }
+}
+
+export async function executeCliTextRequest(
+    options: ExecuteCliRequestOptions,
+): Promise<string> {
+    const response = await executeCliRequest(options);
+
+    return await response.text();
+}
+
+function createBaseLogFields(
+    requestUrl: URL,
+    method: string,
+    options: Pick<ExecuteCliRequestOptions, "includeMethod" | "includeRequestTarget">,
+): LogFields {
+    return {
+        ...(options.includeMethod === true ? { method } : {}),
+        ...(options.includeRequestTarget === false
+            ? {}
+            : withRequestTarget(requestUrl.host, requestUrl.pathname)),
+    };
+}
+
+function resolveLogFields<TValue>(
+    value: LogFieldsResolver<TValue> | undefined,
+    input: TValue,
+): LogFields {
+    if (typeof value === "function") {
+        return value(input);
+    }
+
+    return value ?? {};
+}
+
+export async function performLoggedRequest(
+    options: PerformLoggedRequestOptions,
+): Promise<Response> {
+    return await executeCliRequest({
+        allowedStatusCodes: options.allowedStatuses,
+        context: options.context,
+        createRequestError: options.createUnexpectedError,
+        createRequestFailedError: options.createRequestFailedError,
+        label: options.requestLabel,
+        nonSuccessLogFields: response => ({
+            ...(options.fields?.common ?? {}),
+            ...resolveLogFields(options.fields?.response, response),
+        }),
+        requestUrl: options.requestUrl,
+        startLogFields: {
+            ...(options.fields?.common ?? {}),
+            ...(options.fields?.start ?? {}),
+        },
+        successLogFields: response => ({
+            ...(options.fields?.common ?? {}),
+            ...resolveLogFields(options.fields?.response, response),
+            ...resolveLogFields(options.fields?.success, response),
+        }),
+        unexpectedLogFields: error => ({
+            ...(options.fields?.common ?? {}),
+            ...resolveLogFields(options.fields?.error, error),
+        }),
+        init: options.init,
+    });
+}
+
+export async function requestText(
+    options: PerformLoggedRequestOptions,
+): Promise<string> {
+    const response = await performLoggedRequest(options);
+
+    return await response.text();
+}

--- a/src/application/commands/shared/schema-utils.test.ts
+++ b/src/application/commands/shared/schema-utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { isPlainObject, readWidgetName } from "./schema-utils.ts";
+
+describe("schema utils", () => {
+    test("reads widget names only from plain objects", () => {
+        expect(readWidgetName({
+            widget: "file",
+        })).toBe("file");
+        expect(readWidgetName({
+            widget: 1,
+        })).toBeUndefined();
+        expect(readWidgetName(["file"])).toBeUndefined();
+    });
+
+    test("identifies plain objects and null-prototype objects", () => {
+        expect(isPlainObject({})).toBe(true);
+        expect(isPlainObject(Object.create(null))).toBe(true);
+        expect(isPlainObject([])).toBe(false);
+        expect(isPlainObject(new URL("https://example.com"))).toBe(false);
+    });
+});

--- a/src/application/commands/shared/schema-utils.ts
+++ b/src/application/commands/shared/schema-utils.ts
@@ -1,0 +1,19 @@
+export function isPlainObject<T extends object = Record<string, unknown>>(
+    value: unknown,
+): value is T {
+    if (value === null || typeof value !== "object") {
+        return false;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+
+    return prototype === Object.prototype || prototype === null;
+}
+
+export function readWidgetName(ext: unknown): string | undefined {
+    if (!isPlainObject<{ widget?: unknown }>(ext) || typeof ext.widget !== "string") {
+        return undefined;
+    }
+
+    return ext.widget;
+}

--- a/src/application/commands/skills/config/set.test.ts
+++ b/src/application/commands/skills/config/set.test.ts
@@ -72,6 +72,14 @@ describe("skills config set command", () => {
             expect(await readFile(ownershipFilePath, "utf8")).toContain(
                 "allow_implicit_invocation: false",
             );
+            expect(await readFile(
+                resolveStorePaths({
+                    appName: APP_NAME,
+                    env: sandbox.env,
+                    platform: process.platform,
+                }).settingsFilePath,
+                "utf8",
+            )).toContain("implicit_invocation = false");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/config/set.ts
+++ b/src/application/commands/skills/config/set.ts
@@ -1,4 +1,5 @@
 import type { CliCommandDefinition } from "../../../contracts/cli.ts";
+import type { AppSettings } from "../../../schemas/settings.ts";
 import type { SkillConfigSkillName } from "./shared.ts";
 
 import { z } from "zod";
@@ -6,12 +7,14 @@ import { maybeSynchronizeInstalledBundledSkills } from "../shared.ts";
 import {
     createInvalidSkillConfigKeyError,
     createInvalidSkillConfigSkillError,
-    getSkillConfigDefinition,
     getSkillConfigDefinitionByRawInput,
     skillConfigSkillSchema,
 } from "./shared.ts";
 
-interface SkillsConfigSetInput {
+interface ResolvedSkillsConfigSetInput {
+    definition: {
+        setValue: (settings: AppSettings, value: string) => AppSettings;
+    };
     key: string;
     skill: SkillConfigSkillName;
     value: string;
@@ -46,10 +49,15 @@ const skillsConfigSetInputSchema = z.object({
         return z.NEVER;
     }
 
-    return input;
+    return {
+        definition,
+        key: input.key,
+        skill: input.skill,
+        value: input.value,
+    } as ResolvedSkillsConfigSetInput;
 });
 
-export const skillsConfigSetCommand: CliCommandDefinition<SkillsConfigSetInput> = {
+export const skillsConfigSetCommand: CliCommandDefinition<ResolvedSkillsConfigSetInput> = {
     name: "set",
     summaryKey: "commands.skills.config.set.summary",
     descriptionKey: "commands.skills.config.set.description",
@@ -86,14 +94,13 @@ export const skillsConfigSetCommand: CliCommandDefinition<SkillsConfigSetInput> 
         }
 
         return definition.createInvalidValueError(
-            rawInput.skill as SkillsConfigSetInput["skill"],
+            rawInput.skill as ResolvedSkillsConfigSetInput["skill"],
             rawInput.value,
         );
     },
     handler: async (input, context) => {
-        const definition = getSkillConfigDefinition(input.skill, input.key);
         const nextSettings = await context.settingsStore.update(settings =>
-            definition.setValue(settings, input.value),
+            input.definition.setValue(settings, input.value),
         );
 
         await maybeSynchronizeInstalledBundledSkills(context, {

--- a/src/application/commands/skills/config/shared.test.ts
+++ b/src/application/commands/skills/config/shared.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { defaultSettings } from "../../../schemas/settings.ts";
 import {
     getSkillConfigDefinition,
+    getSkillConfigDefinitionByRawInput,
     getSkillConfigKeyChoices,
     listSkillConfigValues,
     skillConfigSkillChoices,
@@ -26,5 +27,15 @@ describe("skills config shared contracts", () => {
         );
 
         expect(definition.valueChoices).toEqual(["true", "false"]);
+    });
+
+    test("keeps skill config lookup helpers aligned with key choices", () => {
+        const [key] = getSkillConfigKeyChoices("oo");
+
+        expect(key).toBe("allow-implicit-invocation");
+        expect(getSkillConfigDefinitionByRawInput("oo", key)).toBe(
+            getSkillConfigDefinition("oo", key!),
+        );
+        expect(getSkillConfigDefinitionByRawInput("oo", "missing")).toBeUndefined();
     });
 });

--- a/src/application/commands/skills/config/shared.ts
+++ b/src/application/commands/skills/config/shared.ts
@@ -103,14 +103,14 @@ export function createInvalidSkillConfigKeyError(
 export function getSkillConfigKeyChoices(
     skillName: SkillConfigSkillName,
 ): readonly string[] {
-    return Object.keys(skillConfigDefinitions[skillName]);
+    return Object.keys(getSkillConfigDefinitions(skillName));
 }
 
 export function getSkillConfigDefinition(
     skillName: SkillConfigSkillName,
     key: string,
 ): SkillConfigDefinition {
-    return skillConfigDefinitions[skillName][key]!;
+    return getSkillConfigDefinitions(skillName)[key]!;
 }
 
 export function getSkillConfigValue(
@@ -138,9 +138,17 @@ export function getSkillConfigDefinitionByRawInput(
         return undefined;
     }
 
-    if (!(rawKey in skillConfigDefinitions[rawSkillName])) {
+    const definitions = getSkillConfigDefinitions(rawSkillName);
+
+    if (!(rawKey in definitions)) {
         return undefined;
     }
 
-    return skillConfigDefinitions[rawSkillName][rawKey];
+    return definitions[rawKey];
+}
+
+function getSkillConfigDefinitions(
+    skillName: SkillConfigSkillName,
+): Record<string, SkillConfigDefinition> {
+    return skillConfigDefinitions[skillName];
 }

--- a/src/application/commands/skills/search.ts
+++ b/src/application/commands/skills/search.ts
@@ -4,12 +4,10 @@ import type { AuthAccount } from "../../schemas/auth.ts";
 import type { TerminalColors } from "../../terminal-colors.ts";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import {
-    withRequestTarget,
-} from "../../logging/log-fields.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { readCurrentAuth } from "../auth/shared.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { requestText } from "../shared/request.ts";
 
 const searchFormatValues = ["json"] as const;
 const skillSearchResultLimit = 5;
@@ -169,71 +167,40 @@ async function requestSkillsSearch(
     apiKey: string,
     context: Pick<CliExecutionContext, "fetcher" | "logger">,
 ): Promise<string> {
-    const requestStartedAt = Date.now();
     const keywordCount = requestUrl.searchParams.getAll("keywords").length;
 
-    context.logger.debug(
-        {
-            keywordCount,
-            textLength: requestUrl.searchParams.get("text")?.length ?? 0,
-            ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+    return await requestText({
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.skillsSearch.requestFailed",
+            1,
+            {
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.skillsSearch.requestError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            common: {
+                keywordCount,
+            },
+            start: {
+                textLength: requestUrl.searchParams.get("text")?.length ?? 0,
+            },
         },
-        "Skills search request started.",
-    );
-
-    try {
-        const response = await context.fetcher(requestUrl, {
+        init: {
             headers: {
                 Authorization: apiKey,
             },
-        });
-        const durationMs = Date.now() - requestStartedAt;
-
-        if (!response.ok) {
-            context.logger.warn(
-                {
-                    durationMs,
-                    keywordCount,
-                    status: response.status,
-                    ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-                },
-                "Skills search request returned a non-success status.",
-            );
-            throw new CliUserError("errors.skillsSearch.requestFailed", 1, {
-                status: response.status,
-            });
-        }
-
-        context.logger.debug(
-            {
-                durationMs,
-                keywordCount,
-                status: response.status,
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-            },
-            "Skills search request completed.",
-        );
-
-        return await response.text();
-    }
-    catch (error) {
-        if (error instanceof CliUserError) {
-            throw error;
-        }
-
-        context.logger.warn(
-            {
-                durationMs: Date.now() - requestStartedAt,
-                err: error,
-                keywordCount,
-                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
-            },
-            "Skills search request failed unexpectedly.",
-        );
-        throw new CliUserError("errors.skillsSearch.requestError", 1, {
-            message: error instanceof Error ? error.message : String(error),
-        });
-    }
+        },
+        requestLabel: "Skills search",
+        requestUrl,
+    });
 }
 
 function parseSkillsSearchResponse(rawResponse: string): {

--- a/src/application/semver.test.ts
+++ b/src/application/semver.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { compareSemver, isSemver } from "./semver.ts";
+
+describe("semver", () => {
+    test("accepts valid semver strings and rejects invalid ones", () => {
+        expect(isSemver("1.2.3")).toBe(true);
+        expect(isSemver("1.2.3-beta.1+build.09")).toBe(true);
+        expect(isSemver("1.2")).toBe(false);
+        expect(isSemver("1.2.3-beta.01")).toBe(false);
+    });
+
+    test("compares stable, prerelease, and invalid versions", () => {
+        expect(compareSemver("1.2.4", "1.2.3")).toBe(1);
+        expect(compareSemver("1.2.3", "1.2.3")).toBe(0);
+        expect(compareSemver("1.2.3", "1.2.3-beta.1")).toBe(1);
+        expect(compareSemver("1.2.3-beta.2", "1.2.3-beta.10")).toBe(-1);
+        expect(compareSemver("invalid", "1.2.3")).toBe(0);
+    });
+});

--- a/src/application/semver.ts
+++ b/src/application/semver.ts
@@ -1,0 +1,225 @@
+export function isSemver(value: string): boolean {
+    return parseSemver(value) !== null;
+}
+
+export function compareSemver(left: string, right: string): number {
+    const parsedLeft = parseSemver(left);
+    const parsedRight = parseSemver(right);
+
+    if (parsedLeft === null || parsedRight === null) {
+        return 0;
+    }
+
+    for (const [index, leftValue] of parsedLeft.core.entries()) {
+        const rightValue = parsedRight.core[index]!;
+
+        if (leftValue !== rightValue) {
+            return leftValue > rightValue ? 1 : -1;
+        }
+    }
+
+    return comparePrereleaseIdentifiers(
+        parsedLeft.prerelease,
+        parsedRight.prerelease,
+    );
+}
+
+interface ParsedSemver {
+    core: readonly [number, number, number];
+    prerelease: readonly (number | string)[];
+}
+
+function parseSemver(value: string): ParsedSemver | null {
+    if (value === "") {
+        return null;
+    }
+
+    const [versionWithoutBuild, buildMetadata] = splitSection(value, "+");
+    const [coreVersion, prereleaseVersion] = splitSection(versionWithoutBuild, "-");
+    const coreParts = coreVersion.split(".");
+
+    if (coreParts.length !== 3) {
+        return null;
+    }
+
+    const parsedCore = coreParts.map(parseNumericIdentifier);
+
+    if (parsedCore.includes(null)) {
+        return null;
+    }
+
+    if (buildMetadata !== undefined && !isIdentifierList(buildMetadata, true)) {
+        return null;
+    }
+
+    const prereleaseParts = prereleaseVersion === undefined
+        ? []
+        : prereleaseVersion.split(".");
+    const parsedPrerelease = prereleaseParts.map(parsePrereleaseIdentifier);
+
+    if (parsedPrerelease.includes(null)) {
+        return null;
+    }
+
+    return {
+        core: [
+            parsedCore[0]!,
+            parsedCore[1]!,
+            parsedCore[2]!,
+        ],
+        prerelease: parsedPrerelease as readonly (number | string)[],
+    };
+}
+
+function splitSection(
+    value: string,
+    separator: string,
+): [string, string | undefined] {
+    const separatorIndex = value.indexOf(separator);
+
+    if (separatorIndex < 0) {
+        return [value, undefined];
+    }
+
+    return [
+        value.slice(0, separatorIndex),
+        value.slice(separatorIndex + separator.length),
+    ];
+}
+
+function isIdentifierList(
+    value: string,
+    allowLeadingZeroNumeric: boolean,
+): boolean {
+    if (value === "") {
+        return false;
+    }
+
+    return value.split(".").every((identifier) => {
+        if (!isIdentifier(identifier)) {
+            return false;
+        }
+
+        if (
+            !allowLeadingZeroNumeric
+            && isDigits(identifier)
+            && identifier.length > 1
+            && identifier.startsWith("0")
+        ) {
+            return false;
+        }
+
+        return true;
+    });
+}
+
+function isIdentifier(value: string): boolean {
+    if (value === "") {
+        return false;
+    }
+
+    return Array.from(value).every(character =>
+        isAsciiDigit(character)
+        || isAsciiLetter(character)
+        || character === "-",
+    );
+}
+
+function parseNumericIdentifier(value: string): number | null {
+    if (!isDigits(value) || (value.length > 1 && value.startsWith("0"))) {
+        return null;
+    }
+
+    const parsedValue = Number.parseInt(value, 10);
+
+    return Number.isSafeInteger(parsedValue) ? parsedValue : null;
+}
+
+function parsePrereleaseIdentifier(value: string): number | string | null {
+    if (!isIdentifier(value)) {
+        return null;
+    }
+
+    if (!isDigits(value)) {
+        return value;
+    }
+
+    if (value.length > 1 && value.startsWith("0")) {
+        return null;
+    }
+
+    const parsedValue = Number.parseInt(value, 10);
+
+    return Number.isSafeInteger(parsedValue) ? parsedValue : null;
+}
+
+function comparePrereleaseIdentifiers(
+    left: readonly (number | string)[],
+    right: readonly (number | string)[],
+): number {
+    if (left.length === 0 && right.length === 0) {
+        return 0;
+    }
+
+    if (left.length === 0) {
+        return 1;
+    }
+
+    if (right.length === 0) {
+        return -1;
+    }
+
+    const partCount = Math.max(left.length, right.length);
+
+    for (let index = 0; index < partCount; index += 1) {
+        const leftPart = left[index];
+        const rightPart = right[index];
+
+        if (leftPart === undefined) {
+            return -1;
+        }
+
+        if (rightPart === undefined) {
+            return 1;
+        }
+
+        if (leftPart === rightPart) {
+            continue;
+        }
+
+        if (typeof leftPart === "number" && typeof rightPart === "number") {
+            return leftPart > rightPart ? 1 : -1;
+        }
+
+        if (typeof leftPart === "number") {
+            return -1;
+        }
+
+        if (typeof rightPart === "number") {
+            return 1;
+        }
+
+        return leftPart > rightPart ? 1 : -1;
+    }
+
+    return 0;
+}
+
+function isDigits(value: string): boolean {
+    if (value === "") {
+        return false;
+    }
+
+    return Array.from(value).every(character => isAsciiDigit(character));
+}
+
+function isAsciiDigit(character: string): boolean {
+    return character >= "0" && character <= "9";
+}
+
+function isAsciiLetter(character: string): boolean {
+    return (
+        (character >= "a" && character <= "z")
+        || (character >= "A" && character <= "Z")
+    );
+}

--- a/src/application/update/update-notifier.test.ts
+++ b/src/application/update/update-notifier.test.ts
@@ -28,6 +28,32 @@ describe("update notifier", () => {
         expect(compareReleaseVersions("1.2.3", "1.2.4")).toBe(-1);
         expect(compareReleaseVersions("1.2.3", "1.2.3-beta.1")).toBe(1);
         expect(compareReleaseVersions("1.2.3-beta.2", "1.2.3-beta.10")).toBe(-1);
+        expect(compareReleaseVersions("1.2.3+build.1", "1.2.3+build.2")).toBe(0);
+    });
+
+    test("accepts build metadata in the current version check", async () => {
+        const notifier = createUpdateNotifierHarness({
+            fetcher: async () => new Response(JSON.stringify({
+                "dist-tags": {
+                    latest: "1.0.1",
+                },
+            })),
+        });
+
+        try {
+            notifier.context.version = "1.0.0+build.1";
+            notifier.context.versionText = "1.0.0+build.1";
+
+            const result = await checkForCliUpdate(notifier.context);
+
+            expect(result).toEqual({
+                latestVersion: "1.0.1",
+                status: "update-available",
+            });
+        }
+        finally {
+            notifier.close();
+        }
     });
 
     test("resolves package-manager-specific upgrade commands", () => {

--- a/src/application/update/update-notifier.ts
+++ b/src/application/update/update-notifier.ts
@@ -2,6 +2,7 @@ import type { CliExecutionContext, Fetcher, Writer } from "../contracts/cli.ts";
 
 import type { TerminalColors } from "../terminal-colors.ts";
 import { APP_NAME } from "../config/app-config.ts";
+import { compareSemver, isSemver as isValidSemver } from "../semver.ts";
 import { createWriterColors } from "../terminal-colors.ts";
 
 const defaultRegistryUrl = "https://registry.npmjs.org/";
@@ -26,11 +27,6 @@ type LatestReleaseRequestAttemptResult
         | LatestReleaseRequestRetryableFailure
         | LatestReleaseRequestTerminalFailure;
 
-interface ParsedReleaseVersion {
-    core: readonly [number, number, number];
-    prerelease: readonly (number | string)[];
-}
-
 export type CliUpdateCheckResult
     = | {
         status: "failed";
@@ -52,7 +48,7 @@ export async function checkForCliUpdate(
     context: CliExecutionContext,
 ): Promise<CliUpdateCheckResult> {
     try {
-        if (parseReleaseVersion(context.version) === null) {
+        if (!isValidSemver(context.version)) {
             context.logger.debug(
                 {
                     currentVersion: context.version,
@@ -193,25 +189,7 @@ function renderNoticeBodyLine(
 }
 
 export function compareReleaseVersions(left: string, right: string): number {
-    const parsedLeft = parseReleaseVersion(left);
-    const parsedRight = parseReleaseVersion(right);
-
-    if (parsedLeft === null || parsedRight === null) {
-        return 0;
-    }
-
-    for (const [index, leftValue] of parsedLeft.core.entries()) {
-        const rightValue = parsedRight.core[index]!;
-
-        if (leftValue !== rightValue) {
-            return leftValue > rightValue ? 1 : -1;
-        }
-    }
-
-    return comparePrereleaseIdentifiers(
-        parsedLeft.prerelease,
-        parsedRight.prerelease,
-    );
+    return compareSemver(left, right);
 }
 
 export function resolvePackageManagerUpgradeCommand(
@@ -486,164 +464,6 @@ function normalizePackageManagerName(value: string | undefined): string | undefi
         default:
             return undefined;
     }
-}
-
-function parseReleaseVersion(value: string): ParsedReleaseVersion | null {
-    if (value === "") {
-        return null;
-    }
-
-    const buildSeparatorIndex = value.indexOf("+");
-    const versionWithoutBuild = buildSeparatorIndex >= 0
-        ? value.slice(0, buildSeparatorIndex)
-        : value;
-    const prereleaseSeparatorIndex = versionWithoutBuild.indexOf("-");
-    const coreVersion = prereleaseSeparatorIndex >= 0
-        ? versionWithoutBuild.slice(0, prereleaseSeparatorIndex)
-        : versionWithoutBuild;
-    const prereleaseVersion = prereleaseSeparatorIndex >= 0
-        ? versionWithoutBuild.slice(prereleaseSeparatorIndex + 1)
-        : "";
-    const coreParts = coreVersion.split(".");
-
-    if (coreParts.length !== 3) {
-        return null;
-    }
-
-    const parsedCore = coreParts.map(parseNumericIdentifier);
-
-    if (parsedCore.includes(null)) {
-        return null;
-    }
-
-    const prereleaseParts = prereleaseVersion === ""
-        ? []
-        : prereleaseVersion.split(".");
-    const parsedPrerelease = prereleaseParts.map(parsePrereleaseIdentifier);
-
-    if (parsedPrerelease.includes(null)) {
-        return null;
-    }
-
-    return {
-        core: [
-            parsedCore[0]!,
-            parsedCore[1]!,
-            parsedCore[2]!,
-        ],
-        prerelease: parsedPrerelease as readonly (number | string)[],
-    };
-}
-
-function parseNumericIdentifier(value: string): number | null {
-    if (value === "" || (value.length > 1 && value.startsWith("0"))) {
-        return null;
-    }
-
-    for (const character of value) {
-        if (!isAsciiDigit(character)) {
-            return null;
-        }
-    }
-
-    const parsedValue = Number.parseInt(value, 10);
-
-    return Number.isSafeInteger(parsedValue) ? parsedValue : null;
-}
-
-function parsePrereleaseIdentifier(value: string): number | string | null {
-    if (value === "") {
-        return null;
-    }
-
-    let isNumeric = true;
-
-    for (const character of value) {
-        if (!isAllowedPrereleaseCharacter(character)) {
-            return null;
-        }
-
-        if (!isAsciiDigit(character)) {
-            isNumeric = false;
-        }
-    }
-
-    if (!isNumeric) {
-        return value;
-    }
-
-    if (value.length > 1 && value.startsWith("0")) {
-        return null;
-    }
-
-    const parsedValue = Number.parseInt(value, 10);
-
-    return Number.isSafeInteger(parsedValue) ? parsedValue : null;
-}
-
-function comparePrereleaseIdentifiers(
-    left: readonly (number | string)[],
-    right: readonly (number | string)[],
-): number {
-    if (left.length === 0 && right.length === 0) {
-        return 0;
-    }
-
-    if (left.length === 0) {
-        return 1;
-    }
-
-    if (right.length === 0) {
-        return -1;
-    }
-
-    const partCount = Math.max(left.length, right.length);
-
-    for (let index = 0; index < partCount; index += 1) {
-        const leftPart = left[index];
-        const rightPart = right[index];
-
-        if (leftPart === undefined) {
-            return -1;
-        }
-
-        if (rightPart === undefined) {
-            return 1;
-        }
-
-        if (leftPart === rightPart) {
-            continue;
-        }
-
-        if (typeof leftPart === "number" && typeof rightPart === "number") {
-            return leftPart > rightPart ? 1 : -1;
-        }
-
-        if (typeof leftPart === "number") {
-            return -1;
-        }
-
-        if (typeof rightPart === "number") {
-            return 1;
-        }
-
-        return leftPart > rightPart ? 1 : -1;
-    }
-
-    return 0;
-}
-
-function isAsciiDigit(value: string): boolean {
-    return value >= "0" && value <= "9";
-}
-
-function isAsciiLetter(value: string): boolean {
-    return (value >= "a" && value <= "z")
-        || (value >= "A" && value <= "Z");
-}
-
-function isAllowedPrereleaseCharacter(value: string): boolean {
-    return isAsciiDigit(value) || isAsciiLetter(value) || value === "-";
 }
 
 function measureDisplayWidth(value: string): number {


### PR DESCRIPTION
Consolidate duplicated HTTP request boilerplate (logging, error handling, duration tracking) from cloud-task, file, package, and skills commands into shared request helpers. Extract semver parsing and comparison into a dedicated module, replacing inline implementations in package/shared and update-notifier. Pull isPlainObject and readWidgetName into schema-utils. Decompose large methods in commander-cli-adapter and run-cli into focused functions (configureCommand, bindCommandHandler,
initializeCliStores, createCliExecutionContext).