### PR TITLE
refactor(skills): replace picocolors with project terminal colors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,6 @@
         "ajv-formats": "^3.0.1",
         "ajv-i18n": "^4.2.0",
         "commander": "^14.0.3",
-        "picocolors": "^1.1.1",
         "pino": "^10.3.1",
         "smol-toml": "^1.6.0",
         "zod": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "ajv-formats": "^3.0.1",
     "ajv-i18n": "^4.2.0",
     "commander": "^14.0.3",
-    "picocolors": "^1.1.1",
     "pino": "^10.3.1",
     "smol-toml": "^1.6.0",
     "zod": "^4.3.6"

--- a/src/application/commands/cloud-task/index.cli.test.ts
+++ b/src/application/commands/cloud-task/index.cli.test.ts
@@ -775,7 +775,7 @@ describe("cloudTaskCommand CLI", () => {
                 },
             )).toMatchSnapshot();
             expect(result.stdout).toContain(colors.green("✓"));
-            expect(result.stdout).toContain(colors.green.bold("success"));
+            expect(result.stdout).toContain(colors.green(colors.bold("success")));
             expect(result.stdout).toContain(colors.bold("task-1"));
         }
         finally {
@@ -853,7 +853,7 @@ describe("cloudTaskCommand CLI", () => {
                 },
             )).toMatchSnapshot();
             expect(result.stdout).toContain(colors.blue("▶"));
-            expect(result.stdout).toContain(colors.blue.bold("running"));
+            expect(result.stdout).toContain(colors.blue(colors.bold("running")));
             expect(result.stdout).toContain(colors.hex(searchDisplayNameColor)("foo"));
         }
         finally {

--- a/src/application/commands/cloud-task/text.ts
+++ b/src/application/commands/cloud-task/text.ts
@@ -260,13 +260,13 @@ function readCloudTaskStatusLabel(
         case "queued":
         case "scheduling":
         case "scheduled":
-            return colors.yellow.bold(label);
+            return colors.yellow(colors.bold(label));
         case "running":
-            return colors.blue.bold(label);
+            return colors.blue(colors.bold(label));
         case "success":
-            return colors.green.bold(label);
+            return colors.green(colors.bold(label));
         case "failed":
-            return colors.red.bold(label);
+            return colors.red(colors.bold(label));
     }
 }
 

--- a/src/application/commands/skills/interactive-prompts.test.ts
+++ b/src/application/commands/skills/interactive-prompts.test.ts
@@ -99,4 +99,97 @@ describe("interactive prompts", () => {
         expect(plainOutput).toContain("conflict");
         expect(plainOutput).toContain("First description");
     });
+
+    test("uses project terminal colors for the multiselect prompt", async () => {
+        const stdin = createInteractiveInput();
+        const stdout = createTextBuffer({
+            hasColors: true,
+            isTTY: true,
+        });
+        const selectionPromise = selectInteractiveSkills(
+            {
+                stdin,
+                stdout: stdout.writer,
+            },
+            {
+                items: [
+                    {
+                        description: "First description",
+                        name: "alpha",
+                        title: "Alpha",
+                    },
+                ],
+                prompt: "Select skills to install",
+            },
+        );
+
+        await waitForOutputText(stdout, "Select skills to install");
+        stdin.feed("\r");
+
+        await expect(selectionPromise).resolves.toEqual([]);
+
+        const renderedOutput = stdout.read();
+        const plainOutput = stripVTControlCharacters(renderedOutput).replaceAll("\u200B", "");
+
+        expect(renderedOutput).not.toContain("\u001B[36m◆\u001B[39m");
+        expect(renderedOutput).not.toContain("\u001B[90m│\u001B[39m");
+        expect(renderedOutput).not.toContain("\u001B[36m│\u001B[39m");
+        expect(plainOutput).toContain("\n ◻ alpha");
+    });
+
+    test("truncates long option descriptions to avoid wrapped prompt rows", async () => {
+        const columnsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+        const rowsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "rows");
+
+        Object.defineProperty(process.stdout, "columns", {
+            configurable: true,
+            value: 90,
+        });
+        Object.defineProperty(process.stdout, "rows", {
+            configurable: true,
+            value: 12,
+        });
+
+        try {
+            const stdin = createInteractiveInput();
+            const stdout = createTextBuffer({
+                hasColors: true,
+                isTTY: true,
+            });
+            const selectionPromise = selectInteractiveSkills(
+                {
+                    stdin,
+                    stdout: stdout.writer,
+                },
+                {
+                    items: [
+                        {
+                            description: "Adapt UI for different contexts, screen sizes, and user needs with responsive behavior and layout changes",
+                            name: "adapt",
+                            title: "Adapt",
+                        },
+                    ],
+                    prompt: "Select skills to install",
+                },
+            );
+
+            await waitForOutputText(stdout, "Select skills to install");
+
+            const plainOutput = stripVTControlCharacters(stdout.read());
+
+            expect(plainOutput).toContain("...");
+            expect(plainOutput).not.toContain("behavior and layout changes");
+
+            stdin.feed("\r");
+            await expect(selectionPromise).resolves.toEqual([]);
+        }
+        finally {
+            if (columnsDescriptor) {
+                Object.defineProperty(process.stdout, "columns", columnsDescriptor);
+            }
+            if (rowsDescriptor) {
+                Object.defineProperty(process.stdout, "rows", rowsDescriptor);
+            }
+        }
+    });
 });

--- a/src/application/commands/skills/interactive-prompts.ts
+++ b/src/application/commands/skills/interactive-prompts.ts
@@ -3,25 +3,19 @@ import type {
     Writer,
 } from "../../contracts/cli.ts";
 
+import type { TerminalColors } from "../../terminal-colors.ts";
 import process from "node:process";
-import { PassThrough, Writable } from "node:stream";
 
+import { PassThrough, Writable } from "node:stream";
 import { isCancel, MultiSelectPrompt } from "@clack/core";
-import color from "picocolors";
+import {
+    measureDisplayWidth,
+    truncateDisplayWidth,
+} from "../../display-width.ts";
+import { createWriterColors } from "../../terminal-colors.ts";
 
 const outputTextDecoder = new TextDecoder();
 const inputTextDecoder = new TextDecoder();
-
-const promptSymbols = {
-    active: color.cyan("◆"),
-    cancelled: color.red("■"),
-    inactive: color.dim("◻"),
-    line: color.cyan("│"),
-    mutedLine: color.gray("│"),
-    selected: color.green("◼"),
-    submitted: color.green("◇"),
-    tail: color.cyan("└"),
-} as const;
 
 export interface InteractivePromptContext {
     stdin: InteractiveInput;
@@ -79,11 +73,20 @@ export async function selectInteractiveSkills(
     },
 ): Promise<string[]> {
     const promptStreams = createPromptStreams(context);
-    const promptOptions = options.items.map(item => ({
-        hint: item.description,
-        label: formatSkillOptionLabel(item, promptStreams.output.columns),
-        value: item.name,
-    }));
+    const colors = createWriterColors(context.stdout);
+    const promptOptions = options.items.map((item) => {
+        const label = formatSkillOptionLabel(item, promptStreams.output.columns);
+
+        return {
+            hint: formatSkillOptionHint(
+                item.description,
+                label,
+                promptStreams.output.columns,
+            ),
+            label,
+            value: item.name,
+        };
+    });
 
     try {
         const selectedValues = await withPatchedPromptOutput(
@@ -94,7 +97,11 @@ export async function selectInteractiveSkills(
                 options: promptOptions,
                 output: promptStreams.output,
                 render() {
-                    return renderMultiSelectPrompt(this, options.prompt);
+                    return renderMultiSelectPrompt(
+                        this,
+                        options.prompt,
+                        colors,
+                    );
                 },
                 required: false,
             }).prompt() as string[] | symbol,
@@ -148,31 +155,33 @@ function createPromptStreams(
 function renderMultiSelectPrompt(
     prompt: Omit<MultiSelectPrompt<MultiSelectOption>, "prompt">,
     message: string,
+    colors: TerminalColors,
 ): string {
-    const header = `${color.gray("│")}\n${readPromptStateSymbol(prompt.state)}  ${message}\n`;
+    const header = `${message}\n`;
+    const itemIndent = "\u200B ";
 
     switch (prompt.state) {
         case "submit":
-            return `${header}${color.gray("│")}  ${prompt.options
+            return `${header}${itemIndent}${prompt.options
                 .filter(({ value }) => prompt.value.includes(value))
-                .map(option => formatRenderedOption(option, "submitted"))
-                .join(color.dim(", ")) || color.dim("none")}`;
+                .map(option => formatRenderedOption(option, "submitted", colors))
+                .join(colors.dim(", ")) || colors.dim("none")}`;
         case "cancel": {
             const selectedOptions = prompt.options
                 .filter(({ value }) => prompt.value.includes(value))
-                .map(option => formatRenderedOption(option, "cancelled"))
-                .join(color.dim(", "));
+                .map(option => formatRenderedOption(option, "cancelled", colors))
+                .join(colors.dim(", "));
 
-            return `${header}${color.gray("│")}  ${selectedOptions.trim() === "" ? "" : `${selectedOptions}\n${color.gray("│")}`}`;
+            return `${header}${selectedOptions.trim() === "" ? "" : `${itemIndent}${selectedOptions}\n`}`;
         }
         case "error": {
             const renderedError = prompt.error.split("\n").map((line, index) =>
                 index === 0
-                    ? `${color.yellow("└")}  ${color.yellow(line)}`
+                    ? `${itemIndent}${colors.yellow("└")}  ${colors.yellow(line)}`
                     : `   ${line}`,
             ).join("\n");
 
-            return `${header}${color.yellow("│")}  ${renderScrollableOptions(
+            return `${header}${itemIndent}${renderScrollableOptions(
                 prompt.cursor,
                 prompt.options,
                 option => formatRenderedOption(
@@ -180,26 +189,36 @@ function renderMultiSelectPrompt(
                     isOptionSelected(prompt, option)
                         ? "active-selected"
                         : "active",
-                ),
-            ).join(`\n${color.yellow("│")}  `)}\n${renderedError}\n`;
-        }
-        default:
-            return `${header}${promptSymbols.line}  ${renderScrollableOptions(
-                prompt.cursor,
-                prompt.options,
-                option => formatRenderedOption(
-                    option,
-                    isOptionSelected(prompt, option)
-                        ? "active-selected"
-                        : "active",
+                    colors,
                 ),
                 option => formatRenderedOption(
                     option,
                     isOptionSelected(prompt, option)
                         ? "selected"
                         : "inactive",
+                    colors,
                 ),
-            ).join(`\n${promptSymbols.line}  `)}\n${promptSymbols.tail}\n`;
+            ).join(`\n${itemIndent}`)}\n${renderedError}\n`;
+        }
+        default:
+            return `${header}${itemIndent}${renderScrollableOptions(
+                prompt.cursor,
+                prompt.options,
+                option => formatRenderedOption(
+                    option,
+                    isOptionSelected(prompt, option)
+                        ? "active-selected"
+                        : "active",
+                    colors,
+                ),
+                option => formatRenderedOption(
+                    option,
+                    isOptionSelected(prompt, option)
+                        ? "selected"
+                        : "inactive",
+                    colors,
+                ),
+            ).join(`\n${itemIndent}`)}\n`;
     }
 }
 
@@ -207,8 +226,7 @@ function renderScrollableOptions(
     cursor: number,
     options: readonly MultiSelectOption[],
     activeStyle: (option: MultiSelectOption) => string,
-    inactiveStyle: (option: MultiSelectOption) => string = option =>
-        formatRenderedOption(option, "inactive"),
+    inactiveStyle: (option: MultiSelectOption) => string,
 ): string[] {
     const maxItems = Number.POSITIVE_INFINITY;
     const visibleRows = Math.max((process.stdout.rows ?? 24) - 4, 0);
@@ -236,31 +254,21 @@ function renderScrollableOptions(
 function formatRenderedOption(
     option: MultiSelectOption,
     state: "active" | "active-selected" | "cancelled" | "inactive" | "selected" | "submitted",
+    colors: TerminalColors,
 ): string {
     switch (state) {
         case "active":
-            return `${color.cyan("◻")} ${option.label} ${option.hint === "" ? "" : color.dim(`(${option.hint})`)}`;
+            return `${colors.cyan("◻")} ${option.label} ${option.hint === "" ? "" : colors.dim(`(${option.hint})`)}`;
         case "active-selected":
-            return `${color.green("◼")} ${option.label} ${option.hint === "" ? "" : color.dim(`(${option.hint})`)}`;
+            return `${colors.green("◼")} ${option.label} ${option.hint === "" ? "" : colors.dim(`(${option.hint})`)}`;
         case "cancelled":
-            return color.strikethrough(color.dim(option.label));
+            return colors.strikethrough(colors.dim(option.label));
         case "inactive":
-            return `${color.dim("◻")} ${color.dim(option.label)}`;
+            return `${colors.dim("◻")} ${colors.dim(option.label)}`;
         case "selected":
-            return `${color.green("◼")} ${color.dim(option.label)} ${option.hint === "" ? "" : color.dim(`(${option.hint})`)}`;
+            return `${colors.green("◼")} ${colors.dim(option.label)} ${option.hint === "" ? "" : colors.dim(`(${option.hint})`)}`;
         case "submitted":
-            return color.dim(option.label);
-    }
-}
-
-function readPromptStateSymbol(state: string): string {
-    switch (state) {
-        case "cancel":
-            return promptSymbols.cancelled;
-        case "submit":
-            return promptSymbols.submitted;
-        default:
-            return promptSymbols.active;
+            return colors.dim(option.label);
     }
 }
 
@@ -295,6 +303,26 @@ function formatSkillOptionLabel(
     );
 
     return `${displayName}${" ".repeat(paddingWidth)}${item.statusLabel}`;
+}
+
+function formatSkillOptionHint(
+    hint: string,
+    label: string,
+    terminalColumns: number,
+): string {
+    if (hint === "") {
+        return "";
+    }
+
+    const safeColumns = terminalColumns > 0 ? terminalColumns : 80;
+    const reservedWidth = measureDisplayWidth(label) + 8;
+    const availableWidth = safeColumns - reservedWidth;
+
+    if (availableWidth <= 0) {
+        return "";
+    }
+
+    return truncateDisplayWidth(hint, availableWidth);
 }
 
 async function readPromptLine(stdin: InteractiveInput): Promise<string> {

--- a/src/application/commands/skills/registry-skill-source.test.ts
+++ b/src/application/commands/skills/registry-skill-source.test.ts
@@ -33,7 +33,19 @@ describe("registry skill source", () => {
                 "1.2.3",
             ).toString(),
         ).toBe(
-            "https://registry.oomol.com/%40foo%2Fbar/-/meta/%40foo%2Fbar-1.2.3.tgz",
+            "https://registry.oomol.com/@foo/bar/-/meta/bar-1.2.3.tgz",
+        );
+    });
+
+    test("creates the package tarball URL for unscoped packages", () => {
+        expect(
+            createRegistryPackageTarballRequestUrl(
+                "oomol.com",
+                "openai",
+                "1.2.3",
+            ).toString(),
+        ).toBe(
+            "https://registry.oomol.com/openai/-/meta/openai-1.2.3.tgz",
         );
     });
 

--- a/src/application/commands/skills/registry-skill-source.ts
+++ b/src/application/commands/skills/registry-skill-source.ts
@@ -63,10 +63,11 @@ export function createRegistryPackageTarballRequestUrl(
     packageName: string,
     packageVersion: string,
 ): URL {
-    const encodedPackageName = encodeURIComponent(packageName);
+    const packagePath = encodeURI(packageName);
+    const tarballPackageName = resolveRegistryPackageTarballPackageName(packageName);
 
     return new URL(
-        `https://registry.${endpoint}/${encodedPackageName}/-/meta/${encodedPackageName}-${encodeURIComponent(packageVersion)}.tgz`,
+        `https://registry.${endpoint}/${packagePath}/-/meta/${encodeURIComponent(tarballPackageName)}-${encodeURIComponent(packageVersion)}.tgz`,
     );
 }
 
@@ -180,4 +181,18 @@ function parseRegistryPackageSkillInfo(
     catch {
         throw new CliUserError("errors.skills.install.invalidPackageInfo", 1);
     }
+}
+
+function resolveRegistryPackageTarballPackageName(packageName: string): string {
+    if (!packageName.startsWith("@")) {
+        return packageName;
+    }
+
+    const scopeSeparatorIndex = packageName.indexOf("/");
+
+    if (scopeSeparatorIndex < 0 || scopeSeparatorIndex === packageName.length - 1) {
+        return packageName;
+    }
+
+    return packageName.slice(scopeSeparatorIndex + 1);
 }

--- a/src/application/display-width.test.ts
+++ b/src/application/display-width.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    measureDisplayWidth,
+    truncateDisplayWidth,
+} from "./display-width.ts";
+
+describe("display width", () => {
+    test("measures ASCII and wide characters", () => {
+        expect(measureDisplayWidth("abc")).toBe(3);
+        expect(measureDisplayWidth("你好")).toBe(4);
+        expect(measureDisplayWidth("a你b")).toBe(4);
+    });
+
+    test("truncates by visible width", () => {
+        expect(truncateDisplayWidth("hello world", 8)).toBe("hello...");
+        expect(truncateDisplayWidth("你好世界", 5)).toBe("你...");
+        expect(truncateDisplayWidth("abc", 2)).toBe("ab");
+    });
+});

--- a/src/application/display-width.ts
+++ b/src/application/display-width.ts
@@ -1,0 +1,75 @@
+export function truncateDisplayWidth(value: string, maxWidth: number): string {
+    if (measureDisplayWidth(value) <= maxWidth) {
+        return value;
+    }
+
+    if (maxWidth <= 3) {
+        return sliceDisplayWidth(value, maxWidth);
+    }
+
+    return `${sliceDisplayWidth(value, maxWidth - 3)}...`;
+}
+
+export function measureDisplayWidth(value: string): number {
+    let width = 0;
+
+    for (let index = 0; index < value.length; index += 1) {
+        const codePoint = value.codePointAt(index);
+
+        if (codePoint === undefined) {
+            continue;
+        }
+
+        width += isWideCodePoint(codePoint) ? 2 : 1;
+
+        if (codePoint > 0xFFFF) {
+            index += 1;
+        }
+    }
+
+    return width;
+}
+
+function sliceDisplayWidth(value: string, maxWidth: number): string {
+    let result = "";
+    let width = 0;
+
+    for (let index = 0; index < value.length; index += 1) {
+        const codePoint = value.codePointAt(index);
+
+        if (codePoint === undefined) {
+            continue;
+        }
+
+        const segment = String.fromCodePoint(codePoint);
+        const nextWidth = width + (isWideCodePoint(codePoint) ? 2 : 1);
+
+        if (nextWidth > maxWidth) {
+            break;
+        }
+
+        result += segment;
+        width = nextWidth;
+
+        if (codePoint > 0xFFFF) {
+            index += 1;
+        }
+    }
+
+    return result;
+}
+
+function isWideCodePoint(codePoint: number): boolean {
+    return codePoint >= 0x1100 && (
+        codePoint <= 0x115F
+        || codePoint === 0x2329
+        || codePoint === 0x232A
+        || (codePoint >= 0x2E80 && codePoint <= 0xA4CF && codePoint !== 0x303F)
+        || (codePoint >= 0xAC00 && codePoint <= 0xD7A3)
+        || (codePoint >= 0xF900 && codePoint <= 0xFAFF)
+        || (codePoint >= 0xFE10 && codePoint <= 0xFE19)
+        || (codePoint >= 0xFE30 && codePoint <= 0xFE6F)
+        || (codePoint >= 0xFF00 && codePoint <= 0xFF60)
+        || (codePoint >= 0xFFE0 && codePoint <= 0xFFE6)
+    );
+}

--- a/src/application/terminal-colors.test.ts
+++ b/src/application/terminal-colors.test.ts
@@ -12,18 +12,51 @@ describe("terminal colors", () => {
         expect(colors.blue("x")).toBe("\u001B[34mx\u001B[39m");
         expect(colors.magenta("x")).toBe("\u001B[35mx\u001B[39m");
         expect(colors.cyan("x")).toBe("\u001B[36mx\u001B[39m");
+        expect(colors.gray("x")).toBe("\u001B[90mx\u001B[39m");
     });
 
-    test("preserves chained intensity modifiers", () => {
+    test("composes nested formatters like picocolors", () => {
         const colors = createTerminalColors(true);
 
-        expect(colors.green.bold("x")).toBe("\u001B[32m\u001B[1mx\u001B[22m\u001B[39m");
-        expect(colors.yellow.dim("x")).toBe("\u001B[33m\u001B[2mx\u001B[22m\u001B[39m");
+        expect(colors.green(colors.bold("x"))).toBe(
+            "\u001B[32m\u001B[1mx\u001B[22m\u001B[39m",
+        );
+        expect(colors.yellow(colors.dim("x"))).toBe(
+            "\u001B[33m\u001B[2mx\u001B[22m\u001B[39m",
+        );
+    });
+
+    test("reopens outer styles when nested formatters close them", () => {
+        const colors = createTerminalColors(true);
+
+        expect(colors.bold(colors.dim("x"))).toBe(
+            "\u001B[1m\u001B[2mx\u001B[22m\u001B[1m\u001B[22m",
+        );
+        expect(colors.green(colors.red("x"))).toBe(
+            "\u001B[32m\u001B[31mx\u001B[32m\u001B[39m",
+        );
     });
 
     test("keeps hex colors on truecolor output", () => {
         const colors = createTerminalColors(true);
 
         expect(colors.hex("#59F78D")("x")).toBe("\u001B[38;2;89;247;141mx\u001B[39m");
+    });
+
+    test("supports strikethrough decoration", () => {
+        const colors = createTerminalColors(true);
+
+        expect(colors.strikethrough("x")).toBe("\u001B[9mx\u001B[29m");
+        expect(colors.strikethrough(colors.dim("x"))).toBe(
+            "\u001B[9m\u001B[2mx\u001B[22m\u001B[29m",
+        );
+    });
+
+    test("returns plain strings when colors are disabled", () => {
+        const colors = createTerminalColors(false);
+
+        expect(colors.isColorSupported).toBeFalse();
+        expect(colors.green(123)).toBe("123");
+        expect(colors.bold(null)).toBe("null");
     });
 });

--- a/src/application/terminal-colors.ts
+++ b/src/application/terminal-colors.ts
@@ -1,59 +1,81 @@
 import type { Writer } from "./contracts/cli.ts";
 
 const colorResetCode = "\u001B[39m";
-const intensityResetCode = "\u001B[22m";
-const basicColorOpenCodes = {
-    blue: "\u001B[34m",
-    cyan: "\u001B[36m",
-    green: "\u001B[32m",
-    magenta: "\u001B[35m",
-    red: "\u001B[31m",
-    yellow: "\u001B[33m",
-} as const;
-const boldStyle = {
-    close: intensityResetCode,
-    open: "\u001B[1m",
-} as const;
-const dimStyle = {
-    close: intensityResetCode,
-    open: "\u001B[2m",
-} as const;
+const stringFormatter = String as TerminalFormatter;
 
-interface TerminalStyle {
+interface TerminalFormatterDefinition {
     close: string;
     open: string;
+    replace?: string;
 }
 
-export type TerminalFormatter = ((value: string) => string) & {
-    bold: (value: string) => string;
-    dim: (value: string) => string;
-};
+const formatterDefinitions = {
+    reset: {
+        close: "\u001B[0m",
+        open: "\u001B[0m",
+    },
+    bold: {
+        close: "\u001B[22m",
+        open: "\u001B[1m",
+        replace: "\u001B[22m\u001B[1m",
+    },
+    dim: {
+        close: "\u001B[22m",
+        open: "\u001B[2m",
+        replace: "\u001B[22m\u001B[2m",
+    },
+    strikethrough: {
+        close: "\u001B[29m",
+        open: "\u001B[9m",
+    },
+    red: {
+        close: colorResetCode,
+        open: "\u001B[31m",
+    },
+    green: {
+        close: colorResetCode,
+        open: "\u001B[32m",
+    },
+    yellow: {
+        close: colorResetCode,
+        open: "\u001B[33m",
+    },
+    blue: {
+        close: colorResetCode,
+        open: "\u001B[34m",
+    },
+    magenta: {
+        close: colorResetCode,
+        open: "\u001B[35m",
+    },
+    cyan: {
+        close: colorResetCode,
+        open: "\u001B[36m",
+    },
+    gray: {
+        close: colorResetCode,
+        open: "\u001B[90m",
+    },
+} as const satisfies Record<string, TerminalFormatterDefinition>;
 
-export interface TerminalColors {
-    blue: TerminalFormatter;
-    bold: (value: string) => string;
-    cyan: TerminalFormatter;
-    dim: (value: string) => string;
-    green: TerminalFormatter;
+type TerminalFormatterName = keyof typeof formatterDefinitions;
+
+export type TerminalInput = string | number | null | undefined;
+
+export type TerminalFormatter = (value: TerminalInput) => string;
+
+export type TerminalColors = Record<TerminalFormatterName, TerminalFormatter> & {
+    isColorSupported: boolean;
     hex: (color: string) => TerminalFormatter;
-    magenta: TerminalFormatter;
-    red: TerminalFormatter;
     strip: (value: string) => string;
-    yellow: TerminalFormatter;
-}
+};
 
 export function createTerminalColors(enabled: boolean): TerminalColors {
     return {
-        blue: createBasicColorFormatter(enabled, "blue"),
-        bold: value => applyTerminalStyles(value, enabled, [boldStyle]),
-        cyan: createBasicColorFormatter(enabled, "cyan"),
-        dim: value => applyTerminalStyles(value, enabled, [dimStyle]),
-        green: createBasicColorFormatter(enabled, "green"),
-        hex: color => createColorFormatter(enabled, color),
-        magenta: createBasicColorFormatter(enabled, "magenta"),
-        red: createBasicColorFormatter(enabled, "red"),
+        ...createNamedFormatters(enabled),
+        isColorSupported: enabled,
+        hex: color => createHexFormatter(enabled, color),
         strip: value => Bun.stripANSI(value),
-        yellow: createBasicColorFormatter(enabled, "yellow"),
     };
 }
 
@@ -63,76 +85,85 @@ export function createWriterColors(
     return createTerminalColors(writer.hasColors?.() ?? false);
 }
 
-function createColorFormatter(
+function createNamedFormatters(
+    enabled: boolean,
+): Record<TerminalFormatterName, TerminalFormatter> {
+    const formatters = {} as Record<TerminalFormatterName, TerminalFormatter>;
+
+    for (const [name, definition] of Object.entries(
+        formatterDefinitions,
+    ) as [TerminalFormatterName, TerminalFormatterDefinition][]) {
+        formatters[name] = createFormatter(enabled, definition);
+    }
+
+    return formatters;
+}
+
+function createHexFormatter(
     enabled: boolean,
     color: string,
 ): TerminalFormatter {
-    const style = createColorStyle(color);
-
-    if (style === null) {
-        return createFormatter(enabled, []);
+    if (!enabled) {
+        return stringFormatter;
     }
 
-    return createFormatter(enabled, [style]);
-}
+    const open = Bun.color(color, "ansi-16m");
 
-function createBasicColorFormatter(
-    enabled: boolean,
-    color: keyof typeof basicColorOpenCodes,
-): TerminalFormatter {
-    return createFormatter(enabled, [
-        {
-            close: colorResetCode,
-            open: basicColorOpenCodes[color],
-        },
-    ]);
+    if (typeof open !== "string" || open === "") {
+        return stringFormatter;
+    }
+
+    return createFormatter(enabled, {
+        close: colorResetCode,
+        open,
+    });
 }
 
 function createFormatter(
     enabled: boolean,
-    styles: readonly TerminalStyle[],
+    definition: TerminalFormatterDefinition,
 ): TerminalFormatter {
-    const formatter = ((value: string) =>
-        applyTerminalStyles(value, enabled, styles)) as TerminalFormatter;
-
-    formatter.bold = (value: string) =>
-        applyTerminalStyles(value, enabled, [...styles, boldStyle]);
-    formatter.dim = (value: string) =>
-        applyTerminalStyles(value, enabled, [...styles, dimStyle]);
-
-    return formatter;
-}
-
-function createColorStyle(color: string): TerminalStyle | null {
-    // Bun exposes ANSI conversion and stripping, but not ansis-style chaining.
-    // Keep that behavior local so the rest of the CLI stays unchanged.
-    const open = Bun.color(color, "ansi-16m");
-
-    if (typeof open !== "string" || open === "") {
-        return null;
+    if (!enabled) {
+        return stringFormatter;
     }
 
-    return {
-        close: colorResetCode,
-        open,
+    const replace = definition.replace ?? definition.open;
+
+    return (value) => {
+        const stringValue = String(value);
+        const closeIndex = stringValue.indexOf(
+            definition.close,
+            definition.open.length,
+        );
+
+        if (closeIndex === -1) {
+            return `${definition.open}${stringValue}${definition.close}`;
+        }
+
+        return `${definition.open}${replaceClose(
+            stringValue,
+            definition.close,
+            replace,
+            closeIndex,
+        )}${definition.close}`;
     };
 }
 
-function applyTerminalStyles(
+function replaceClose(
     value: string,
-    enabled: boolean,
-    styles: readonly TerminalStyle[],
+    close: string,
+    replace: string,
+    index: number,
 ): string {
-    if (!enabled || styles.length === 0) {
-        return value;
+    let result = "";
+    let cursor = 0;
+    let currentIndex = index;
+
+    while (currentIndex !== -1) {
+        result += value.slice(cursor, currentIndex) + replace;
+        cursor = currentIndex + close.length;
+        currentIndex = value.indexOf(close, cursor);
     }
 
-    const openCodes = styles.map(style => style.open).join("");
-    const closeCodes = styles
-        .slice()
-        .reverse()
-        .map(style => style.close)
-        .join("");
-
-    return `${openCodes}${value}${closeCodes}`;
+    return result + value.slice(cursor);
 }

--- a/src/application/update/update-notifier.ts
+++ b/src/application/update/update-notifier.ts
@@ -2,6 +2,7 @@ import type { CliExecutionContext, Fetcher, Writer } from "../contracts/cli.ts";
 
 import type { TerminalColors } from "../terminal-colors.ts";
 import { APP_NAME } from "../config/app-config.ts";
+import { measureDisplayWidth } from "../display-width.ts";
 import { compareSemver, isSemver as isValidSemver } from "../semver.ts";
 import { createWriterColors } from "../terminal-colors.ts";
 
@@ -126,7 +127,7 @@ export function renderCliUpdateNotice(options: {
     const lines = [
         options.context.translator.t("update.available.message", {
             currentVersion: colors.dim(options.context.version),
-            latestVersion: colors.green.bold(options.latestVersion),
+            latestVersion: colors.green(colors.bold(options.latestVersion)),
         }),
         options.context.translator.t("update.available.command", {
             command: colors.cyan(options.updateCommand),
@@ -464,39 +465,4 @@ function normalizePackageManagerName(value: string | undefined): string | undefi
         default:
             return undefined;
     }
-}
-
-function measureDisplayWidth(value: string): number {
-    let width = 0;
-
-    for (let index = 0; index < value.length; index += 1) {
-        const codePoint = value.codePointAt(index);
-
-        if (codePoint === undefined) {
-            continue;
-        }
-
-        width += isWideCodePoint(codePoint) ? 2 : 1;
-
-        if (codePoint > 0xFFFF) {
-            index += 1;
-        }
-    }
-
-    return width;
-}
-
-function isWideCodePoint(codePoint: number): boolean {
-    return codePoint >= 0x1100 && (
-        codePoint <= 0x115F
-        || codePoint === 0x2329
-        || codePoint === 0x232A
-        || (codePoint >= 0x2E80 && codePoint <= 0xA4CF && codePoint !== 0x303F)
-        || (codePoint >= 0xAC00 && codePoint <= 0xD7A3)
-        || (codePoint >= 0xF900 && codePoint <= 0xFAFF)
-        || (codePoint >= 0xFE10 && codePoint <= 0xFE19)
-        || (codePoint >= 0xFE30 && codePoint <= 0xFE6F)
-        || (codePoint >= 0xFF00 && codePoint <= 0xFF60)
-        || (codePoint >= 0xFFE0 && codePoint <= 0xFFE6)
-    );
 }


### PR DESCRIPTION
- Remove picocolors dependency in favor of the project's own createWriterColors utility for consistent color handling
- Add display-width module for measuring and truncating strings with wide character support
- Truncate long skill descriptions in interactive prompts to prevent wrapped rows in narrow terminals
- Fix scoped package tarball URL construction to use unencoded path separators and strip scope prefix from filename