### PR TITLE
feat(skills): add published skill installation from registry

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -27,6 +27,10 @@ export interface TextBuffer {
     read: () => string;
 }
 
+export interface TestInteractiveInput extends InteractiveInput {
+    feed: (chunk: string) => void;
+}
+
 export interface TextBufferOptions {
     hasColors?: boolean;
     isTTY?: boolean;
@@ -189,6 +193,64 @@ export function createTextBuffer(options: TextBufferOptions = {}): TextBuffer {
             return chunks.join("");
         },
     };
+}
+
+export function createInteractiveInput(): TestInteractiveInput {
+    const listeners = new Set<(chunk: string | Uint8Array) => void>();
+    const bufferedChunks: Uint8Array[] = [];
+    const textEncoder = new TextEncoder();
+
+    return {
+        isTTY: true,
+        feed(chunk) {
+            const encodedChunk = textEncoder.encode(chunk);
+
+            if (listeners.size === 0) {
+                bufferedChunks.push(encodedChunk);
+                return;
+            }
+
+            for (const listener of listeners) {
+                listener(encodedChunk);
+            }
+        },
+        off(_, listener) {
+            listeners.delete(listener);
+        },
+        on(_, listener) {
+            listeners.add(listener);
+
+            while (bufferedChunks.length > 0) {
+                const chunk = bufferedChunks.shift();
+
+                if (chunk === undefined) {
+                    break;
+                }
+
+                listener(chunk);
+            }
+        },
+        pause() {},
+        resume() {},
+        setRawMode() {},
+    };
+}
+
+export async function waitForOutputText(
+    buffer: Pick<TextBuffer, "read">,
+    text: string,
+): Promise<void> {
+    const deadline = Date.now() + 1000;
+
+    while (Date.now() < deadline) {
+        if (buffer.read().includes(text)) {
+            return;
+        }
+
+        await Bun.sleep(10);
+    }
+
+    throw new Error(`Timed out waiting for output text: ${text}`);
 }
 
 export async function createTemporaryDirectory(prefix: string): Promise<string> {

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,12 @@
     "": {
       "name": "oo",
       "dependencies": {
+        "@clack/core": "0.5.0",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "ajv-i18n": "^4.2.0",
         "commander": "^14.0.3",
+        "picocolors": "^1.1.1",
         "pino": "^10.3.1",
         "smol-toml": "^1.6.0",
         "zod": "^4.3.6",
@@ -38,7 +40,7 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
+    "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
 
     "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
 
@@ -711,6 +713,8 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@clack/prompts/@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
 
     "@eslint-community/eslint-plugin-eslint-comments/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -161,37 +161,69 @@ Persist one skill configuration value.
   persists the setting and applies it on the next install or startup
   synchronization.
 
-### `oo skills install [skill]`
+### `oo skills install [packageName]`
 
-Install one bundled skill into the local Codex skills directory.
+Install bundled or published Codex skills into the local Codex skills
+directory.
 
-- Arguments: `[skill]` is optional. When omitted, the command behaves the same
-  as `oo skills install oo`.
-- Supported skill names: currently `oo`.
-- Canonical directory: the bundled files are materialized to
+- Arguments: `[packageName]` is optional.
+- Arguments: when omitted, the command behaves the same as
+  `oo skills install oo`.
+- Arguments: when `[packageName]` is `oo`, the command installs the
+  bundled `oo` skill.
+- Arguments: when `[packageName]` is a published package name, the command
+  installs skills from that package.
+- Options: `-s, --skill <skills...>` installs one or more named published
+  skills from the package.
+- Options: `-s, --skill '*'` installs all published skills from the package.
+- Options: `--all` is shorthand for installing all published skills from the
+  package without a skill-selection prompt.
+- Options: `-y, --yes` skips confirmation prompts. When a package publishes
+  multiple skills and no explicit `--skill` is provided, `-y` installs all of
+  them.
+- Notes: when a package publishes exactly one skill and no `--skill` is
+  provided, the command installs that skill automatically.
+- Notes: when a package publishes multiple skills and no `--skill`, `--all`, or
+  `-y` is provided, the command opens an interactive picker in a TTY.
+- Canonical directory: bundled `oo` is materialized to
   `<config-dir>/skills/oo`, where `<config-dir>` is the directory that
   contains `settings.toml`.
-- Target directory: `${CODEX_HOME:-~/.codex}/skills/oo`.
+- Canonical directory: published skills are materialized to
+  `<config-dir>/skills/<skill-id>`.
+- Target directory: every installed skill is published to
+  `${CODEX_HOME:-~/.codex}/skills/<skill-id>`.
 - Installation mode: `oo` publishes the target directory as a symlink to the
   canonical directory when the current platform and environment allow it. When
   symlink creation fails, `oo` falls back to copying the canonical files into
   the Codex skills directory.
-- Metadata: the installation writes a hidden `.oo-metadata.json` file inside
-  the skill directory with a `version` field for the current `oo` version.
-- Metadata: `agents/openai.yaml` uses the persisted
+- Metadata: bundled `oo` writes a hidden `.oo-metadata.json` file whose
+  `version` field matches the current `oo` version.
+- Metadata: published skills write a hidden `.oo-metadata.json` file whose
+  `version` field matches the package version and whose `packageName` field
+  records the source package.
+- Metadata: `agents/openai.yaml` in bundled `oo` uses the persisted
   `skills.oo.implicit_invocation` value when configured, otherwise the
   bundled default is used.
+- Notes: all registry requests for published skills send the active account's
+  `Authorization` header.
+- Notes: when a package publishes multiple skills and the command runs outside
+  an interactive terminal, you must provide `--skill <name>` or `--all -y`.
+- Notes: when an explicitly requested published skill conflicts with an
+  existing same-name skill, the command asks for `yes` or `no` before
+  overwriting it in an interactive terminal.
+- Notes: in the interactive picker, conflicting skills are marked in the list;
+  selecting one means it will be overwritten.
 - Notes: the command exits with an error when the Codex home directory does
   not exist, which indicates Codex is not installed on the current machine.
 - Notes: an existing `oo/agents/openai.yaml` is considered managed by
   `oo` only when it contains the string `OOMOL`. Otherwise `oo` treats it as a
   different skill and will not overwrite it.
 - Notes: on the first `oo` run, when there is no existing config, auth, or log
-  data yet, `oo` silently installs the managed skill automatically if the
-  Codex home directory already exists.
-- Notes: when a bundled skill is already installed, every `oo` startup checks
-  whether the recorded metadata `version` matches the current CLI version and
-  silently refreshes the installed files when needed.
+  data yet, `oo` silently installs the bundled managed skill automatically if
+  the Codex home directory already exists.
+- Notes: when the bundled `oo` skill is already installed, every `oo` startup
+  checks whether the recorded metadata `version` matches the current CLI
+  version and silently refreshes the installed files when needed.
 
 ### `oo skills uninstall`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -145,32 +145,58 @@
 - 说明：当目标受管 skill 尚未安装时，命令仍会写入设置，并在下次安装或启
   动同步时生效。
 
-### `oo skills install [skill]`
+### `oo skills install [packageName]`
 
-将一个内置 skill 安装到本地 Codex skills 目录。
+将内置或已发布的 Codex skill 安装到本地 Codex skills 目录。
 
-- 参数：`[skill]` 可选。未提供时，该命令等价于 `oo skills install oo`。
-- 支持的 skill 名称：当前仅 `oo`。
-- canonical 目录：内置文件会先释放到 `<config-dir>/skills/oo`，
+- 参数：`[packageName]` 可选。
+- 参数：未提供时，该命令等价于 `oo skills install oo`。
+- 参数：当 `[packageName]` 为 `oo` 时，命令安装内置的 `oo` skill。
+- 参数：当 `[packageName]` 为已发布 package 名称时，命令从该 package 中
+  安装 skill。
+- 选项：`-s, --skill <skills...>` 用于安装 package 中一个或多个指定的
+  skill。
+- 选项：`-s, --skill '*'` 用于安装该 package 中全部已发布 skill。
+- 选项：`--all` 是安装全部已发布 skill 的快捷方式，并跳过 skill 选择提示。
+- 选项：`-y, --yes` 用于跳过确认提示。当 package 下有多个 skill 且未显式
+  提供 `--skill` 时，`-y` 会安装全部 skill。
+- 说明：如果 package 只发布了一个 skill，且未提供 `--skill`，命令会自动
+  安装这个唯一的 skill。
+- 说明：如果 package 发布了多个 skill，且未提供 `--skill`、`--all` 或
+  `-y`，命令会在 TTY 中打开交互选择页面。
+- canonical 目录：内置 `oo` 的文件会先释放到 `<config-dir>/skills/oo`，
   其中 `<config-dir>` 是 `settings.toml` 所在目录。
-- 目标目录：`${CODEX_HOME:-~/.codex}/skills/oo`。
+- canonical 目录：已发布 skill 会先释放到 `<config-dir>/skills/<skill-id>`。
+- 目标目录：所有已安装 skill 都会发布到
+  `${CODEX_HOME:-~/.codex}/skills/<skill-id>`。
 - 安装方式：`oo` 会优先将目标目录发布为指向 canonical 目录的软连接。
   如果当前平台或环境下创建软连接失败，则会回退为把 canonical 目录内容复制
   到 Codex skills 目录。
-- 元数据：安装时会在 skill 目录内写入一个隐藏的 `.oo-metadata.json`
-  文件，并在其中记录 `version` 字段。
+- 元数据：内置 `oo` 会写入一个隐藏的 `.oo-metadata.json` 文件，其中
+  `version` 字段记录当前 `oo` 版本。
+- 元数据：已发布 skill 也会写入一个隐藏的 `.oo-metadata.json` 文件，
+  其中 `version` 字段记录 package 版本，`packageName` 字段记录来源
+  package。
 - 元数据：当存在持久化的 `skills.oo.implicit_invocation` 配置时，
-  `agents/openai.yaml` 会使用该值；否则使用内置默认值。
+  bundled `oo` 的 `agents/openai.yaml` 会使用该值；否则使用内置默认值。
+- 说明：安装已发布 skill 时，所有 registry 请求都会携带当前激活账号的
+  `Authorization` header。
+- 说明：如果 package 下有多个 skill，且当前不是交互终端，则必须提供
+  `--skill <name>` 或 `--all -y`。
+- 说明：如果显式安装的已发布 skill 与现有同名 skill 冲突，命令会在交互终
+  端中要求用户输入 `yes` 或 `no` 决定是否覆盖。
+- 说明：在交互选择页面中，存在重名冲突的 skill 会在列表中显示状态标记；
+  只要用户仍然选择该项，就会执行覆盖。
 - 说明：当 Codex 根目录不存在时，命令会直接报错退出，这表示当前机器上没有
   安装 Codex。
 - 说明：只有当 `oo/agents/openai.yaml` 中包含 `OOMOL` 字符串时，`oo`
-  才会认为这是自己管理的 skill；否则会视为其他 skill，并拒绝覆盖。
+  才会认为这是自己管理的内置 skill；否则会视为其他 skill，并拒绝覆盖。
 - 说明：如果这是 `oo` 的首次运行，且当前还没有已有的 config、auth、log
-  数据，那么只要 Codex 根目录已经存在，`oo` 就会静默自动安装这个受管
-  skill。
-- 说明：如果内置 skill 已经安装，`oo` 每次启动都会检查其记录版本是否与当前
-  CLI 版本一致；这里的版本来自元数据文件中的 `version` 字段。不一致时会
-  静默刷新已安装的文件。
+  数据，那么只要 Codex 根目录已经存在，`oo` 就会静默自动安装这个 bundled
+  受管 skill。
+- 说明：如果 bundled `oo` 已经安装，`oo` 每次启动都会检查其记录版本是否
+  与当前 CLI 版本一致；这里的版本来自元数据文件中的 `version` 字段。不一
+  致时会静默刷新已安装的文件。
 
 ### `oo skills uninstall`
 

--- a/package.json
+++ b/package.json
@@ -40,10 +40,12 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "@clack/core": "0.5.0",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "ajv-i18n": "^4.2.0",
     "commander": "^14.0.3",
+    "picocolors": "^1.1.1",
     "pino": "^10.3.1",
     "smol-toml": "^1.6.0",
     "zod": "^4.3.6"

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -3,17 +3,22 @@ import type { FileDownloadSessionStore } from "../contracts/file-download-sessio
 import type { FileUploadRecordStore } from "../contracts/file-upload-store.ts";
 import type { SettingsStore } from "../contracts/settings-store.ts";
 
-import { readdir, readFile, stat } from "node:fs/promises";
+import { mkdir, readdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import { describe, expect, test } from "bun:test";
 import {
     createCliSandbox,
     createCliSnapshot,
+    createInteractiveInput,
     createTextBuffer,
     readLatestLogContent,
+    toRequest,
+    writeAuthFile,
 } from "../../../__tests__/helpers.ts";
 import packageManifest from "../../../package.json" with { type: "json" };
 import { resolveStorePaths } from "../../adapters/store/store-path.ts";
+import { resolveCodexHomeDirectory } from "../commands/skills/shared.ts";
 import { APP_NAME } from "../config/app-config.ts";
 import { CliUserError } from "../contracts/cli.ts";
 import { createTerminalColors } from "../terminal-colors.ts";
@@ -33,6 +38,77 @@ describe("runCli bootstrap", () => {
             expect(createCliSnapshot(result)).toMatchSnapshot();
         }
         finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("executes published skill installation with explicit --skill", async () => {
+        const sandbox = await createCliSandbox();
+        const originalCwd = process.cwd;
+        const originalEnv = process.env;
+        const stdout = createTextBuffer({
+            isTTY: true,
+        });
+        const stderr = createTextBuffer();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+
+        try {
+            await writeAuthFile(sandbox);
+            await mkdir(codexHomeDirectory, { recursive: true });
+            process.cwd = () => sandbox.cwd;
+            process.env = sandbox.env;
+
+            const exitCode = await executeCli({
+                argv: [
+                    "skills",
+                    "install",
+                    "red-note-ng",
+                    "--skill",
+                    "writer",
+                ],
+                cwd: sandbox.cwd,
+                env: sandbox.env,
+                fetcher: async (input, init) => {
+                    const request = toRequest(input, init);
+
+                    if (request.url.includes("/package-info/")) {
+                        return new Response(JSON.stringify({
+                            packageName: "red-note-ng",
+                            version: "0.0.3",
+                            skills: [
+                                {
+                                    description: "Optimize notes",
+                                    name: "writer",
+                                    title: "Writer",
+                                },
+                            ],
+                        }));
+                    }
+
+                    if (request.url.endsWith("/red-note-ng/-/meta/red-note-ng-0.0.3.tgz")) {
+                        return new Response(await new Bun.Archive({
+                            "package/package/skills/writer/SKILL.md": "# Writer\n",
+                        }, {
+                            compress: "gzip",
+                        }).bytes());
+                    }
+
+                    throw new Error(`Unexpected request: ${request.url}`);
+                },
+                stderr: stderr.writer,
+                stdin: createInteractiveInput(),
+                stdout: stdout.writer,
+                systemLocale: "en-US",
+            });
+            const plainOutput = stripVTControlCharacters(stdout.read());
+
+            expect(exitCode).toBe(0);
+            expect(stderr.read()).toBe("");
+            expect(plainOutput).toContain("Installed Codex skill writer");
+        }
+        finally {
+            process.cwd = originalCwd;
+            process.env = originalEnv;
             await sandbox.cleanup();
         }
     });

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -96,6 +96,7 @@ export async function runCli(argv: string[]): Promise<number> {
         cwd: process.cwd(),
         env: process.env,
         fetcher: fetch,
+        stdin: process.stdin,
         stdout: process.stdout,
         stderr: process.stderr,
         systemLocale: getSystemLocale(),

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -1,10 +1,10 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`skills CLI rejects unsupported skill names for skills install 1`] = `
+exports[`skills CLI requires login before installing published skills 1`] = `
 {
-  "exitCode": 2,
+  "exitCode": 1,
   "stderr": 
-"Unsupported skill: unknown. Use oo.
+"You must log in before installing published skills.
 "
 ,
   "stdout": "",

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -16,7 +16,7 @@ import {
 } from "./shared.ts";
 
 describe("skills CLI", () => {
-    test("rejects unsupported skill names for skills install", async () => {
+    test("requires login before installing published skills", async () => {
         const sandbox = await createCliSandbox();
 
         try {

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -1,12 +1,30 @@
 import { mkdir, readFile, realpath, stat } from "node:fs/promises";
+
 import { join } from "node:path";
+import { stripVTControlCharacters } from "node:util";
 
 import { describe, expect, test } from "bun:test";
 
-import { createCliSandbox } from "../../../../__tests__/helpers.ts";
+import {
+    createCliSandbox,
+    createInteractiveInput,
+    createTextBuffer,
+    toRequest,
+    waitForOutputText,
+    writeAuthFile,
+} from "../../../../__tests__/helpers.ts";
 import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
+import { executeCli } from "../../bootstrap/run-cli.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import { getBundledSkillFiles } from "./embedded-assets.ts";
+import {
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillMetadataFilePath,
+} from "./managed-skill-paths.ts";
+import {
+    installedRegistrySkillCompatibility,
+    renderOoPackageExecutionGuidance,
+} from "./registry-skill-markdown.ts";
 import {
     resolveBundledSkillCanonicalDirectoryPath,
     resolveBundledSkillMetadataFilePath,
@@ -14,6 +32,8 @@ import {
 } from "./shared.ts";
 
 describe("skills commands", () => {
+    const guidance = renderOoPackageExecutionGuidance();
+
     test("installs the default bundled Codex skill when no skill name is provided", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -610,8 +630,378 @@ describe("skills commands", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("installs a published registry skill by explicit --skill name", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+        const metadataFilePath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
+        const requests: Request[] = [];
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "--skill", "chatgpt"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.3",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/openai/-/meta/openai-0.0.3.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
+                                "package/package/skills/chatgpt/agents/openai.yaml":
+                                    "agent\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Installed Codex skill chatgpt to ${skillDirectoryPath}.\n`,
+            );
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect(await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8")).toBe(
+                [
+                    "---",
+                    "name: chatgpt",
+                    "description: \"Chat with a model\"",
+                    `compatibility: ${JSON.stringify(installedRegistrySkillCompatibility)}`,
+                    "metadata:",
+                    "  title: \"ChatGPT\"",
+                    "---",
+                    "",
+                    "# ChatGPT",
+                    "",
+                    guidance,
+                    "",
+                ].join("\n"),
+            );
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                formatManagedSkillMetadataContent("openai", "0.0.3"),
+            );
+            expect(requests).toHaveLength(2);
+            expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
+            expect(requests[1]!.headers.get("Authorization")).toBe("secret-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("installs selected published skills through the interactive picker", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const selectedSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const unselectedSkillDirectoryPath = join(codexHomeDirectory, "skills", "vision");
+        const stdin = createInteractiveInput();
+        const stdout = createTextBuffer({
+            isTTY: true,
+        });
+        const stderr = createTextBuffer();
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+            const execution = executeCli({
+                argv: ["skills", "install", "openai"],
+                cwd: sandbox.cwd,
+                env: sandbox.env,
+                fetcher: async (input, init) => {
+                    const request = toRequest(input, init);
+
+                    if (request.url.includes("/package-info/")) {
+                        return new Response(JSON.stringify({
+                            packageName: "openai",
+                            version: "0.0.3",
+                            skills: [
+                                {
+                                    description: "Chat with a model",
+                                    name: "chatgpt",
+                                    title: "ChatGPT",
+                                },
+                                {
+                                    description: "See images",
+                                    name: "vision",
+                                    title: "Vision",
+                                },
+                            ],
+                        }));
+                    }
+
+                    if (request.url.endsWith("/openai/-/meta/openai-0.0.3.tgz")) {
+                        return new Response(await createRegistrySkillArchiveBytes({
+                            "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
+                            "package/package/skills/vision/SKILL.md": "# Vision\n",
+                        }));
+                    }
+
+                    throw new Error(`Unexpected request: ${request.url}`);
+                },
+                stdin,
+                stderr: stderr.writer,
+                stdout: stdout.writer,
+                systemLocale: "en-US",
+            });
+
+            await waitForOutputText(stdout, "Select skills to install");
+            stdin.feed(" ");
+            stdin.feed("\r");
+
+            const exitCode = await execution;
+            const plainOutput = stripVTControlCharacters(stdout.read());
+
+            expect(exitCode).toBe(0);
+            expect(stderr.read()).toBe("");
+            expect(plainOutput).toContain("Select skills to install");
+            expect(plainOutput).toContain("chatgpt");
+            expect(plainOutput).toContain("vision");
+            expect(plainOutput).toContain(
+                `Installed Codex skill chatgpt to ${selectedSkillDirectoryPath}.`,
+            );
+            await expect(stat(join(selectedSkillDirectoryPath, "SKILL.md"))).resolves.toMatchObject({
+                isFile: expect.any(Function),
+            });
+            await expect(stat(unselectedSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("skips overwriting an existing published skill when confirmation is declined", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+        const stdin = createInteractiveInput();
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+            await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "stale\n");
+            stdin.feed("n\n");
+
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "--skill", "chatgpt"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.3",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/openai/-/meta/openai-0.0.3.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                    stdin,
+                    stdout: {
+                        isTTY: true,
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain(
+                "Skill chatgpt already exists. Overwrite? [y/N] ",
+            );
+            expect(result.stdout).toContain("Skipped Codex skill chatgpt.");
+            expect(await readFile(join(canonicalSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
+                "stale\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("installs all published skills when --yes is passed without --skill", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const chatgptSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const visionSkillDirectoryPath = join(codexHomeDirectory, "skills", "vision");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "--yes"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.3",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                    {
+                                        description: "See images",
+                                        name: "vision",
+                                        title: "Vision",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/openai/-/meta/openai-0.0.3.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
+                                "package/package/skills/vision/SKILL.md": "# Vision\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain("Installing all 2 skills.");
+            await expect(stat(join(chatgptSkillDirectoryPath, "SKILL.md"))).resolves.toMatchObject({
+                isFile: expect.any(Function),
+            });
+            await expect(stat(join(visionSkillDirectoryPath, "SKILL.md"))).resolves.toMatchObject({
+                isFile: expect.any(Function),
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails outside a TTY when multiple skills require selection", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "openai"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.3",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                    {
+                                        description: "See images",
+                                        name: "vision",
+                                        title: "Vision",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Package openai has multiple skills. Use --skill <name>, --all -y, or run in an interactive terminal.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });
 
 function formatBundledSkillMetadataContent(version: string): string {
     return `${JSON.stringify({ version }, null, 2)}\n`;
+}
+
+function formatManagedSkillMetadataContent(
+    packageName: string,
+    version: string,
+): string {
+    return `${JSON.stringify({ packageName, version }, null, 2)}\n`;
+}
+
+async function createRegistrySkillArchiveBytes(
+    files: Record<string, string>,
+): Promise<Uint8Array<ArrayBuffer>> {
+    return await new Bun.Archive(files, {
+        compress: "gzip",
+    }).bytes();
 }

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -2,20 +2,18 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import type { BundledSkillName } from "./embedded-assets.ts";
 
 import { z } from "zod";
-import { CliUserError } from "../../contracts/cli.ts";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
+import { installRegistrySkills } from "./registry-skill-install.ts";
 import { installBundledSkill } from "./shared.ts";
 
 interface SkillsInstallInput {
-    skill: BundledSkillName;
+    all?: boolean;
+    packageName?: string;
+    skill?: string[];
+    yes?: boolean;
 }
 
 const defaultBundledSkillName = "oo" as const;
-const bundledSkillNameSchema = z.enum(availableBundledSkillNames);
-
-const skillsInstallInputSchema = z.object({
-    skill: bundledSkillNameSchema.default(defaultBundledSkillName),
-});
 
 export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
     name: "install",
@@ -23,18 +21,62 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
     descriptionKey: "commands.skills.install.description",
     arguments: [
         {
-            name: "skill",
-            descriptionKey: "arguments.skill",
+            name: "packageName",
+            descriptionKey: "arguments.packageName",
             required: false,
         },
     ],
-    inputSchema: skillsInstallInputSchema,
-    mapInputError: (_, rawInput) =>
-        new CliUserError("errors.skills.invalidName", 2, {
-            choices: availableBundledSkillNames.join(", "),
-            value: String(rawInput.skill ?? ""),
-        }),
+    options: [
+        {
+            name: "skill",
+            longFlag: "--skill",
+            shortFlag: "-s",
+            valueName: "skills...",
+            descriptionKey: "options.skill",
+        },
+        {
+            name: "yes",
+            longFlag: "--yes",
+            shortFlag: "-y",
+            descriptionKey: "options.yes",
+        },
+        {
+            name: "all",
+            longFlag: "--all",
+            descriptionKey: "options.all",
+        },
+    ],
+    inputSchema: z.object({
+        all: z.boolean().optional(),
+        packageName: z.string().optional(),
+        skill: z.array(z.string()).optional(),
+        yes: z.boolean().optional(),
+    }),
     handler: async (input, context) => {
-        await installBundledSkill(input.skill, context);
+        if (
+            input.packageName === undefined
+            || isBundledSkillName(input.packageName)
+        ) {
+            await installBundledSkill(
+                (input.packageName as BundledSkillName | undefined)
+                ?? defaultBundledSkillName,
+                context,
+            );
+            return;
+        }
+
+        await installRegistrySkills(
+            {
+                all: input.all === true,
+                packageName: input.packageName,
+                skillNames: input.skill ?? [],
+                yes: input.yes === true,
+            },
+            context,
+        );
     },
 };
+
+function isBundledSkillName(value: string): value is BundledSkillName {
+    return availableBundledSkillNames.includes(value as BundledSkillName);
+}

--- a/src/application/commands/skills/interactive-prompts.test.ts
+++ b/src/application/commands/skills/interactive-prompts.test.ts
@@ -1,0 +1,102 @@
+import { stripVTControlCharacters } from "node:util";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    createInteractiveInput,
+    createTextBuffer,
+    waitForOutputText,
+} from "../../../../__tests__/helpers.ts";
+import {
+    confirmInteractiveValue,
+    selectInteractiveSkills,
+} from "./interactive-prompts.ts";
+
+describe("interactive prompts", () => {
+    test("accepts yes/no confirmation input", async () => {
+        const stdin = createInteractiveInput();
+        const stdout = createTextBuffer({
+            isTTY: true,
+        });
+        const confirmationPromise = confirmInteractiveValue(
+            {
+                stdin,
+                stdout: stdout.writer,
+            },
+            {
+                invalidMessage: "invalid",
+                prompt: "Overwrite? [y/N] ",
+            },
+        );
+
+        stdin.feed("yes\n");
+
+        await expect(confirmationPromise).resolves.toBeTrue();
+        expect(stdout.read()).toBe("Overwrite? [y/N] ");
+    });
+
+    test("re-prompts on invalid confirmation input", async () => {
+        const stdin = createInteractiveInput();
+        const stdout = createTextBuffer({
+            isTTY: true,
+        });
+        const confirmationPromise = confirmInteractiveValue(
+            {
+                stdin,
+                stdout: stdout.writer,
+            },
+            {
+                invalidMessage: "invalid",
+                prompt: "Overwrite? [y/N] ",
+            },
+        );
+
+        stdin.feed("maybe\n");
+        stdin.feed("n\n");
+
+        await expect(confirmationPromise).resolves.toBeFalse();
+        expect(stdout.read()).toBe("Overwrite? [y/N] invalid\nOverwrite? [y/N] ");
+    });
+
+    test("renders a clack-style multiselect prompt", async () => {
+        const stdin = createInteractiveInput();
+        const stdout = createTextBuffer({
+            isTTY: true,
+        });
+        const selectionPromise = selectInteractiveSkills(
+            {
+                stdin,
+                stdout: stdout.writer,
+            },
+            {
+                items: [
+                    {
+                        description: "First description",
+                        name: "alpha",
+                        title: "Alpha",
+                    },
+                    {
+                        description: "Second description",
+                        name: "beta",
+                        statusLabel: "conflict",
+                        title: "Beta",
+                    },
+                ],
+                prompt: "Select skills to install (space to toggle)",
+            },
+        );
+
+        await waitForOutputText(stdout, "Select skills to install");
+        stdin.feed(" ");
+        stdin.feed("\r");
+
+        await expect(selectionPromise).resolves.toEqual(["alpha"]);
+        const plainOutput = stripVTControlCharacters(stdout.read());
+
+        expect(plainOutput).toContain("Select skills to install");
+        expect(plainOutput).toContain("alpha");
+        expect(plainOutput).toContain("beta");
+        expect(plainOutput).toContain("conflict");
+        expect(plainOutput).toContain("First description");
+    });
+});

--- a/src/application/commands/skills/interactive-prompts.ts
+++ b/src/application/commands/skills/interactive-prompts.ts
@@ -1,0 +1,406 @@
+import type {
+    InteractiveInput,
+    Writer,
+} from "../../contracts/cli.ts";
+
+import process from "node:process";
+import { PassThrough, Writable } from "node:stream";
+
+import { isCancel, MultiSelectPrompt } from "@clack/core";
+import color from "picocolors";
+
+const outputTextDecoder = new TextDecoder();
+const inputTextDecoder = new TextDecoder();
+
+const promptSymbols = {
+    active: color.cyan("◆"),
+    cancelled: color.red("■"),
+    inactive: color.dim("◻"),
+    line: color.cyan("│"),
+    mutedLine: color.gray("│"),
+    selected: color.green("◼"),
+    submitted: color.green("◇"),
+    tail: color.cyan("└"),
+} as const;
+
+export interface InteractivePromptContext {
+    stdin: InteractiveInput;
+    stdout: Writer;
+}
+
+export interface InteractiveSkillSelectItem {
+    description: string;
+    name: string;
+    statusLabel?: string;
+    title: string;
+}
+
+interface MultiSelectOption {
+    hint: string;
+    label: string;
+    value: string;
+}
+
+export async function confirmInteractiveValue(
+    context: InteractivePromptContext,
+    options: {
+        defaultValue?: boolean;
+        invalidMessage: string;
+        prompt: string;
+    },
+): Promise<boolean> {
+    const defaultValue = options.defaultValue ?? false;
+
+    while (true) {
+        context.stdout.write(options.prompt);
+        const value = normalizePromptValue(await readPromptLine(context.stdin));
+
+        if (value === "") {
+            return defaultValue;
+        }
+
+        if (value === "y" || value === "yes") {
+            return true;
+        }
+
+        if (value === "n" || value === "no") {
+            return false;
+        }
+
+        context.stdout.write(`${options.invalidMessage}\n`);
+    }
+}
+
+export async function selectInteractiveSkills(
+    context: InteractivePromptContext,
+    options: {
+        items: readonly InteractiveSkillSelectItem[];
+        prompt: string;
+    },
+): Promise<string[]> {
+    const promptStreams = createPromptStreams(context);
+    const promptOptions = options.items.map(item => ({
+        hint: item.description,
+        label: formatSkillOptionLabel(item, promptStreams.output.columns),
+        value: item.name,
+    }));
+
+    try {
+        const selectedValues = await withPatchedPromptOutput(
+            promptStreams.output,
+            async () => await new MultiSelectPrompt<MultiSelectOption>({
+                cursorAt: promptOptions[0]?.value,
+                input: promptStreams.input,
+                options: promptOptions,
+                output: promptStreams.output,
+                render() {
+                    return renderMultiSelectPrompt(this, options.prompt);
+                },
+                required: false,
+            }).prompt() as string[] | symbol,
+        );
+
+        if (isCancel(selectedValues)) {
+            return [];
+        }
+
+        return selectedValues;
+    }
+    finally {
+        promptStreams.input.dispose();
+    }
+}
+
+async function withPatchedPromptOutput<T>(
+    output: PromptOutputAdapter,
+    action: () => Promise<T>,
+): Promise<T> {
+    const originalStdout = process.stdout;
+
+    Object.defineProperty(process, "stdout", {
+        configurable: true,
+        value: output,
+    });
+
+    try {
+        return await action();
+    }
+    finally {
+        Object.defineProperty(process, "stdout", {
+            configurable: true,
+            value: originalStdout,
+        });
+    }
+}
+
+function createPromptStreams(
+    context: InteractivePromptContext,
+): {
+    input: PromptInputAdapter;
+    output: PromptOutputAdapter;
+} {
+    return {
+        input: new PromptInputAdapter(context.stdin),
+        output: new PromptOutputAdapter(context.stdout, process.stdout),
+    };
+}
+
+function renderMultiSelectPrompt(
+    prompt: Omit<MultiSelectPrompt<MultiSelectOption>, "prompt">,
+    message: string,
+): string {
+    const header = `${color.gray("│")}\n${readPromptStateSymbol(prompt.state)}  ${message}\n`;
+
+    switch (prompt.state) {
+        case "submit":
+            return `${header}${color.gray("│")}  ${prompt.options
+                .filter(({ value }) => prompt.value.includes(value))
+                .map(option => formatRenderedOption(option, "submitted"))
+                .join(color.dim(", ")) || color.dim("none")}`;
+        case "cancel": {
+            const selectedOptions = prompt.options
+                .filter(({ value }) => prompt.value.includes(value))
+                .map(option => formatRenderedOption(option, "cancelled"))
+                .join(color.dim(", "));
+
+            return `${header}${color.gray("│")}  ${selectedOptions.trim() === "" ? "" : `${selectedOptions}\n${color.gray("│")}`}`;
+        }
+        case "error": {
+            const renderedError = prompt.error.split("\n").map((line, index) =>
+                index === 0
+                    ? `${color.yellow("└")}  ${color.yellow(line)}`
+                    : `   ${line}`,
+            ).join("\n");
+
+            return `${header}${color.yellow("│")}  ${renderScrollableOptions(
+                prompt.cursor,
+                prompt.options,
+                option => formatRenderedOption(
+                    option,
+                    isOptionSelected(prompt, option)
+                        ? "active-selected"
+                        : "active",
+                ),
+            ).join(`\n${color.yellow("│")}  `)}\n${renderedError}\n`;
+        }
+        default:
+            return `${header}${promptSymbols.line}  ${renderScrollableOptions(
+                prompt.cursor,
+                prompt.options,
+                option => formatRenderedOption(
+                    option,
+                    isOptionSelected(prompt, option)
+                        ? "active-selected"
+                        : "active",
+                ),
+                option => formatRenderedOption(
+                    option,
+                    isOptionSelected(prompt, option)
+                        ? "selected"
+                        : "inactive",
+                ),
+            ).join(`\n${promptSymbols.line}  `)}\n${promptSymbols.tail}\n`;
+    }
+}
+
+function renderScrollableOptions(
+    cursor: number,
+    options: readonly MultiSelectOption[],
+    activeStyle: (option: MultiSelectOption) => string,
+    inactiveStyle: (option: MultiSelectOption) => string = option =>
+        formatRenderedOption(option, "inactive"),
+): string[] {
+    const maxItems = Number.POSITIVE_INFINITY;
+    const visibleRows = Math.max((process.stdout.rows ?? 24) - 4, 0);
+    const windowSize = Math.min(
+        visibleRows,
+        Math.max(maxItems, 5),
+    );
+    let offset = 0;
+
+    if (cursor >= offset + windowSize - 3) {
+        offset = Math.max(
+            Math.min(cursor - windowSize + 3, options.length - windowSize),
+            0,
+        );
+    }
+    else if (cursor < offset + 2) {
+        offset = Math.max(cursor - 2, 0);
+    }
+
+    return options.slice(offset, offset + windowSize).map((option, index) =>
+        index + offset === cursor ? activeStyle(option) : inactiveStyle(option),
+    );
+}
+
+function formatRenderedOption(
+    option: MultiSelectOption,
+    state: "active" | "active-selected" | "cancelled" | "inactive" | "selected" | "submitted",
+): string {
+    switch (state) {
+        case "active":
+            return `${color.cyan("◻")} ${option.label} ${option.hint === "" ? "" : color.dim(`(${option.hint})`)}`;
+        case "active-selected":
+            return `${color.green("◼")} ${option.label} ${option.hint === "" ? "" : color.dim(`(${option.hint})`)}`;
+        case "cancelled":
+            return color.strikethrough(color.dim(option.label));
+        case "inactive":
+            return `${color.dim("◻")} ${color.dim(option.label)}`;
+        case "selected":
+            return `${color.green("◼")} ${color.dim(option.label)} ${option.hint === "" ? "" : color.dim(`(${option.hint})`)}`;
+        case "submitted":
+            return color.dim(option.label);
+    }
+}
+
+function readPromptStateSymbol(state: string): string {
+    switch (state) {
+        case "cancel":
+            return promptSymbols.cancelled;
+        case "submit":
+            return promptSymbols.submitted;
+        default:
+            return promptSymbols.active;
+    }
+}
+
+function isOptionSelected(
+    prompt: Pick<MultiSelectPrompt<MultiSelectOption>, "value">,
+    option: MultiSelectOption,
+): boolean {
+    return prompt.value.includes(option.value);
+}
+
+function formatSkillOptionLabel(
+    item: InteractiveSkillSelectItem,
+    terminalColumns: number,
+): string {
+    if (!item.statusLabel) {
+        return item.name;
+    }
+
+    const minimumSpacing = 2;
+    const reservedWidth = item.statusLabel.length + minimumSpacing;
+    const safeColumns = terminalColumns > 0 ? terminalColumns : 80;
+    const maxNameWidth = Math.max(
+        safeColumns - reservedWidth - 12,
+        item.name.length,
+    );
+    const displayName = item.name.length > maxNameWidth
+        ? item.name.slice(0, maxNameWidth)
+        : item.name;
+    const paddingWidth = Math.max(
+        safeColumns - displayName.length - reservedWidth - 12,
+        minimumSpacing,
+    );
+
+    return `${displayName}${" ".repeat(paddingWidth)}${item.statusLabel}`;
+}
+
+async function readPromptLine(stdin: InteractiveInput): Promise<string> {
+    return await new Promise((resolve) => {
+        let bufferedValue = "";
+
+        const onData = (chunk: string | Uint8Array) => {
+            bufferedValue += typeof chunk === "string"
+                ? chunk
+                : inputTextDecoder.decode(chunk, { stream: true });
+
+            const lineBreakIndex = resolveLineBreakIndex(bufferedValue);
+
+            if (lineBreakIndex === -1) {
+                return;
+            }
+
+            stdin.off("data", onData);
+            stdin.pause?.();
+
+            resolve(stripTrailingCarriageReturn(bufferedValue.slice(0, lineBreakIndex)));
+        };
+
+        stdin.resume?.();
+        stdin.on("data", onData);
+    });
+}
+
+function normalizePromptValue(value: string): string {
+    return value.trim().toLowerCase();
+}
+
+function resolveLineBreakIndex(value: string): number {
+    const lineFeedIndex = value.indexOf("\n");
+
+    if (lineFeedIndex !== -1) {
+        return lineFeedIndex;
+    }
+
+    return value.indexOf("\r");
+}
+
+function stripTrailingCarriageReturn(value: string): string {
+    return value.endsWith("\r") ? value.slice(0, -1) : value;
+}
+
+class PromptInputAdapter extends PassThrough {
+    readonly isTTY: boolean;
+
+    constructor(
+        private readonly input: InteractiveInput,
+    ) {
+        super();
+        this.isTTY = input.isTTY === true;
+        this.input.on("data", this.handleData);
+    }
+
+    override pause(): this {
+        super.pause();
+        this.input.pause?.();
+
+        return this;
+    }
+
+    override resume(): this {
+        super.resume();
+        this.input.resume?.();
+
+        return this;
+    }
+
+    setRawMode(value: boolean): void {
+        this.input.setRawMode?.(value);
+    }
+
+    dispose(): void {
+        this.input.off("data", this.handleData);
+        this.end();
+    }
+
+    private readonly handleData = (chunk: string | Uint8Array) => {
+        this.write(chunk);
+    };
+}
+
+class PromptOutputAdapter extends Writable {
+    readonly columns: number;
+    readonly isTTY: boolean;
+    readonly rows: number;
+
+    constructor(
+        private readonly writer: Writer,
+        output: NodeJS.WriteStream,
+    ) {
+        super();
+        this.columns = output.columns ?? 80;
+        this.isTTY = writer.isTTY === true;
+        this.rows = output.rows ?? 24;
+    }
+
+    override _write(
+        chunk: Uint8Array,
+        _encoding: BufferEncoding,
+        callback: (error?: Error | null) => void,
+    ): void {
+        this.writer.write(outputTextDecoder.decode(chunk, { stream: true }));
+        callback();
+    }
+}

--- a/src/application/commands/skills/managed-skill-metadata.test.ts
+++ b/src/application/commands/skills/managed-skill-metadata.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    parseManagedSkillMetadataContent,
+    renderManagedSkillMetadataContent,
+} from "./managed-skill-metadata.ts";
+
+describe("managed skill metadata", () => {
+    test("parses version-only metadata", () => {
+        expect(
+            parseManagedSkillMetadataContent(
+                JSON.stringify({
+                    version: "1.2.3",
+                }),
+            ),
+        ).toEqual({
+            packageName: undefined,
+            version: "1.2.3",
+        });
+    });
+
+    test("parses package-backed metadata", () => {
+        expect(
+            parseManagedSkillMetadataContent(
+                JSON.stringify({
+                    packageName: "@foo/bar",
+                    version: "1.2.3",
+                }),
+            ),
+        ).toEqual({
+            packageName: "@foo/bar",
+            version: "1.2.3",
+        });
+    });
+
+    test("rejects metadata with an empty version", () => {
+        expect(
+            parseManagedSkillMetadataContent(
+                JSON.stringify({
+                    version: "",
+                }),
+            ),
+        ).toBeUndefined();
+    });
+
+    test("renders metadata with packageName when present", () => {
+        expect(
+            renderManagedSkillMetadataContent({
+                packageName: "openai",
+                version: "0.0.3",
+            }),
+        ).toBe(
+            [
+                "{",
+                "  \"packageName\": \"openai\",",
+                "  \"version\": \"0.0.3\"",
+                "}",
+                "",
+            ].join("\n"),
+        );
+    });
+});

--- a/src/application/commands/skills/managed-skill-metadata.ts
+++ b/src/application/commands/skills/managed-skill-metadata.ts
@@ -1,0 +1,90 @@
+import { readFile } from "node:fs/promises";
+
+import { resolveManagedSkillMetadataFilePath } from "./managed-skill-paths.ts";
+
+export interface ManagedSkillMetadata {
+    packageName?: string;
+    version: string;
+}
+
+export function parseManagedSkillMetadataContent(
+    content: string,
+): ManagedSkillMetadata | undefined {
+    let parsedContent: unknown;
+
+    try {
+        parsedContent = JSON.parse(content);
+    }
+    catch {
+        return undefined;
+    }
+
+    if (
+        typeof parsedContent !== "object"
+        || parsedContent === null
+        || Array.isArray(parsedContent)
+    ) {
+        return undefined;
+    }
+
+    const rawVersion = (parsedContent as Record<string, unknown>).version;
+
+    if (typeof rawVersion !== "string" || rawVersion.trim() === "") {
+        return undefined;
+    }
+
+    const rawPackageName = (parsedContent as Record<string, unknown>).packageName;
+
+    if (rawPackageName !== undefined && typeof rawPackageName !== "string") {
+        return undefined;
+    }
+
+    if (typeof rawPackageName === "string" && rawPackageName.trim() === "") {
+        return undefined;
+    }
+
+    return {
+        packageName: typeof rawPackageName === "string" ? rawPackageName : undefined,
+        version: rawVersion.trim(),
+    };
+}
+
+export function renderManagedSkillMetadataContent(
+    metadata: ManagedSkillMetadata,
+): string {
+    return `${JSON.stringify(metadata, null, 2)}\n`;
+}
+
+export async function readManagedSkillMetadata(
+    skillDirectoryPath: string,
+): Promise<ManagedSkillMetadata | undefined> {
+    try {
+        return parseManagedSkillMetadataContent(
+            await readFile(
+                resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+                "utf8",
+            ),
+        );
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
+}
+
+export async function writeManagedSkillMetadata(
+    skillDirectoryPath: string,
+    metadata: ManagedSkillMetadata,
+): Promise<void> {
+    await Bun.write(
+        resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+        renderManagedSkillMetadataContent(metadata),
+    );
+}
+
+function isNodeNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/src/application/commands/skills/managed-skill-paths.test.ts
+++ b/src/application/commands/skills/managed-skill-paths.test.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import { describe, expect, test } from "bun:test";
 
 import {
@@ -10,7 +12,7 @@ import {
 describe("managed skill paths", () => {
     test("resolves the Codex installation directory for any skill name", () => {
         expect(resolveManagedSkillDirectoryPath("/tmp/.codex", "chatgpt")).toBe(
-            "/tmp/.codex/skills/chatgpt",
+            join("/tmp/.codex", "skills", "chatgpt"),
         );
     });
 
@@ -20,12 +22,21 @@ describe("managed skill paths", () => {
                 "/tmp/config/settings.toml",
                 "chatgpt",
             ),
-        ).toBe("/tmp/config/skills/chatgpt");
+        ).toBe(join("/tmp/config", "skills", "chatgpt"));
     });
 
     test("resolves the managed skill metadata file path", () => {
         expect(
-            resolveManagedSkillMetadataFilePath("/tmp/config/skills/chatgpt"),
-        ).toBe(`/tmp/config/skills/chatgpt/${managedSkillMetadataFileName}`);
+            resolveManagedSkillMetadataFilePath(
+                join("/tmp/config", "skills", "chatgpt"),
+            ),
+        ).toBe(
+            join(
+                "/tmp/config",
+                "skills",
+                "chatgpt",
+                managedSkillMetadataFileName,
+            ),
+        );
     });
 });

--- a/src/application/commands/skills/managed-skill-paths.test.ts
+++ b/src/application/commands/skills/managed-skill-paths.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    managedSkillMetadataFileName,
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillDirectoryPath,
+    resolveManagedSkillMetadataFilePath,
+} from "./managed-skill-paths.ts";
+
+describe("managed skill paths", () => {
+    test("resolves the Codex installation directory for any skill name", () => {
+        expect(resolveManagedSkillDirectoryPath("/tmp/.codex", "chatgpt")).toBe(
+            "/tmp/.codex/skills/chatgpt",
+        );
+    });
+
+    test("resolves the canonical config directory for any skill name", () => {
+        expect(
+            resolveManagedSkillCanonicalDirectoryPath(
+                "/tmp/config/settings.toml",
+                "chatgpt",
+            ),
+        ).toBe("/tmp/config/skills/chatgpt");
+    });
+
+    test("resolves the managed skill metadata file path", () => {
+        expect(
+            resolveManagedSkillMetadataFilePath("/tmp/config/skills/chatgpt"),
+        ).toBe(`/tmp/config/skills/chatgpt/${managedSkillMetadataFileName}`);
+    });
+});

--- a/src/application/commands/skills/managed-skill-paths.ts
+++ b/src/application/commands/skills/managed-skill-paths.ts
@@ -1,0 +1,25 @@
+import { dirname, join } from "node:path";
+
+const codexSkillsDirectoryName = "skills";
+
+export const managedSkillMetadataFileName = ".oo-metadata.json";
+
+export function resolveManagedSkillDirectoryPath(
+    codexHomeDirectory: string,
+    skillName: string,
+): string {
+    return join(codexHomeDirectory, codexSkillsDirectoryName, skillName);
+}
+
+export function resolveManagedSkillCanonicalDirectoryPath(
+    settingsFilePath: string,
+    skillName: string,
+): string {
+    return join(dirname(settingsFilePath), codexSkillsDirectoryName, skillName);
+}
+
+export function resolveManagedSkillMetadataFilePath(
+    skillDirectoryPath: string,
+): string {
+    return join(skillDirectoryPath, managedSkillMetadataFileName);
+}

--- a/src/application/commands/skills/registry-skill-archive.test.ts
+++ b/src/application/commands/skills/registry-skill-archive.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    extractRegistryPackageArchive,
+    requireExtractedRegistrySkillDirectory,
+} from "./registry-skill-archive.ts";
+
+describe("registry skill archive", () => {
+    test("extracts a package archive and locates the requested skill directory", async () => {
+        const bytes = await new Bun.Archive(
+            {
+                "package/package/package.json": "{}\n",
+                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
+                "package/package/skills/chatgpt/agents/openai.yaml": "agent\n",
+            },
+            {
+                compress: "gzip",
+            },
+        ).bytes();
+        const archive = await extractRegistryPackageArchive(bytes);
+
+        try {
+            await expect(
+                requireExtractedRegistrySkillDirectory(archive, "chatgpt"),
+            ).resolves.toContain("/skills/chatgpt");
+        }
+        finally {
+            await archive.cleanup();
+        }
+    });
+
+    test("rejects an extracted skill directory when SKILL.md is missing", async () => {
+        const bytes = await new Bun.Archive(
+            {
+                "package/package/skills/chatgpt/agents/openai.yaml": "agent\n",
+            },
+            {
+                compress: "gzip",
+            },
+        ).bytes();
+        const archive = await extractRegistryPackageArchive(bytes);
+
+        try {
+            await expect(
+                requireExtractedRegistrySkillDirectory(archive, "chatgpt"),
+            ).rejects.toThrow("errors.skills.install.invalidArchive");
+        }
+        finally {
+            await archive.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/registry-skill-archive.test.ts
+++ b/src/application/commands/skills/registry-skill-archive.test.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import { describe, expect, test } from "bun:test";
 
 import {
@@ -22,7 +24,7 @@ describe("registry skill archive", () => {
         try {
             await expect(
                 requireExtractedRegistrySkillDirectory(archive, "chatgpt"),
-            ).resolves.toContain("/skills/chatgpt");
+            ).resolves.toContain(join("skills", "chatgpt"));
         }
         finally {
             await archive.cleanup();

--- a/src/application/commands/skills/registry-skill-archive.ts
+++ b/src/application/commands/skills/registry-skill-archive.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { CliUserError } from "../../contracts/cli.ts";
+
+export interface ExtractedRegistryPackageArchive {
+    cleanup: () => Promise<void>;
+    rootDirectoryPath: string;
+    skillsDirectoryPath: string;
+}
+
+export async function extractRegistryPackageArchive(
+    bytes: Uint8Array<ArrayBuffer>,
+): Promise<ExtractedRegistryPackageArchive> {
+    const rootDirectoryPath = await mkdtemp(
+        join(tmpdir(), "oo-registry-skill-"),
+    );
+    const archive = new Bun.Archive(bytes);
+
+    await archive.extract(rootDirectoryPath);
+
+    return {
+        cleanup: async () => {
+            await rm(rootDirectoryPath, { force: true, recursive: true });
+        },
+        rootDirectoryPath,
+        skillsDirectoryPath: join(
+            rootDirectoryPath,
+            "package",
+            "package",
+            "skills",
+        ),
+    };
+}
+
+export async function requireExtractedRegistrySkillDirectory(
+    archive: Pick<ExtractedRegistryPackageArchive, "skillsDirectoryPath">,
+    skillName: string,
+): Promise<string> {
+    const skillDirectoryPath = join(archive.skillsDirectoryPath, skillName);
+    const skillFilePath = join(skillDirectoryPath, "SKILL.md");
+
+    if (
+        !(await directoryExists(skillDirectoryPath))
+        || !(await fileExists(skillFilePath))
+    ) {
+        throw new CliUserError("errors.skills.install.invalidArchive", 1, {
+            name: skillName,
+        });
+    }
+
+    return skillDirectoryPath;
+}
+
+async function directoryExists(path: string): Promise<boolean> {
+    try {
+        return (await stat(path)).isDirectory();
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+    try {
+        return (await stat(path)).isFile();
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+function isNodeNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -1,0 +1,424 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+import { cp, mkdir } from "node:fs/promises";
+
+import { dirname } from "node:path";
+import { CliUserError } from "../../contracts/cli.ts";
+import { withPackageIdentity } from "../../logging/log-fields.ts";
+import {
+    publishBundledSkillInstallation,
+    removePath,
+} from "./bundled-skill-filesystem.ts";
+import { directoryExists, requireCodexHomeDirectory } from "./bundled-skill-observation.ts";
+import {
+    confirmInteractiveValue,
+    selectInteractiveSkills,
+} from "./interactive-prompts.ts";
+import {
+    readManagedSkillMetadata,
+    writeManagedSkillMetadata,
+} from "./managed-skill-metadata.ts";
+import {
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillDirectoryPath,
+} from "./managed-skill-paths.ts";
+import {
+    extractRegistryPackageArchive,
+    requireExtractedRegistrySkillDirectory,
+} from "./registry-skill-archive.ts";
+import { rewriteInstalledRegistrySkillMarkdown } from "./registry-skill-markdown.ts";
+import {
+    downloadRegistryPackageTarball,
+    loadRegistryPackageSkillInfo,
+    requireCurrentSkillsInstallAccount,
+} from "./registry-skill-source.ts";
+
+interface ManagedSkillPathState {
+    exists: boolean;
+    metadataPackageName: string | undefined;
+}
+
+export interface RegistrySkillInstallRequest {
+    all: boolean;
+    packageName: string;
+    skillNames: string[];
+    yes: boolean;
+}
+
+type RegistrySkillInstallStatus = "conflict" | "installed" | "new";
+
+export async function installRegistrySkills(
+    request: RegistrySkillInstallRequest,
+    context: CliExecutionContext,
+): Promise<void> {
+    const account = await requireCurrentSkillsInstallAccount(context);
+    const codexHomeDirectory = await requireCodexHomeDirectory(context);
+    const packageInfo = await loadRegistryPackageSkillInfo(
+        request.packageName,
+        account,
+        context,
+    );
+
+    if (packageInfo.skills.length === 0) {
+        throw new CliUserError("errors.skills.install.noPublishedSkills", 1, {
+            packageName: packageInfo.packageName,
+        });
+    }
+
+    const selectedSkillNames = await resolveSelectedSkillNames(
+        request,
+        packageInfo,
+        codexHomeDirectory,
+        context,
+    );
+
+    if (selectedSkillNames.length === 0) {
+        return;
+    }
+
+    const packageBytes = await downloadRegistryPackageTarball(
+        packageInfo.packageName,
+        packageInfo.packageVersion,
+        account,
+        context,
+    );
+    const extractedPackage = await extractRegistryPackageArchive(packageBytes);
+
+    try {
+        for (const skillName of selectedSkillNames) {
+            const skill = findPackageSkillOrThrow(packageInfo, skillName);
+            const canonicalSkillDirectoryPath
+                = resolveManagedSkillCanonicalDirectoryPath(
+                    context.settingsStore.getFilePath(),
+                    skillName,
+                );
+            const installedSkillDirectoryPath = resolveManagedSkillDirectoryPath(
+                codexHomeDirectory,
+                skillName,
+            );
+
+            await removePath(canonicalSkillDirectoryPath);
+            await mkdir(dirname(canonicalSkillDirectoryPath), { recursive: true });
+            await cp(
+                await requireExtractedRegistrySkillDirectory(
+                    extractedPackage,
+                    skillName,
+                ),
+                canonicalSkillDirectoryPath,
+                {
+                    force: true,
+                    recursive: true,
+                },
+            );
+            await rewriteInstalledRegistrySkillMarkdown(
+                canonicalSkillDirectoryPath,
+                skill,
+                packageInfo.packageName,
+            );
+            await writeManagedSkillMetadata(
+                canonicalSkillDirectoryPath,
+                {
+                    packageName: packageInfo.packageName,
+                    version: packageInfo.packageVersion,
+                },
+            );
+
+            const installation = await publishBundledSkillInstallation({
+                canonicalSkillDirectoryPath,
+                installedSkillDirectoryPath,
+            });
+
+            writeLine(
+                context,
+                context.translator.t("skills.install.success", {
+                    name: skillName,
+                    path: installation.path,
+                }),
+            );
+            context.logger.info(
+                {
+                    ...withPackageIdentity(
+                        packageInfo.packageName,
+                        packageInfo.packageVersion,
+                    ),
+                    installMode: installation.mode,
+                    path: installation.path,
+                    skillName,
+                },
+                "Registry Codex skill installed explicitly.",
+            );
+        }
+    }
+    finally {
+        await extractedPackage.cleanup();
+    }
+}
+
+async function resolveSelectedSkillNames(
+    request: RegistrySkillInstallRequest,
+    packageInfo: Awaited<ReturnType<typeof loadRegistryPackageSkillInfo>>,
+    codexHomeDirectory: string,
+    context: Pick<
+        CliExecutionContext,
+        "settingsStore" | "stdin" | "stdout" | "translator"
+    >,
+): Promise<string[]> {
+    if (request.all) {
+        writeLine(
+            context,
+            context.translator.t("skills.install.allSelected", {
+                count: packageInfo.skills.length,
+            }),
+        );
+
+        return packageInfo.skills.map(skill => skill.name);
+    }
+
+    if (request.skillNames.includes("*")) {
+        writeLine(
+            context,
+            context.translator.t("skills.install.allSelected", {
+                count: packageInfo.skills.length,
+            }),
+        );
+
+        return packageInfo.skills.map(skill => skill.name);
+    }
+
+    if (request.skillNames.length > 0) {
+        const selectedSkillNames = request.skillNames.flatMap((skillName) => {
+            findPackageSkillOrThrow(packageInfo, skillName);
+
+            return skillName;
+        });
+
+        return await filterConfirmedSkillNames(
+            packageInfo.packageName,
+            selectedSkillNames,
+            codexHomeDirectory,
+            context,
+        );
+    }
+
+    if (packageInfo.skills.length === 1) {
+        const firstSkill = packageInfo.skills[0]!;
+
+        writeLine(
+            context,
+            context.translator.t("skills.install.singleSelected", {
+                name: firstSkill.name,
+            }),
+        );
+
+        return [firstSkill.name];
+    }
+
+    if (request.yes) {
+        writeLine(
+            context,
+            context.translator.t("skills.install.allSelected", {
+                count: packageInfo.skills.length,
+            }),
+        );
+
+        return packageInfo.skills.map(skill => skill.name);
+    }
+
+    if (context.stdin.isTTY !== true || context.stdout.isTTY !== true) {
+        throw new CliUserError("errors.skills.install.nonInteractiveSelection", 1, {
+            packageName: packageInfo.packageName,
+        });
+    }
+
+    return await selectInteractiveSkills(
+        context,
+        {
+            items: await Promise.all(
+                packageInfo.skills.map(async skill => ({
+                    description: skill.description,
+                    name: skill.name,
+                    statusLabel: readRegistrySkillStatusLabel(
+                        await readRegistrySkillInstallStatus(
+                            packageInfo.packageName,
+                            skill.name,
+                            codexHomeDirectory,
+                            context.settingsStore.getFilePath(),
+                        ),
+                        context.translator,
+                    ),
+                    title: skill.title,
+                })),
+            ),
+            prompt: context.translator.t("skills.install.selection.prompt"),
+        },
+    );
+}
+
+async function filterConfirmedSkillNames(
+    packageName: string,
+    skillNames: readonly string[],
+    codexHomeDirectory: string,
+    context: Pick<
+        CliExecutionContext,
+        "settingsStore" | "stdin" | "stdout" | "translator"
+    >,
+): Promise<string[]> {
+    const confirmedSkillNames: string[] = [];
+
+    for (const skillName of skillNames) {
+        const status = await readRegistrySkillInstallStatus(
+            packageName,
+            skillName,
+            codexHomeDirectory,
+            context.settingsStore.getFilePath(),
+        );
+
+        if (status !== "conflict") {
+            confirmedSkillNames.push(skillName);
+            continue;
+        }
+
+        if (context.stdin.isTTY !== true) {
+            throw new CliUserError(
+                "errors.skills.install.confirmationRequired",
+                1,
+                {
+                    name: skillName,
+                },
+            );
+        }
+
+        const confirmed = await confirmInteractiveValue(
+            context,
+            {
+                invalidMessage: context.translator.t(
+                    "skills.install.overwrite.invalid",
+                ),
+                prompt: context.translator.t(
+                    "skills.install.overwrite.prompt",
+                    {
+                        name: skillName,
+                    },
+                ),
+            },
+        );
+
+        if (!confirmed) {
+            writeLine(
+                context,
+                context.translator.t("skills.install.skipped", {
+                    name: skillName,
+                }),
+            );
+            continue;
+        }
+
+        confirmedSkillNames.push(skillName);
+    }
+
+    return confirmedSkillNames;
+}
+
+function findPackageSkillOrThrow(
+    packageInfo: Awaited<ReturnType<typeof loadRegistryPackageSkillInfo>>,
+    skillName: string,
+): Awaited<ReturnType<typeof loadRegistryPackageSkillInfo>>["skills"][number] {
+    const skill = packageInfo.skills.find(entry => entry.name === skillName);
+
+    if (skill === undefined) {
+        throw new CliUserError("errors.skills.install.skillNotFound", 1, {
+            name: skillName,
+            packageName: packageInfo.packageName,
+        });
+    }
+
+    return skill;
+}
+
+async function readRegistrySkillInstallStatus(
+    packageName: string,
+    skillName: string,
+    codexHomeDirectory: string,
+    settingsFilePath: string,
+): Promise<RegistrySkillInstallStatus> {
+    const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+        settingsFilePath,
+        skillName,
+    );
+    const installedSkillDirectoryPath = resolveManagedSkillDirectoryPath(
+        codexHomeDirectory,
+        skillName,
+    );
+    const [canonicalState, installedState] = await Promise.all([
+        readManagedSkillPathState(canonicalSkillDirectoryPath),
+        readManagedSkillPathState(installedSkillDirectoryPath),
+    ]);
+
+    if (
+        hasManagedSkillPathConflict(canonicalState, packageName)
+        || hasManagedSkillPathConflict(installedState, packageName)
+    ) {
+        return "conflict";
+    }
+
+    if (
+        isSameManagedRegistryPackage(canonicalState.metadataPackageName, packageName)
+        || isSameManagedRegistryPackage(installedState.metadataPackageName, packageName)
+    ) {
+        return "installed";
+    }
+
+    return "new";
+}
+
+async function readManagedSkillPathState(
+    skillDirectoryPath: string,
+): Promise<ManagedSkillPathState> {
+    if (!(await directoryExists(skillDirectoryPath))) {
+        return {
+            exists: false,
+            metadataPackageName: undefined,
+        };
+    }
+
+    return {
+        exists: true,
+        metadataPackageName: (await readManagedSkillMetadata(skillDirectoryPath))
+            ?.packageName,
+    };
+}
+
+function hasManagedSkillPathConflict(
+    state: ManagedSkillPathState,
+    packageName: string,
+): boolean {
+    return state.exists
+        && !isSameManagedRegistryPackage(state.metadataPackageName, packageName);
+}
+
+function isSameManagedRegistryPackage(
+    metadataPackageName: string | undefined,
+    packageName: string,
+): boolean {
+    return metadataPackageName === packageName;
+}
+
+function readRegistrySkillStatusLabel(
+    status: RegistrySkillInstallStatus,
+    translator: Pick<CliExecutionContext["translator"], "t">,
+): string | undefined {
+    switch (status) {
+        case "conflict":
+            return translator.t("skills.install.status.conflict");
+        case "installed":
+            return translator.t("skills.install.status.installed");
+        case "new":
+            return undefined;
+    }
+}
+
+function writeLine(
+    context: Pick<CliExecutionContext, "stdout">,
+    message: string,
+): void {
+    context.stdout.write(`${message}\n`);
+}

--- a/src/application/commands/skills/registry-skill-markdown.test.ts
+++ b/src/application/commands/skills/registry-skill-markdown.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    installedRegistrySkillCompatibility,
+    normalizeInstalledRegistrySkillMarkdown,
+    renderOoPackageExecutionGuidance,
+} from "./registry-skill-markdown.ts";
+
+describe("registry skill markdown", () => {
+    const guidance = renderOoPackageExecutionGuidance();
+
+    test("adds compatibility and places the guidance immediately after the title", () => {
+        const content = [
+            "---",
+            "name: chatgpt",
+            "description: >-",
+            "  Chat with a model",
+            "metadata:",
+            "  title: ChatGPT",
+            "---",
+            "",
+            "# ChatGPT",
+            "",
+            "Use `oo::text-tools::chat` for the remote workflow.",
+            "",
+        ].join("\n");
+
+        const result = normalizeInstalledRegistrySkillMarkdown(
+            content,
+            {
+                description: "Chat with a model",
+                name: "chatgpt",
+                title: "ChatGPT",
+            },
+            "openai",
+        );
+
+        expect(result).toBe(
+            [
+                "---",
+                "name: chatgpt",
+                "description: >-",
+                "  Chat with a model",
+                `compatibility: ${JSON.stringify(installedRegistrySkillCompatibility)}`,
+                "metadata:",
+                "  title: ChatGPT",
+                "---",
+                "",
+                "# ChatGPT",
+                "",
+                guidance,
+                "",
+                "Use `oo::text-tools::chat` for the remote workflow.",
+                "",
+            ].join("\n"),
+        );
+    });
+
+    test("creates a minimal frontmatter when the skill file does not have one", () => {
+        const result = normalizeInstalledRegistrySkillMarkdown(
+            "# ChatGPT\n",
+            {
+                description: "Chat with a model",
+                name: "chatgpt",
+                title: "ChatGPT",
+            },
+            "openai",
+        );
+
+        expect(result).toBe(
+            [
+                "---",
+                "name: chatgpt",
+                "description: \"Chat with a model\"",
+                `compatibility: ${JSON.stringify(installedRegistrySkillCompatibility)}`,
+                "metadata:",
+                "  title: \"ChatGPT\"",
+                "---",
+                "",
+                "# ChatGPT",
+                "",
+                guidance,
+                "",
+            ].join("\n"),
+        );
+    });
+
+    test("places the oo execution note at the start when the body has no title", () => {
+        const result = normalizeInstalledRegistrySkillMarkdown(
+            [
+                "---",
+                "name: chatgpt",
+                "description: \"Chat with a model\"",
+                "---",
+                "",
+                "Use `oo::text-tools::chat` for the remote workflow.",
+                "",
+            ].join("\n"),
+            {
+                description: "Chat with a model",
+                name: "chatgpt",
+                title: "ChatGPT",
+            },
+            "openai",
+        );
+
+        expect(result).toBe(
+            [
+                "---",
+                "name: chatgpt",
+                "description: \"Chat with a model\"",
+                `compatibility: ${JSON.stringify(installedRegistrySkillCompatibility)}`,
+                "---",
+                "",
+                guidance,
+                "",
+                "Use `oo::text-tools::chat` for the remote workflow.",
+                "",
+            ].join("\n"),
+        );
+    });
+
+    test("moves the guidance to immediately follow the title", () => {
+        const content = [
+            "---",
+            "name: chatgpt",
+            "description: \"Chat with a model\"",
+            `compatibility: ${JSON.stringify(installedRegistrySkillCompatibility)}`,
+            "---",
+            "",
+            "# ChatGPT",
+            "",
+            "Use `oo::text-tools::chat` for the remote workflow.",
+            "",
+        ].join("\n");
+
+        const result = normalizeInstalledRegistrySkillMarkdown(
+            content,
+            {
+                description: "Chat with a model",
+                name: "chatgpt",
+                title: "ChatGPT",
+            },
+            "openai",
+        );
+
+        expect(result).toBe(
+            [
+                "---",
+                "name: chatgpt",
+                "description: \"Chat with a model\"",
+                `compatibility: ${JSON.stringify(installedRegistrySkillCompatibility)}`,
+                "---",
+                "",
+                "# ChatGPT",
+                "",
+                guidance,
+                "",
+                "Use `oo::text-tools::chat` for the remote workflow.",
+                "",
+            ].join("\n"),
+        );
+    });
+});

--- a/src/application/commands/skills/registry-skill-markdown.ts
+++ b/src/application/commands/skills/registry-skill-markdown.ts
@@ -1,0 +1,287 @@
+import type { RegistrySkillSummary } from "./registry-skill-source.ts";
+import { readFile, writeFile } from "node:fs/promises";
+
+import { join } from "node:path";
+
+export const installedRegistrySkillCompatibility = "Requires the oo CLI.";
+
+interface SplitFrontmatterResult {
+    body: string;
+    frontmatterLines: string[];
+}
+
+interface FrontmatterFieldRange {
+    end: number;
+    key: string;
+    start: number;
+}
+
+export async function rewriteInstalledRegistrySkillMarkdown(
+    skillDirectoryPath: string,
+    skill: RegistrySkillSummary,
+    packageName: string,
+): Promise<void> {
+    const skillFilePath = join(skillDirectoryPath, "SKILL.md");
+    const content = await readFile(skillFilePath, "utf8");
+    const normalizedContent = normalizeInstalledRegistrySkillMarkdown(
+        content,
+        skill,
+        packageName,
+    );
+
+    await writeFile(skillFilePath, normalizedContent, "utf8");
+}
+
+export function normalizeInstalledRegistrySkillMarkdown(
+    content: string,
+    skill: RegistrySkillSummary,
+    packageName: string,
+): string {
+    const normalizedContent = normalizeLineEndings(content);
+    const splitFrontmatter = trySplitFrontmatter(normalizedContent);
+
+    if (splitFrontmatter === undefined) {
+        return renderSkillMarkdown(
+            createDefaultFrontmatterLines(skill, packageName),
+            insertOoPackageExecutionGuidance(normalizedContent),
+        );
+    }
+
+    return renderSkillMarkdown(
+        upsertCompatibilityField(splitFrontmatter.frontmatterLines),
+        insertOoPackageExecutionGuidance(splitFrontmatter.body),
+    );
+}
+
+function normalizeLineEndings(content: string): string {
+    return content
+        .replaceAll("\r\n", "\n")
+        .replaceAll("\r", "\n");
+}
+
+function trySplitFrontmatter(content: string): SplitFrontmatterResult | undefined {
+    const lines = content.split("\n");
+
+    if (lines[0] !== "---") {
+        return undefined;
+    }
+
+    let delimiterIndex = 1;
+
+    while (delimiterIndex < lines.length && lines[delimiterIndex] !== "---") {
+        delimiterIndex += 1;
+    }
+
+    if (delimiterIndex >= lines.length) {
+        return undefined;
+    }
+
+    return {
+        body: lines.slice(delimiterIndex + 1).join("\n"),
+        frontmatterLines: lines.slice(1, delimiterIndex),
+    };
+}
+
+function createDefaultFrontmatterLines(
+    skill: RegistrySkillSummary,
+    packageName: string,
+): string[] {
+    const frontmatterLines = [
+        `name: ${skill.name}`,
+        `description: ${JSON.stringify(resolveSkillDescription(skill, packageName))}`,
+        `compatibility: ${JSON.stringify(installedRegistrySkillCompatibility)}`,
+    ];
+    const title = resolveSkillTitle(skill);
+
+    if (title !== skill.name) {
+        frontmatterLines.push("metadata:");
+        frontmatterLines.push(`  title: ${JSON.stringify(title)}`);
+    }
+
+    return frontmatterLines;
+}
+
+function resolveSkillDescription(
+    skill: RegistrySkillSummary,
+    packageName: string,
+): string {
+    const description = skill.description.trim();
+
+    if (description !== "") {
+        return description;
+    }
+
+    return `Use this skill when the task matches the installed instructions from the ${packageName} package.`;
+}
+
+function resolveSkillTitle(skill: RegistrySkillSummary): string {
+    const title = skill.title.trim();
+
+    if (title !== "") {
+        return title;
+    }
+
+    return skill.name;
+}
+
+function upsertCompatibilityField(frontmatterLines: string[]): string[] {
+    const fieldRanges = readFrontmatterFieldRanges(frontmatterLines);
+    const compatibilityFieldLine
+        = `compatibility: ${JSON.stringify(installedRegistrySkillCompatibility)}`;
+    const compatibilityField = fieldRanges.find(
+        field => field.key === "compatibility",
+    );
+
+    if (compatibilityField !== undefined) {
+        return [
+            ...frontmatterLines.slice(0, compatibilityField.start),
+            compatibilityFieldLine,
+            ...frontmatterLines.slice(compatibilityField.end),
+        ];
+    }
+
+    const descriptionField = fieldRanges.find(field => field.key === "description");
+
+    if (descriptionField !== undefined) {
+        return [
+            ...frontmatterLines.slice(0, descriptionField.end),
+            compatibilityFieldLine,
+            ...frontmatterLines.slice(descriptionField.end),
+        ];
+    }
+
+    const nameField = fieldRanges.find(field => field.key === "name");
+
+    if (nameField !== undefined) {
+        return [
+            ...frontmatterLines.slice(0, nameField.end),
+            compatibilityFieldLine,
+            ...frontmatterLines.slice(nameField.end),
+        ];
+    }
+
+    return [compatibilityFieldLine, ...frontmatterLines];
+}
+
+function readFrontmatterFieldRanges(
+    frontmatterLines: string[],
+): FrontmatterFieldRange[] {
+    const fieldRanges: FrontmatterFieldRange[] = [];
+    let currentField: FrontmatterFieldRange | undefined;
+
+    for (const [index, line] of frontmatterLines.entries()) {
+        const fieldKey = readTopLevelFieldKey(line);
+
+        if (fieldKey === undefined) {
+            continue;
+        }
+
+        if (currentField !== undefined) {
+            currentField.end = index;
+            fieldRanges.push(currentField);
+        }
+
+        currentField = {
+            end: frontmatterLines.length,
+            key: fieldKey,
+            start: index,
+        };
+    }
+
+    if (currentField !== undefined) {
+        fieldRanges.push(currentField);
+    }
+
+    return fieldRanges;
+}
+
+function readTopLevelFieldKey(line: string): string | undefined {
+    if (line.startsWith(" ") || line.startsWith("\t")) {
+        return undefined;
+    }
+
+    const separatorIndex = line.indexOf(":");
+
+    if (separatorIndex <= 0) {
+        return undefined;
+    }
+
+    return line.slice(0, separatorIndex).trim();
+}
+
+function insertOoPackageExecutionGuidance(body: string): string {
+    const guidance = renderOoPackageExecutionGuidance();
+    const trimmedBody = body.trim();
+
+    if (trimmedBody === "") {
+        return `${guidance}\n`;
+    }
+
+    const lines = trimmedBody.split("\n");
+    const firstLine = lines[0] ?? "";
+
+    if (isTopLevelHeading(firstLine)) {
+        const remainingBody = trimExtraWhitespace(lines.slice(1).join("\n"));
+
+        if (remainingBody === "") {
+            return `${firstLine}\n\n${guidance}\n`;
+        }
+
+        return `${firstLine}\n\n${guidance}\n\n${remainingBody}\n`;
+    }
+
+    return `${guidance}\n\n${trimmedBody}\n`;
+}
+
+function renderSkillMarkdown(frontmatterLines: string[], body: string): string {
+    return [
+        "---",
+        ...frontmatterLines,
+        "---",
+        "",
+        body.trimEnd(),
+        "",
+    ].join("\n");
+}
+
+function isTopLevelHeading(line: string): boolean {
+    return line.startsWith("# ");
+}
+
+function trimExtraWhitespace(content: string): string {
+    return content.trim();
+}
+
+export function renderOoPackageExecutionGuidance(): string {
+    return [
+        "Important:",
+        "If this skill mentions `oo::packageName` or `oo::packageName::blockName`,",
+        "follow the `oo` CLI path instead of reimplementing the capability locally.",
+        "First inspect the package with `oo packages info \"<packageName>\" --json`",
+        "or `oo packages info \"<packageName>@<version>\" --json`.",
+        "If only a package is referenced, choose the correct block id from the",
+        "returned metadata.",
+        "Even if a block is already named, inspect that block's `inputHandle` before",
+        "running it.",
+        "Use the resolved `packageVersion`, `blocks[].blockName`, and `inputHandle`",
+        "metadata to build `oo cloud-task run \"<packageName>@<packageVersion>\"",
+        "--block-id \"<blockName>\" --data '<json>' --json`.",
+        "Use only argument names and values that are defined by or directly derived",
+        "from the inspected metadata.",
+        "If a required local file input is URI-compatible, upload it first with",
+        "`oo file upload \"<filePath>\" --json` and pass the returned `downloadUrl`.",
+        "`oo cloud-task run ... --json` returns a `taskID`, not the final result.",
+        "To wait for completion, use `oo cloud-task wait \"<taskId>\" --timeout",
+        "\"<window>\"`.",
+        "Do not add `--json` to `oo cloud-task wait`.",
+        "Use a bounded timeout such as `2m` to `10m` for short tasks, `15m` to",
+        "`30m` for medium tasks, or `30m` to `60m` for long or unknown tasks.",
+        "If `wait` exits non-zero, do not assume failure. Check",
+        "`oo cloud-task result \"<taskId>\" --json` to distinguish timeout,",
+        "failure, and late success, and do not create a new task just because a",
+        "wait window ended.",
+        "If the metadata is not sufficient to choose a safe block or construct safe",
+        "arguments, stop and inspect further; do not guess parameters and do not run",
+        "yet.",
+    ].join("\n");
+}

--- a/src/application/commands/skills/registry-skill-source.test.ts
+++ b/src/application/commands/skills/registry-skill-source.test.ts
@@ -1,0 +1,120 @@
+import type { CliExecutionContext, Fetcher } from "../../contracts/cli.ts";
+
+import { describe, expect, test } from "bun:test";
+import pino from "pino";
+
+import {
+    toRequest,
+} from "../../../../__tests__/helpers.ts";
+import {
+    createRegistryPackageInfoRequestUrl,
+    createRegistryPackageTarballRequestUrl,
+    downloadRegistryPackageTarball,
+    loadRegistryPackageSkillInfo,
+} from "./registry-skill-source.ts";
+
+describe("registry skill source", () => {
+    test("creates the package info URL for scoped packages", () => {
+        expect(
+            createRegistryPackageInfoRequestUrl(
+                "oomol.com",
+                "@foo/bar",
+            ).toString(),
+        ).toBe(
+            "https://registry.oomol.com/-/oomol/package-info/%40foo%2Fbar/latest",
+        );
+    });
+
+    test("creates the package tarball URL for scoped packages", () => {
+        expect(
+            createRegistryPackageTarballRequestUrl(
+                "oomol.com",
+                "@foo/bar",
+                "1.2.3",
+            ).toString(),
+        ).toBe(
+            "https://registry.oomol.com/%40foo%2Fbar/-/meta/%40foo%2Fbar-1.2.3.tgz",
+        );
+    });
+
+    test("loads package skills info and ignores the when field", async () => {
+        const requests: Request[] = [];
+        const context = createRegistrySkillSourceContext({
+            fetcher: async (input, init) => {
+                requests.push(toRequest(input, init));
+
+                return new Response(JSON.stringify({
+                    packageName: "openai",
+                    version: "0.0.3",
+                    skills: [
+                        {
+                            description: "Chat with a model",
+                            name: "chatgpt",
+                            title: "ChatGPT",
+                            when: "ignored",
+                        },
+                    ],
+                }));
+            },
+        });
+
+        await expect(
+            loadRegistryPackageSkillInfo(
+                "openai",
+                {
+                    apiKey: "secret-1",
+                    endpoint: "oomol.com",
+                },
+                context,
+            ),
+        ).resolves.toEqual({
+            packageName: "openai",
+            packageVersion: "0.0.3",
+            skills: [
+                {
+                    description: "Chat with a model",
+                    name: "chatgpt",
+                    title: "ChatGPT",
+                },
+            ],
+        });
+        expect(requests).toHaveLength(1);
+        expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
+    });
+
+    test("downloads the package tarball with authorization", async () => {
+        const requests: Request[] = [];
+        const context = createRegistrySkillSourceContext({
+            fetcher: async (input, init) => {
+                requests.push(toRequest(input, init));
+
+                return new Response(new Uint8Array([1, 2, 3]));
+            },
+        });
+
+        await expect(
+            downloadRegistryPackageTarball(
+                "openai",
+                "0.0.3",
+                {
+                    apiKey: "secret-1",
+                    endpoint: "oomol.com",
+                },
+                context,
+            ),
+        ).resolves.toEqual(new Uint8Array([1, 2, 3]));
+        expect(requests).toHaveLength(1);
+        expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
+    });
+});
+
+function createRegistrySkillSourceContext(options: {
+    fetcher: Fetcher;
+}): Pick<CliExecutionContext, "fetcher" | "logger"> {
+    return {
+        fetcher: options.fetcher,
+        logger: pino({
+            enabled: false,
+        }),
+    };
+}

--- a/src/application/commands/skills/registry-skill-source.ts
+++ b/src/application/commands/skills/registry-skill-source.ts
@@ -1,0 +1,183 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+import type { AuthAccount } from "../../schemas/auth.ts";
+
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { withPackageIdentity } from "../../logging/log-fields.ts";
+import { readCurrentAuth } from "../auth/shared.ts";
+import { performLoggedRequest, requestText } from "../shared/request.ts";
+
+const registrySkillSchema = z.object({
+    description: z.string().optional().default(""),
+    name: z.string().min(1),
+    title: z.string().optional().default(""),
+}).passthrough();
+
+const registryPackageSkillInfoSchema = z.object({
+    packageName: z.string().min(1),
+    packageVersion: z.string().optional(),
+    skills: z.array(registrySkillSchema).optional().default([]),
+    version: z.string().optional(),
+}).passthrough();
+
+export interface RegistrySkillSummary {
+    description: string;
+    name: string;
+    title: string;
+}
+
+export interface RegistryPackageSkillInfo {
+    packageName: string;
+    packageVersion: string;
+    skills: RegistrySkillSummary[];
+}
+
+export async function requireCurrentSkillsInstallAccount(
+    context: CliExecutionContext,
+): Promise<AuthAccount> {
+    const { authFile, currentAccount } = await readCurrentAuth(context);
+
+    if (currentAccount !== undefined) {
+        return currentAccount;
+    }
+
+    throw new CliUserError(
+        authFile.id === ""
+            ? "errors.skills.install.authRequired"
+            : "errors.skills.install.activeAccountMissing",
+        1,
+    );
+}
+
+export function createRegistryPackageInfoRequestUrl(
+    endpoint: string,
+    packageName: string,
+): URL {
+    return new URL(
+        `https://registry.${endpoint}/-/oomol/package-info/${encodeURIComponent(packageName)}/latest`,
+    );
+}
+
+export function createRegistryPackageTarballRequestUrl(
+    endpoint: string,
+    packageName: string,
+    packageVersion: string,
+): URL {
+    const encodedPackageName = encodeURIComponent(packageName);
+
+    return new URL(
+        `https://registry.${endpoint}/${encodedPackageName}/-/meta/${encodedPackageName}-${encodeURIComponent(packageVersion)}.tgz`,
+    );
+}
+
+export async function loadRegistryPackageSkillInfo(
+    packageName: string,
+    account: Pick<AuthAccount, "apiKey" | "endpoint">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+): Promise<RegistryPackageSkillInfo> {
+    const requestUrl = createRegistryPackageInfoRequestUrl(
+        account.endpoint,
+        packageName,
+    );
+    const rawResponse = await requestText({
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.skills.install.packageInfoRequestFailed",
+            1,
+            {
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.skills.install.packageInfoRequestError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            common: withPackageIdentity(packageName, "latest"),
+        },
+        init: {
+            headers: {
+                Authorization: account.apiKey,
+            },
+        },
+        requestLabel: "Skills install package info",
+        requestUrl,
+    });
+
+    return parseRegistryPackageSkillInfo(rawResponse);
+}
+
+export async function downloadRegistryPackageTarball(
+    packageName: string,
+    packageVersion: string,
+    account: Pick<AuthAccount, "apiKey" | "endpoint">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+): Promise<Uint8Array<ArrayBuffer>> {
+    const requestUrl = createRegistryPackageTarballRequestUrl(
+        account.endpoint,
+        packageName,
+        packageVersion,
+    );
+    const response = await performLoggedRequest({
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.skills.install.packageDownloadFailed",
+            1,
+            {
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.skills.install.packageDownloadError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            common: withPackageIdentity(packageName, packageVersion),
+        },
+        init: {
+            headers: {
+                Authorization: account.apiKey,
+            },
+        },
+        requestLabel: "Skills install package download",
+        requestUrl,
+    });
+
+    return new Uint8Array(await response.arrayBuffer());
+}
+
+function parseRegistryPackageSkillInfo(
+    rawResponse: string,
+): RegistryPackageSkillInfo {
+    try {
+        const parsedResponse = registryPackageSkillInfoSchema.parse(
+            JSON.parse(rawResponse) as unknown,
+        );
+        const packageVersion = parsedResponse.packageVersion?.trim()
+            || parsedResponse.version?.trim()
+            || "";
+
+        if (packageVersion === "") {
+            throw new Error("Missing package version.");
+        }
+
+        return {
+            packageName: parsedResponse.packageName,
+            packageVersion,
+            skills: parsedResponse.skills.map(skill => ({
+                description: skill.description,
+                name: skill.name,
+                title: skill.title === "" ? skill.name : skill.title,
+            })),
+        };
+    }
+    catch {
+        throw new CliUserError("errors.skills.install.invalidPackageInfo", 1);
+    }
+}

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -122,8 +122,8 @@ export const enMessages = {
     "commands.skills.search.summary":
         "Search published skills",
     "commands.skills.install.description":
-        "Install one bundled Codex skill into the local Codex skills directory.",
-    "commands.skills.install.summary": "Install a bundled Codex skill",
+        "Install bundled or published Codex skills into the local Codex skills directory.",
+    "commands.skills.install.summary": "Install Codex skills",
     "commands.skills.uninstall.description":
         "Remove one bundled Codex skill from the local Codex skills directory.",
     "commands.skills.uninstall.summary": "Remove a bundled Codex skill",
@@ -305,6 +305,30 @@ export const enMessages = {
         "The package info request returned HTTP {status}.",
     "errors.skills.codexNotInstalled":
         "Codex is not installed. Expected the Codex home directory at {path}.",
+    "errors.skills.install.activeAccountMissing":
+        "The active auth account is missing from the auth store.",
+    "errors.skills.install.authRequired":
+        "You must log in before installing published skills.",
+    "errors.skills.install.confirmationRequired":
+        "Skill {name} already exists and requires interactive confirmation.",
+    "errors.skills.install.invalidArchive":
+        "Downloaded package archive does not contain a valid skill directory for {name}.",
+    "errors.skills.install.invalidPackageInfo":
+        "The skills install package info service returned an unsupported response body.",
+    "errors.skills.install.noPublishedSkills":
+        "Package {packageName} does not publish any skills.",
+    "errors.skills.install.nonInteractiveSelection":
+        "Package {packageName} has multiple skills. Use --skill <name>, --all -y, or run in an interactive terminal.",
+    "errors.skills.install.packageDownloadError":
+        "The skills package download failed: {message}",
+    "errors.skills.install.packageDownloadFailed":
+        "The skills package download returned HTTP {status}.",
+    "errors.skills.install.packageInfoRequestError":
+        "The skills install package info request failed: {message}",
+    "errors.skills.install.packageInfoRequestFailed":
+        "The skills install package info request returned HTTP {status}.",
+    "errors.skills.install.skillNotFound":
+        "Skill {name} was not found in package {packageName}.",
     "errors.skills.nameConflict":
         "Skill name {name} is already used by a non-OOMOL Codex skill at {path}.",
     "errors.skills.storageConflict":
@@ -357,7 +381,11 @@ export const enMessages = {
     "options.json": "Alias for --format=json",
     "options.keywords":
         "Specify comma-separated keywords to refine the skill search",
+    "options.skill":
+        "Specify skill names to install (use * for all skills)",
     "options.onlyPackageId": "Return only package ids",
+    "options.all":
+        "Install all published skills without prompting for skill selection",
     "options.nextToken": "Specify the pagination token for the next page",
     "options.packageId": "Filter by package id",
     "options.packageName": "Alias for --package-id",
@@ -367,11 +395,27 @@ export const enMessages = {
     "options.status": "Filter by task status",
     "options.timeout":
         "Set how long to wait before timing out (default 6h, range 10s to 24h)",
+    "options.yes": "Skip confirmation prompts",
     "options.lang": "Specify the display language",
     "options.version": "Show the current version",
+    "skills.install.allSelected":
+        "Installing all {count} skills.",
     "skills.config.set.success":
         "Set Codex skill {name} {key} to {value}.",
     "skills.install.success": "Installed Codex skill {name} to {path}.",
+    "skills.install.overwrite.invalid":
+        "Invalid choice. Enter y/yes or n/no.",
+    "skills.install.overwrite.prompt":
+        "Skill {name} already exists. Overwrite? [y/N] ",
+    "skills.install.selection.invalid":
+        "Invalid selection. Use one or more comma-separated numbers, or press Enter to cancel.",
+    "skills.install.selection.prompt":
+        "Select skills to install (space to toggle)",
+    "skills.install.skipped": "Skipped Codex skill {name}.",
+    "skills.install.status.conflict": "conflict",
+    "skills.install.status.installed": "installed",
+    "skills.install.singleSelected":
+        "Skill: {name}",
     "skills.uninstall.success": "Removed Codex skill {name} from {path}.",
     "versionInfo.version": "Version",
     "versionInfo.buildTime": "Build Time",
@@ -381,6 +425,7 @@ export const enMessages = {
     "arguments.index": "Log index",
     "arguments.key": "Configuration key",
     "arguments.outDir": "Output directory",
+    "arguments.packageName": "Package name",
     "arguments.packageSpecifier": "Package specifier",
     "arguments.shell": "Target shell",
     "arguments.skill": "Skill name",
@@ -544,8 +589,9 @@ export const zhMessages = {
         "使用自由文本通过 skills search API 搜索已发布的 skill。",
     "commands.skills.search.summary":
         "搜索已发布的 skill",
-    "commands.skills.install.description": "将一个内置 Codex skill 安装到本地 Codex skills 目录。",
-    "commands.skills.install.summary": "安装一个内置 Codex skill",
+    "commands.skills.install.description":
+        "将内置或已发布的 Codex skill 安装到本地 Codex skills 目录。",
+    "commands.skills.install.summary": "安装 Codex skills",
     "commands.skills.uninstall.description": "从本地 Codex skills 目录移除一个内置 Codex skill。",
     "commands.skills.uninstall.summary": "移除一个内置 Codex skill",
     "config.set.success": "已将 {key} 设置为 {value}。",
@@ -719,6 +765,30 @@ export const zhMessages = {
         "包信息请求返回了 HTTP {status}。",
     "errors.skills.codexNotInstalled":
         "未检测到 Codex 安装。期望的 Codex 根目录为 {path}。",
+    "errors.skills.install.activeAccountMissing":
+        "当前激活账号不存在于认证数据中。",
+    "errors.skills.install.authRequired":
+        "安装已发布 skill 前请先登录。",
+    "errors.skills.install.confirmationRequired":
+        "Skill {name} 已存在，且需要在交互终端中确认覆盖。",
+    "errors.skills.install.invalidArchive":
+        "下载的包归档中不包含 {name} 对应的有效 skill 目录。",
+    "errors.skills.install.invalidPackageInfo":
+        "skills install 使用的包信息服务返回了不受支持的响应内容。",
+    "errors.skills.install.noPublishedSkills":
+        "包 {packageName} 没有发布任何 skill。",
+    "errors.skills.install.nonInteractiveSelection":
+        "包 {packageName} 包含多个 skill。请使用 --skill <name>、--all -y，或在交互终端中运行。",
+    "errors.skills.install.packageDownloadError":
+        "下载 skills 包失败：{message}",
+    "errors.skills.install.packageDownloadFailed":
+        "skills 包下载请求返回了 HTTP {status}。",
+    "errors.skills.install.packageInfoRequestError":
+        "skills install 的包信息请求失败：{message}",
+    "errors.skills.install.packageInfoRequestFailed":
+        "skills install 的包信息请求返回了 HTTP {status}。",
+    "errors.skills.install.skillNotFound":
+        "在包 {packageName} 中未找到 skill {name}。",
     "errors.skills.nameConflict":
         "Skill 名称 {name} 已被 {path} 中的非 OOMOL Codex skill 占用。",
     "errors.skills.storageConflict":
@@ -766,7 +836,11 @@ export const zhMessages = {
     "options.json": "--format=json 的别名",
     "options.keywords":
         "指定用于细化 skill 搜索的逗号分隔关键词",
+    "options.skill":
+        "指定要安装的 skill 名称（使用 * 表示全部）",
     "options.onlyPackageId": "仅返回 package id",
+    "options.all":
+        "安装全部已发布 skill，并跳过 skill 选择提示",
     "options.nextToken": "指定下一页分页令牌",
     "options.packageId": "按 package id 过滤",
     "options.packageName": "--package-id 的别名",
@@ -775,11 +849,27 @@ export const zhMessages = {
     "options.size": "指定每页数量",
     "options.status": "按任务状态过滤",
     "options.timeout": "设置等待超时时间（默认 6h，范围 10s 到 24h）",
+    "options.yes": "跳过确认提示",
     "options.lang": "指定显示语言",
     "options.version": "显示当前版本",
+    "skills.install.allSelected":
+        "将安装全部 {count} 个 skill。",
     "skills.config.set.success":
         "已将 Codex skill {name} 的 {key} 设置为 {value}。",
     "skills.install.success": "已将 Codex skill {name} 安装到 {path}。",
+    "skills.install.overwrite.invalid":
+        "输入无效。请输入 y/yes 或 n/no。",
+    "skills.install.overwrite.prompt":
+        "Skill {name} 已存在，是否覆盖？[y/N] ",
+    "skills.install.selection.invalid":
+        "选择无效。请输入一个或多个逗号分隔的序号，或直接回车取消。",
+    "skills.install.selection.prompt":
+        "选择要安装的 skill（空格切换）",
+    "skills.install.skipped": "已跳过 Codex skill {name}。",
+    "skills.install.status.conflict": "冲突",
+    "skills.install.status.installed": "已安装",
+    "skills.install.singleSelected":
+        "Skill：{name}",
     "skills.uninstall.success": "已从 {path} 移除 Codex skill {name}。",
     "versionInfo.version": "版本",
     "versionInfo.buildTime": "构建时间",
@@ -789,6 +879,7 @@ export const zhMessages = {
     "arguments.index": "日志序号",
     "arguments.key": "配置键",
     "arguments.outDir": "输出目录",
+    "arguments.packageName": "包名",
     "arguments.packageSpecifier": "包标识",
     "arguments.shell": "目标 shell",
     "arguments.skill": "skill 名称",


### PR DESCRIPTION
Introduce registry-based skill installation alongside the existing bundled `oo` skill. Users can now install published skills by package name with interactive selection, explicit --skill flags, or --all.

Key changes:
- Add registry skill source fetching with auth headers
- Add tarball archive extraction for skill packages
- Add interactive multi-select prompt for skill picking
- Add managed skill metadata and path resolution
- Extend install command with -s/--skill, --all, -y/--yes options
- Add @clack/core and picocolors dependencies
- Update CLI docs in both English and Chinese