### PR TITLE
refactor: extract shared request, semver, and schema utilities

### DIFF
--- a/src/application/commands/skills/bundled-skill-filesystem.ts
+++ b/src/application/commands/skills/bundled-skill-filesystem.ts
@@ -1,0 +1,321 @@
+import {
+    cp,
+    lstat,
+    mkdir,
+    readlink,
+    realpath,
+    rm,
+    rmdir,
+    symlink,
+} from "node:fs/promises";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import process from "node:process";
+
+export interface BundledSkillPublicationResult {
+    mode: "copy" | "symlink";
+    path: string;
+}
+
+interface BundledSkillPublicationDependencies {
+    createDirectorySymlink?: (
+        targetPath: string,
+        linkPath: string,
+    ) => Promise<boolean>;
+}
+
+type BundledSkillDirectorySymlinkAttempt
+    = | {
+        kind: "reuse";
+    }
+    | {
+        kind: "create";
+        resolvedLinkPath: string;
+        resolvedTargetPath: string;
+    };
+
+export interface CreateBundledSkillDirectorySymlinkDependencies {
+    lstat?: (path: string) => Promise<{
+        isSymbolicLink: () => boolean;
+    }>;
+    mkdir?: (
+        path: string,
+        options: {
+            recursive: true;
+        },
+    ) => Promise<void>;
+    readlink?: (path: string) => Promise<string>;
+    realpath?: (path: string) => Promise<string>;
+    removePath?: (path: string) => Promise<void>;
+    resolveParentSymlinks?: (path: string) => Promise<string>;
+    symlink?: (
+        targetPath: string,
+        linkPath: string,
+        type: "dir" | "junction",
+    ) => Promise<void>;
+}
+
+export interface RemoveBundledSkillSymbolicPathDependencies {
+    rm?: (
+        path: string,
+        options: {
+            force: true;
+        },
+    ) => Promise<void>;
+    rmdir?: (path: string) => Promise<void>;
+}
+
+export async function publishBundledSkillInstallation(
+    options: {
+        canonicalSkillDirectoryPath: string;
+        installedSkillDirectoryPath: string;
+    },
+    dependencies: BundledSkillPublicationDependencies = {},
+): Promise<BundledSkillPublicationResult> {
+    const createDirectoryLink
+        = dependencies.createDirectorySymlink ?? createBundledSkillDirectorySymlink;
+    const symlinkCreated = await createDirectoryLink(
+        options.canonicalSkillDirectoryPath,
+        options.installedSkillDirectoryPath,
+    );
+
+    if (symlinkCreated) {
+        return {
+            mode: "symlink",
+            path: options.installedSkillDirectoryPath,
+        };
+    }
+
+    await copyBundledSkillDirectory(
+        options.canonicalSkillDirectoryPath,
+        options.installedSkillDirectoryPath,
+    );
+
+    return {
+        mode: "copy",
+        path: options.installedSkillDirectoryPath,
+    };
+}
+
+export function isNodeNotFoundError(
+    error: unknown,
+): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function isSymlinkLoopError(error: unknown): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "ELOOP";
+}
+
+export async function createBundledSkillDirectorySymlink(
+    targetPath: string,
+    linkPath: string,
+    dependencies: CreateBundledSkillDirectorySymlinkDependencies = {},
+): Promise<boolean> {
+    const lstatFn = dependencies.lstat ?? lstat;
+    const mkdirFn = dependencies.mkdir ?? mkdir;
+    const readlinkFn = dependencies.readlink ?? readlink;
+    const realpathFn = dependencies.realpath ?? realpath;
+    const removePathFn = dependencies.removePath ?? removePath;
+    const resolveParentSymlinksFn
+        = dependencies.resolveParentSymlinks ?? resolveParentSymlinks;
+    const symlinkFn = dependencies.symlink ?? symlink;
+
+    try {
+        const attempt = await resolveBundledSkillDirectorySymlinkAttempt(
+            targetPath,
+            linkPath,
+            {
+                lstat: lstatFn,
+                readlink: readlinkFn,
+                realpath: realpathFn,
+                removePath: removePathFn,
+                resolveParentSymlinks: resolveParentSymlinksFn,
+            },
+        );
+
+        if (attempt.kind === "reuse") {
+            return true;
+        }
+
+        const linkDirectoryPath = dirname(attempt.resolvedLinkPath);
+
+        await mkdirFn(linkDirectoryPath, { recursive: true });
+
+        const symlinkTargetPath = process.platform === "win32"
+            ? attempt.resolvedTargetPath
+            : relative(
+                    await resolveParentSymlinksFn(linkDirectoryPath),
+                    attempt.resolvedTargetPath,
+                );
+
+        await symlinkFn(
+            symlinkTargetPath,
+            attempt.resolvedLinkPath,
+            process.platform === "win32" ? "junction" : "dir",
+        );
+
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+
+async function resolveBundledSkillDirectorySymlinkAttempt(
+    targetPath: string,
+    linkPath: string,
+    dependencies: Pick<
+        CreateBundledSkillDirectorySymlinkDependencies,
+        "lstat" | "readlink" | "realpath" | "removePath" | "resolveParentSymlinks"
+    >,
+): Promise<BundledSkillDirectorySymlinkAttempt> {
+    const resolvedTargetPath = resolve(targetPath);
+    const resolvedLinkPath = resolve(linkPath);
+    const realpathFn = dependencies.realpath ?? realpath;
+    const [realTargetPath, realLinkPath] = await Promise.all([
+        realpathFn(resolvedTargetPath).catch(() => resolvedTargetPath),
+        realpathFn(resolvedLinkPath).catch(() => resolvedLinkPath),
+    ]);
+
+    if (realTargetPath === realLinkPath) {
+        return {
+            kind: "reuse",
+        };
+    }
+
+    const resolveParentSymlinksFn
+        = dependencies.resolveParentSymlinks ?? resolveParentSymlinks;
+    const [realTargetPathWithParents, realLinkPathWithParents] = await Promise.all([
+        resolveParentSymlinksFn(resolvedTargetPath),
+        resolveParentSymlinksFn(resolvedLinkPath),
+    ]);
+
+    if (realTargetPathWithParents === realLinkPathWithParents) {
+        return {
+            kind: "reuse",
+        };
+    }
+
+    const lstatFn = dependencies.lstat ?? lstat;
+    const readlinkFn = dependencies.readlink ?? readlink;
+    const removePathFn = dependencies.removePath ?? removePath;
+
+    try {
+        const existingStats = await lstatFn(resolvedLinkPath);
+
+        if (existingStats.isSymbolicLink()) {
+            const existingTarget = await readlinkFn(resolvedLinkPath);
+
+            if (
+                resolveSymlinkTarget(resolvedLinkPath, existingTarget)
+                === resolvedTargetPath
+            ) {
+                return {
+                    kind: "reuse",
+                };
+            }
+        }
+
+        await removePathFn(resolvedLinkPath);
+    }
+    catch (error) {
+        if (isSymlinkLoopError(error)) {
+            try {
+                await removePathFn(resolvedLinkPath);
+            }
+            catch {
+                // Let symlink creation determine whether copy fallback is needed.
+            }
+        }
+        else if (!isNodeNotFoundError(error)) {
+            throw error;
+        }
+    }
+
+    return {
+        kind: "create",
+        resolvedLinkPath,
+        resolvedTargetPath,
+    };
+}
+
+async function copyBundledSkillDirectory(
+    sourcePath: string,
+    destinationPath: string,
+): Promise<void> {
+    await removePath(destinationPath);
+    await mkdir(dirname(destinationPath), { recursive: true });
+    await cp(sourcePath, destinationPath, {
+        dereference: true,
+        force: true,
+        recursive: true,
+    });
+}
+
+export async function removePath(path: string): Promise<void> {
+    try {
+        const pathStats = await lstat(path);
+
+        if (pathStats.isSymbolicLink()) {
+            await removeBundledSkillSymbolicPath(path);
+            return;
+        }
+
+        await rm(path, { force: true, recursive: true });
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return;
+        }
+
+        throw error;
+    }
+}
+
+export async function removeBundledSkillSymbolicPath(
+    path: string,
+    dependencies: RemoveBundledSkillSymbolicPathDependencies = {},
+): Promise<void> {
+    const rmFn = dependencies.rm ?? rm;
+    const rmdirFn = dependencies.rmdir ?? rmdir;
+
+    try {
+        await rmFn(path, { force: true });
+    }
+    catch (error) {
+        if (process.platform === "win32" && isWindowsBadAddressError(error)) {
+            await rmdirFn(path);
+            return;
+        }
+
+        throw error;
+    }
+}
+
+function isWindowsBadAddressError(
+    error: unknown,
+): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "EFAULT";
+}
+
+async function resolveParentSymlinks(path: string): Promise<string> {
+    const resolvedPath = resolve(path);
+    const parentPath = dirname(resolvedPath);
+    const baseName = basename(resolvedPath);
+
+    try {
+        const realParentPath = await realpath(parentPath);
+
+        return join(realParentPath, baseName);
+    }
+    catch {
+        return resolvedPath;
+    }
+}
+
+function resolveSymlinkTarget(
+    linkPath: string,
+    linkTargetPath: string,
+): string {
+    return resolve(dirname(linkPath), linkTargetPath);
+}

--- a/src/application/commands/skills/bundled-skill-model.test.ts
+++ b/src/application/commands/skills/bundled-skill-model.test.ts
@@ -1,0 +1,159 @@
+import type { AppSettings } from "../../schemas/settings.ts";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    canUninstallManagedBundledSkillInstallation,
+    isBundledSkillInstallationCurrentState,
+    isManagedBundledSkillOwnershipContent,
+    parseBundledSkillMetadataContent,
+    readImplicitInvocationValue,
+    renderBundledSkillFileContent,
+    renderBundledSkillMetadataContent,
+    resolveBundledSkillInstallConflict,
+    resolveBundledSkillManagedSynchronizationAction,
+    resolveBundledSkillMissingInstallationAction,
+    writeImplicitInvocationValue,
+} from "./bundled-skill-model.ts";
+
+describe("bundled skill model", () => {
+    test("renders the ownership policy file with the configured implicit invocation value", () => {
+        const settings: AppSettings = {
+            skills: {
+                oo: {
+                    implicit_invocation: false,
+                },
+            },
+        };
+        const content = [
+            "policy:",
+            "  allow_implicit_invocation: true",
+            "",
+        ].join("\n");
+
+        expect(
+            renderBundledSkillFileContent(
+                "oo",
+                "agents/openai.yaml",
+                content,
+                settings,
+            ),
+        ).toContain("allow_implicit_invocation: false");
+        expect(
+            renderBundledSkillFileContent("oo", "SKILL.md", "skill\n", settings),
+        ).toBe("skill\n");
+    });
+
+    test("reads and writes the implicit invocation value while preserving CRLF formatting", () => {
+        const content = [
+            "policy:",
+            "  allow_implicit_invocation: true",
+            "",
+        ].join("\r\n");
+
+        expect(readImplicitInvocationValue(content)).toBeTrue();
+        expect(writeImplicitInvocationValue(content, false)).toBe(
+            [
+                "policy:",
+                "  allow_implicit_invocation: false",
+                "",
+            ].join("\r\n"),
+        );
+        expect(writeImplicitInvocationValue("allow_implicit_invocation: true\n", false)).toBe(
+            "allow_implicit_invocation: false\n",
+        );
+    });
+
+    test("parses and renders bundled skill metadata content", () => {
+        expect(parseBundledSkillMetadataContent("{\"version\":\" 1.2.3 \"}\n")).toEqual({
+            version: "1.2.3",
+        });
+        expect(parseBundledSkillMetadataContent("{\"version\":\"\"}\n")).toBeUndefined();
+        expect(parseBundledSkillMetadataContent("not json")).toBeUndefined();
+        expect(parseBundledSkillMetadataContent("[]")).toBeUndefined();
+        expect(parseBundledSkillMetadataContent("{}")).toBeUndefined();
+        expect(parseBundledSkillMetadataContent("{\"version\":1}")).toBeUndefined();
+        expect(renderBundledSkillMetadataContent({ version: "1.2.3" })).toBe(
+            "{\n  \"version\": \"1.2.3\"\n}\n",
+        );
+    });
+
+    test("detects managed ownership content using the OOMOL marker", () => {
+        expect(isManagedBundledSkillOwnershipContent("# OOMOL\n")).toBeTrue();
+        expect(isManagedBundledSkillOwnershipContent("custom skill\n")).toBeFalse();
+    });
+
+    test("throws when the ownership policy file does not define implicit invocation", () => {
+        expect(() => writeImplicitInvocationValue("policy:\n", false)).toThrow(
+            "Missing allow_implicit_invocation in bundled skill policy file.",
+        );
+    });
+
+    test("resolves install conflicts with the installed path taking priority over canonical storage", () => {
+        expect(resolveBundledSkillInstallConflict({
+            canonicalDirectoryExists: true,
+            canonicalDirectoryManaged: false,
+            installedDirectoryExists: false,
+            installedDirectoryManaged: false,
+        })).toBe("storageConflict");
+        expect(resolveBundledSkillInstallConflict({
+            canonicalDirectoryExists: true,
+            canonicalDirectoryManaged: false,
+            installedDirectoryExists: true,
+            installedDirectoryManaged: false,
+        })).toBe("nameConflict");
+        expect(resolveBundledSkillInstallConflict({
+            canonicalDirectoryExists: true,
+            canonicalDirectoryManaged: true,
+            installedDirectoryExists: true,
+            installedDirectoryManaged: true,
+        })).toBeUndefined();
+    });
+
+    test("resolves synchronization actions for missing and managed installations", () => {
+        expect(resolveBundledSkillMissingInstallationAction(false)).toBe("skip-missing");
+        expect(resolveBundledSkillMissingInstallationAction(true)).toBe("install-missing");
+
+        expect(resolveBundledSkillManagedSynchronizationAction({
+            desiredImplicitInvocation: true,
+            installedImplicitInvocation: true,
+            isCurrentInstallation: false,
+        })).toBe("sync-installation");
+        expect(resolveBundledSkillManagedSynchronizationAction({
+            desiredImplicitInvocation: true,
+            installedImplicitInvocation: true,
+            isCurrentInstallation: true,
+        })).toBe("skip-current");
+        expect(resolveBundledSkillManagedSynchronizationAction({
+            desiredImplicitInvocation: false,
+            installedImplicitInvocation: true,
+            isCurrentInstallation: true,
+        })).toBe("sync-policy");
+    });
+
+    test("evaluates current-state and uninstall decisions from precomputed facts", () => {
+        expect(isBundledSkillInstallationCurrentState({
+            hasAllBundledFiles: true,
+            hasMetadataFile: true,
+            installedVersion: "1.2.3",
+            isManagedInstallation: true,
+            version: "1.2.3",
+        })).toBeTrue();
+        expect(isBundledSkillInstallationCurrentState({
+            hasAllBundledFiles: true,
+            hasMetadataFile: false,
+            installedVersion: "1.2.3",
+            isManagedInstallation: true,
+            version: "1.2.3",
+        })).toBeFalse();
+
+        expect(canUninstallManagedBundledSkillInstallation({
+            installedDirectoryExists: true,
+            installedDirectoryManaged: true,
+        })).toBeTrue();
+        expect(canUninstallManagedBundledSkillInstallation({
+            installedDirectoryExists: true,
+            installedDirectoryManaged: false,
+        })).toBeFalse();
+    });
+});

--- a/src/application/commands/skills/bundled-skill-model.ts
+++ b/src/application/commands/skills/bundled-skill-model.ts
@@ -1,0 +1,211 @@
+import type { AppSettings } from "../../schemas/settings.ts";
+
+import type { BundledSkillName } from "./embedded-assets.ts";
+import { getOoSkillImplicitInvocation } from "../../schemas/settings.ts";
+import { bundledSkillOwnershipFileRelativePath } from "./bundled-skill-paths.ts";
+
+const bundledSkillOwnershipMarker = "OOMOL";
+const bundledSkillImplicitInvocationKey = "allow_implicit_invocation";
+
+export interface BundledSkillMetadata {
+    version: string;
+}
+
+export type BundledSkillInstallConflict = "nameConflict" | "storageConflict";
+
+export type BundledSkillMissingInstallationAction
+    = "install-missing" | "skip-missing";
+
+export type BundledSkillManagedSynchronizationAction
+    = "skip-current" | "sync-installation" | "sync-policy";
+
+export function resolveBundledSkillInstallConflict(input: {
+    canonicalDirectoryExists: boolean;
+    canonicalDirectoryManaged: boolean;
+    installedDirectoryExists: boolean;
+    installedDirectoryManaged: boolean;
+}): BundledSkillInstallConflict | undefined {
+    if (input.installedDirectoryExists && !input.installedDirectoryManaged) {
+        return "nameConflict";
+    }
+
+    if (input.canonicalDirectoryExists && !input.canonicalDirectoryManaged) {
+        return "storageConflict";
+    }
+
+    return undefined;
+}
+
+export function resolveBundledSkillMissingInstallationAction(
+    installMissing: boolean,
+): BundledSkillMissingInstallationAction {
+    return installMissing ? "install-missing" : "skip-missing";
+}
+
+export function resolveBundledSkillManagedSynchronizationAction(input: {
+    desiredImplicitInvocation: boolean;
+    installedImplicitInvocation: boolean | undefined;
+    isCurrentInstallation: boolean;
+}): BundledSkillManagedSynchronizationAction {
+    if (!input.isCurrentInstallation) {
+        return "sync-installation";
+    }
+
+    if (input.installedImplicitInvocation === input.desiredImplicitInvocation) {
+        return "skip-current";
+    }
+
+    return "sync-policy";
+}
+
+export function canUninstallManagedBundledSkillInstallation(input: {
+    installedDirectoryExists: boolean;
+    installedDirectoryManaged: boolean;
+}): boolean {
+    return input.installedDirectoryExists && input.installedDirectoryManaged;
+}
+
+export function resolveBundledSkillImplicitInvocation(
+    skillName: BundledSkillName,
+    settings: AppSettings,
+): boolean {
+    switch (skillName) {
+        case "oo":
+            return getOoSkillImplicitInvocation(settings);
+    }
+}
+
+export function renderBundledSkillFileContent(
+    skillName: BundledSkillName,
+    relativePath: string,
+    content: string,
+    settings: AppSettings,
+): string {
+    if (relativePath !== bundledSkillOwnershipFileRelativePath) {
+        return content;
+    }
+
+    return writeImplicitInvocationValue(
+        content,
+        resolveBundledSkillImplicitInvocation(skillName, settings),
+    );
+}
+
+export function isManagedBundledSkillOwnershipContent(content: string): boolean {
+    return content.includes(bundledSkillOwnershipMarker);
+}
+
+export function readImplicitInvocationValue(
+    content: string,
+): boolean | undefined {
+    for (const line of content.split("\n")) {
+        const trimmedLine = line.trim();
+
+        if (!trimmedLine.startsWith(`${bundledSkillImplicitInvocationKey}:`)) {
+            continue;
+        }
+
+        const rawValue = trimmedLine
+            .slice(bundledSkillImplicitInvocationKey.length + 1)
+            .trim();
+
+        if (rawValue === "true") {
+            return true;
+        }
+
+        if (rawValue === "false") {
+            return false;
+        }
+
+        return undefined;
+    }
+
+    return undefined;
+}
+
+export function writeImplicitInvocationValue(
+    content: string,
+    value: boolean,
+): string {
+    const lineSeparator = content.includes("\r\n") ? "\r\n" : "\n";
+    const lines = content.split(lineSeparator);
+
+    for (const [index, line] of lines.entries()) {
+        const trimmedLine = line.trim();
+
+        if (!trimmedLine.startsWith(`${bundledSkillImplicitInvocationKey}:`)) {
+            continue;
+        }
+
+        const indentation = line.slice(0, line.length - line.trimStart().length);
+
+        lines[index] = [
+            indentation,
+            bundledSkillImplicitInvocationKey,
+            ": ",
+            value ? "true" : "false",
+        ].join("");
+
+        return lines.join(lineSeparator);
+    }
+
+    throw new Error(
+        `Missing ${bundledSkillImplicitInvocationKey} in bundled skill policy file.`,
+    );
+}
+
+export function parseBundledSkillMetadataContent(
+    content: string,
+): BundledSkillMetadata | undefined {
+    let parsedContent: unknown;
+
+    try {
+        parsedContent = JSON.parse(content);
+    }
+    catch {
+        return undefined;
+    }
+
+    if (
+        typeof parsedContent !== "object"
+        || parsedContent === null
+        || Array.isArray(parsedContent)
+    ) {
+        return undefined;
+    }
+
+    const rawVersion = (parsedContent as Record<string, unknown>).version;
+
+    if (typeof rawVersion !== "string") {
+        return undefined;
+    }
+
+    const version = rawVersion.trim();
+
+    if (version === "") {
+        return undefined;
+    }
+
+    return {
+        version,
+    };
+}
+
+export function renderBundledSkillMetadataContent(
+    metadata: BundledSkillMetadata,
+): string {
+    return `${JSON.stringify(metadata, null, 2)}\n`;
+}
+
+export function isBundledSkillInstallationCurrentState(input: {
+    hasAllBundledFiles: boolean;
+    hasMetadataFile: boolean;
+    installedVersion: string | undefined;
+    isManagedInstallation: boolean;
+    version: string;
+}): boolean {
+    return input.isManagedInstallation
+        && input.hasMetadataFile
+        && input.installedVersion === input.version
+        && input.hasAllBundledFiles;
+}

--- a/src/application/commands/skills/bundled-skill-observation.test.ts
+++ b/src/application/commands/skills/bundled-skill-observation.test.ts
@@ -1,0 +1,198 @@
+import { mkdir, readFile, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
+import {
+    directoryExists,
+    fileExists,
+    isBundledSkillInstallationCurrent,
+    isManagedBundledSkillInstallation,
+    readInstalledBundledSkillImplicitInvocation,
+    readInstalledBundledSkillMetadata,
+    readInstalledBundledSkillVersion,
+    requireCodexHomeDirectory,
+    writeInstalledBundledSkillMetadata,
+} from "./bundled-skill-observation.ts";
+import { getBundledSkillFiles } from "./embedded-assets.ts";
+
+describe("bundled skill observation", () => {
+    test("reports directory and file existence from stat-backed wrappers", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const directoryPath = join(rootDirectory, "skill-directory");
+        const filePath = join(rootDirectory, "skill-file.txt");
+
+        try {
+            await mkdir(directoryPath, { recursive: true });
+            await Bun.write(filePath, "skill\n");
+
+            expect(await directoryExists(directoryPath)).toBeTrue();
+            expect(await directoryExists(filePath)).toBeFalse();
+            expect(await directoryExists(join(rootDirectory, "missing"))).toBeFalse();
+
+            expect(await fileExists(filePath)).toBeTrue();
+            expect(await fileExists(directoryPath)).toBeFalse();
+            expect(await fileExists(join(rootDirectory, "missing.txt"))).toBeFalse();
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("reads bundled skill metadata and versions while treating missing or invalid files as undefined", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const skillDirectoryPath = join(rootDirectory, "skills", "oo");
+        const metadataFilePath = join(skillDirectoryPath, ".oo-metadata.json");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+
+            expect(await readInstalledBundledSkillMetadata(skillDirectoryPath)).toBeUndefined();
+            expect(await readInstalledBundledSkillVersion(skillDirectoryPath)).toBeUndefined();
+
+            await Bun.write(metadataFilePath, "not json");
+            expect(await readInstalledBundledSkillMetadata(skillDirectoryPath)).toBeUndefined();
+            expect(await readInstalledBundledSkillVersion(skillDirectoryPath)).toBeUndefined();
+
+            await writeInstalledBundledSkillMetadata(skillDirectoryPath, {
+                version: "1.2.3",
+            });
+            expect(await readInstalledBundledSkillMetadata(skillDirectoryPath)).toEqual({
+                version: "1.2.3",
+            });
+            expect(await readInstalledBundledSkillVersion(skillDirectoryPath)).toBe("1.2.3");
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                "{\n  \"version\": \"1.2.3\"\n}\n",
+            );
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("reads implicit invocation and managed ownership from the ownership file", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const skillDirectoryPath = join(rootDirectory, "skills", "oo");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+
+            expect(await readInstalledBundledSkillImplicitInvocation(skillDirectoryPath)).toBeUndefined();
+            expect(await isManagedBundledSkillInstallation(skillDirectoryPath)).toBeFalse();
+
+            await Bun.write(
+                ownershipFilePath,
+                [
+                    "# OOMOL",
+                    "policy:",
+                    "  allow_implicit_invocation: false",
+                    "",
+                ].join("\n"),
+            );
+
+            expect(await readInstalledBundledSkillImplicitInvocation(skillDirectoryPath)).toBeFalse();
+            expect(await isManagedBundledSkillInstallation(skillDirectoryPath)).toBeTrue();
+
+            await Bun.write(
+                ownershipFilePath,
+                [
+                    "interface:",
+                    "  display_name: oo",
+                    "  short_description: Custom skill",
+                    "",
+                ].join("\n"),
+            );
+
+            expect(await readInstalledBundledSkillImplicitInvocation(skillDirectoryPath)).toBeUndefined();
+            expect(await isManagedBundledSkillInstallation(skillDirectoryPath)).toBeFalse();
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("evaluates current installations using the existing observation order and file facts", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const skillDirectoryPath = join(rootDirectory, "skills", "oo");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(ownershipFilePath, "# OOMOL\n");
+
+            expect(
+                await isBundledSkillInstallationCurrent(
+                    "oo",
+                    skillDirectoryPath,
+                    "1.2.3",
+                ),
+            ).toBeFalse();
+
+            await writeInstalledBundledSkillMetadata(skillDirectoryPath, {
+                version: "0.0.1",
+            });
+            expect(
+                await isBundledSkillInstallationCurrent(
+                    "oo",
+                    skillDirectoryPath,
+                    "1.2.3",
+                ),
+            ).toBeFalse();
+
+            await writeInstalledBundledSkillMetadata(skillDirectoryPath, {
+                version: "1.2.3",
+            });
+            expect(
+                await isBundledSkillInstallationCurrent(
+                    "oo",
+                    skillDirectoryPath,
+                    "1.2.3",
+                ),
+            ).toBeFalse();
+
+            for (const file of getBundledSkillFiles("oo")) {
+                const filePath = join(skillDirectoryPath, file.relativePath);
+
+                await mkdir(join(filePath, ".."), { recursive: true });
+                await Bun.write(filePath, await Bun.file(file.sourcePath).text());
+            }
+
+            expect(
+                await isBundledSkillInstallationCurrent(
+                    "oo",
+                    skillDirectoryPath,
+                    "1.2.3",
+                ),
+            ).toBeTrue();
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("requires the resolved Codex home directory to exist", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const codexHomeDirectory = join(rootDirectory, ".codex");
+        const env = {
+            CODEX_HOME: codexHomeDirectory,
+            HOME: rootDirectory,
+        };
+
+        try {
+            await expect(requireCodexHomeDirectory({ env })).rejects.toMatchObject({
+                exitCode: 1,
+                key: "errors.skills.codexNotInstalled",
+            });
+
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            expect(await requireCodexHomeDirectory({ env })).toBe(codexHomeDirectory);
+            expect((await stat(codexHomeDirectory)).isDirectory()).toBeTrue();
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+});

--- a/src/application/commands/skills/bundled-skill-observation.ts
+++ b/src/application/commands/skills/bundled-skill-observation.ts
@@ -1,0 +1,177 @@
+import type { BundledSkillMetadata } from "./bundled-skill-model.ts";
+import type { BundledSkillName } from "./embedded-assets.ts";
+
+import { readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { CliUserError } from "../../contracts/cli.ts";
+import {
+    isBundledSkillInstallationCurrentState,
+    isManagedBundledSkillOwnershipContent,
+    parseBundledSkillMetadataContent,
+    readImplicitInvocationValue,
+    renderBundledSkillMetadataContent,
+} from "./bundled-skill-model.ts";
+import {
+    bundledSkillOwnershipFileRelativePath,
+    resolveBundledSkillMetadataFilePath,
+    resolveCodexHomeDirectory,
+} from "./bundled-skill-paths.ts";
+import { getBundledSkillFiles } from "./embedded-assets.ts";
+
+export async function requireCodexHomeDirectory(
+    context: Pick<{ env: Record<string, string | undefined> }, "env">,
+): Promise<string> {
+    const codexHomeDirectory = resolveCodexHomeDirectory(context.env);
+
+    if (!(await directoryExists(codexHomeDirectory))) {
+        throw new CliUserError("errors.skills.codexNotInstalled", 1, {
+            path: codexHomeDirectory,
+        });
+    }
+
+    return codexHomeDirectory;
+}
+
+export async function directoryExists(path: string): Promise<boolean> {
+    try {
+        return (await stat(path)).isDirectory();
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+export async function fileExists(path: string): Promise<boolean> {
+    try {
+        return (await stat(path)).isFile();
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+export async function readInstalledBundledSkillImplicitInvocation(
+    skillDirectoryPath: string,
+): Promise<boolean | undefined> {
+    try {
+        const content = await readFile(
+            join(skillDirectoryPath, bundledSkillOwnershipFileRelativePath),
+            "utf8",
+        );
+
+        return readImplicitInvocationValue(content);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
+}
+
+export async function isManagedBundledSkillInstallation(
+    skillDirectoryPath: string,
+): Promise<boolean> {
+    try {
+        const content = await readFile(
+            join(skillDirectoryPath, bundledSkillOwnershipFileRelativePath),
+            "utf8",
+        );
+
+        return isManagedBundledSkillOwnershipContent(content);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+export async function readInstalledBundledSkillVersion(
+    skillDirectoryPath: string,
+): Promise<string | undefined> {
+    const metadata = await readInstalledBundledSkillMetadata(skillDirectoryPath);
+
+    return metadata?.version;
+}
+
+export async function readInstalledBundledSkillMetadata(
+    skillDirectoryPath: string,
+): Promise<BundledSkillMetadata | undefined> {
+    try {
+        const content = await readFile(
+            resolveBundledSkillMetadataFilePath(skillDirectoryPath),
+            "utf8",
+        );
+
+        return parseBundledSkillMetadataContent(content);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
+}
+
+export async function writeInstalledBundledSkillMetadata(
+    skillDirectoryPath: string,
+    metadata: BundledSkillMetadata,
+): Promise<void> {
+    await Bun.write(
+        resolveBundledSkillMetadataFilePath(skillDirectoryPath),
+        renderBundledSkillMetadataContent(metadata),
+    );
+}
+
+export async function isBundledSkillInstallationCurrent(
+    skillName: BundledSkillName,
+    skillDirectoryPath: string,
+    version: string,
+): Promise<boolean> {
+    const managedInstallation = await isManagedBundledSkillInstallation(
+        skillDirectoryPath,
+    );
+    const hasMetadataFile = managedInstallation
+        ? await fileExists(resolveBundledSkillMetadataFilePath(skillDirectoryPath))
+        : false;
+    const installedVersion = hasMetadataFile
+        ? await readInstalledBundledSkillVersion(skillDirectoryPath)
+        : undefined;
+    let hasAllBundledFiles = false;
+
+    if (installedVersion === version) {
+        hasAllBundledFiles = true;
+
+        for (const file of getBundledSkillFiles(skillName)) {
+            if (!(await fileExists(join(skillDirectoryPath, file.relativePath)))) {
+                hasAllBundledFiles = false;
+                break;
+            }
+        }
+    }
+
+    return isBundledSkillInstallationCurrentState({
+        hasAllBundledFiles,
+        hasMetadataFile,
+        installedVersion,
+        isManagedInstallation: managedInstallation,
+        version,
+    });
+}
+
+function isNodeNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/src/application/commands/skills/bundled-skill-paths.ts
+++ b/src/application/commands/skills/bundled-skill-paths.ts
@@ -1,0 +1,42 @@
+import type { BundledSkillName } from "./embedded-assets.ts";
+
+import { dirname, join } from "node:path";
+import { resolveHomeDirectory } from "../../path/home-directory.ts";
+
+const codexDirectoryName = ".codex";
+const codexSkillsDirectoryName = "skills";
+
+export const bundledSkillMetadataFileName = ".oo-metadata.json";
+export const bundledSkillOwnershipFileRelativePath = "agents/openai.yaml";
+
+export function resolveCodexHomeDirectory(
+    env: Record<string, string | undefined>,
+): string {
+    const explicitCodexHome = env.CODEX_HOME?.trim();
+
+    if (explicitCodexHome) {
+        return explicitCodexHome;
+    }
+
+    return join(resolveHomeDirectory(env), codexDirectoryName);
+}
+
+export function resolveBundledSkillDirectoryPath(
+    codexHomeDirectory: string,
+    skillName: BundledSkillName,
+): string {
+    return join(codexHomeDirectory, codexSkillsDirectoryName, skillName);
+}
+
+export function resolveBundledSkillCanonicalDirectoryPath(
+    settingsFilePath: string,
+    skillName: BundledSkillName,
+): string {
+    return join(dirname(settingsFilePath), codexSkillsDirectoryName, skillName);
+}
+
+export function resolveBundledSkillMetadataFilePath(
+    skillDirectoryPath: string,
+): string {
+    return join(skillDirectoryPath, bundledSkillMetadataFileName);
+}

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -190,6 +190,53 @@ describe("skills commands", () => {
         }
     });
 
+    test("refuses to install when the canonical bundled skill storage is occupied by unmanaged content", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+        );
+        const ownershipFilePath = join(
+            canonicalSkillDirectoryPath,
+            "agents",
+            "openai.yaml",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
+                recursive: true,
+            });
+            await Bun.write(
+                ownershipFilePath,
+                [
+                    "interface:",
+                    "  display_name: oo",
+                    "  short_description: Custom skill",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["skills", "install"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                `Bundled skill storage for oo is already occupied by non-OOMOL content at ${canonicalSkillDirectoryPath}.\n`,
+            );
+            expect(await readFile(ownershipFilePath, "utf8")).not.toContain("OOMOL");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("uninstalls a bundled Codex skill from the Codex skills directory", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -263,6 +310,61 @@ describe("skills commands", () => {
         }
     });
 
+    test("uninstall removes canonical bundled skill storage even when it contains unmanaged content", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+        );
+        const canonicalOwnershipFilePath = join(
+            canonicalSkillDirectoryPath,
+            "agents",
+            "openai.yaml",
+        );
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
+                recursive: true,
+            });
+            await Bun.write(ownershipFilePath, "# OOMOL\n");
+            await Bun.write(
+                canonicalOwnershipFilePath,
+                [
+                    "interface:",
+                    "  display_name: oo",
+                    "  short_description: Custom skill",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["skills", "uninstall"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Removed Codex skill oo from ${skillDirectoryPath}.\n`,
+            );
+            expect(result.stderr).toBe("");
+            await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(canonicalSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("silently synchronizes installed bundled skills when the oo version changes", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -303,6 +405,69 @@ describe("skills commands", () => {
             await expect(stat(obsoleteFilePath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rewrites canonical bundled skill storage during synchronization even when it contains unmanaged content", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+        );
+        const canonicalOwnershipPath = join(
+            canonicalSkillDirectoryPath,
+            "agents",
+            "openai.yaml",
+        );
+        const managedOwnershipPath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const expectedOwnershipContent = await Bun.file(
+            getBundledSkillFiles("oo").find(file => file.relativePath === "agents/openai.yaml")!.sourcePath,
+        ).text();
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
+                recursive: true,
+            });
+            await Bun.write(
+                metadataFilePath,
+                formatBundledSkillMetadataContent("0.0.1"),
+            );
+            await Bun.write(managedOwnershipPath, expectedOwnershipContent);
+            await Bun.write(
+                canonicalOwnershipPath,
+                [
+                    "interface:",
+                    "  display_name: oo",
+                    "  short_description: Custom skill",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["--help"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                formatBundledSkillMetadataContent("9.9.9"),
+            );
+            expect(await readFile(canonicalOwnershipPath, "utf8")).toContain("OOMOL");
+            expect(await readFile(canonicalOwnershipPath, "utf8")).not.toContain(
+                "Custom skill",
+            );
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/shared.test.ts
+++ b/src/application/commands/skills/shared.test.ts
@@ -356,6 +356,60 @@ function registerPosixBundledSkillPublicationTests(
             ]);
         });
 
+        test("uses the symlink-resolved parent directory when computing a relative POSIX target", async () => {
+            const createdSymlinks: Array<{
+                linkPath: string;
+                targetPath: string;
+                type: string | null | undefined;
+            }> = [];
+            const targetPath = "/tmp/canonical/skills/oo";
+            const linkPath = "/tmp/link-parent/skills/oo";
+            const resolvedTargetPath = resolve(targetPath);
+            const resolvedLinkPath = resolve(linkPath);
+            const resolvedLinkDirectoryPath = dirname(resolvedLinkPath);
+            const realLinkDirectoryPath = "/private/tmp/link-parent/skills";
+
+            const result = await createBundledSkillDirectorySymlink(
+                targetPath,
+                linkPath,
+                {
+                    lstat: async () => {
+                        const error = new Error("missing") as NodeJS.ErrnoException;
+
+                        error.code = "ENOENT";
+
+                        throw error;
+                    },
+                    mkdir: async () => undefined,
+                    readlink: async () => {
+                        throw new Error("readlink should not run when the link is missing");
+                    },
+                    realpath: async path => path,
+                    removePath: async () => {
+                        throw new Error("removePath should not run when the link is missing");
+                    },
+                    resolveParentSymlinks: async path =>
+                        path === resolvedLinkDirectoryPath ? realLinkDirectoryPath : path,
+                    symlink: async (createdTargetPath, createdLinkPath, type) => {
+                        createdSymlinks.push({
+                            linkPath: createdLinkPath,
+                            targetPath: createdTargetPath,
+                            type,
+                        });
+                    },
+                },
+            );
+
+            expect(result).toBeTrue();
+            expect(createdSymlinks).toEqual([
+                {
+                    linkPath: resolvedLinkPath,
+                    targetPath: relative(realLinkDirectoryPath, resolvedTargetPath),
+                    type: "dir",
+                },
+            ]);
+        });
+
         test("rethrows EFAULT when removing a symbolic path on POSIX", async () => {
             const symlinkPath = "/tmp/.codex/skills/oo";
 

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -1,127 +1,61 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { AppSettings } from "../../schemas/settings.ts";
 
+import type { BundledSkillPublicationResult } from "./bundled-skill-filesystem.ts";
 import type { BundledSkillName } from "./embedded-assets.ts";
 import {
-    cp,
-    lstat,
     mkdir,
-    readFile,
-    readlink,
-    realpath,
-    rm,
-    rmdir,
-    stat,
-    symlink,
 } from "node:fs/promises";
-import { basename, dirname, join, relative, resolve } from "node:path";
-import process from "node:process";
+import { dirname, join } from "node:path";
 import { CliUserError } from "../../contracts/cli.ts";
-import { resolveHomeDirectory } from "../../path/home-directory.ts";
+import { defaultSettings } from "../../schemas/settings.ts";
 import {
-    defaultSettings,
-    getOoSkillImplicitInvocation,
-} from "../../schemas/settings.ts";
+    publishBundledSkillInstallation,
+    removePath,
+} from "./bundled-skill-filesystem.ts";
+import {
+    canUninstallManagedBundledSkillInstallation,
+    renderBundledSkillFileContent,
+    resolveBundledSkillImplicitInvocation,
+    resolveBundledSkillInstallConflict,
+    resolveBundledSkillManagedSynchronizationAction,
+    resolveBundledSkillMissingInstallationAction,
+} from "./bundled-skill-model.ts";
+import {
+    directoryExists,
+    isBundledSkillInstallationCurrent,
+    isManagedBundledSkillInstallation,
+    readInstalledBundledSkillImplicitInvocation,
+    readInstalledBundledSkillVersion,
+    requireCodexHomeDirectory,
+    writeInstalledBundledSkillMetadata,
+} from "./bundled-skill-observation.ts";
+import {
+    resolveBundledSkillCanonicalDirectoryPath,
+    resolveBundledSkillDirectoryPath,
+    resolveCodexHomeDirectory,
+} from "./bundled-skill-paths.ts";
 import {
     availableBundledSkillNames,
     getBundledSkillFiles,
 } from "./embedded-assets.ts";
 
-const codexDirectoryName = ".codex";
-const codexSkillsDirectoryName = "skills";
-const bundledSkillMetadataFileName = ".oo-metadata.json";
-const bundledSkillOwnershipMarker = "OOMOL";
-const bundledSkillOwnershipFileRelativePath = "agents/openai.yaml";
-const bundledSkillImplicitInvocationKey = "allow_implicit_invocation";
-
-interface BundledSkillMetadata {
-    version: string;
-}
-
-export interface BundledSkillPublicationResult {
-    mode: "copy" | "symlink";
-    path: string;
-}
-
-interface BundledSkillPublicationDependencies {
-    createDirectorySymlink?: (
-        targetPath: string,
-        linkPath: string,
-    ) => Promise<boolean>;
-}
-
-type BundledSkillDirectorySymlinkAttempt
-    = | {
-        kind: "reuse";
-    }
-    | {
-        kind: "create";
-        resolvedLinkPath: string;
-        resolvedTargetPath: string;
-    };
-
-export interface CreateBundledSkillDirectorySymlinkDependencies {
-    lstat?: (path: string) => Promise<{
-        isSymbolicLink: () => boolean;
-    }>;
-    mkdir?: (
-        path: string,
-        options: {
-            recursive: true;
-        },
-    ) => Promise<void>;
-    readlink?: (path: string) => Promise<string>;
-    realpath?: (path: string) => Promise<string>;
-    removePath?: (path: string) => Promise<void>;
-    resolveParentSymlinks?: (path: string) => Promise<string>;
-    symlink?: (
-        targetPath: string,
-        linkPath: string,
-        type: "dir" | "junction",
-    ) => Promise<void>;
-}
-
-export interface RemoveBundledSkillSymbolicPathDependencies {
-    rm?: (
-        path: string,
-        options: {
-            force: true;
-        },
-    ) => Promise<void>;
-    rmdir?: (path: string) => Promise<void>;
-}
-
-export function resolveCodexHomeDirectory(
-    env: Record<string, string | undefined>,
-): string {
-    const explicitCodexHome = env.CODEX_HOME?.trim();
-
-    if (explicitCodexHome) {
-        return explicitCodexHome;
-    }
-
-    return join(resolveHomeDirectory(env), codexDirectoryName);
-}
-
-export function resolveBundledSkillDirectoryPath(
-    codexHomeDirectory: string,
-    skillName: BundledSkillName,
-): string {
-    return join(codexHomeDirectory, codexSkillsDirectoryName, skillName);
-}
-
-export function resolveBundledSkillCanonicalDirectoryPath(
-    settingsFilePath: string,
-    skillName: BundledSkillName,
-): string {
-    return join(dirname(settingsFilePath), codexSkillsDirectoryName, skillName);
-}
-
-export function resolveBundledSkillMetadataFilePath(
-    skillDirectoryPath: string,
-): string {
-    return join(skillDirectoryPath, bundledSkillMetadataFileName);
-}
+export {
+    createBundledSkillDirectorySymlink,
+    publishBundledSkillInstallation,
+    removeBundledSkillSymbolicPath,
+} from "./bundled-skill-filesystem.ts";
+export type {
+    BundledSkillPublicationResult,
+    CreateBundledSkillDirectorySymlinkDependencies,
+    RemoveBundledSkillSymbolicPathDependencies,
+} from "./bundled-skill-filesystem.ts";
+export {
+    resolveBundledSkillCanonicalDirectoryPath,
+    resolveBundledSkillDirectoryPath,
+    resolveBundledSkillMetadataFilePath,
+    resolveCodexHomeDirectory,
+} from "./bundled-skill-paths.ts";
 
 export async function installBundledSkill(
     skillName: BundledSkillName,
@@ -139,38 +73,60 @@ export async function installBundledSkill(
         skillName,
     );
 
-    if (
-        await directoryExists(installedSkillDirectoryPath)
-        && !(await isManagedBundledSkillInstallation(installedSkillDirectoryPath))
-    ) {
-        context.logger.warn(
-            {
+    const installedSkillDirectoryExists = await directoryExists(
+        installedSkillDirectoryPath,
+    );
+
+    if (installedSkillDirectoryExists) {
+        const installedSkillDirectoryManaged
+            = await isManagedBundledSkillInstallation(installedSkillDirectoryPath);
+
+        if (resolveBundledSkillInstallConflict({
+            canonicalDirectoryExists: false,
+            canonicalDirectoryManaged: false,
+            installedDirectoryExists: true,
+            installedDirectoryManaged: installedSkillDirectoryManaged,
+        }) === "nameConflict") {
+            context.logger.warn(
+                {
+                    path: installedSkillDirectoryPath,
+                    skillName,
+                },
+                "Bundled Codex skill install was blocked by an unmanaged directory.",
+            );
+            throw new CliUserError("errors.skills.nameConflict", 1, {
+                name: skillName,
                 path: installedSkillDirectoryPath,
-                skillName,
-            },
-            "Bundled Codex skill install was blocked by an unmanaged directory.",
-        );
-        throw new CliUserError("errors.skills.nameConflict", 1, {
-            name: skillName,
-            path: installedSkillDirectoryPath,
-        });
+            });
+        }
     }
 
-    if (
-        await directoryExists(canonicalSkillDirectoryPath)
-        && !(await isManagedBundledSkillInstallation(canonicalSkillDirectoryPath))
-    ) {
-        context.logger.warn(
-            {
+    const canonicalSkillDirectoryExists = await directoryExists(
+        canonicalSkillDirectoryPath,
+    );
+
+    if (canonicalSkillDirectoryExists) {
+        const canonicalSkillDirectoryManaged
+            = await isManagedBundledSkillInstallation(canonicalSkillDirectoryPath);
+
+        if (resolveBundledSkillInstallConflict({
+            canonicalDirectoryExists: true,
+            canonicalDirectoryManaged: canonicalSkillDirectoryManaged,
+            installedDirectoryExists: false,
+            installedDirectoryManaged: false,
+        }) === "storageConflict") {
+            context.logger.warn(
+                {
+                    path: canonicalSkillDirectoryPath,
+                    skillName,
+                },
+                "Bundled Codex skill install was blocked by an unmanaged canonical directory.",
+            );
+            throw new CliUserError("errors.skills.storageConflict", 1, {
+                name: skillName,
                 path: canonicalSkillDirectoryPath,
-                skillName,
-            },
-            "Bundled Codex skill install was blocked by an unmanaged canonical directory.",
-        );
-        throw new CliUserError("errors.skills.storageConflict", 1, {
-            name: skillName,
-            path: canonicalSkillDirectoryPath,
-        });
+            });
+        }
     }
 
     const installation = await writeBundledSkillInstallation({
@@ -232,8 +188,16 @@ export async function maybeSynchronizeInstalledBundledSkills(
         );
 
         try {
-            if (!(await directoryExists(skillDirectoryPath))) {
-                if (options.installMissing !== true) {
+            const installedSkillDirectoryExists = await directoryExists(
+                skillDirectoryPath,
+            );
+
+            if (!installedSkillDirectoryExists) {
+                if (
+                    resolveBundledSkillMissingInstallationAction(
+                        options.installMissing === true,
+                    ) === "skip-missing"
+                ) {
                     context.logger.debug(
                         {
                             path: skillDirectoryPath,
@@ -265,7 +229,11 @@ export async function maybeSynchronizeInstalledBundledSkills(
                 continue;
             }
 
-            if (!(await isManagedBundledSkillInstallation(skillDirectoryPath))) {
+            const managedInstallation = await isManagedBundledSkillInstallation(
+                skillDirectoryPath,
+            );
+
+            if (!managedInstallation) {
                 context.logger.debug(
                     {
                         path: skillDirectoryPath,
@@ -276,13 +244,28 @@ export async function maybeSynchronizeInstalledBundledSkills(
                 continue;
             }
 
-            if (
-                !(await isBundledSkillInstallationCurrent(
-                    skillName,
-                    skillDirectoryPath,
-                    context.version,
-                ))
-            ) {
+            const isCurrentInstallation = await isBundledSkillInstallationCurrent(
+                skillName,
+                skillDirectoryPath,
+                context.version,
+            );
+            const desiredImplicitInvocation = resolveBundledSkillImplicitInvocation(
+                skillName,
+                settings,
+            );
+            const installedImplicitInvocation = isCurrentInstallation
+                ? await readInstalledBundledSkillImplicitInvocation(
+                        skillDirectoryPath,
+                    )
+                : undefined;
+            const managedSynchronizationAction
+                = resolveBundledSkillManagedSynchronizationAction({
+                    desiredImplicitInvocation,
+                    installedImplicitInvocation,
+                    isCurrentInstallation,
+                });
+
+            if (managedSynchronizationAction === "sync-installation") {
                 const previousVersion
                     = await readInstalledBundledSkillVersion(skillDirectoryPath);
                 const installation = await writeBundledSkillInstallation({
@@ -307,16 +290,7 @@ export async function maybeSynchronizeInstalledBundledSkills(
                 continue;
             }
 
-            const desiredImplicitInvocation = resolveBundledSkillImplicitInvocation(
-                skillName,
-                settings,
-            );
-            const installedImplicitInvocation
-                = await readInstalledBundledSkillImplicitInvocation(
-                    skillDirectoryPath,
-                );
-
-            if (installedImplicitInvocation === desiredImplicitInvocation) {
+            if (managedSynchronizationAction === "skip-current") {
                 context.logger.debug(
                     {
                         path: skillDirectoryPath,
@@ -374,11 +348,15 @@ export async function uninstallBundledSkill(
         context.settingsStore.getFilePath(),
         skillName,
     );
+    const installedSkillDirectoryExists = await directoryExists(skillDirectoryPath);
+    const installedSkillDirectoryManaged = installedSkillDirectoryExists
+        ? await isManagedBundledSkillInstallation(skillDirectoryPath)
+        : false;
 
-    if (
-        !(await directoryExists(skillDirectoryPath))
-        || !(await isManagedBundledSkillInstallation(skillDirectoryPath))
-    ) {
+    if (!canUninstallManagedBundledSkillInstallation({
+        installedDirectoryExists: installedSkillDirectoryExists,
+        installedDirectoryManaged: installedSkillDirectoryManaged,
+    })) {
         context.logger.warn(
             {
                 path: skillDirectoryPath,
@@ -463,537 +441,6 @@ async function writeBundledSkillInstallation(options: {
         canonicalSkillDirectoryPath,
         installedSkillDirectoryPath,
     });
-}
-
-function renderBundledSkillFileContent(
-    skillName: BundledSkillName,
-    relativePath: string,
-    content: string,
-    settings: AppSettings,
-): string {
-    if (relativePath !== bundledSkillOwnershipFileRelativePath) {
-        return content;
-    }
-
-    return writeImplicitInvocationValue(
-        content,
-        resolveBundledSkillImplicitInvocation(skillName, settings),
-    );
-}
-
-function resolveBundledSkillImplicitInvocation(
-    skillName: BundledSkillName,
-    settings: AppSettings,
-): boolean {
-    switch (skillName) {
-        case "oo":
-            return getOoSkillImplicitInvocation(settings);
-    }
-}
-
-async function readInstalledBundledSkillImplicitInvocation(
-    skillDirectoryPath: string,
-): Promise<boolean | undefined> {
-    try {
-        const content = await readFile(
-            join(skillDirectoryPath, bundledSkillOwnershipFileRelativePath),
-            "utf8",
-        );
-
-        return readImplicitInvocationValue(content);
-    }
-    catch (error) {
-        if (isNodeNotFoundError(error)) {
-            return undefined;
-        }
-
-        throw error;
-    }
-}
-
-function readImplicitInvocationValue(
-    content: string,
-): boolean | undefined {
-    for (const line of content.split("\n")) {
-        const trimmedLine = line.trim();
-
-        if (!trimmedLine.startsWith(`${bundledSkillImplicitInvocationKey}:`)) {
-            continue;
-        }
-
-        const rawValue = trimmedLine
-            .slice(bundledSkillImplicitInvocationKey.length + 1)
-            .trim();
-
-        if (rawValue === "true") {
-            return true;
-        }
-
-        if (rawValue === "false") {
-            return false;
-        }
-
-        return undefined;
-    }
-
-    return undefined;
-}
-
-function writeImplicitInvocationValue(
-    content: string,
-    value: boolean,
-): string {
-    const lineSeparator = content.includes("\r\n") ? "\r\n" : "\n";
-    const lines = content.split(lineSeparator);
-
-    for (const [index, line] of lines.entries()) {
-        const trimmedLine = line.trim();
-
-        if (!trimmedLine.startsWith(`${bundledSkillImplicitInvocationKey}:`)) {
-            continue;
-        }
-
-        const indentation = line.slice(0, line.length - line.trimStart().length);
-
-        lines[index] = [
-            indentation,
-            bundledSkillImplicitInvocationKey,
-            ": ",
-            value ? "true" : "false",
-        ].join("");
-
-        return lines.join(lineSeparator);
-    }
-
-    throw new Error(
-        `Missing ${bundledSkillImplicitInvocationKey} in bundled skill policy file.`,
-    );
-}
-
-async function isBundledSkillInstallationCurrent(
-    skillName: BundledSkillName,
-    skillDirectoryPath: string,
-    version: string,
-): Promise<boolean> {
-    if (!(await isManagedBundledSkillInstallation(skillDirectoryPath))) {
-        return false;
-    }
-
-    if (!(await fileExists(resolveBundledSkillMetadataFilePath(skillDirectoryPath)))) {
-        return false;
-    }
-
-    const installedVersion = await readInstalledBundledSkillVersion(skillDirectoryPath);
-
-    if (installedVersion !== version) {
-        return false;
-    }
-
-    for (const file of getBundledSkillFiles(skillName)) {
-        if (!(await fileExists(join(skillDirectoryPath, file.relativePath)))) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-async function isManagedBundledSkillInstallation(
-    skillDirectoryPath: string,
-): Promise<boolean> {
-    try {
-        const content = await readFile(
-            join(
-                skillDirectoryPath,
-                bundledSkillOwnershipFileRelativePath,
-            ),
-            "utf8",
-        );
-
-        return content.includes(bundledSkillOwnershipMarker);
-    }
-    catch (error) {
-        if (isNodeNotFoundError(error)) {
-            return false;
-        }
-
-        throw error;
-    }
-}
-
-async function readInstalledBundledSkillVersion(
-    skillDirectoryPath: string,
-): Promise<string | undefined> {
-    const metadata = await readInstalledBundledSkillMetadata(
-        skillDirectoryPath,
-    );
-
-    return metadata?.version;
-}
-
-async function readInstalledBundledSkillMetadata(
-    skillDirectoryPath: string,
-): Promise<BundledSkillMetadata | undefined> {
-    try {
-        const content = await readFile(
-            resolveBundledSkillMetadataFilePath(skillDirectoryPath),
-            "utf8",
-        );
-
-        return parseBundledSkillMetadataContent(content);
-    }
-    catch (error) {
-        if (isNodeNotFoundError(error)) {
-            return undefined;
-        }
-
-        throw error;
-    }
-}
-
-async function writeInstalledBundledSkillMetadata(
-    skillDirectoryPath: string,
-    metadata: BundledSkillMetadata,
-): Promise<void> {
-    await Bun.write(
-        resolveBundledSkillMetadataFilePath(skillDirectoryPath),
-        renderBundledSkillMetadataContent(metadata),
-    );
-}
-
-function parseBundledSkillMetadataContent(
-    content: string,
-): BundledSkillMetadata | undefined {
-    let parsedContent: unknown;
-
-    try {
-        parsedContent = JSON.parse(content);
-    }
-    catch {
-        return undefined;
-    }
-
-    if (
-        typeof parsedContent !== "object"
-        || parsedContent === null
-        || Array.isArray(parsedContent)
-    ) {
-        return undefined;
-    }
-
-    const rawVersion = (parsedContent as Record<string, unknown>).version;
-
-    if (typeof rawVersion !== "string") {
-        return undefined;
-    }
-
-    const version = rawVersion.trim();
-
-    if (version === "") {
-        return undefined;
-    }
-
-    return {
-        version,
-    };
-}
-
-function renderBundledSkillMetadataContent(
-    metadata: BundledSkillMetadata,
-): string {
-    return `${JSON.stringify(metadata, null, 2)}\n`;
-}
-
-async function requireCodexHomeDirectory(
-    context: Pick<CliExecutionContext, "env">,
-): Promise<string> {
-    const codexHomeDirectory = resolveCodexHomeDirectory(context.env);
-
-    if (!(await directoryExists(codexHomeDirectory))) {
-        throw new CliUserError("errors.skills.codexNotInstalled", 1, {
-            path: codexHomeDirectory,
-        });
-    }
-
-    return codexHomeDirectory;
-}
-
-export async function publishBundledSkillInstallation(
-    options: {
-        canonicalSkillDirectoryPath: string;
-        installedSkillDirectoryPath: string;
-    },
-    dependencies: BundledSkillPublicationDependencies = {},
-): Promise<BundledSkillPublicationResult> {
-    const createDirectoryLink
-        = dependencies.createDirectorySymlink ?? createBundledSkillDirectorySymlink;
-    const symlinkCreated = await createDirectoryLink(
-        options.canonicalSkillDirectoryPath,
-        options.installedSkillDirectoryPath,
-    );
-
-    if (symlinkCreated) {
-        return {
-            mode: "symlink",
-            path: options.installedSkillDirectoryPath,
-        };
-    }
-
-    await copyBundledSkillDirectory(
-        options.canonicalSkillDirectoryPath,
-        options.installedSkillDirectoryPath,
-    );
-
-    return {
-        mode: "copy",
-        path: options.installedSkillDirectoryPath,
-    };
-}
-
-async function directoryExists(path: string): Promise<boolean> {
-    try {
-        return (await stat(path)).isDirectory();
-    }
-    catch (error) {
-        if (isNodeNotFoundError(error)) {
-            return false;
-        }
-
-        throw error;
-    }
-}
-
-async function fileExists(path: string): Promise<boolean> {
-    try {
-        return (await stat(path)).isFile();
-    }
-    catch (error) {
-        if (isNodeNotFoundError(error)) {
-            return false;
-        }
-
-        throw error;
-    }
-}
-
-function isNodeNotFoundError(error: unknown): error is NodeJS.ErrnoException {
-    return error instanceof Error && "code" in error && error.code === "ENOENT";
-}
-
-function isSymlinkLoopError(error: unknown): error is NodeJS.ErrnoException {
-    return error instanceof Error && "code" in error && error.code === "ELOOP";
-}
-
-export async function createBundledSkillDirectorySymlink(
-    targetPath: string,
-    linkPath: string,
-    dependencies: CreateBundledSkillDirectorySymlinkDependencies = {},
-): Promise<boolean> {
-    const lstatFn = dependencies.lstat ?? lstat;
-    const mkdirFn = dependencies.mkdir ?? mkdir;
-    const readlinkFn = dependencies.readlink ?? readlink;
-    const realpathFn = dependencies.realpath ?? realpath;
-    const removePathFn = dependencies.removePath ?? removePath;
-    const resolveParentSymlinksFn
-        = dependencies.resolveParentSymlinks ?? resolveParentSymlinks;
-    const symlinkFn = dependencies.symlink ?? symlink;
-
-    try {
-        const attempt = await resolveBundledSkillDirectorySymlinkAttempt(
-            targetPath,
-            linkPath,
-            {
-                lstat: lstatFn,
-                readlink: readlinkFn,
-                realpath: realpathFn,
-                removePath: removePathFn,
-                resolveParentSymlinks: resolveParentSymlinksFn,
-            },
-        );
-
-        if (attempt.kind === "reuse") {
-            return true;
-        }
-
-        const linkDirectoryPath = dirname(attempt.resolvedLinkPath);
-
-        await mkdirFn(linkDirectoryPath, { recursive: true });
-
-        const symlinkTargetPath = process.platform === "win32"
-            ? attempt.resolvedTargetPath
-            : relative(
-                    await resolveParentSymlinksFn(linkDirectoryPath),
-                    attempt.resolvedTargetPath,
-                );
-
-        await symlinkFn(
-            symlinkTargetPath,
-            attempt.resolvedLinkPath,
-            process.platform === "win32" ? "junction" : "dir",
-        );
-
-        return true;
-    }
-    catch {
-        return false;
-    }
-}
-
-async function resolveBundledSkillDirectorySymlinkAttempt(
-    targetPath: string,
-    linkPath: string,
-    dependencies: Pick<
-        CreateBundledSkillDirectorySymlinkDependencies,
-        "lstat" | "readlink" | "realpath" | "removePath" | "resolveParentSymlinks"
-    >,
-): Promise<BundledSkillDirectorySymlinkAttempt> {
-    const resolvedTargetPath = resolve(targetPath);
-    const resolvedLinkPath = resolve(linkPath);
-    const realpathFn = dependencies.realpath ?? realpath;
-    const [realTargetPath, realLinkPath] = await Promise.all([
-        realpathFn(resolvedTargetPath).catch(() => resolvedTargetPath),
-        realpathFn(resolvedLinkPath).catch(() => resolvedLinkPath),
-    ]);
-
-    if (realTargetPath === realLinkPath) {
-        return {
-            kind: "reuse",
-        };
-    }
-
-    const resolveParentSymlinksFn
-        = dependencies.resolveParentSymlinks ?? resolveParentSymlinks;
-    const [realTargetPathWithParents, realLinkPathWithParents] = await Promise.all([
-        resolveParentSymlinksFn(resolvedTargetPath),
-        resolveParentSymlinksFn(resolvedLinkPath),
-    ]);
-
-    if (realTargetPathWithParents === realLinkPathWithParents) {
-        return {
-            kind: "reuse",
-        };
-    }
-
-    const lstatFn = dependencies.lstat ?? lstat;
-    const readlinkFn = dependencies.readlink ?? readlink;
-    const removePathFn = dependencies.removePath ?? removePath;
-
-    try {
-        const existingStats = await lstatFn(resolvedLinkPath);
-
-        if (existingStats.isSymbolicLink()) {
-            const existingTarget = await readlinkFn(resolvedLinkPath);
-
-            if (
-                resolveSymlinkTarget(resolvedLinkPath, existingTarget)
-                === resolvedTargetPath
-            ) {
-                return {
-                    kind: "reuse",
-                };
-            }
-        }
-
-        await removePathFn(resolvedLinkPath);
-    }
-    catch (error) {
-        if (isSymlinkLoopError(error)) {
-            try {
-                await removePathFn(resolvedLinkPath);
-            }
-            catch {
-                // Let symlink creation determine whether copy fallback is needed.
-            }
-        }
-        else if (!isNodeNotFoundError(error)) {
-            throw error;
-        }
-    }
-
-    return {
-        kind: "create",
-        resolvedLinkPath,
-        resolvedTargetPath,
-    };
-}
-
-async function copyBundledSkillDirectory(
-    sourcePath: string,
-    destinationPath: string,
-): Promise<void> {
-    await removePath(destinationPath);
-    await mkdir(dirname(destinationPath), { recursive: true });
-    await cp(sourcePath, destinationPath, {
-        dereference: true,
-        force: true,
-        recursive: true,
-    });
-}
-
-async function removePath(path: string): Promise<void> {
-    try {
-        const pathStats = await lstat(path);
-
-        if (pathStats.isSymbolicLink()) {
-            await removeBundledSkillSymbolicPath(path);
-            return;
-        }
-
-        await rm(path, { force: true, recursive: true });
-    }
-    catch (error) {
-        if (isNodeNotFoundError(error)) {
-            return;
-        }
-
-        throw error;
-    }
-}
-
-export async function removeBundledSkillSymbolicPath(
-    path: string,
-    dependencies: RemoveBundledSkillSymbolicPathDependencies = {},
-): Promise<void> {
-    const rmFn = dependencies.rm ?? rm;
-    const rmdirFn = dependencies.rmdir ?? rmdir;
-
-    try {
-        await rmFn(path, { force: true });
-    }
-    catch (error) {
-        if (process.platform === "win32" && isWindowsBadAddressError(error)) {
-            await rmdirFn(path);
-            return;
-        }
-
-        throw error;
-    }
-}
-
-function isWindowsBadAddressError(error: unknown): error is NodeJS.ErrnoException {
-    return error instanceof Error && "code" in error && error.code === "EFAULT";
-}
-
-async function resolveParentSymlinks(path: string): Promise<string> {
-    const resolvedPath = resolve(path);
-    const parentPath = dirname(resolvedPath);
-    const baseName = basename(resolvedPath);
-
-    try {
-        const realParentPath = await realpath(parentPath);
-
-        return join(realParentPath, baseName);
-    }
-    catch {
-        return resolvedPath;
-    }
-}
-
-function resolveSymlinkTarget(
-    linkPath: string,
-    linkTargetPath: string,
-): string {
-    return resolve(dirname(linkPath), linkTargetPath);
 }
 
 function writeLine(context: CliExecutionContext, message: string): void {


### PR DESCRIPTION
Consolidate duplicated HTTP request boilerplate (logging, error
handling, duration tracking) from cloud-task, file, package, and
skills commands into shared request helpers. Extract semver
parsing and comparison into a dedicated module, replacing inline
implementations in package/shared and update-notifier. Pull
isPlainObject and readWidgetName into schema-utils. Decompose
large methods in commander-cli-adapter and run-cli into focused
functions (configureCommand, bindCommandHandler,
initializeCliStores, createCliExecutionContext).

Signed-off-by: Kevin Cui <bh@bugs.cc>