### PR TITLE
feat(skills): add list command to show oo-managed skills

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,18 @@ Check whether a newer CLI release is available.
 
 ## Codex Skills
 
+### `oo skills list`
+
+List oo-managed skills from the local Codex skills directory.
+
+- Ownership rule: the command scans `${CODEX_HOME:-~/.codex}/skills` and keeps
+  only child directories that contain `.oo-metadata.json`.
+- Output: text output prints a summary line and one block per skill.
+- Ordering: `oo` is always listed first when present; the remaining skills are
+  ordered by skill name.
+- Output: each skill block shows the skill name, source package or bundled
+  marker, and recorded version.
+
 ### `oo skills search <text>`
 
 Search published skills with free-form text.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -108,6 +108,17 @@
 
 ## Codex Skill
 
+### `oo skills list`
+
+列出本地 Codex skills 目录中由 oo 管理的 skill。
+
+- 所有权规则：命令会扫描 `${CODEX_HOME:-~/.codex}/skills`，只保留包含
+  `.oo-metadata.json` 的子目录。
+- 输出：文本输出会先打印摘要行，再为每个 skill 打印一个块。
+- 排序：如果存在 `oo`，它总是排在最前面；其余 skill 按名称排序。
+- 输出：每个 skill 块会显示 skill 名称、来源 package 或内置标记、记录的版
+  本号。
+
 ### `oo skills search <text>`
 
 使用自由文本搜索已发布的 skill。

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -2,6 +2,7 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { skillsConfigCommand } from "./config/index.ts";
 import { skillsInstallCommand } from "./install.ts";
+import { skillsListCommand } from "./list.ts";
 import { skillsSearchCommand } from "./search.ts";
 import { skillsUninstallCommand } from "./uninstall.ts";
 
@@ -11,6 +12,7 @@ export const skillsCommand: CliCommandDefinition = {
     descriptionKey: "commands.skills.description",
     children: [
         skillsSearchCommand,
+        skillsListCommand,
         skillsConfigCommand,
         skillsInstallCommand,
         skillsUninstallCommand,

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -102,7 +102,7 @@ describe("skills list CLI", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toContain(
-                colors.hex(managedSkillNameColor).bold("alpha-skill"),
+                colors.bold(colors.hex(managedSkillNameColor)("alpha-skill")),
             );
             expect(result.stdout).toContain(
                 `${colors.dim("Source:")} ${colors.hex(managedSkillSourceColor)("@oomol/alpha")}`,

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -1,0 +1,118 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { createCliSandbox } from "../../../../__tests__/helpers.ts";
+import { createTerminalColors } from "../../terminal-colors.ts";
+import { renderManagedSkillMetadataContent } from "./managed-skill-metadata.ts";
+import { resolveCodexHomeDirectory } from "./shared.ts";
+
+const managedSkillNameColor = "#59F78D";
+const managedSkillSourceColor = "#CAA8FA";
+const managedSkillVersionColor = "#7DD3FC";
+
+describe("skills list CLI", () => {
+    test("lists oo-managed skills with source and version details", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillsDirectoryPath = join(codexHomeDirectory, "skills");
+        const alphaSkillDirectoryPath = join(skillsDirectoryPath, "alpha-skill");
+        const unmanagedSkillDirectoryPath = join(skillsDirectoryPath, "custom-skill");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
+            });
+            await mkdir(alphaSkillDirectoryPath, { recursive: true });
+            await mkdir(unmanagedSkillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(alphaSkillDirectoryPath, ".oo-metadata.json"),
+                renderManagedSkillMetadataContent({
+                    packageName: "@oomol/alpha",
+                    version: "1.2.3",
+                }),
+            );
+
+            const result = await sandbox.run(["skills", "list"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    "✓ Found 2 oo-managed skills.",
+                    "",
+                    "oo",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "alpha-skill",
+                    "  Source: @oomol/alpha",
+                    "  Version: 1.2.3",
+                    "",
+                ].join("\n"),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("prints a no-results message when no oo-managed skills are installed", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "list"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe("! No oo-managed skills were found.\n");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders skills list output with field-specific colors", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillsDirectoryPath = join(codexHomeDirectory, "skills");
+        const alphaSkillDirectoryPath = join(skillsDirectoryPath, "alpha-skill");
+        const colors = createTerminalColors(true);
+
+        try {
+            await mkdir(alphaSkillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(alphaSkillDirectoryPath, ".oo-metadata.json"),
+                renderManagedSkillMetadataContent({
+                    packageName: "@oomol/alpha",
+                    version: "1.2.3",
+                }),
+            );
+
+            const result = await sandbox.run(["skills", "list"], {
+                stdout: {
+                    hasColors: true,
+                },
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                colors.hex(managedSkillNameColor).bold("alpha-skill"),
+            );
+            expect(result.stdout).toContain(
+                `${colors.dim("Source:")} ${colors.hex(managedSkillSourceColor)("@oomol/alpha")}`,
+            );
+            expect(result.stdout).toContain(
+                `${colors.dim("Version:")} ${colors.hex(managedSkillVersionColor)("1.2.3")}`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/list.test.ts
+++ b/src/application/commands/skills/list.test.ts
@@ -1,0 +1,86 @@
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
+import { listManagedSkillInstallations } from "./list.ts";
+import { renderManagedSkillMetadataContent } from "./managed-skill-metadata.ts";
+
+describe("skills list command helpers", () => {
+    test("lists managed skills and keeps oo before the remaining sorted names", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-skills-list");
+        const skillsDirectoryPath = join(rootDirectory, "skills");
+        const unmanagedSkillDirectoryPath = join(skillsDirectoryPath, "custom-skill");
+        const zebraSkillDirectoryPath = join(skillsDirectoryPath, "zebra-skill");
+        const alphaSkillDirectoryPath = join(skillsDirectoryPath, "alpha-skill");
+        const ooSkillDirectoryPath = join(skillsDirectoryPath, "oo");
+
+        try {
+            await mkdir(unmanagedSkillDirectoryPath, { recursive: true });
+            await mkdir(zebraSkillDirectoryPath, { recursive: true });
+            await mkdir(alphaSkillDirectoryPath, { recursive: true });
+            await mkdir(ooSkillDirectoryPath, { recursive: true });
+
+            await Bun.write(
+                join(zebraSkillDirectoryPath, ".oo-metadata.json"),
+                renderManagedSkillMetadataContent({
+                    packageName: "@oomol/zebra",
+                    version: "2.0.0",
+                }),
+            );
+            await Bun.write(
+                join(alphaSkillDirectoryPath, ".oo-metadata.json"),
+                "{\n",
+            );
+            await Bun.write(
+                join(ooSkillDirectoryPath, ".oo-metadata.json"),
+                renderManagedSkillMetadataContent({
+                    version: "9.9.9",
+                }),
+            );
+
+            await expect(
+                listManagedSkillInstallations(skillsDirectoryPath),
+            ).resolves.toEqual([
+                {
+                    metadata: {
+                        packageName: undefined,
+                        version: "9.9.9",
+                    },
+                    name: "oo",
+                    path: ooSkillDirectoryPath,
+                },
+                {
+                    metadata: undefined,
+                    name: "alpha-skill",
+                    path: alphaSkillDirectoryPath,
+                },
+                {
+                    metadata: {
+                        packageName: "@oomol/zebra",
+                        version: "2.0.0",
+                    },
+                    name: "zebra-skill",
+                    path: zebraSkillDirectoryPath,
+                },
+            ]);
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("returns an empty list when the skills directory is missing", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-skills-list");
+
+        try {
+            await expect(
+                listManagedSkillInstallations(join(rootDirectory, "skills")),
+            ).resolves.toEqual([]);
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+});

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -1,0 +1,219 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+import type { TerminalColors } from "../../terminal-colors.ts";
+
+import type { ManagedSkillMetadata } from "./managed-skill-metadata.ts";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { createWriterColors } from "../../terminal-colors.ts";
+import {
+    directoryExists,
+    fileExists,
+    requireCodexHomeDirectory,
+} from "./bundled-skill-observation.ts";
+import { availableBundledSkillNames } from "./embedded-assets.ts";
+import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
+import { resolveManagedSkillMetadataFilePath } from "./managed-skill-paths.ts";
+
+const managedSkillNameColor = "#59F78D";
+const managedSkillSourceColor = "#CAA8FA";
+const managedSkillVersionColor = "#7DD3FC";
+const codexSkillsDirectoryName = "skills";
+
+export interface ManagedSkillListItem {
+    metadata?: ManagedSkillMetadata;
+    name: string;
+    path: string;
+}
+
+interface SkillsListInput {}
+
+type ManagedSkillListTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
+
+export const skillsListCommand: CliCommandDefinition<SkillsListInput> = {
+    name: "list",
+    summaryKey: "commands.skills.list.summary",
+    descriptionKey: "commands.skills.list.description",
+    inputSchema: z.object({}),
+    handler: async (_, context) => {
+        const codexHomeDirectory = await requireCodexHomeDirectory(context);
+        const skillsDirectoryPath = join(
+            codexHomeDirectory,
+            codexSkillsDirectoryName,
+        );
+        const skills = await listManagedSkillInstallations(skillsDirectoryPath);
+
+        context.logger.info(
+            {
+                count: skills.length,
+                path: skillsDirectoryPath,
+                skillNames: skills.map(skill => skill.name),
+            },
+            "Managed Codex skills listed.",
+        );
+
+        context.stdout.write(
+            `${
+                formatManagedSkillListAsText({
+                    skills,
+                }, context)
+            }\n`,
+        );
+    },
+};
+
+export async function listManagedSkillInstallations(
+    skillsDirectoryPath: string,
+): Promise<ManagedSkillListItem[]> {
+    const entryNames = await readSkillsDirectoryEntries(skillsDirectoryPath);
+    const skills: Array<ManagedSkillListItem | undefined> = await Promise.all(
+        entryNames.map(async (entryName) => {
+            const skillDirectoryPath = join(skillsDirectoryPath, entryName);
+
+            if (!(await directoryExists(skillDirectoryPath))) {
+                return undefined;
+            }
+
+            if (
+                !(await fileExists(
+                    resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+                ))
+            ) {
+                return undefined;
+            }
+
+            return {
+                metadata: await readManagedSkillMetadata(skillDirectoryPath),
+                name: entryName,
+                path: skillDirectoryPath,
+            } satisfies ManagedSkillListItem;
+        }),
+    );
+
+    return skills
+        .filter(isManagedSkillListItem)
+        .sort(compareManagedSkillListItems);
+}
+
+export function formatManagedSkillListAsText(
+    inventory: {
+        skills: readonly ManagedSkillListItem[];
+    },
+    context: ManagedSkillListTextContext,
+): string {
+    const colors = createManagedSkillListColors(context);
+
+    if (inventory.skills.length === 0) {
+        return `${colors.yellow("!")} ${context.translator.t("skills.list.noResults")}`;
+    }
+
+    const blocks = inventory.skills.map(
+        skill => formatManagedSkillListItem(skill, context, colors),
+    );
+
+    return [
+        `${colors.green("✓")} ${
+            context.translator.t("skills.list.summary", {
+                count: inventory.skills.length,
+            })
+        }`,
+        ...blocks,
+    ].join("\n\n");
+}
+
+async function readSkillsDirectoryEntries(
+    skillsDirectoryPath: string,
+): Promise<string[]> {
+    try {
+        return await readdir(skillsDirectoryPath);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return [];
+        }
+
+        throw error;
+    }
+}
+
+function formatManagedSkillListItem(
+    skill: ManagedSkillListItem,
+    context: ManagedSkillListTextContext,
+    colors: TerminalColors,
+): string {
+    const lines = [
+        colors.hex(managedSkillNameColor).bold(skill.name),
+        formatManagedSkillDetailLine(
+            context.translator.t("skills.list.source"),
+            colors.hex(managedSkillSourceColor)(readManagedSkillSource(skill, context)),
+            colors,
+        ),
+        formatManagedSkillDetailLine(
+            context.translator.t("skills.list.version"),
+            colors.hex(managedSkillVersionColor)(
+                skill.metadata?.version ?? context.translator.t("versionInfo.unknown"),
+            ),
+            colors,
+        ),
+    ];
+
+    return lines.join("\n");
+}
+
+function formatManagedSkillDetailLine(
+    label: string,
+    value: string,
+    colors: TerminalColors,
+): string {
+    return `  ${colors.dim(`${label}:`)} ${value}`;
+}
+
+function readManagedSkillSource(
+    skill: ManagedSkillListItem,
+    context: Pick<CliExecutionContext, "translator">,
+): string {
+    if (skill.metadata?.packageName !== undefined) {
+        return skill.metadata.packageName;
+    }
+
+    if (
+        availableBundledSkillNames.includes(
+            skill.name as (typeof availableBundledSkillNames)[number],
+        )
+    ) {
+        return context.translator.t("skills.list.source.bundled");
+    }
+
+    return context.translator.t("versionInfo.unknown");
+}
+
+function createManagedSkillListColors(
+    context: Pick<CliExecutionContext, "stdout">,
+): TerminalColors {
+    return createWriterColors(context.stdout);
+}
+
+function isNodeNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+function isManagedSkillListItem(
+    skill: ManagedSkillListItem | undefined,
+): skill is ManagedSkillListItem {
+    return skill !== undefined;
+}
+
+function compareManagedSkillListItems(
+    left: ManagedSkillListItem,
+    right: ManagedSkillListItem,
+): number {
+    if (left.name === "oo" && right.name !== "oo") {
+        return -1;
+    }
+
+    if (left.name !== "oo" && right.name === "oo") {
+        return 1;
+    }
+
+    return left.name.localeCompare(right.name);
+}

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -142,7 +142,7 @@ function formatManagedSkillListItem(
     colors: TerminalColors,
 ): string {
     const lines = [
-        colors.hex(managedSkillNameColor).bold(skill.name),
+        colors.bold(colors.hex(managedSkillNameColor)(skill.name)),
         formatManagedSkillDetailLine(
             context.translator.t("skills.list.source"),
             colors.hex(managedSkillSourceColor)(readManagedSkillSource(skill, context)),

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -121,6 +121,10 @@ export const enMessages = {
         "Search published skills against the skills search API.",
     "commands.skills.search.summary":
         "Search published skills",
+    "commands.skills.list.description":
+        "List oo-managed Codex skills from the local Codex skills directory.",
+    "commands.skills.list.summary":
+        "List oo-managed Codex skills",
     "commands.skills.install.description":
         "Install bundled or published Codex skills into the local Codex skills directory.",
     "commands.skills.install.summary": "Install Codex skills",
@@ -402,6 +406,13 @@ export const enMessages = {
         "Installing all {count} skills.",
     "skills.config.set.success":
         "Set Codex skill {name} {key} to {value}.",
+    "skills.list.noResults":
+        "No oo-managed skills were found.",
+    "skills.list.source": "Source",
+    "skills.list.source.bundled": "bundled",
+    "skills.list.summary":
+        "Found {count} oo-managed skills.",
+    "skills.list.version": "Version",
     "skills.install.success": "Installed Codex skill {name} to {path}.",
     "skills.install.overwrite.invalid":
         "Invalid choice. Enter y/yes or n/no.",
@@ -589,6 +600,10 @@ export const zhMessages = {
         "使用自由文本通过 skills search API 搜索已发布的 skill。",
     "commands.skills.search.summary":
         "搜索已发布的 skill",
+    "commands.skills.list.description":
+        "列出本地 Codex skills 目录中由 oo 管理的 Codex skill。",
+    "commands.skills.list.summary":
+        "列出由 oo 管理的 Codex skill",
     "commands.skills.install.description":
         "将内置或已发布的 Codex skill 安装到本地 Codex skills 目录。",
     "commands.skills.install.summary": "安装 Codex skills",
@@ -856,6 +871,13 @@ export const zhMessages = {
         "将安装全部 {count} 个 skill。",
     "skills.config.set.success":
         "已将 Codex skill {name} 的 {key} 设置为 {value}。",
+    "skills.list.noResults":
+        "未找到由 oo 管理的 skill。",
+    "skills.list.source": "来源",
+    "skills.list.source.bundled": "内置",
+    "skills.list.summary":
+        "找到 {count} 个由 oo 管理的 skill。",
+    "skills.list.version": "版本",
     "skills.install.success": "已将 Codex skill {name} 安装到 {path}。",
     "skills.install.overwrite.invalid":
         "输入无效。请输入 y/yes 或 n/no。",


### PR DESCRIPTION
Introduce `oo skills list` which scans the local Codex skills directory for child directories containing `.oo-metadata.json` and prints a summary with skill name, source package (or bundled marker), and recorded version. The `oo` skill is always listed first; remaining skills are sorted alphabetically.

Includes unit tests for the listing/sorting logic, CLI integration tests for text and color output, and bilingual documentation.