### PR TITLE
fix(skills): prevent path traversal in skill install and uninstall

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -204,6 +204,8 @@ directory.
   `<config-dir>/skills/<skill-id>`.
 - Target directory: every installed skill is published to
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`.
+- Path rule: published skill names are accepted only when their resolved
+  canonical and target directories remain under those local `skills` roots.
 - Installation mode: `oo` publishes the target directory as a symlink to the
   canonical directory when the current platform and environment allow it. When
   symlink creation fails, `oo` falls back to copying the canonical files into
@@ -248,6 +250,8 @@ Remove one oo-managed skill from the local Codex skills directory.
 - Canonical directory removed: `<config-dir>/skills/<skill>`, where
   `<config-dir>` is the directory that contains `settings.toml`.
 - Target directory removed: `${CODEX_HOME:-~/.codex}/skills/<skill>`.
+- Path rule: `[skill]` must resolve to child directories under those local
+  `skills` roots. Names that escape those roots are rejected.
 - Notes: when the target directory is missing, or it exists without
   `.oo-metadata.json`, the command exits with an error and does not remove
   anything.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -221,6 +221,8 @@
 - 会同时移除 canonical 目录：`<config-dir>/skills/<skill>`，其中
   `<config-dir>` 是 `settings.toml` 所在目录。
 - 会同时移除目标目录：`${CODEX_HOME:-~/.codex}/skills/<skill>`。
+- 路径规则：`[skill]` 解析后必须仍然落在这些本地 `skills` 根目录的子目录中。
+  任何会逃出这些根目录的名称都会被拒绝。
 - 说明：如果目标目录不存在，或者目录存在但没有 `.oo-metadata.json`，
   命令会直接报错，不会删除任何内容。
 

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -339,6 +339,61 @@ describe("skills commands", () => {
         }
     });
 
+    test("rejects uninstall when the skill path escapes the Codex skills directory", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const escapedSkillDirectoryPath = join(
+            codexHomeDirectory,
+            "skills",
+            "../../outside",
+        );
+        const escapedCanonicalSkillDirectoryPath = join(
+            storePaths.settingsFilePath,
+            "..",
+            "skills",
+            "../../outside",
+        );
+        const installedSentinelPath = join(escapedSkillDirectoryPath, "sentinel.txt");
+        const canonicalSentinelPath = join(
+            escapedCanonicalSkillDirectoryPath,
+            "sentinel.txt",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(escapedSkillDirectoryPath, { recursive: true });
+            await mkdir(escapedCanonicalSkillDirectoryPath, { recursive: true });
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(escapedSkillDirectoryPath),
+                formatManagedSkillMetadataContent("openai", "0.0.3"),
+            );
+            await Bun.write(installedSentinelPath, "installed\n");
+            await Bun.write(canonicalSentinelPath, "canonical\n");
+
+            const result = await sandbox.run(["skills", "uninstall", "../../outside"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Skill name ../../outside resolves outside the local Codex skills directory.\n",
+            );
+            await expect(stat(installedSentinelPath)).resolves.toMatchObject({
+                isFile: expect.any(Function),
+            });
+            await expect(stat(canonicalSentinelPath)).resolves.toMatchObject({
+                isFile: expect.any(Function),
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("supports skills remove as an alias for uninstall", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -402,7 +457,7 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(1);
             expect(result.stdout).toBe("");
             expect(result.stderr).toBe(
-                `Codex skill oo is not installed at ${skillDirectoryPath}.\n`,
+                "oo is not managed by oo and cannot be removed.\n",
             );
             await expect(stat(skillDirectoryPath)).resolves.toMatchObject({
                 isDirectory: expect.any(Function),
@@ -427,11 +482,32 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(1);
             expect(result.stdout).toBe("");
             expect(result.stderr).toBe(
-                `Codex skill chatgpt is not installed at ${skillDirectoryPath}.\n`,
+                "chatgpt is not managed by oo and cannot be removed.\n",
             );
             await expect(stat(skillDirectoryPath)).resolves.toMatchObject({
                 isDirectory: expect.any(Function),
             });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports an unmanaged existing skill directory clearly", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", ".system");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+
+            const result = await sandbox.run(["skills", "remove", ".system"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                ".system is not managed by oo and cannot be removed.\n",
+            );
         }
         finally {
             await sandbox.cleanup();
@@ -829,6 +905,54 @@ describe("skills commands", () => {
             expect(requests).toHaveLength(2);
             expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
             expect(requests[1]!.headers.get("Authorization")).toBe("secret-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects published registry skills that escape the Codex skills directory", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const requests: Request[] = [];
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "openai"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.3",
+                                skills: [
+                                    {
+                                        description: "Escapes the skills root",
+                                        name: "../../outside",
+                                        title: "Outside",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("Skill: ../../outside\n");
+            expect(result.stderr).toBe(
+                "Skill name ../../outside resolves outside the local Codex skills directory.\n",
+            );
+            expect(requests).toHaveLength(1);
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/managed-skill-paths.test.ts
+++ b/src/application/commands/skills/managed-skill-paths.test.ts
@@ -1,18 +1,28 @@
-import { join } from "node:path";
+import { join, posix, win32 } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
 import {
+    isManagedSkillPathContained,
+    isPathWithinDirectory,
     managedSkillMetadataFileName,
     resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillCanonicalRootDirectoryPath,
     resolveManagedSkillDirectoryPath,
     resolveManagedSkillMetadataFilePath,
+    resolveManagedSkillsDirectoryPath,
 } from "./managed-skill-paths.ts";
 
 describe("managed skill paths", () => {
     test("resolves the Codex installation directory for any skill name", () => {
         expect(resolveManagedSkillDirectoryPath("/tmp/.codex", "chatgpt")).toBe(
             join("/tmp/.codex", "skills", "chatgpt"),
+        );
+    });
+
+    test("resolves the Codex skills root directory", () => {
+        expect(resolveManagedSkillsDirectoryPath("/tmp/.codex")).toBe(
+            join("/tmp/.codex", "skills"),
         );
     });
 
@@ -23,6 +33,83 @@ describe("managed skill paths", () => {
                 "chatgpt",
             ),
         ).toBe(join("/tmp/config", "skills", "chatgpt"));
+    });
+
+    test("resolves the canonical skills root directory", () => {
+        expect(
+            resolveManagedSkillCanonicalRootDirectoryPath(
+                "/tmp/config/settings.toml",
+            ),
+        ).toBe(join("/tmp/config", "skills"));
+    });
+
+    test("keeps contained managed skill paths and rejects escaping ones", () => {
+        expect(
+            isManagedSkillPathContained(
+                "/tmp/.codex",
+                "/tmp/config/settings.toml",
+                "chatgpt",
+            ),
+        ).toBeTrue();
+        expect(
+            isManagedSkillPathContained(
+                "/tmp/.codex",
+                "/tmp/config/settings.toml",
+                ".hidden",
+            ),
+        ).toBeTrue();
+        expect(
+            isManagedSkillPathContained(
+                "/tmp/.codex",
+                "/tmp/config/settings.toml",
+                "..foo",
+            ),
+        ).toBeTrue();
+        expect(
+            isManagedSkillPathContained(
+                "/tmp/.codex",
+                "/tmp/config/settings.toml",
+                "../..",
+            ),
+        ).toBeFalse();
+        expect(
+            isManagedSkillPathContained(
+                "/tmp/.codex",
+                "/tmp/config/settings.toml",
+                "../../outside",
+            ),
+        ).toBeFalse();
+    });
+
+    test("detects escaping paths in posix and win32 mode", () => {
+        expect(
+            isPathWithinDirectory(
+                "/tmp/.codex/skills",
+                "/tmp/.codex/skills/.hidden",
+                posix,
+            ),
+        ).toBeTrue();
+        expect(
+            isPathWithinDirectory(
+                "/tmp/.codex/skills",
+                "/tmp/.codex",
+                posix,
+            ),
+        ).toBeFalse();
+        expect(
+            isPathWithinDirectory(
+                "C:\\codex\\skills",
+                "C:\\codex\\skills\\..foo",
+                win32,
+            ),
+        ).toBeTrue();
+        expect(
+            isPathWithinDirectory(
+                "C:\\codex\\skills",
+                "D:\\elsewhere",
+                win32,
+            ),
+        ).toBeFalse();
     });
 
     test("resolves the managed skill metadata file path", () => {

--- a/src/application/commands/skills/managed-skill-paths.ts
+++ b/src/application/commands/skills/managed-skill-paths.ts
@@ -1,21 +1,81 @@
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 const codexSkillsDirectoryName = "skills";
 
 export const managedSkillMetadataFileName = ".oo-metadata.json";
 
+interface PathOperations {
+    isAbsolute: (path: string) => boolean;
+    relative: (from: string, to: string) => string;
+    resolve: (...paths: string[]) => string;
+    sep: string;
+}
+
+const defaultPathOperations: PathOperations = {
+    isAbsolute,
+    relative,
+    resolve,
+    sep,
+};
+
+export function resolveManagedSkillsDirectoryPath(
+    codexHomeDirectory: string,
+): string {
+    return join(codexHomeDirectory, codexSkillsDirectoryName);
+}
+
 export function resolveManagedSkillDirectoryPath(
     codexHomeDirectory: string,
     skillName: string,
 ): string {
-    return join(codexHomeDirectory, codexSkillsDirectoryName, skillName);
+    return join(resolveManagedSkillsDirectoryPath(codexHomeDirectory), skillName);
+}
+
+export function resolveManagedSkillCanonicalRootDirectoryPath(
+    settingsFilePath: string,
+): string {
+    return join(dirname(settingsFilePath), codexSkillsDirectoryName);
 }
 
 export function resolveManagedSkillCanonicalDirectoryPath(
     settingsFilePath: string,
     skillName: string,
 ): string {
-    return join(dirname(settingsFilePath), codexSkillsDirectoryName, skillName);
+    return join(
+        resolveManagedSkillCanonicalRootDirectoryPath(settingsFilePath),
+        skillName,
+    );
+}
+
+export function isPathWithinDirectory(
+    baseDirectoryPath: string,
+    targetPath: string,
+    pathOperations: PathOperations = defaultPathOperations,
+): boolean {
+    const relativePath = pathOperations.relative(
+        pathOperations.resolve(baseDirectoryPath),
+        pathOperations.resolve(targetPath),
+    );
+
+    if (relativePath === "" || pathOperations.isAbsolute(relativePath)) {
+        return false;
+    }
+
+    return relativePath.split(pathOperations.sep)[0] !== "..";
+}
+
+export function isManagedSkillPathContained(
+    codexHomeDirectory: string,
+    settingsFilePath: string,
+    skillName: string,
+): boolean {
+    return isPathWithinDirectory(
+        resolveManagedSkillsDirectoryPath(codexHomeDirectory),
+        resolveManagedSkillDirectoryPath(codexHomeDirectory, skillName),
+    ) && isPathWithinDirectory(
+        resolveManagedSkillCanonicalRootDirectoryPath(settingsFilePath),
+        resolveManagedSkillCanonicalDirectoryPath(settingsFilePath, skillName),
+    );
 }
 
 export function resolveManagedSkillMetadataFilePath(

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -18,6 +18,7 @@ import {
     writeManagedSkillMetadata,
 } from "./managed-skill-metadata.ts";
 import {
+    isManagedSkillPathContained,
     resolveManagedSkillCanonicalDirectoryPath,
     resolveManagedSkillDirectoryPath,
 } from "./managed-skill-paths.ts";
@@ -75,6 +76,20 @@ export async function installRegistrySkills(
         return;
     }
 
+    const settingsFilePath = context.settingsStore.getFilePath();
+
+    for (const skillName of selectedSkillNames) {
+        if (!isManagedSkillPathContained(
+            codexHomeDirectory,
+            settingsFilePath,
+            skillName,
+        )) {
+            throw new CliUserError("errors.skills.invalidPath", 1, {
+                name: skillName,
+            });
+        }
+    }
+
     const packageBytes = await downloadRegistryPackageTarball(
         packageInfo.packageName,
         packageInfo.packageVersion,
@@ -88,7 +103,7 @@ export async function installRegistrySkills(
             const skill = findPackageSkillOrThrow(packageInfo, skillName);
             const canonicalSkillDirectoryPath
                 = resolveManagedSkillCanonicalDirectoryPath(
-                    context.settingsStore.getFilePath(),
+                    settingsFilePath,
                     skillName,
                 );
             const installedSkillDirectoryPath = resolveManagedSkillDirectoryPath(

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -43,6 +43,7 @@ import {
 } from "./embedded-assets.ts";
 import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
 import {
+    isManagedSkillPathContained,
     resolveManagedSkillCanonicalDirectoryPath,
     resolveManagedSkillDirectoryPath,
     resolveManagedSkillMetadataFilePath,
@@ -372,9 +373,10 @@ export async function uninstallBundledSkill(
             },
             "Bundled Codex skill uninstall skipped because no managed installation was found.",
         );
-        throw new CliUserError("errors.skills.notInstalled", 1, {
-            name: skillName,
+        throw createManagedSkillUninstallError({
+            installedDirectoryExists: installedSkillDirectoryExists,
             path: skillDirectoryPath,
+            skillName,
         });
     }
 
@@ -472,12 +474,24 @@ async function uninstallRegistrySkill(
     context: CliExecutionContext,
 ): Promise<void> {
     const codexHomeDirectory = await requireCodexHomeDirectory(context);
+    const settingsFilePath = context.settingsStore.getFilePath();
+
+    if (!isManagedSkillPathContained(
+        codexHomeDirectory,
+        settingsFilePath,
+        skillName,
+    )) {
+        throw new CliUserError("errors.skills.invalidPath", 1, {
+            name: skillName,
+        });
+    }
+
     const skillDirectoryPath = resolveManagedSkillDirectoryPath(
         codexHomeDirectory,
         skillName,
     );
     const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
-        context.settingsStore.getFilePath(),
+        settingsFilePath,
         skillName,
     );
     const installedSkillDirectoryExists = await directoryExists(skillDirectoryPath);
@@ -498,9 +512,10 @@ async function uninstallRegistrySkill(
             },
             "Managed Codex skill uninstall skipped because no OOMOL metadata was found.",
         );
-        throw new CliUserError("errors.skills.notInstalled", 1, {
-            name: skillName,
+        throw createManagedSkillUninstallError({
+            installedDirectoryExists: installedSkillDirectoryExists,
             path: skillDirectoryPath,
+            skillName,
         });
     }
 
@@ -525,6 +540,23 @@ async function uninstallRegistrySkill(
             skillName,
         },
         "Managed Codex skill removed explicitly.",
+    );
+}
+
+function createManagedSkillUninstallError(options: {
+    installedDirectoryExists: boolean;
+    path: string;
+    skillName: string;
+}): CliUserError {
+    return new CliUserError(
+        options.installedDirectoryExists
+            ? "errors.skills.notManaged"
+            : "errors.skills.notInstalled",
+        1,
+        {
+            name: options.skillName,
+            path: options.path,
+        },
     );
 }
 

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -225,6 +225,8 @@ export const enMessages = {
         "Invalid skills.oo.implicit_invocation value: {value}. Use true or false.",
     "errors.skills.invalidName":
         "Unsupported skill: {value}. Use {choices}.",
+    "errors.skills.invalidPath":
+        "Skill name {name} resolves outside the local Codex skills directory.",
     "errors.skills.config.invalidKey":
         "Invalid config key for skill {skill}: {value}. Use {choices}.",
     "errors.skills.config.invalidAllowImplicitInvocationValue":
@@ -339,6 +341,8 @@ export const enMessages = {
         "Bundled skill storage for {name} is already occupied by non-OOMOL content at {path}.",
     "errors.skills.notInstalled":
         "Codex skill {name} is not installed at {path}.",
+    "errors.skills.notManaged":
+        "{name} is not managed by oo and cannot be removed.",
     "errors.store.invalidToml":
         "The settings file at {path} is not valid TOML.",
     "errors.store.invalidSchema":
@@ -696,6 +700,8 @@ export const zhMessages = {
         "无效的 skills.oo.implicit_invocation 值：{value}。请使用 true 或 false。",
     "errors.skills.invalidName":
         "不支持的 skill：{value}。请使用 {choices}。",
+    "errors.skills.invalidPath":
+        "skill 名称 {name} 解析到了本地 Codex skills 目录之外。",
     "errors.skills.config.invalidKey":
         "skill {skill} 的配置键无效：{value}。请使用 {choices}。",
     "errors.skills.config.invalidAllowImplicitInvocationValue":
@@ -810,6 +816,8 @@ export const zhMessages = {
         "{path} 中用于 {name} 的内置 skill 存储目录已被非 OOMOL 内容占用。",
     "errors.skills.notInstalled":
         "Codex skill {name} 未安装在 {path}。",
+    "errors.skills.notManaged":
+        "{name} 不是由 oo 管理的 skill，无法移除。",
     "errors.store.invalidToml": "配置文件 {path} 不是有效的 TOML。",
     "errors.store.invalidSchema": "配置文件 {path} 的结构不受支持。",
     "errors.store.readFailed": "读取配置文件 {path} 失败。",


### PR DESCRIPTION
Skill names containing path components like `../..` could resolve outside the local `skills` root directories, allowing arbitrary directory removal on uninstall or arbitrary writes on install.

Add `isPathWithinDirectory` and `isManagedSkillPathContained` guards that reject any skill name whose resolved canonical or target path escapes the expected roots. Improve the unmanaged-skill error message to clarify that only oo-managed skills can be removed.