### PR TITLE
feat(skills): add update command to check and refresh skills

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -240,6 +240,26 @@ directory.
   checks whether the recorded metadata `version` matches the current CLI
   version and silently refreshes the installed files when needed.
 
+### `oo skills update [skills...]`
+
+Update installed oo-managed Codex skills.
+
+- Arguments: when omitted, the command checks every installed oo-managed
+  published skill.
+- Arguments: when one or more skill names are provided, only those named skills
+  are checked and updated.
+- Bundled skills: the bundled `oo` skill is excluded from this command because
+  the CLI synchronizes it automatically during startup when needed.
+- Published skills: registry-backed skills derive their package identity from
+  `.oo-metadata.json`, then fetch package info without an explicit version to
+  determine the latest available package version.
+- Update order: the command refreshes the canonical
+  `<config-dir>/skills/<skill-id>` copy before republishing to
+  `${CODEX_HOME:-~/.codex}/skills/<skill-id>`.
+- Interactive terminals: renders live progress while checking and updating
+  skills.
+- Non-interactive terminals: prints one status line per processed skill.
+
 ### `oo skills uninstall [skill]`
 
 Remove one oo-managed skill from the local Codex skills directory.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -210,6 +210,22 @@
   与当前 CLI 版本一致；这里的版本来自元数据文件中的 `version` 字段。不一
   致时会静默刷新已安装的文件。
 
+### `oo skills update [skills...]`
+
+更新已安装且由 oo 管理的 Codex skill。
+
+- 参数：省略时，会检查所有已安装且由 oo 管理的已发布 skill。
+- 参数：提供一个或多个 skill 名称时，只会检查并更新这些指定 skill。
+- 内置 skill：bundled `oo` 不在此命令处理范围内，因为 CLI 启动时会在需要时
+  自动同步它。
+- 已发布 skill：registry skill 会从 `.oo-metadata.json` 读取所属包名，再通过
+  不带显式版本的 package info 请求判断最新可用版本。
+- 更新顺序：命令会先刷新 canonical 目录
+  `<config-dir>/skills/<skill-id>`，再同步到
+  `${CODEX_HOME:-~/.codex}/skills/<skill-id>`。
+- 交互式终端：会显示实时进度。
+- 非交互式终端：每个处理过的 skill 输出一行状态信息。
+
 ### `oo skills uninstall [skill]`
 
 从本地 Codex skills 目录移除一个由 oo 管理的 skill。

--- a/src/adapters/commander/commander-cli-adapter.ts
+++ b/src/adapters/commander/commander-cli-adapter.ts
@@ -291,12 +291,17 @@ function createOption(
 function formatArgumentSyntax(argument: {
     name: string;
     required?: boolean;
+    variadic?: boolean;
 }): string {
+    const argumentName = argument.variadic === true
+        ? `${argument.name}...`
+        : argument.name;
+
     if (argument.required === false) {
-        return `[${argument.name}]`;
+        return `[${argumentName}]`;
     }
 
-    return `<${argument.name}>`;
+    return `<${argumentName}>`;
 }
 
 function createArgument(
@@ -305,6 +310,7 @@ function createArgument(
         descriptionKey: string;
         required?: boolean;
         choices?: readonly string[];
+        variadic?: boolean;
     },
     translator: Translator,
 ): Argument {

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -5,6 +5,7 @@ import { skillsInstallCommand } from "./install.ts";
 import { skillsListCommand } from "./list.ts";
 import { skillsSearchCommand } from "./search.ts";
 import { skillsUninstallCommand } from "./uninstall.ts";
+import { skillsUpdateCommand } from "./update.ts";
 
 export const skillsCommand: CliCommandDefinition = {
     name: "skills",
@@ -15,6 +16,7 @@ export const skillsCommand: CliCommandDefinition = {
         skillsListCommand,
         skillsConfigCommand,
         skillsInstallCommand,
+        skillsUpdateCommand,
         skillsUninstallCommand,
     ],
 };

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -1,13 +1,8 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
-import { cp, mkdir } from "node:fs/promises";
 
-import { dirname } from "node:path";
 import { CliUserError } from "../../contracts/cli.ts";
 import { withPackageIdentity } from "../../logging/log-fields.ts";
-import {
-    publishBundledSkillInstallation,
-    removePath,
-} from "./bundled-skill-filesystem.ts";
+
 import { directoryExists, requireCodexHomeDirectory } from "./bundled-skill-observation.ts";
 import {
     confirmInteractiveValue,
@@ -15,18 +10,17 @@ import {
 } from "./interactive-prompts.ts";
 import {
     readManagedSkillMetadata,
-    writeManagedSkillMetadata,
 } from "./managed-skill-metadata.ts";
 import {
     isManagedSkillPathContained,
     resolveManagedSkillCanonicalDirectoryPath,
     resolveManagedSkillDirectoryPath,
 } from "./managed-skill-paths.ts";
+import { extractRegistryPackageArchive } from "./registry-skill-archive.ts";
 import {
-    extractRegistryPackageArchive,
-    requireExtractedRegistrySkillDirectory,
-} from "./registry-skill-archive.ts";
-import { rewriteInstalledRegistrySkillMarkdown } from "./registry-skill-markdown.ts";
+    prepareRegistrySkillPublication,
+    publishPreparedRegistrySkillPublication,
+} from "./registry-skill-publication.ts";
 import {
     downloadRegistryPackageTarball,
     loadRegistryPackageSkillInfo,
@@ -101,46 +95,17 @@ export async function installRegistrySkills(
     try {
         for (const skillName of selectedSkillNames) {
             const skill = findPackageSkillOrThrow(packageInfo, skillName);
-            const canonicalSkillDirectoryPath
-                = resolveManagedSkillCanonicalDirectoryPath(
-                    settingsFilePath,
-                    skillName,
-                );
-            const installedSkillDirectoryPath = resolveManagedSkillDirectoryPath(
-                codexHomeDirectory,
-                skillName,
-            );
-
-            await removePath(canonicalSkillDirectoryPath);
-            await mkdir(dirname(canonicalSkillDirectoryPath), { recursive: true });
-            await cp(
-                await requireExtractedRegistrySkillDirectory(
+            const installation = await publishPreparedRegistrySkillPublication(
+                await prepareRegistrySkillPublication({
+                    codexHomeDirectory,
                     extractedPackage,
-                    skillName,
-                ),
-                canonicalSkillDirectoryPath,
-                {
-                    force: true,
-                    recursive: true,
-                },
-            );
-            await rewriteInstalledRegistrySkillMarkdown(
-                canonicalSkillDirectoryPath,
-                skill,
-                packageInfo.packageName,
-            );
-            await writeManagedSkillMetadata(
-                canonicalSkillDirectoryPath,
-                {
                     packageName: packageInfo.packageName,
-                    version: packageInfo.packageVersion,
-                },
+                    packageVersion: packageInfo.packageVersion,
+                    settingsFilePath,
+                    skill,
+                    skillName,
+                }),
             );
-
-            const installation = await publishBundledSkillInstallation({
-                canonicalSkillDirectoryPath,
-                installedSkillDirectoryPath,
-            });
 
             writeLine(
                 context,

--- a/src/application/commands/skills/registry-skill-publication.ts
+++ b/src/application/commands/skills/registry-skill-publication.ts
@@ -1,0 +1,87 @@
+import type { BundledSkillPublicationResult } from "./bundled-skill-filesystem.ts";
+import type { ExtractedRegistryPackageArchive } from "./registry-skill-archive.ts";
+import type { RegistrySkillSummary } from "./registry-skill-source.ts";
+
+import { cp, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import {
+    publishBundledSkillInstallation,
+    removePath,
+} from "./bundled-skill-filesystem.ts";
+import { writeManagedSkillMetadata } from "./managed-skill-metadata.ts";
+import {
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillDirectoryPath,
+} from "./managed-skill-paths.ts";
+import { requireExtractedRegistrySkillDirectory } from "./registry-skill-archive.ts";
+import { rewriteInstalledRegistrySkillMarkdown } from "./registry-skill-markdown.ts";
+
+export interface PreparedRegistrySkillPublication {
+    canonicalSkillDirectoryPath: string;
+    installedSkillDirectoryPath: string;
+    packageName: string;
+    packageVersion: string;
+    skillName: string;
+}
+
+export async function prepareRegistrySkillPublication(options: {
+    codexHomeDirectory: string;
+    extractedPackage: ExtractedRegistryPackageArchive;
+    packageName: string;
+    packageVersion: string;
+    settingsFilePath: string;
+    skill: RegistrySkillSummary;
+    skillName: string;
+}): Promise<PreparedRegistrySkillPublication> {
+    const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+        options.settingsFilePath,
+        options.skillName,
+    );
+    const installedSkillDirectoryPath = resolveManagedSkillDirectoryPath(
+        options.codexHomeDirectory,
+        options.skillName,
+    );
+
+    await removePath(canonicalSkillDirectoryPath);
+    await mkdir(dirname(canonicalSkillDirectoryPath), { recursive: true });
+    await cp(
+        await requireExtractedRegistrySkillDirectory(
+            options.extractedPackage,
+            options.skillName,
+        ),
+        canonicalSkillDirectoryPath,
+        {
+            force: true,
+            recursive: true,
+        },
+    );
+    await rewriteInstalledRegistrySkillMarkdown(
+        canonicalSkillDirectoryPath,
+        options.skill,
+        options.packageName,
+    );
+    await writeManagedSkillMetadata(
+        canonicalSkillDirectoryPath,
+        {
+            packageName: options.packageName,
+            version: options.packageVersion,
+        },
+    );
+
+    return {
+        canonicalSkillDirectoryPath,
+        installedSkillDirectoryPath,
+        packageName: options.packageName,
+        packageVersion: options.packageVersion,
+        skillName: options.skillName,
+    };
+}
+
+export async function publishPreparedRegistrySkillPublication(
+    preparedPublication: PreparedRegistrySkillPublication,
+): Promise<BundledSkillPublicationResult> {
+    return publishBundledSkillInstallation({
+        canonicalSkillDirectoryPath: preparedPublication.canonicalSkillDirectoryPath,
+        installedSkillDirectoryPath: preparedPublication.installedSkillDirectoryPath,
+    });
+}

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -422,6 +422,21 @@ async function writeBundledSkillInstallation(options: {
     skillName: BundledSkillName;
     version: string;
 }): Promise<BundledSkillPublicationResult> {
+    const installationPaths = await writeBundledSkillCanonicalInstallation(options);
+
+    return publishBundledSkillInstallation(installationPaths);
+}
+
+export async function writeBundledSkillCanonicalInstallation(options: {
+    codexHomeDirectory: string;
+    settings: AppSettings;
+    settingsFilePath: string;
+    skillName: BundledSkillName;
+    version: string;
+}): Promise<{
+    canonicalSkillDirectoryPath: string;
+    installedSkillDirectoryPath: string;
+}> {
     const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
         options.settingsFilePath,
         options.skillName,
@@ -459,10 +474,10 @@ async function writeBundledSkillInstallation(options: {
         },
     );
 
-    return publishBundledSkillInstallation({
+    return {
         canonicalSkillDirectoryPath,
         installedSkillDirectoryPath,
-    });
+    };
 }
 
 function writeLine(context: CliExecutionContext, message: string): void {

--- a/src/application/commands/skills/update-progress.ts
+++ b/src/application/commands/skills/update-progress.ts
@@ -1,0 +1,164 @@
+import type { CliExecutionContext, Writer } from "../../contracts/cli.ts";
+
+import { createWriterColors } from "../../terminal-colors.ts";
+
+export type SkillUpdateProgressState
+    = | "checking"
+        | "preparing"
+        | "publishing"
+        | "current"
+        | "updated"
+        | "failed";
+
+interface SkillUpdateProgressItem {
+    detail?: string;
+    state: SkillUpdateProgressState;
+}
+
+const spinnerFrames = ["|", "/", "-", "\\"] as const;
+
+export class SkillsUpdateProgressReporter {
+    private frameIndex = 0;
+    private intervalId: ReturnType<typeof setInterval> | undefined;
+    private readonly itemOrder: string[];
+    private readonly items = new Map<string, SkillUpdateProgressItem>();
+    private renderedLineCount = 0;
+    private renderedOutput = "";
+    private started = false;
+
+    constructor(
+        private readonly writer: Pick<Writer, "hasColors" | "write">,
+        skillNames: readonly string[],
+        private readonly translator: Pick<CliExecutionContext["translator"], "t">,
+    ) {
+        this.itemOrder = [...skillNames];
+
+        for (const skillName of skillNames) {
+            this.items.set(skillName, {
+                detail: undefined,
+                state: "checking",
+            });
+        }
+    }
+
+    start(): void {
+        if (this.started) {
+            return;
+        }
+
+        this.started = true;
+        this.render();
+        this.intervalId = setInterval(() => {
+            this.frameIndex = (this.frameIndex + 1) % spinnerFrames.length;
+            this.render();
+        }, 80);
+        this.intervalId.unref?.();
+    }
+
+    stop(): void {
+        if (this.intervalId !== undefined) {
+            clearInterval(this.intervalId);
+            this.intervalId = undefined;
+        }
+
+        if (!this.started) {
+            return;
+        }
+
+        this.render();
+        this.writer.write("\u001B[?25h");
+    }
+
+    updateSkill(
+        skillName: string,
+        state: SkillUpdateProgressState,
+        detail?: string,
+    ): void {
+        this.items.set(skillName, {
+            detail,
+            state,
+        });
+        this.render();
+    }
+
+    private render(): void {
+        const nextOutput = this.renderLines().join("\n");
+
+        if (nextOutput === this.renderedOutput) {
+            return;
+        }
+
+        if (this.renderedLineCount === 0) {
+            this.writer.write("\u001B[?25l");
+            this.writer.write(`${nextOutput}\n`);
+            this.renderedLineCount = countRenderedLines(nextOutput);
+            this.renderedOutput = nextOutput;
+            return;
+        }
+
+        const renderedLines = nextOutput.split("\n");
+        const rewrittenContent = renderedLines.map(
+            line => `\r\u001B[2K${line}`,
+        ).join("\n");
+
+        this.writer.write(
+            `\u001B[${this.renderedLineCount}A${rewrittenContent}\n`,
+        );
+        this.renderedLineCount = renderedLines.length;
+        this.renderedOutput = nextOutput;
+    }
+
+    private renderLines(): string[] {
+        const colors = createWriterColors(this.writer);
+
+        return [
+            colors.bold(this.translator.t("skills.update.progress.header")),
+            ...this.itemOrder.map((skillName) => {
+                const item = this.items.get(skillName) ?? {
+                    detail: undefined,
+                    state: "checking" as const,
+                };
+
+                return formatProgressItemLine(
+                    skillName,
+                    item,
+                    spinnerFrames[this.frameIndex]!,
+                    colors,
+                    this.translator,
+                );
+            }),
+        ];
+    }
+}
+
+function formatProgressItemLine(
+    skillName: string,
+    item: SkillUpdateProgressItem,
+    frame: string,
+    colors: ReturnType<typeof createWriterColors>,
+    translator: Pick<CliExecutionContext["translator"], "t">,
+): string {
+    switch (item.state) {
+        case "checking":
+        case "preparing":
+        case "publishing":
+            return `${colors.cyan(frame)} ${colors.bold(skillName)} ${readProgressStateLabel(item.state, translator)}`;
+        case "current":
+            return `${colors.yellow("=")} ${colors.bold(skillName)} ${item.detail ?? readProgressStateLabel(item.state, translator)}`;
+        case "updated":
+            return `${colors.green("✓")} ${colors.bold(skillName)} ${item.detail ?? readProgressStateLabel(item.state, translator)}`;
+        case "failed":
+            return `${colors.red("!")} ${colors.bold(skillName)} ${item.detail ?? readProgressStateLabel(item.state, translator)}`;
+    }
+}
+
+function readProgressStateLabel(
+    state: SkillUpdateProgressState,
+    translator: Pick<CliExecutionContext["translator"], "t">,
+): string {
+    return translator.t(`skills.update.progress.${state}`);
+}
+
+function countRenderedLines(output: string): number {
+    return output.split("\n").length;
+}

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -1,0 +1,556 @@
+import { mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { stripVTControlCharacters } from "node:util";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    createCliSandbox,
+    createInteractiveInput,
+    createTextBuffer,
+    toRequest,
+    waitForOutputText,
+    writeAuthFile,
+} from "../../../../__tests__/helpers.ts";
+import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
+import { executeCli } from "../../bootstrap/run-cli.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import {
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillMetadataFilePath,
+} from "./managed-skill-paths.ts";
+import { resolveCodexHomeDirectory } from "./shared.ts";
+
+describe("skills update command", () => {
+    test("skips bundled oo when no explicit skill names are provided", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const ooInstalledDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const ooCanonicalDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(ooCanonicalDirectoryPath, { recursive: true });
+            await mkdir(ooInstalledDirectoryPath, { recursive: true });
+            await Bun.write(join(ooCanonicalDirectoryPath, "SKILL.md"), "# oo\n");
+            await Bun.write(join(ooInstalledDirectoryPath, "SKILL.md"), "# oo\n");
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(ooCanonicalDirectoryPath),
+                `${JSON.stringify({ version: "1.0.0" }, null, 2)}\n`,
+            );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(ooInstalledDirectoryPath),
+                `${JSON.stringify({ version: "1.0.0" }, null, 2)}\n`,
+            );
+
+            const result = await sandbox.run(["skills", "update"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe("No updatable oo-managed skills were found.\n");
+            expect(result.stderr).toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects the bundled oo skill as an explicit update target", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "update", "oo"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Codex skill oo is synchronized automatically and cannot be updated with skills update.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("updates a published managed skill to the latest version", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const installedSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+            await writeManagedRegistrySkillInstallation({
+                canonicalSkillDirectoryPath,
+                installedSkillDirectoryPath,
+                packageName: "openai",
+                skillMarkdown: "# ChatGPT stale\n",
+                version: "0.0.3",
+            });
+
+            const result = await sandbox.run(
+                ["skills", "update", "chatgpt"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.4",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/openai/-/meta/openai-0.0.4.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT fresh\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Updated Codex skill chatgpt to ${installedSkillDirectoryPath}.\n`,
+            );
+            expect(await readFile(
+                resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
+                "utf8",
+            )).toBe(formatManagedSkillMetadataContent("openai", "0.0.4"));
+            expect(await readFile(join(installedSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
+                "# ChatGPT fresh",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("updates published skills in parallel", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const chatgptCanonicalDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+        const claudeCanonicalDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "claude",
+        );
+        const chatgptInstalledDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const claudeInstalledDirectoryPath = join(codexHomeDirectory, "skills", "claude");
+        let tarballRequestCount = 0;
+        let releaseTarballs: (() => void) | undefined;
+        const tarballGate = new Promise<void>((resolve) => {
+            releaseTarballs = resolve;
+        });
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+            await writeManagedRegistrySkillInstallation({
+                canonicalSkillDirectoryPath: chatgptCanonicalDirectoryPath,
+                installedSkillDirectoryPath: chatgptInstalledDirectoryPath,
+                packageName: "openai",
+                skillMarkdown: "# ChatGPT stale\n",
+                version: "0.0.3",
+            });
+            await writeManagedRegistrySkillInstallation({
+                canonicalSkillDirectoryPath: claudeCanonicalDirectoryPath,
+                installedSkillDirectoryPath: claudeInstalledDirectoryPath,
+                packageName: "anthropic",
+                skillMarkdown: "# Claude stale\n",
+                version: "0.1.0",
+            });
+
+            const resultPromise = sandbox.run(
+                ["skills", "update", "chatgpt", "claude"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/openai/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.4",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.includes("/package-info/anthropic/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "anthropic",
+                                version: "0.1.1",
+                                skills: [
+                                    {
+                                        description: "Chat with Claude",
+                                        name: "claude",
+                                        title: "Claude",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/openai/-/meta/openai-0.0.4.tgz")) {
+                            tarballRequestCount += 1;
+
+                            if (tarballRequestCount === 2) {
+                                releaseTarballs?.();
+                            }
+
+                            await tarballGate;
+
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT fresh\n",
+                            }));
+                        }
+
+                        if (request.url.endsWith("/anthropic/-/meta/anthropic-0.1.1.tgz")) {
+                            tarballRequestCount += 1;
+
+                            if (tarballRequestCount === 2) {
+                                releaseTarballs?.();
+                            }
+
+                            await tarballGate;
+
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/claude/SKILL.md": "# Claude fresh\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            const racedResult = await Promise.race([
+                resultPromise,
+                Bun.sleep(500).then(() => "timeout" as const),
+            ]);
+
+            expect(racedResult).not.toBe("timeout");
+            expect(tarballRequestCount).toBe(2);
+
+            const result = racedResult as Awaited<typeof resultPromise>;
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("updates only the selected skills", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const chatgptCanonicalDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+        const visionCanonicalDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "vision",
+        );
+        const chatgptInstalledDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const visionInstalledDirectoryPath = join(codexHomeDirectory, "skills", "vision");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+            await writeManagedRegistrySkillInstallation({
+                canonicalSkillDirectoryPath: chatgptCanonicalDirectoryPath,
+                installedSkillDirectoryPath: chatgptInstalledDirectoryPath,
+                packageName: "openai",
+                skillMarkdown: "# ChatGPT stale\n",
+                version: "0.0.3",
+            });
+            await writeManagedRegistrySkillInstallation({
+                canonicalSkillDirectoryPath: visionCanonicalDirectoryPath,
+                installedSkillDirectoryPath: visionInstalledDirectoryPath,
+                packageName: "openai",
+                skillMarkdown: "# Vision stale\n",
+                version: "0.0.3",
+            });
+
+            const result = await sandbox.run(
+                ["skills", "update", "chatgpt"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.4",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                    {
+                                        description: "See images",
+                                        name: "vision",
+                                        title: "Vision",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/openai/-/meta/openai-0.0.4.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT fresh\n",
+                                "package/package/skills/vision/SKILL.md": "# Vision fresh\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(await readFile(
+                resolveManagedSkillMetadataFilePath(chatgptInstalledDirectoryPath),
+                "utf8",
+            )).toBe(formatManagedSkillMetadataContent("openai", "0.0.4"));
+            expect(await readFile(
+                resolveManagedSkillMetadataFilePath(visionInstalledDirectoryPath),
+                "utf8",
+            )).toBe(formatManagedSkillMetadataContent("openai", "0.0.3"));
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders interactive progress while updating skills", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const installedSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+        const stdin = createInteractiveInput();
+        const stdout = createTextBuffer({
+            isTTY: true,
+        });
+        const stderr = createTextBuffer();
+        let releaseTarball: (() => void) | undefined;
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+            await writeManagedRegistrySkillInstallation({
+                canonicalSkillDirectoryPath,
+                installedSkillDirectoryPath,
+                packageName: "openai",
+                skillMarkdown: "# ChatGPT stale\n",
+                version: "0.0.3",
+            });
+
+            const execution = executeCli({
+                argv: ["skills", "update", "chatgpt"],
+                cwd: sandbox.cwd,
+                env: sandbox.env,
+                fetcher: async (input, init) => {
+                    const request = toRequest(input, init);
+
+                    if (request.url.includes("/package-info/")) {
+                        return new Response(JSON.stringify({
+                            packageName: "openai",
+                            version: "0.0.4",
+                            skills: [
+                                {
+                                    description: "Chat with a model",
+                                    name: "chatgpt",
+                                    title: "ChatGPT",
+                                },
+                            ],
+                        }));
+                    }
+
+                    if (request.url.endsWith("/openai/-/meta/openai-0.0.4.tgz")) {
+                        await new Promise<void>((resolve) => {
+                            releaseTarball = resolve;
+                        });
+
+                        return new Response(await createRegistrySkillArchiveBytes({
+                            "package/package/skills/chatgpt/SKILL.md": "# ChatGPT fresh\n",
+                        }));
+                    }
+
+                    throw new Error(`Unexpected request: ${request.url}`);
+                },
+                stdin,
+                stderr: stderr.writer,
+                stdout: stdout.writer,
+                systemLocale: "en-US",
+            });
+
+            await waitForOutputText(stdout, "Updating installed skills");
+            await waitForOutputText(stdout, "chatgpt");
+
+            releaseTarball?.();
+
+            const exitCode = await execution;
+            const plainOutput = stripVTControlCharacters(stdout.read());
+
+            expect(exitCode).toBe(0);
+            expect(stderr.read()).toBe("");
+            expect(plainOutput).toContain("Updating installed skills");
+            expect(plainOutput).toContain("chatgpt");
+            expect(plainOutput).toContain("updated");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails when a non-bundled managed skill is missing package metadata", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const installedSkillDirectoryPath = join(codexHomeDirectory, "skills", "custom");
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "custom",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+            await mkdir(installedSkillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(canonicalSkillDirectoryPath, "SKILL.md"),
+                "# Custom\n",
+            );
+            await Bun.write(
+                join(installedSkillDirectoryPath, "SKILL.md"),
+                "# Custom\n",
+            );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath),
+                `${JSON.stringify({ version: "1.0.0" }, null, 2)}\n`,
+            );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
+                `${JSON.stringify({ version: "1.0.0" }, null, 2)}\n`,
+            );
+
+            const result = await sandbox.run(["skills", "update", "custom"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe(
+                "Failed to update Codex skill custom: Managed skill custom cannot be updated because its package metadata is missing.\n",
+            );
+            expect(result.stderr).toBe(
+                "Managed skill custom cannot be updated because its package metadata is missing.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});
+
+function formatManagedSkillMetadataContent(
+    packageName: string,
+    version: string,
+): string {
+    return `${JSON.stringify({ packageName, version }, null, 2)}\n`;
+}
+
+async function createRegistrySkillArchiveBytes(
+    files: Record<string, string>,
+): Promise<Uint8Array<ArrayBuffer>> {
+    return await new Bun.Archive(files, {
+        compress: "gzip",
+    }).bytes();
+}
+
+async function writeManagedRegistrySkillInstallation(options: {
+    canonicalSkillDirectoryPath: string;
+    installedSkillDirectoryPath: string;
+    packageName: string;
+    skillMarkdown: string;
+    version: string;
+}): Promise<void> {
+    await mkdir(options.canonicalSkillDirectoryPath, { recursive: true });
+    await mkdir(options.installedSkillDirectoryPath, { recursive: true });
+    await Bun.write(
+        join(options.canonicalSkillDirectoryPath, "SKILL.md"),
+        options.skillMarkdown,
+    );
+    await Bun.write(
+        join(options.installedSkillDirectoryPath, "SKILL.md"),
+        options.skillMarkdown,
+    );
+    await Bun.write(
+        resolveManagedSkillMetadataFilePath(options.canonicalSkillDirectoryPath),
+        formatManagedSkillMetadataContent(options.packageName, options.version),
+    );
+    await Bun.write(
+        resolveManagedSkillMetadataFilePath(options.installedSkillDirectoryPath),
+        formatManagedSkillMetadataContent(options.packageName, options.version),
+    );
+}

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -1,0 +1,551 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+import type { ManagedSkillListItem } from "./list.ts";
+import type { PreparedRegistrySkillPublication } from "./registry-skill-publication.ts";
+import type { RegistrySkillSummary } from "./registry-skill-source.ts";
+
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import {
+    directoryExists,
+    fileExists,
+    requireCodexHomeDirectory,
+} from "./bundled-skill-observation.ts";
+import { availableBundledSkillNames } from "./embedded-assets.ts";
+import { listManagedSkillInstallations } from "./list.ts";
+import {
+    isManagedSkillPathContained,
+    resolveManagedSkillDirectoryPath,
+    resolveManagedSkillMetadataFilePath,
+    resolveManagedSkillsDirectoryPath,
+} from "./managed-skill-paths.ts";
+import { extractRegistryPackageArchive } from "./registry-skill-archive.ts";
+import {
+    prepareRegistrySkillPublication,
+    publishPreparedRegistrySkillPublication,
+} from "./registry-skill-publication.ts";
+import {
+    downloadRegistryPackageTarball,
+    loadRegistryPackageSkillInfo,
+    requireCurrentSkillsInstallAccount,
+} from "./registry-skill-source.ts";
+import { SkillsUpdateProgressReporter } from "./update-progress.ts";
+
+interface SkillsUpdateInput {
+    skill?: string[];
+}
+
+interface RegistrySkillGroup {
+    packageName: string;
+    skills: ManagedSkillListItem[];
+}
+
+interface CurrentSkillUpdate {
+    kind: "current";
+    skillName: string;
+    version: string;
+}
+
+interface FailedSkillUpdate {
+    error: Error;
+    kind: "failed";
+    skillName: string;
+}
+
+interface RegistryPreparedSkillUpdate {
+    kind: "registry";
+    preparedPublication: PreparedRegistrySkillPublication;
+}
+
+type PreparedSkillUpdate = RegistryPreparedSkillUpdate;
+type SkillUpdateEvent = CurrentSkillUpdate | FailedSkillUpdate;
+
+interface SkillPreparationResult {
+    events: SkillUpdateEvent[];
+    publications: PreparedSkillUpdate[];
+}
+
+export const skillsUpdateCommand: CliCommandDefinition<SkillsUpdateInput> = {
+    name: "update",
+    summaryKey: "commands.skills.update.summary",
+    descriptionKey: "commands.skills.update.description",
+    arguments: [
+        {
+            name: "skill",
+            descriptionKey: "arguments.skill",
+            required: false,
+            variadic: true,
+        },
+    ],
+    inputSchema: z.object({
+        skill: z.array(z.string()).optional(),
+    }),
+    handler: async (input, context) => {
+        await updateManagedSkills(
+            {
+                skillNames: input.skill ?? [],
+            },
+            context,
+        );
+    },
+};
+
+export async function updateManagedSkills(
+    request: {
+        skillNames: readonly string[];
+    },
+    context: CliExecutionContext,
+): Promise<void> {
+    const codexHomeDirectory = await requireCodexHomeDirectory(context);
+    const settingsFilePath = context.settingsStore.getFilePath();
+    const installedSkills = await listManagedSkillInstallations(
+        resolveManagedSkillsDirectoryPath(codexHomeDirectory),
+    );
+    const selectedSkills = await resolveSelectedManagedSkills(
+        request.skillNames,
+        installedSkills,
+        codexHomeDirectory,
+        settingsFilePath,
+    );
+
+    if (selectedSkills.length === 0) {
+        writeLine(context, context.translator.t("skills.update.noResults"));
+        return;
+    }
+
+    const progressReporter = context.stdout.isTTY === true
+        ? new SkillsUpdateProgressReporter(
+                context.stdout,
+                selectedSkills.map(skill => skill.name),
+                context.translator,
+            )
+        : undefined;
+    const registrySkillGroups = groupRegistrySkills(selectedSkills);
+    const unresolvedSkills = selectedSkills.filter(skill =>
+        !isBundledSkillName(skill.name) && skill.metadata?.packageName === undefined,
+    );
+    const failures: Error[] = [];
+
+    progressReporter?.start();
+
+    try {
+        const account = registrySkillGroups.length > 0
+            ? await requireCurrentSkillsInstallAccount(context)
+            : undefined;
+        const phaseOneResults = await Promise.all([
+            ...unresolvedSkills.map(skill => Promise.resolve({
+                events: [
+                    {
+                        error: new CliUserError(
+                            "errors.skills.update.packageNameMissing",
+                            1,
+                            {
+                                name: skill.name,
+                            },
+                        ),
+                        kind: "failed" as const,
+                        skillName: skill.name,
+                    },
+                ],
+                publications: [],
+            })),
+            ...registrySkillGroups.map(group =>
+                prepareRegistrySkillGroupUpdate(
+                    group,
+                    {
+                        account: account!,
+                        codexHomeDirectory,
+                        progressReporter,
+                        settingsFilePath,
+                    },
+                    context,
+                ),
+            ),
+        ]);
+        const publications = phaseOneResults.flatMap(result => result.publications);
+
+        for (const event of phaseOneResults.flatMap(result => result.events)) {
+            if (event.kind === "failed") {
+                failures.push(event.error);
+                progressReporter?.updateSkill(event.skillName, "failed");
+                writeUpdateFailureLine(context, event.skillName, event.error);
+                continue;
+            }
+
+            progressReporter?.updateSkill(
+                event.skillName,
+                "current",
+                context.translator.t("skills.update.current", {
+                    name: event.skillName,
+                    version: event.version,
+                }),
+            );
+            writeUpdateCurrentLine(context, event.skillName, event.version);
+        }
+
+        const publicationResults: Array<
+            | {
+                error: Error;
+                skillName: string;
+            }
+            | {
+                installationPath: string;
+                skillName: string;
+            }
+        > = await Promise.all(
+            publications.map(async (publication) => {
+                try {
+                    progressReporter?.updateSkill(
+                        publication.preparedPublication.skillName,
+                        "publishing",
+                    );
+                    const installation = await publishPreparedRegistrySkillPublication(
+                        publication.preparedPublication,
+                    );
+
+                    return {
+                        installationPath: installation.path,
+                        skillName: publication.preparedPublication.skillName,
+                    };
+                }
+                catch (error) {
+                    const normalizedError = normalizeSkillUpdateError(error);
+
+                    failures.push(normalizedError);
+
+                    return {
+                        error: normalizedError,
+                        skillName: publication.preparedPublication.skillName,
+                    };
+                }
+            }),
+        );
+
+        for (const result of publicationResults) {
+            if ("error" in result) {
+                progressReporter?.updateSkill(result.skillName, "failed");
+                writeUpdateFailureLine(context, result.skillName, result.error);
+                continue;
+            }
+
+            progressReporter?.updateSkill(
+                result.skillName,
+                "updated",
+                context.translator.t("skills.update.progress.updated"),
+            );
+            writeUpdateSuccessLine(
+                context,
+                result.skillName,
+                result.installationPath,
+            );
+        }
+    }
+    finally {
+        progressReporter?.stop();
+    }
+
+    const firstFailure = failures[0];
+
+    if (firstFailure !== undefined) {
+        throw firstFailure;
+    }
+}
+
+async function resolveSelectedManagedSkills(
+    requestedSkillNames: readonly string[],
+    installedSkills: readonly ManagedSkillListItem[],
+    codexHomeDirectory: string,
+    settingsFilePath: string,
+): Promise<ManagedSkillListItem[]> {
+    if (requestedSkillNames.length === 0) {
+        return installedSkills.filter(
+            skill => !isBundledSkillName(skill.name),
+        );
+    }
+
+    const selectedSkills: ManagedSkillListItem[] = [];
+    const installedSkillIndex = new Map(
+        installedSkills.map(skill => [skill.name, skill] as const),
+    );
+    const seenSkillNames = new Set<string>();
+
+    for (const requestedSkillName of requestedSkillNames) {
+        if (seenSkillNames.has(requestedSkillName)) {
+            continue;
+        }
+
+        seenSkillNames.add(requestedSkillName);
+
+        if (isBundledSkillName(requestedSkillName)) {
+            throw new CliUserError(
+                "errors.skills.update.bundledUnsupported",
+                1,
+                {
+                    name: requestedSkillName,
+                },
+            );
+        }
+
+        if (
+            !isManagedSkillPathContained(
+                codexHomeDirectory,
+                settingsFilePath,
+                requestedSkillName,
+            )
+        ) {
+            throw new CliUserError("errors.skills.invalidPath", 1, {
+                name: requestedSkillName,
+            });
+        }
+
+        const installedSkill = installedSkillIndex.get(requestedSkillName);
+
+        if (installedSkill !== undefined) {
+            selectedSkills.push(installedSkill);
+            continue;
+        }
+
+        const installedSkillDirectoryPath = resolveManagedSkillDirectoryPath(
+            codexHomeDirectory,
+            requestedSkillName,
+        );
+        const installedDirectoryExists = await directoryExists(
+            installedSkillDirectoryPath,
+        );
+
+        throw new CliUserError(
+            installedDirectoryExists
+            && !(await fileExists(
+                resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
+            ))
+                ? "errors.skills.notManaged"
+                : "errors.skills.notInstalled",
+            1,
+            {
+                name: requestedSkillName,
+                path: installedSkillDirectoryPath,
+            },
+        );
+    }
+
+    return selectedSkills;
+}
+
+function groupRegistrySkills(
+    skills: readonly ManagedSkillListItem[],
+): RegistrySkillGroup[] {
+    const groups = new Map<string, ManagedSkillListItem[]>();
+
+    for (const skill of skills) {
+        const packageName = skill.metadata?.packageName;
+
+        if (packageName === undefined) {
+            continue;
+        }
+
+        const group = groups.get(packageName);
+
+        if (group === undefined) {
+            groups.set(packageName, [skill]);
+            continue;
+        }
+
+        group.push(skill);
+    }
+
+    return Array.from(groups.entries(), ([packageName, groupedSkills]) => ({
+        packageName,
+        skills: groupedSkills,
+    }));
+}
+
+async function prepareRegistrySkillGroupUpdate(
+    group: RegistrySkillGroup,
+    options: {
+        account: Awaited<ReturnType<typeof requireCurrentSkillsInstallAccount>>;
+        codexHomeDirectory: string;
+        progressReporter?: SkillsUpdateProgressReporter;
+        settingsFilePath: string;
+    },
+    context: CliExecutionContext,
+): Promise<SkillPreparationResult> {
+    try {
+        for (const skill of group.skills) {
+            options.progressReporter?.updateSkill(skill.name, "checking");
+        }
+
+        const packageInfo = await loadRegistryPackageSkillInfo(
+            group.packageName,
+            options.account,
+            context,
+        );
+
+        if (
+            group.skills.every(
+                skill => skill.metadata?.version === packageInfo.packageVersion,
+            )
+        ) {
+            return {
+                events: group.skills.map(skill => ({
+                    kind: "current",
+                    skillName: skill.name,
+                    version: packageInfo.packageVersion,
+                })),
+                publications: [],
+            };
+        }
+
+        for (const skill of group.skills) {
+            options.progressReporter?.updateSkill(skill.name, "preparing");
+        }
+
+        const packageBytes = await downloadRegistryPackageTarball(
+            packageInfo.packageName,
+            packageInfo.packageVersion,
+            options.account,
+            context,
+        );
+        const extractedPackage = await extractRegistryPackageArchive(packageBytes);
+
+        try {
+            return {
+                events: [],
+                publications: await Promise.all(
+                    group.skills.map(async skill => ({
+                        kind: "registry",
+                        preparedPublication: await prepareRegistrySkillPublication({
+                            codexHomeDirectory: options.codexHomeDirectory,
+                            extractedPackage,
+                            packageName: packageInfo.packageName,
+                            packageVersion: packageInfo.packageVersion,
+                            settingsFilePath: options.settingsFilePath,
+                            skill: findRegistrySkillOrThrow(
+                                packageInfo.skills,
+                                skill.name,
+                                packageInfo.packageName,
+                            ),
+                            skillName: skill.name,
+                        }),
+                    })),
+                ),
+            };
+        }
+        finally {
+            await extractedPackage.cleanup();
+        }
+    }
+    catch (error) {
+        const normalizedError = normalizeSkillUpdateError(error);
+
+        return {
+            events: group.skills.map(skill => ({
+                error: normalizedError,
+                kind: "failed",
+                skillName: skill.name,
+            })),
+            publications: [],
+        };
+    }
+}
+
+function findRegistrySkillOrThrow(
+    skills: readonly RegistrySkillSummary[],
+    skillName: string,
+    packageName: string,
+): RegistrySkillSummary {
+    const skill = skills.find(entry => entry.name === skillName);
+
+    if (skill !== undefined) {
+        return skill;
+    }
+
+    throw new CliUserError("errors.skills.install.skillNotFound", 1, {
+        name: skillName,
+        packageName,
+    });
+}
+
+function isBundledSkillName(value: string): value is (typeof availableBundledSkillNames)[number] {
+    return availableBundledSkillNames.includes(
+        value as (typeof availableBundledSkillNames)[number],
+    );
+}
+
+function normalizeSkillUpdateError(error: unknown): Error {
+    if (error instanceof Error) {
+        return error;
+    }
+
+    return new Error(String(error));
+}
+
+function writeUpdateSuccessLine(
+    context: CliExecutionContext,
+    skillName: string,
+    installationPath: string,
+): void {
+    if (context.stdout.isTTY === true) {
+        return;
+    }
+
+    writeLine(
+        context,
+        context.translator.t("skills.update.success", {
+            name: skillName,
+            path: installationPath,
+        }),
+    );
+}
+
+function writeUpdateCurrentLine(
+    context: CliExecutionContext,
+    skillName: string,
+    version: string,
+): void {
+    if (context.stdout.isTTY === true) {
+        return;
+    }
+
+    writeLine(
+        context,
+        context.translator.t("skills.update.current", {
+            name: skillName,
+            version,
+        }),
+    );
+}
+
+function writeUpdateFailureLine(
+    context: CliExecutionContext,
+    skillName: string,
+    error: Error,
+): void {
+    if (context.stdout.isTTY === true) {
+        return;
+    }
+
+    writeLine(
+        context,
+        context.translator.t("skills.update.failure", {
+            message: localizeSkillUpdateError(error, context),
+            name: skillName,
+        }),
+    );
+}
+
+function localizeSkillUpdateError(
+    error: Error,
+    context: Pick<CliExecutionContext, "translator">,
+): string {
+    if (error instanceof CliUserError) {
+        return context.translator.t(error.key, error.params);
+    }
+
+    return error.message;
+}
+
+function writeLine(
+    context: Pick<CliExecutionContext, "stdout">,
+    message: string,
+): void {
+    context.stdout.write(`${message}\n`);
+}

--- a/src/application/contracts/cli.ts
+++ b/src/application/contracts/cli.ts
@@ -49,6 +49,7 @@ export interface CliArgumentDefinition {
     descriptionKey: string;
     required?: boolean;
     choices?: readonly string[];
+    variadic?: boolean;
 }
 
 export type CliCommandHandler<TInput> = {

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -128,6 +128,9 @@ export const enMessages = {
     "commands.skills.install.description":
         "Install bundled or published Codex skills into the local Codex skills directory.",
     "commands.skills.install.summary": "Install Codex skills",
+    "commands.skills.update.description":
+        "Update installed oo-managed Codex skills to the latest available version.",
+    "commands.skills.update.summary": "Update oo-managed Codex skills",
     "commands.skills.uninstall.description":
         "Remove one oo-managed Codex skill from the local Codex skills directory.",
     "commands.skills.uninstall.summary": "Remove an oo-managed Codex skill",
@@ -335,6 +338,10 @@ export const enMessages = {
         "The skills install package info request returned HTTP {status}.",
     "errors.skills.install.skillNotFound":
         "Skill {name} was not found in package {packageName}.",
+    "errors.skills.update.bundledUnsupported":
+        "Codex skill {name} is synchronized automatically and cannot be updated with skills update.",
+    "errors.skills.update.packageNameMissing":
+        "Managed skill {name} cannot be updated because its package metadata is missing.",
     "errors.skills.nameConflict":
         "Skill name {name} is already used by a non-OOMOL Codex skill at {path}.",
     "errors.skills.storageConflict":
@@ -431,6 +438,20 @@ export const enMessages = {
     "skills.install.status.installed": "installed",
     "skills.install.singleSelected":
         "Skill: {name}",
+    "skills.update.noResults":
+        "No updatable oo-managed skills were found.",
+    "skills.update.current":
+        "Codex skill {name} is already up to date at {version}.",
+    "skills.update.failure":
+        "Failed to update Codex skill {name}: {message}",
+    "skills.update.progress.header": "Updating installed skills",
+    "skills.update.progress.checking": "checking for updates",
+    "skills.update.progress.preparing": "updating canonical files",
+    "skills.update.progress.publishing": "publishing to Codex",
+    "skills.update.progress.current": "up to date",
+    "skills.update.progress.updated": "updated",
+    "skills.update.progress.failed": "failed",
+    "skills.update.success": "Updated Codex skill {name} to {path}.",
     "skills.uninstall.success": "Removed Codex skill {name} from {path}.",
     "versionInfo.version": "Version",
     "versionInfo.buildTime": "Build Time",
@@ -611,6 +632,9 @@ export const zhMessages = {
     "commands.skills.install.description":
         "将内置或已发布的 Codex skill 安装到本地 Codex skills 目录。",
     "commands.skills.install.summary": "安装 Codex skills",
+    "commands.skills.update.description":
+        "将已安装且由 oo 管理的 Codex skill 更新到最新可用版本。",
+    "commands.skills.update.summary": "更新由 oo 管理的 Codex skill",
     "commands.skills.uninstall.description": "从本地 Codex skills 目录移除一个由 oo 管理的 Codex skill。",
     "commands.skills.uninstall.summary": "移除一个由 oo 管理的 Codex skill",
     "config.set.success": "已将 {key} 设置为 {value}。",
@@ -810,6 +834,10 @@ export const zhMessages = {
         "skills install 的包信息请求返回了 HTTP {status}。",
     "errors.skills.install.skillNotFound":
         "在包 {packageName} 中未找到 skill {name}。",
+    "errors.skills.update.bundledUnsupported":
+        "Codex skill {name} 会自动同步，不能通过 skills update 更新。",
+    "errors.skills.update.packageNameMissing":
+        "由 oo 管理的 skill {name} 缺少 package 元数据，无法更新。",
     "errors.skills.nameConflict":
         "Skill 名称 {name} 已被 {path} 中的非 OOMOL Codex skill 占用。",
     "errors.skills.storageConflict":
@@ -900,6 +928,20 @@ export const zhMessages = {
     "skills.install.status.installed": "已安装",
     "skills.install.singleSelected":
         "Skill：{name}",
+    "skills.update.noResults":
+        "未找到可更新的 oo-managed skill。",
+    "skills.update.current":
+        "Codex skill {name} 已是最新版本 {version}。",
+    "skills.update.failure":
+        "更新 Codex skill {name} 失败：{message}",
+    "skills.update.progress.header": "正在更新已安装的 skill",
+    "skills.update.progress.checking": "检查更新中",
+    "skills.update.progress.preparing": "更新 canonical 文件中",
+    "skills.update.progress.publishing": "同步到 Codex 中",
+    "skills.update.progress.current": "已是最新",
+    "skills.update.progress.updated": "已更新",
+    "skills.update.progress.failed": "失败",
+    "skills.update.success": "已将 Codex skill {name} 更新到 {path}。",
     "skills.uninstall.success": "已从 {path} 移除 Codex skill {name}。",
     "versionInfo.version": "版本",
     "versionInfo.buildTime": "构建时间",


### PR DESCRIPTION
Introduce `oo skills update [skills...]` that checks installed oo-managed published skills against the registry and updates them when a newer version is available.

Key changes:
- Extract registry skill publication logic into a shared module so both install and update can reuse it
- Add variadic argument support to the CLI adapter
- Include interactive progress reporter with spinner animation
- Add comprehensive tests for the update workflow