### PR TITLE
feat(skills): add "add" as alias for install command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -178,6 +178,7 @@ Persist one skill configuration value.
 Install bundled or published Codex skills into the local Codex skills
 directory.
 
+- Alias: `oo skills add [packageName]`.
 - Arguments: `[packageName]` is optional.
 - Arguments: when omitted, the command behaves the same as
   `oo skills install oo`.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -160,6 +160,7 @@
 
 将内置或已发布的 Codex skill 安装到本地 Codex skills 目录。
 
+- 别名：`oo skills add [packageName]`。
 - 参数：`[packageName]` 可选。
 - 参数：未提供时，该命令等价于 `oo skills install oo`。
 - 参数：当 `[packageName]` 为 `oo` 时，命令安装内置的 `oo` skill。

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -165,6 +165,29 @@ describe("skills CLI", () => {
         }
     });
 
+    test("supports skills add as an alias for install", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "add"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Installed Codex skill oo to ${skillDirectoryPath}.\n`,
+            );
+            expect(result.stderr).toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("synchronizes the managed Codex skill policy from persisted settings", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -17,6 +17,7 @@ const defaultBundledSkillName = "oo" as const;
 
 export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
     name: "install",
+    aliases: ["add"],
     summaryKey: "commands.skills.install.summary",
     descriptionKey: "commands.skills.install.description",
     arguments: [


### PR DESCRIPTION
Allow users to run `oo skills add` as a shorthand for `oo skills install`, matching common package manager conventions.