### PR TITLE
feat(skills): support uninstalling published skills by name

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -225,14 +225,20 @@ directory.
   checks whether the recorded metadata `version` matches the current CLI
   version and silently refreshes the installed files when needed.
 
-### `oo skills uninstall`
+### `oo skills uninstall [skill]`
 
-Remove one bundled skill from the local Codex skills directory.
+Remove one oo-managed skill from the local Codex skills directory.
 
-- Managed skill: `oo`.
-- Canonical directory removed: `<config-dir>/skills/oo`, where
+- Alias: `oo skills remove [skill]`.
+- Arguments: `[skill]` defaults to `oo` when omitted.
+- Ownership rule: the target skill is removable only when
+  `${CODEX_HOME:-~/.codex}/skills/<skill>` contains `.oo-metadata.json`.
+- Canonical directory removed: `<config-dir>/skills/<skill>`, where
   `<config-dir>` is the directory that contains `settings.toml`.
-- Target directory: `${CODEX_HOME:-~/.codex}/skills/oo`.
+- Target directory removed: `${CODEX_HOME:-~/.codex}/skills/<skill>`.
+- Notes: when the target directory is missing, or it exists without
+  `.oo-metadata.json`, the command exits with an error and does not remove
+  anything.
 
 ## Logs
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -198,14 +198,20 @@
   与当前 CLI 版本一致；这里的版本来自元数据文件中的 `version` 字段。不一
   致时会静默刷新已安装的文件。
 
-### `oo skills uninstall`
+### `oo skills uninstall [skill]`
 
-从本地 Codex skills 目录移除一个内置 skill。
+从本地 Codex skills 目录移除一个由 oo 管理的 skill。
 
-- 内置 skill：`oo`。
-- 会同时移除 canonical 目录：`<config-dir>/skills/oo`，其中
+- 别名：`oo skills remove [skill]`。
+- 参数：省略 `[skill]` 时，默认使用 `oo`。
+- 所有权规则：只有当
+  `${CODEX_HOME:-~/.codex}/skills/<skill>` 中存在 `.oo-metadata.json`
+  时，才允许移除该 skill。
+- 会同时移除 canonical 目录：`<config-dir>/skills/<skill>`，其中
   `<config-dir>` 是 `settings.toml` 所在目录。
-- 目标目录：`${CODEX_HOME:-~/.codex}/skills/oo`。
+- 会同时移除目标目录：`${CODEX_HOME:-~/.codex}/skills/<skill>`。
+- 说明：如果目标目录不存在，或者目录存在但没有 `.oo-metadata.json`，
+  命令会直接报错，不会删除任何内容。
 
 ## 日志
 

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -141,6 +141,30 @@ describe("skills CLI", () => {
         }
     });
 
+    test("supports skills remove as an alias for uninstall", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
+            });
+
+            const result = await sandbox.run(["skills", "remove"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Removed Codex skill oo from ${skillDirectoryPath}.\n`,
+            );
+            expect(result.stderr).toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("synchronizes the managed Codex skill policy from persisted settings", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -296,7 +296,90 @@ describe("skills commands", () => {
         }
     });
 
-    test("does not uninstall a same-name skill that is not managed by OOMOL", async () => {
+    test("uninstalls a published Codex skill from the Codex skills directory", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+        const metadataFilePath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
+                recursive: true,
+            });
+            await Bun.write(metadataFilePath, formatManagedSkillMetadataContent("openai", "0.0.3"));
+            await Bun.write(join(skillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
+            await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
+
+            const result = await sandbox.run(["skills", "uninstall", "chatgpt"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Removed Codex skill chatgpt from ${skillDirectoryPath}.\n`,
+            );
+            expect(result.stderr).toBe("");
+            await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(canonicalSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports skills remove as an alias for uninstall", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+        const metadataFilePath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
+                recursive: true,
+            });
+            await Bun.write(metadataFilePath, formatManagedSkillMetadataContent("openai", "0.0.3"));
+            await Bun.write(join(skillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
+            await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
+
+            const result = await sandbox.run(["skills", "remove", "chatgpt"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Removed Codex skill chatgpt from ${skillDirectoryPath}.\n`,
+            );
+            expect(result.stderr).toBe("");
+            await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not uninstall a same-name skill without oo metadata", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
@@ -330,10 +413,36 @@ describe("skills commands", () => {
         }
     });
 
+    test("does not uninstall a published skill without oo metadata", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(join(skillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
+
+            const result = await sandbox.run(["skills", "uninstall", "chatgpt"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                `Codex skill chatgpt is not installed at ${skillDirectoryPath}.\n`,
+            );
+            await expect(stat(skillDirectoryPath)).resolves.toMatchObject({
+                isDirectory: expect.any(Function),
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("uninstall removes canonical bundled skill storage even when it contains unmanaged content", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
@@ -355,6 +464,10 @@ describe("skills commands", () => {
             await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
                 recursive: true,
             });
+            await Bun.write(
+                metadataFilePath,
+                formatBundledSkillMetadataContent("9.9.9"),
+            );
             await Bun.write(ownershipFilePath, "# OOMOL\n");
             await Bun.write(
                 canonicalOwnershipFilePath,

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -23,6 +23,7 @@ import {
 } from "./bundled-skill-model.ts";
 import {
     directoryExists,
+    fileExists,
     isBundledSkillInstallationCurrent,
     isManagedBundledSkillInstallation,
     readInstalledBundledSkillImplicitInvocation,
@@ -33,12 +34,19 @@ import {
 import {
     resolveBundledSkillCanonicalDirectoryPath,
     resolveBundledSkillDirectoryPath,
+    resolveBundledSkillMetadataFilePath,
     resolveCodexHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import {
     availableBundledSkillNames,
     getBundledSkillFiles,
 } from "./embedded-assets.ts";
+import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
+import {
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillDirectoryPath,
+    resolveManagedSkillMetadataFilePath,
+} from "./managed-skill-paths.ts";
 
 export {
     createBundledSkillDirectorySymlink,
@@ -349,13 +357,13 @@ export async function uninstallBundledSkill(
         skillName,
     );
     const installedSkillDirectoryExists = await directoryExists(skillDirectoryPath);
-    const installedSkillDirectoryManaged = installedSkillDirectoryExists
-        ? await isManagedBundledSkillInstallation(skillDirectoryPath)
+    const installedSkillMetadataExists = installedSkillDirectoryExists
+        ? await fileExists(resolveBundledSkillMetadataFilePath(skillDirectoryPath))
         : false;
 
     if (!canUninstallManagedBundledSkillInstallation({
         installedDirectoryExists: installedSkillDirectoryExists,
-        installedDirectoryManaged: installedSkillDirectoryManaged,
+        installedDirectoryManaged: installedSkillMetadataExists,
     })) {
         context.logger.warn(
             {
@@ -391,6 +399,18 @@ export async function uninstallBundledSkill(
         },
         "Bundled Codex skill removed explicitly.",
     );
+}
+
+export async function uninstallManagedSkill(
+    skillName: string,
+    context: CliExecutionContext,
+): Promise<void> {
+    if (isBundledSkillName(skillName)) {
+        await uninstallBundledSkill(skillName, context);
+        return;
+    }
+
+    await uninstallRegistrySkill(skillName, context);
 }
 
 async function writeBundledSkillInstallation(options: {
@@ -445,4 +465,69 @@ async function writeBundledSkillInstallation(options: {
 
 function writeLine(context: CliExecutionContext, message: string): void {
     context.stdout.write(`${message}\n`);
+}
+
+async function uninstallRegistrySkill(
+    skillName: string,
+    context: CliExecutionContext,
+): Promise<void> {
+    const codexHomeDirectory = await requireCodexHomeDirectory(context);
+    const skillDirectoryPath = resolveManagedSkillDirectoryPath(
+        codexHomeDirectory,
+        skillName,
+    );
+    const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+        context.settingsStore.getFilePath(),
+        skillName,
+    );
+    const installedSkillDirectoryExists = await directoryExists(skillDirectoryPath);
+    const installedSkillMetadataExists = installedSkillDirectoryExists
+        ? await fileExists(resolveManagedSkillMetadataFilePath(skillDirectoryPath))
+        : false;
+
+    if (
+        !canUninstallManagedBundledSkillInstallation({
+            installedDirectoryExists: installedSkillDirectoryExists,
+            installedDirectoryManaged: installedSkillMetadataExists,
+        })
+    ) {
+        context.logger.warn(
+            {
+                path: skillDirectoryPath,
+                skillName,
+            },
+            "Managed Codex skill uninstall skipped because no OOMOL metadata was found.",
+        );
+        throw new CliUserError("errors.skills.notInstalled", 1, {
+            name: skillName,
+            path: skillDirectoryPath,
+        });
+    }
+
+    const metadata = await readManagedSkillMetadata(skillDirectoryPath);
+
+    await removePath(skillDirectoryPath);
+    await removePath(canonicalSkillDirectoryPath);
+
+    writeLine(
+        context,
+        context.translator.t("skills.uninstall.success", {
+            name: skillName,
+            path: skillDirectoryPath,
+        }),
+    );
+    context.logger.info(
+        {
+            canonicalPath: canonicalSkillDirectoryPath,
+            packageName: metadata?.packageName,
+            path: skillDirectoryPath,
+            previousVersion: metadata?.version ?? "unknown",
+            skillName,
+        },
+        "Managed Codex skill removed explicitly.",
+    );
+}
+
+function isBundledSkillName(value: string): value is BundledSkillName {
+    return availableBundledSkillNames.includes(value as BundledSkillName);
 }

--- a/src/application/commands/skills/uninstall.ts
+++ b/src/application/commands/skills/uninstall.ts
@@ -1,16 +1,30 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
-import { uninstallBundledSkill } from "./shared.ts";
+import { uninstallManagedSkill } from "./shared.ts";
 
 const bundledSkillName = "oo" as const;
 
-export const skillsUninstallCommand: CliCommandDefinition = {
+interface SkillsUninstallInput {
+    skill?: string;
+}
+
+export const skillsUninstallCommand: CliCommandDefinition<SkillsUninstallInput> = {
     name: "uninstall",
+    aliases: ["remove"],
     summaryKey: "commands.skills.uninstall.summary",
     descriptionKey: "commands.skills.uninstall.description",
-    inputSchema: z.object({}),
-    handler: async (_, context) => {
-        await uninstallBundledSkill(bundledSkillName, context);
+    arguments: [
+        {
+            name: "skill",
+            descriptionKey: "arguments.skill",
+            required: false,
+        },
+    ],
+    inputSchema: z.object({
+        skill: z.string().optional(),
+    }),
+    handler: async (input, context) => {
+        await uninstallManagedSkill(input.skill ?? bundledSkillName, context);
     },
 };

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -125,8 +125,8 @@ export const enMessages = {
         "Install bundled or published Codex skills into the local Codex skills directory.",
     "commands.skills.install.summary": "Install Codex skills",
     "commands.skills.uninstall.description":
-        "Remove one bundled Codex skill from the local Codex skills directory.",
-    "commands.skills.uninstall.summary": "Remove a bundled Codex skill",
+        "Remove one oo-managed Codex skill from the local Codex skills directory.",
+    "commands.skills.uninstall.summary": "Remove an oo-managed Codex skill",
     "config.set.success": "Set {key} to {value}.",
     "config.unset.success": "Removed {key}.",
     "errors.commander.excessArguments": "Too many arguments were provided.",
@@ -592,8 +592,8 @@ export const zhMessages = {
     "commands.skills.install.description":
         "将内置或已发布的 Codex skill 安装到本地 Codex skills 目录。",
     "commands.skills.install.summary": "安装 Codex skills",
-    "commands.skills.uninstall.description": "从本地 Codex skills 目录移除一个内置 Codex skill。",
-    "commands.skills.uninstall.summary": "移除一个内置 Codex skill",
+    "commands.skills.uninstall.description": "从本地 Codex skills 目录移除一个由 oo 管理的 Codex skill。",
+    "commands.skills.uninstall.summary": "移除一个由 oo 管理的 Codex skill",
     "config.set.success": "已将 {key} 设置为 {value}。",
     "config.unset.success": "已移除 {key}。",
     "errors.commander.excessArguments": "提供了过多的参数。",


### PR DESCRIPTION
Extend `oo skills uninstall` to accept an optional `[skill]` argument so users can remove any oo-managed skill (bundled or registry-installed), not just the hardcoded `oo` skill.

- Add `remove` as an alias for `uninstall`
- Route bundled vs registry skills through `uninstallManagedSkill`
- Guard removal with `.oo-metadata.json` existence check
- Default to `oo` when the argument is omitted (backward-compatible)