### PR TITLE
feat(skills): preselect installed skills and remove deselected ones

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -198,6 +198,9 @@ directory.
   provided, the command installs that skill automatically.
 - Notes: when a package publishes multiple skills and no `--skill`, `--all`, or
   `-y` is provided, the command opens an interactive picker in a TTY.
+- Notes: in the interactive picker, skills already installed from the same
+  package start selected. Clearing such a selection removes that installed
+  skill when the command completes.
 - Canonical directory: bundled `oo` is materialized to
   `<config-dir>/skills/oo`, where `<config-dir>` is the directory that
   contains `settings.toml`.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -176,6 +176,8 @@
   安装这个唯一的 skill。
 - 说明：如果 package 发布了多个 skill，且未提供 `--skill`、`--all` 或
   `-y`，命令会在 TTY 中打开交互选择页面。
+- 说明：在交互选择页面中，同一 package 下已安装的 skill 会默认保持勾选；
+  如果用户取消这些勾选，命令完成时会移除对应已安装 skill。
 - canonical 目录：内置 `oo` 的文件会先释放到 `<config-dir>/skills/oo`，
   其中 `<config-dir>` 是 `settings.toml` 所在目录。
 - canonical 目录：已发布 skill 会先释放到 `<config-dir>/skills/<skill-id>`。

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -1014,25 +1014,144 @@ describe("skills commands", () => {
                 systemLocale: "en-US",
             });
 
-            await waitForOutputText(stdout, "Select skills to install");
+            await waitForOutputText(
+                stdout,
+                "Select skills to install or keep installed",
+            );
             stdin.feed(" ");
             stdin.feed("\r");
 
             const exitCode = await execution;
-            const plainOutput = stripVTControlCharacters(stdout.read());
+            const plainOutput = stripVTControlCharacters(stdout.read()).replaceAll(
+                "\u200B",
+                "",
+            );
 
             expect(exitCode).toBe(0);
             expect(stderr.read()).toBe("");
-            expect(plainOutput).toContain("Select skills to install");
+            expect(plainOutput).toContain(
+                "Select skills to install or keep installed",
+            );
+            expect(plainOutput).toContain(
+                "◆ Select skills to install or keep installed",
+            );
             expect(plainOutput).toContain("chatgpt");
             expect(plainOutput).toContain("vision");
-            expect(plainOutput).toContain(
+            expect(plainOutput).toContain("Installing selected skills...");
+            expect(plainOutput).toContain("◆ Installed");
+            expect(plainOutput).toContain("  chatgpt");
+            expect(plainOutput).not.toContain(
                 `Installed Codex skill chatgpt to ${selectedSkillDirectoryPath}.`,
             );
             await expect(stat(join(selectedSkillDirectoryPath, "SKILL.md"))).resolves.toMatchObject({
                 isFile: expect.any(Function),
             });
             await expect(stat(unselectedSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("uninstalls deselected published skills through the interactive picker", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const installedSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const stdin = createInteractiveInput();
+        const stdout = createTextBuffer({
+            isTTY: true,
+        });
+        const stderr = createTextBuffer();
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+            await mkdir(join(installedSkillDirectoryPath, "agents"), { recursive: true });
+            await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
+                recursive: true,
+            });
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
+                formatManagedSkillMetadataContent("openai", "0.0.3"),
+            );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath),
+                formatManagedSkillMetadataContent("openai", "0.0.3"),
+            );
+            await Bun.write(join(installedSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
+            await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
+
+            const execution = executeCli({
+                argv: ["skills", "install", "openai"],
+                cwd: sandbox.cwd,
+                env: sandbox.env,
+                fetcher: async (input, init) => {
+                    const request = toRequest(input, init);
+
+                    if (request.url.includes("/package-info/")) {
+                        return new Response(JSON.stringify({
+                            packageName: "openai",
+                            version: "0.0.3",
+                            skills: [
+                                {
+                                    description: "Chat with a model",
+                                    name: "chatgpt",
+                                    title: "ChatGPT",
+                                },
+                                {
+                                    description: "See images",
+                                    name: "vision",
+                                    title: "Vision",
+                                },
+                            ],
+                        }));
+                    }
+
+                    throw new Error(`Unexpected request: ${request.url}`);
+                },
+                stdin,
+                stderr: stderr.writer,
+                stdout: stdout.writer,
+                systemLocale: "en-US",
+            });
+
+            await waitForOutputText(
+                stdout,
+                "Select skills to install or keep installed",
+            );
+            stdin.feed(" ");
+            stdin.feed("\r");
+
+            const exitCode = await execution;
+            const plainOutput = stripVTControlCharacters(stdout.read()).replaceAll(
+                "\u200B",
+                "",
+            );
+
+            expect(exitCode).toBe(0);
+            expect(stderr.read()).toBe("");
+            expect(plainOutput).toContain("\n ◼ chatgpt");
+            expect(plainOutput).toContain("Removing deselected skills...");
+            expect(plainOutput).toContain("◆ Removed");
+            expect(plainOutput).toContain("  chatgpt");
+            expect(plainOutput).not.toContain(
+                `Removed Codex skill chatgpt from ${installedSkillDirectoryPath}.`,
+            );
+            await expect(stat(installedSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(canonicalSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
         }

--- a/src/application/commands/skills/install-progress.test.ts
+++ b/src/application/commands/skills/install-progress.test.ts
@@ -1,0 +1,73 @@
+import { stripVTControlCharacters } from "node:util";
+
+import { describe, expect, test } from "bun:test";
+
+import { createTextBuffer } from "../../../../__tests__/helpers.ts";
+import { SkillsInstallProgressReporter } from "./install-progress.ts";
+
+describe("skills install progress reporter", () => {
+    test("reveals the removing step only after the installing step completes", () => {
+        const stdout = createTextBuffer({
+            hasColors: true,
+            isTTY: true,
+        });
+        const reporter = new SkillsInstallProgressReporter(
+            stdout.writer,
+            {
+                t: (key) => {
+                    switch (key) {
+                        case "skills.install.progress.installing.start":
+                            return "Installing selected skills...";
+                        case "skills.install.progress.installing.complete":
+                            return "Installed";
+                        case "skills.install.progress.installing.failed":
+                            return "Installing selected skills failed";
+                        case "skills.install.progress.removing.start":
+                            return "Removing deselected skills...";
+                        case "skills.install.progress.removing.complete":
+                            return "Removed";
+                        case "skills.install.progress.removing.failed":
+                            return "Removing deselected skills failed";
+                        default:
+                            return key;
+                    }
+                },
+            },
+        );
+
+        reporter.startInstalling(["audit", "frontend-design"]);
+
+        const renderedInstallingOutput = stdout.read();
+        const installingOutput = stripVTControlCharacters(stdout.read());
+
+        expect(installingOutput).toContain("Installing selected skills...");
+        expect(installingOutput).toContain("  audit");
+        expect(installingOutput).toContain("  frontend-design");
+        expect(installingOutput).not.toContain("Removing deselected skills...");
+        expect(renderedInstallingOutput).toContain("\u001B[2maudit\u001B[22m");
+        expect(renderedInstallingOutput).toContain("\u001B[2mfrontend-design\u001B[22m");
+
+        reporter.completeInstalling(["audit", "frontend-design"]);
+        reporter.startRemoving(["clarify"]);
+
+        const removingOutput = stripVTControlCharacters(stdout.read());
+
+        expect(removingOutput).toContain("◆ Installed");
+        expect(removingOutput).toContain("  audit");
+        expect(removingOutput).toContain("  frontend-design");
+        expect(removingOutput).toContain("Removing deselected skills...");
+        expect(removingOutput).toContain("  clarify");
+
+        reporter.completeRemoving(["clarify"]);
+        reporter.stop();
+
+        const finalOutput = stripVTControlCharacters(stdout.read()).replaceAll(
+            "\r",
+            "",
+        );
+
+        expect(finalOutput).toContain("  frontend-design\n\n◆ Removed");
+        expect(finalOutput).toContain("◆ Removed");
+        expect(finalOutput).toContain("  clarify");
+    });
+});

--- a/src/application/commands/skills/install-progress.ts
+++ b/src/application/commands/skills/install-progress.ts
@@ -1,0 +1,111 @@
+import type { CliExecutionContext, Writer } from "../../contracts/cli.ts";
+import type { TerminalColors } from "../../terminal-colors.ts";
+
+import { createWriterColors } from "../../terminal-colors.ts";
+import { TerminalProgressRenderer } from "./progress-renderer.ts";
+
+export class SkillsInstallProgressReporter extends TerminalProgressRenderer {
+    private activeLines: string[] = [];
+    private completedLines: string[] = [];
+    private readonly colors: TerminalColors;
+
+    constructor(
+        writer: Pick<Writer, "hasColors" | "write">,
+        private readonly translator: Pick<CliExecutionContext["translator"], "t">,
+    ) {
+        super(writer);
+        this.colors = createWriterColors(writer);
+    }
+
+    startInstalling(skillNames: readonly string[]): void {
+        this.startStep(
+            this.translator.t("skills.install.progress.installing.start"),
+            skillNames,
+        );
+    }
+
+    completeInstalling(skillNames: readonly string[]): void {
+        this.completeStep(
+            this.translator.t("skills.install.progress.installing.complete"),
+            skillNames,
+        );
+    }
+
+    failInstalling(): void {
+        this.failStep(this.translator.t("skills.install.progress.installing.failed"));
+    }
+
+    startRemoving(skillNames: readonly string[]): void {
+        this.startStep(
+            this.translator.t("skills.install.progress.removing.start"),
+            skillNames,
+        );
+    }
+
+    completeRemoving(skillNames: readonly string[]): void {
+        this.completeStep(
+            this.translator.t("skills.install.progress.removing.complete"),
+            skillNames,
+        );
+    }
+
+    failRemoving(): void {
+        this.failStep(this.translator.t("skills.install.progress.removing.failed"));
+    }
+
+    protected renderLines(): string[] {
+        if (this.activeLines.length === 0) {
+            return this.completedLines;
+        }
+
+        return [
+            ...this.completedLines,
+            ...this.activeLines,
+        ];
+    }
+
+    private completeStep(
+        message: string,
+        skillNames: readonly string[],
+    ): void {
+        this.finishActiveStep([
+            `${this.colors.green("◆")} ${message}`,
+            ...this.formatItemLines(skillNames),
+        ]);
+    }
+
+    private failStep(message: string): void {
+        this.finishActiveStep([`${this.colors.red("◆")} ${message}`]);
+    }
+
+    private finishActiveStep(lines: readonly string[]): void {
+        if (this.activeLines.length > 0) {
+            if (this.completedLines.length > 0) {
+                this.completedLines.push("");
+            }
+            this.completedLines.push(...lines);
+            this.activeLines = [];
+        }
+
+        this.stopSpinner();
+        this.render();
+    }
+
+    private startStep(
+        message: string,
+        skillNames: readonly string[],
+    ): void {
+        const itemLines = this.formatItemLines(skillNames);
+
+        this.startSpinner(() => {
+            this.activeLines = [
+                `${this.colors.cyan(this.currentFrame)} ${message}`,
+                ...itemLines,
+            ];
+        });
+    }
+
+    private formatItemLines(skillNames: readonly string[]): string[] {
+        return skillNames.map(name => `  ${this.colors.dim(name)}`);
+    }
+}

--- a/src/application/commands/skills/interactive-prompts.test.ts
+++ b/src/application/commands/skills/interactive-prompts.test.ts
@@ -82,22 +82,69 @@ describe("interactive prompts", () => {
                         title: "Beta",
                     },
                 ],
-                prompt: "Select skills to install (space to toggle)",
+                prompt: "Select skills to install or keep installed (space to toggle)",
             },
         );
 
-        await waitForOutputText(stdout, "Select skills to install");
+        await waitForOutputText(stdout, "Select skills to install or keep installed");
         stdin.feed(" ");
         stdin.feed("\r");
 
         await expect(selectionPromise).resolves.toEqual(["alpha"]);
         const plainOutput = stripVTControlCharacters(stdout.read());
 
-        expect(plainOutput).toContain("Select skills to install");
+        expect(plainOutput).toContain("◇ Select skills to install or keep installed");
+        expect(plainOutput).toContain("◆ Select skills to install or keep installed");
+        expect(plainOutput).toContain("Select skills to install or keep installed");
         expect(plainOutput).toContain("alpha");
         expect(plainOutput).toContain("beta");
         expect(plainOutput).toContain("conflict");
         expect(plainOutput).toContain("First description");
+    });
+
+    test("preselects installed skills without rendering a right-side status label", async () => {
+        const stdin = createInteractiveInput();
+        const stdout = createTextBuffer({
+            isTTY: true,
+        });
+        const selectionPromise = selectInteractiveSkills(
+            {
+                stdin,
+                stdout: stdout.writer,
+            },
+            {
+                items: [
+                    {
+                        description: "Already installed",
+                        name: "alpha",
+                        selected: true,
+                        title: "Alpha",
+                    },
+                    {
+                        description: "Needs confirmation",
+                        name: "beta",
+                        statusLabel: "conflict",
+                        title: "Beta",
+                    },
+                ],
+                prompt: "Select skills to install or keep installed (space to toggle)",
+            },
+        );
+
+        await waitForOutputText(stdout, "Select skills to install or keep installed");
+        stdin.feed("\r");
+
+        await expect(selectionPromise).resolves.toEqual(["alpha"]);
+        const plainOutput = stripVTControlCharacters(stdout.read()).replaceAll(
+            "\u200B",
+            "",
+        );
+
+        expect(plainOutput).toContain("◆ Select skills to install or keep installed");
+        expect(plainOutput).toContain("\n ◼ alpha");
+        expect(plainOutput).not.toContain("alpha  installed");
+        expect(plainOutput).toContain("beta");
+        expect(plainOutput).toContain("conflict");
     });
 
     test("uses project terminal colors for the multiselect prompt", async () => {
@@ -119,11 +166,11 @@ describe("interactive prompts", () => {
                         title: "Alpha",
                     },
                 ],
-                prompt: "Select skills to install",
+                prompt: "Select skills to install or keep installed",
             },
         );
 
-        await waitForOutputText(stdout, "Select skills to install");
+        await waitForOutputText(stdout, "Select skills to install or keep installed");
         stdin.feed("\r");
 
         await expect(selectionPromise).resolves.toEqual([]);
@@ -169,11 +216,14 @@ describe("interactive prompts", () => {
                             title: "Adapt",
                         },
                     ],
-                    prompt: "Select skills to install",
+                    prompt: "Select skills to install or keep installed",
                 },
             );
 
-            await waitForOutputText(stdout, "Select skills to install");
+            await waitForOutputText(
+                stdout,
+                "Select skills to install or keep installed",
+            );
 
             const plainOutput = stripVTControlCharacters(stdout.read());
 

--- a/src/application/commands/skills/interactive-prompts.ts
+++ b/src/application/commands/skills/interactive-prompts.ts
@@ -25,6 +25,7 @@ export interface InteractivePromptContext {
 export interface InteractiveSkillSelectItem {
     description: string;
     name: string;
+    selected?: boolean;
     statusLabel?: string;
     title: string;
 }
@@ -74,6 +75,9 @@ export async function selectInteractiveSkills(
 ): Promise<string[]> {
     const promptStreams = createPromptStreams(context);
     const colors = createWriterColors(context.stdout);
+    const initialValues = options.items
+        .filter(item => item.selected === true)
+        .map(item => item.name);
     const promptOptions = options.items.map((item) => {
         const label = formatSkillOptionLabel(item, promptStreams.output.columns);
 
@@ -93,6 +97,7 @@ export async function selectInteractiveSkills(
             promptStreams.output,
             async () => await new MultiSelectPrompt<MultiSelectOption>({
                 cursorAt: promptOptions[0]?.value,
+                initialValues,
                 input: promptStreams.input,
                 options: promptOptions,
                 output: promptStreams.output,
@@ -157,15 +162,26 @@ function renderMultiSelectPrompt(
     message: string,
     colors: TerminalColors,
 ): string {
-    const header = `${message}\n`;
+    const header = `${formatPromptHeader(prompt.state, message, colors)}\n`;
     const itemIndent = "\u200B ";
 
     switch (prompt.state) {
-        case "submit":
-            return `${header}${itemIndent}${prompt.options
-                .filter(({ value }) => prompt.value.includes(value))
-                .map(option => formatRenderedOption(option, "submitted", colors))
-                .join(colors.dim(", ")) || colors.dim("none")}`;
+        case "submit": {
+            const formatOption = (option: MultiSelectOption) => formatRenderedOption(
+                option,
+                isOptionSelected(prompt, option)
+                    ? "selected"
+                    : "inactive",
+                colors,
+            );
+
+            return `${header}${itemIndent}${renderScrollableOptions(
+                prompt.cursor,
+                prompt.options,
+                formatOption,
+                formatOption,
+            ).join(`\n${itemIndent}`)}\n`;
+        }
         case "cancel": {
             const selectedOptions = prompt.options
                 .filter(({ value }) => prompt.value.includes(value))
@@ -222,23 +238,33 @@ function renderMultiSelectPrompt(
     }
 }
 
+function formatPromptHeader(
+    state: MultiSelectPrompt<MultiSelectOption>["state"],
+    message: string,
+    colors: TerminalColors,
+): string {
+    switch (state) {
+        case "submit":
+            return `${colors.green("◆")} ${message}`;
+        case "cancel":
+            return `${colors.dim("◇")} ${colors.dim(message)}`;
+        default:
+            return `${colors.green("◇")} ${message}`;
+    }
+}
+
 function renderScrollableOptions(
     cursor: number,
     options: readonly MultiSelectOption[],
     activeStyle: (option: MultiSelectOption) => string,
     inactiveStyle: (option: MultiSelectOption) => string,
 ): string[] {
-    const maxItems = Number.POSITIVE_INFINITY;
     const visibleRows = Math.max((process.stdout.rows ?? 24) - 4, 0);
-    const windowSize = Math.min(
-        visibleRows,
-        Math.max(maxItems, 5),
-    );
     let offset = 0;
 
-    if (cursor >= offset + windowSize - 3) {
+    if (cursor >= offset + visibleRows - 3) {
         offset = Math.max(
-            Math.min(cursor - windowSize + 3, options.length - windowSize),
+            Math.min(cursor - visibleRows + 3, options.length - visibleRows),
             0,
         );
     }
@@ -246,14 +272,14 @@ function renderScrollableOptions(
         offset = Math.max(cursor - 2, 0);
     }
 
-    return options.slice(offset, offset + windowSize).map((option, index) =>
+    return options.slice(offset, offset + visibleRows).map((option, index) =>
         index + offset === cursor ? activeStyle(option) : inactiveStyle(option),
     );
 }
 
 function formatRenderedOption(
     option: MultiSelectOption,
-    state: "active" | "active-selected" | "cancelled" | "inactive" | "selected" | "submitted",
+    state: "active" | "active-selected" | "cancelled" | "inactive" | "selected",
     colors: TerminalColors,
 ): string {
     switch (state) {
@@ -267,8 +293,6 @@ function formatRenderedOption(
             return `${colors.dim("◻")} ${colors.dim(option.label)}`;
         case "selected":
             return `${colors.green("◼")} ${colors.dim(option.label)} ${option.hint === "" ? "" : colors.dim(`(${option.hint})`)}`;
-        case "submitted":
-            return colors.dim(option.label);
     }
 }
 

--- a/src/application/commands/skills/progress-renderer.ts
+++ b/src/application/commands/skills/progress-renderer.ts
@@ -1,0 +1,78 @@
+import type { Writer } from "../../contracts/cli.ts";
+
+const spinnerFrames = ["|", "/", "-", "\\"] as const;
+
+export abstract class TerminalProgressRenderer {
+    private frameIndex = 0;
+    private intervalId: ReturnType<typeof setInterval> | undefined;
+    private renderedLineCount = 0;
+    private renderedOutput = "";
+
+    constructor(
+        protected readonly writer: Pick<Writer, "hasColors" | "write">,
+    ) {}
+
+    stop(): void {
+        this.stopSpinner();
+
+        if (this.renderedLineCount === 0) {
+            return;
+        }
+
+        this.render();
+        this.writer.write("\u001B[?25h");
+    }
+
+    protected get currentFrame(): string {
+        return spinnerFrames[this.frameIndex]!;
+    }
+
+    protected startSpinner(onTick?: () => void): void {
+        this.stopSpinner();
+        this.frameIndex = 0;
+        onTick?.();
+        this.render();
+        this.intervalId = setInterval(() => {
+            this.frameIndex = (this.frameIndex + 1) % spinnerFrames.length;
+            onTick?.();
+            this.render();
+        }, 80);
+        this.intervalId.unref?.();
+    }
+
+    protected stopSpinner(): void {
+        if (this.intervalId !== undefined) {
+            clearInterval(this.intervalId);
+            this.intervalId = undefined;
+        }
+    }
+
+    protected render(): void {
+        const nextOutput = this.renderLines().join("\n");
+
+        if (nextOutput === this.renderedOutput) {
+            return;
+        }
+
+        if (this.renderedLineCount === 0) {
+            this.writer.write("\u001B[?25l");
+            this.writer.write(`${nextOutput}\n`);
+            this.renderedLineCount = nextOutput.split("\n").length;
+            this.renderedOutput = nextOutput;
+            return;
+        }
+
+        const renderedLines = nextOutput.split("\n");
+        const rewrittenContent = renderedLines.map(
+            line => `\r\u001B[2K${line}`,
+        ).join("\n");
+
+        this.writer.write(
+            `\u001B[${this.renderedLineCount}A${rewrittenContent}\n`,
+        );
+        this.renderedLineCount = renderedLines.length;
+        this.renderedOutput = nextOutput;
+    }
+
+    protected abstract renderLines(): string[];
+}

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -4,6 +4,7 @@ import { CliUserError } from "../../contracts/cli.ts";
 import { withPackageIdentity } from "../../logging/log-fields.ts";
 
 import { directoryExists, requireCodexHomeDirectory } from "./bundled-skill-observation.ts";
+import { SkillsInstallProgressReporter } from "./install-progress.ts";
 import {
     confirmInteractiveValue,
     selectInteractiveSkills,
@@ -26,6 +27,7 @@ import {
     loadRegistryPackageSkillInfo,
     requireCurrentSkillsInstallAccount,
 } from "./registry-skill-source.ts";
+import { uninstallManagedSkill } from "./shared.ts";
 
 interface ManagedSkillPathState {
     exists: boolean;
@@ -37,6 +39,23 @@ export interface RegistrySkillInstallRequest {
     packageName: string;
     skillNames: string[];
     yes: boolean;
+}
+
+interface RegistrySkillSelectionResolution {
+    actions: RegistrySkillSelectionAction[];
+    isInteractive: boolean;
+}
+
+interface RegistrySkillSelectionAction {
+    skillName: string;
+    type: "install" | "uninstall";
+}
+
+interface RegistrySkillState {
+    description: string;
+    name: string;
+    status: RegistrySkillInstallStatus;
+    title: string;
 }
 
 type RegistrySkillInstallStatus = "conflict" | "installed" | "new";
@@ -59,20 +78,20 @@ export async function installRegistrySkills(
         });
     }
 
-    const selectedSkillNames = await resolveSelectedSkillNames(
+    const selectionActions = await resolveSelectionActions(
         request,
         packageInfo,
         codexHomeDirectory,
         context,
     );
 
-    if (selectedSkillNames.length === 0) {
+    if (selectionActions.actions.length === 0) {
         return;
     }
 
     const settingsFilePath = context.settingsStore.getFilePath();
 
-    for (const skillName of selectedSkillNames) {
+    for (const { skillName } of selectionActions.actions) {
         if (!isManagedSkillPathContained(
             codexHomeDirectory,
             settingsFilePath,
@@ -84,6 +103,73 @@ export async function installRegistrySkills(
         }
     }
 
+    const installActions = selectionActions.actions.filter(
+        action => action.type === "install",
+    );
+    const uninstallActions = selectionActions.actions.filter(
+        action => action.type === "uninstall",
+    );
+    const progressReporter = selectionActions.isInteractive
+        ? new SkillsInstallProgressReporter(context.stdout, context.translator)
+        : undefined;
+
+    try {
+        if (installActions.length > 0) {
+            const installSkillNames = installActions.map(action => action.skillName);
+            progressReporter?.startInstalling(installSkillNames);
+
+            try {
+                await executeInstallActions(
+                    installActions,
+                    packageInfo,
+                    account,
+                    codexHomeDirectory,
+                    settingsFilePath,
+                    selectionActions.isInteractive,
+                    context,
+                );
+            }
+            catch (error) {
+                progressReporter?.failInstalling();
+                throw error;
+            }
+
+            progressReporter?.completeInstalling(installSkillNames);
+        }
+
+        if (uninstallActions.length > 0) {
+            const uninstallSkillNames = uninstallActions.map(action => action.skillName);
+            progressReporter?.startRemoving(uninstallSkillNames);
+
+            try {
+                for (const { skillName } of uninstallActions) {
+                    await uninstallManagedSkill(skillName, context, {
+                        silent: selectionActions.isInteractive,
+                    });
+                }
+            }
+            catch (error) {
+                progressReporter?.failRemoving();
+                throw error;
+            }
+
+            progressReporter?.completeRemoving(uninstallSkillNames);
+        }
+    }
+    finally {
+        progressReporter?.stop();
+    }
+}
+
+async function executeInstallActions(
+    installActions: readonly RegistrySkillSelectionAction[],
+    packageInfo: Awaited<ReturnType<typeof loadRegistryPackageSkillInfo>>,
+    account: Awaited<ReturnType<typeof requireCurrentSkillsInstallAccount>>,
+    codexHomeDirectory: string,
+    settingsFilePath: string,
+    isInteractive: boolean,
+    context: CliExecutionContext,
+): Promise<void> {
     const packageBytes = await downloadRegistryPackageTarball(
         packageInfo.packageName,
         packageInfo.packageVersion,
@@ -93,7 +179,7 @@ export async function installRegistrySkills(
     const extractedPackage = await extractRegistryPackageArchive(packageBytes);
 
     try {
-        for (const skillName of selectedSkillNames) {
+        for (const { skillName } of installActions) {
             const skill = findPackageSkillOrThrow(packageInfo, skillName);
             const installation = await publishPreparedRegistrySkillPublication(
                 await prepareRegistrySkillPublication({
@@ -107,13 +193,16 @@ export async function installRegistrySkills(
                 }),
             );
 
-            writeLine(
-                context,
-                context.translator.t("skills.install.success", {
-                    name: skillName,
-                    path: installation.path,
-                }),
-            );
+            if (!isInteractive) {
+                writeLine(
+                    context,
+                    context.translator.t("skills.install.success", {
+                        name: skillName,
+                        path: installation.path,
+                    }),
+                );
+            }
+
             context.logger.info(
                 {
                     ...withPackageIdentity(
@@ -133,7 +222,7 @@ export async function installRegistrySkills(
     }
 }
 
-async function resolveSelectedSkillNames(
+async function resolveSelectionActions(
     request: RegistrySkillInstallRequest,
     packageInfo: Awaited<ReturnType<typeof loadRegistryPackageSkillInfo>>,
     codexHomeDirectory: string,
@@ -141,7 +230,7 @@ async function resolveSelectedSkillNames(
         CliExecutionContext,
         "settingsStore" | "stdin" | "stdout" | "translator"
     >,
-): Promise<string[]> {
+): Promise<RegistrySkillSelectionResolution> {
     if (request.all) {
         writeLine(
             context,
@@ -150,7 +239,10 @@ async function resolveSelectedSkillNames(
             }),
         );
 
-        return packageInfo.skills.map(skill => skill.name);
+        return {
+            actions: createInstallActions(packageInfo.skills.map(skill => skill.name)),
+            isInteractive: false,
+        };
     }
 
     if (request.skillNames.includes("*")) {
@@ -161,7 +253,10 @@ async function resolveSelectedSkillNames(
             }),
         );
 
-        return packageInfo.skills.map(skill => skill.name);
+        return {
+            actions: createInstallActions(packageInfo.skills.map(skill => skill.name)),
+            isInteractive: false,
+        };
     }
 
     if (request.skillNames.length > 0) {
@@ -171,12 +266,17 @@ async function resolveSelectedSkillNames(
             return skillName;
         });
 
-        return await filterConfirmedSkillNames(
-            packageInfo.packageName,
-            selectedSkillNames,
-            codexHomeDirectory,
-            context,
-        );
+        return {
+            actions: createInstallActions(
+                await filterConfirmedSkillNames(
+                    packageInfo.packageName,
+                    selectedSkillNames,
+                    codexHomeDirectory,
+                    context,
+                ),
+            ),
+            isInteractive: false,
+        };
     }
 
     if (packageInfo.skills.length === 1) {
@@ -189,7 +289,10 @@ async function resolveSelectedSkillNames(
             }),
         );
 
-        return [firstSkill.name];
+        return {
+            actions: createInstallActions([firstSkill.name]),
+            isInteractive: false,
+        };
     }
 
     if (request.yes) {
@@ -200,7 +303,10 @@ async function resolveSelectedSkillNames(
             }),
         );
 
-        return packageInfo.skills.map(skill => skill.name);
+        return {
+            actions: createInstallActions(packageInfo.skills.map(skill => skill.name)),
+            isInteractive: false,
+        };
     }
 
     if (context.stdin.isTTY !== true || context.stdout.isTTY !== true) {
@@ -209,28 +315,48 @@ async function resolveSelectedSkillNames(
         });
     }
 
-    return await selectInteractiveSkills(
+    const skillStates = await readRegistrySkillStates(
+        packageInfo,
+        codexHomeDirectory,
+        context.settingsStore.getFilePath(),
+    );
+    const selectedSkillNames = await selectInteractiveSkills(
         context,
         {
-            items: await Promise.all(
-                packageInfo.skills.map(async skill => ({
-                    description: skill.description,
-                    name: skill.name,
-                    statusLabel: readRegistrySkillStatusLabel(
-                        await readRegistrySkillInstallStatus(
-                            packageInfo.packageName,
-                            skill.name,
-                            codexHomeDirectory,
-                            context.settingsStore.getFilePath(),
-                        ),
-                        context.translator,
-                    ),
-                    title: skill.title,
-                })),
-            ),
+            items: skillStates.map(skill => ({
+                description: skill.description,
+                name: skill.name,
+                selected: skill.status === "installed",
+                statusLabel: readRegistrySkillStatusLabel(
+                    skill.status,
+                    context.translator,
+                ),
+                title: skill.title,
+            })),
             prompt: context.translator.t("skills.install.selection.prompt"),
         },
     );
+
+    return {
+        actions: skillStates.flatMap((skill) => {
+            if (selectedSkillNames.includes(skill.name)) {
+                return {
+                    skillName: skill.name,
+                    type: "install",
+                } satisfies RegistrySkillSelectionAction;
+            }
+
+            if (skill.status === "installed") {
+                return {
+                    skillName: skill.name,
+                    type: "uninstall",
+                } satisfies RegistrySkillSelectionAction;
+            }
+
+            return [];
+        }),
+        isInteractive: true,
+    };
 }
 
 async function filterConfirmedSkillNames(
@@ -314,6 +440,26 @@ function findPackageSkillOrThrow(
     return skill;
 }
 
+async function readRegistrySkillStates(
+    packageInfo: Awaited<ReturnType<typeof loadRegistryPackageSkillInfo>>,
+    codexHomeDirectory: string,
+    settingsFilePath: string,
+): Promise<RegistrySkillState[]> {
+    return await Promise.all(
+        packageInfo.skills.map(async skill => ({
+            description: skill.description,
+            name: skill.name,
+            status: await readRegistrySkillInstallStatus(
+                packageInfo.packageName,
+                skill.name,
+                codexHomeDirectory,
+                settingsFilePath,
+            ),
+            title: skill.title,
+        })),
+    );
+}
+
 async function readRegistrySkillInstallStatus(
     packageName: string,
     skillName: string,
@@ -390,10 +536,18 @@ function readRegistrySkillStatusLabel(
         case "conflict":
             return translator.t("skills.install.status.conflict");
         case "installed":
-            return translator.t("skills.install.status.installed");
         case "new":
             return undefined;
     }
+}
+
+function createInstallActions(
+    skillNames: readonly string[],
+): RegistrySkillSelectionAction[] {
+    return skillNames.map(skillName => ({
+        skillName,
+        type: "install",
+    }));
 }
 
 function writeLine(

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -406,13 +406,16 @@ export async function uninstallBundledSkill(
 export async function uninstallManagedSkill(
     skillName: string,
     context: CliExecutionContext,
+    options?: {
+        silent?: boolean;
+    },
 ): Promise<void> {
     if (isBundledSkillName(skillName)) {
         await uninstallBundledSkill(skillName, context);
         return;
     }
 
-    await uninstallRegistrySkill(skillName, context);
+    await uninstallRegistrySkill(skillName, context, options);
 }
 
 async function writeBundledSkillInstallation(options: {
@@ -487,6 +490,9 @@ function writeLine(context: CliExecutionContext, message: string): void {
 async function uninstallRegistrySkill(
     skillName: string,
     context: CliExecutionContext,
+    options?: {
+        silent?: boolean;
+    },
 ): Promise<void> {
     const codexHomeDirectory = await requireCodexHomeDirectory(context);
     const settingsFilePath = context.settingsStore.getFilePath();
@@ -539,13 +545,15 @@ async function uninstallRegistrySkill(
     await removePath(skillDirectoryPath);
     await removePath(canonicalSkillDirectoryPath);
 
-    writeLine(
-        context,
-        context.translator.t("skills.uninstall.success", {
-            name: skillName,
-            path: skillDirectoryPath,
-        }),
-    );
+    if (options?.silent !== true) {
+        writeLine(
+            context,
+            context.translator.t("skills.uninstall.success", {
+                name: skillName,
+                path: skillDirectoryPath,
+            }),
+        );
+    }
     context.logger.info(
         {
             canonicalPath: canonicalSkillDirectoryPath,

--- a/src/application/commands/skills/update-progress.ts
+++ b/src/application/commands/skills/update-progress.ts
@@ -1,6 +1,7 @@
 import type { CliExecutionContext, Writer } from "../../contracts/cli.ts";
 
 import { createWriterColors } from "../../terminal-colors.ts";
+import { TerminalProgressRenderer } from "./progress-renderer.ts";
 
 export type SkillUpdateProgressState
     = | "checking"
@@ -15,22 +16,19 @@ interface SkillUpdateProgressItem {
     state: SkillUpdateProgressState;
 }
 
-const spinnerFrames = ["|", "/", "-", "\\"] as const;
-
-export class SkillsUpdateProgressReporter {
-    private frameIndex = 0;
-    private intervalId: ReturnType<typeof setInterval> | undefined;
+export class SkillsUpdateProgressReporter extends TerminalProgressRenderer {
+    private readonly colors;
     private readonly itemOrder: string[];
     private readonly items = new Map<string, SkillUpdateProgressItem>();
-    private renderedLineCount = 0;
-    private renderedOutput = "";
-    private started = false;
+    private spinnerStarted = false;
 
     constructor(
-        private readonly writer: Pick<Writer, "hasColors" | "write">,
+        writer: Pick<Writer, "hasColors" | "write">,
         skillNames: readonly string[],
         private readonly translator: Pick<CliExecutionContext["translator"], "t">,
     ) {
+        super(writer);
+        this.colors = createWriterColors(writer);
         this.itemOrder = [...skillNames];
 
         for (const skillName of skillNames) {
@@ -42,31 +40,12 @@ export class SkillsUpdateProgressReporter {
     }
 
     start(): void {
-        if (this.started) {
+        if (this.spinnerStarted) {
             return;
         }
 
-        this.started = true;
-        this.render();
-        this.intervalId = setInterval(() => {
-            this.frameIndex = (this.frameIndex + 1) % spinnerFrames.length;
-            this.render();
-        }, 80);
-        this.intervalId.unref?.();
-    }
-
-    stop(): void {
-        if (this.intervalId !== undefined) {
-            clearInterval(this.intervalId);
-            this.intervalId = undefined;
-        }
-
-        if (!this.started) {
-            return;
-        }
-
-        this.render();
-        this.writer.write("\u001B[?25h");
+        this.spinnerStarted = true;
+        this.startSpinner();
     }
 
     updateSkill(
@@ -81,38 +60,9 @@ export class SkillsUpdateProgressReporter {
         this.render();
     }
 
-    private render(): void {
-        const nextOutput = this.renderLines().join("\n");
-
-        if (nextOutput === this.renderedOutput) {
-            return;
-        }
-
-        if (this.renderedLineCount === 0) {
-            this.writer.write("\u001B[?25l");
-            this.writer.write(`${nextOutput}\n`);
-            this.renderedLineCount = countRenderedLines(nextOutput);
-            this.renderedOutput = nextOutput;
-            return;
-        }
-
-        const renderedLines = nextOutput.split("\n");
-        const rewrittenContent = renderedLines.map(
-            line => `\r\u001B[2K${line}`,
-        ).join("\n");
-
-        this.writer.write(
-            `\u001B[${this.renderedLineCount}A${rewrittenContent}\n`,
-        );
-        this.renderedLineCount = renderedLines.length;
-        this.renderedOutput = nextOutput;
-    }
-
-    private renderLines(): string[] {
-        const colors = createWriterColors(this.writer);
-
+    protected renderLines(): string[] {
         return [
-            colors.bold(this.translator.t("skills.update.progress.header")),
+            this.colors.bold(this.translator.t("skills.update.progress.header")),
             ...this.itemOrder.map((skillName) => {
                 const item = this.items.get(skillName) ?? {
                     detail: undefined,
@@ -122,8 +72,8 @@ export class SkillsUpdateProgressReporter {
                 return formatProgressItemLine(
                     skillName,
                     item,
-                    spinnerFrames[this.frameIndex]!,
-                    colors,
+                    this.currentFrame,
+                    this.colors,
                     this.translator,
                 );
             }),
@@ -157,8 +107,4 @@ function readProgressStateLabel(
     translator: Pick<CliExecutionContext["translator"], "t">,
 ): string {
     return translator.t(`skills.update.progress.${state}`);
-}
-
-function countRenderedLines(output: string): number {
-    return output.split("\n").length;
 }

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -432,10 +432,19 @@ export const enMessages = {
     "skills.install.selection.invalid":
         "Invalid selection. Use one or more comma-separated numbers, or press Enter to cancel.",
     "skills.install.selection.prompt":
-        "Select skills to install (space to toggle)",
+        "Select skills to install or keep installed (space to toggle)",
+    "skills.install.progress.installing.start": "Installing selected skills...",
+    "skills.install.progress.installing.complete":
+        "Installed",
+    "skills.install.progress.installing.failed":
+        "Installing selected skills failed",
+    "skills.install.progress.removing.start": "Removing deselected skills...",
+    "skills.install.progress.removing.complete":
+        "Removed",
+    "skills.install.progress.removing.failed":
+        "Removing deselected skills failed",
     "skills.install.skipped": "Skipped Codex skill {name}.",
     "skills.install.status.conflict": "conflict",
-    "skills.install.status.installed": "installed",
     "skills.install.singleSelected":
         "Skill: {name}",
     "skills.update.noResults":
@@ -922,10 +931,19 @@ export const zhMessages = {
     "skills.install.selection.invalid":
         "选择无效。请输入一个或多个逗号分隔的序号，或直接回车取消。",
     "skills.install.selection.prompt":
-        "选择要安装的 skill（空格切换）",
+        "选择要安装或保留的 skill（空格切换）",
+    "skills.install.progress.installing.start": "正在安装所选 skill...",
+    "skills.install.progress.installing.complete":
+        "已安装",
+    "skills.install.progress.installing.failed":
+        "安装所选 skill 失败",
+    "skills.install.progress.removing.start": "正在移除未选择的 skill...",
+    "skills.install.progress.removing.complete":
+        "已移除",
+    "skills.install.progress.removing.failed":
+        "移除未选择的 skill 失败",
     "skills.install.skipped": "已跳过 Codex skill {name}。",
     "skills.install.status.conflict": "冲突",
-    "skills.install.status.installed": "已安装",
     "skills.install.singleSelected":
         "Skill：{name}",
     "skills.update.noResults":


### PR DESCRIPTION
The interactive skill picker now preselects skills already installed from the same package. Clearing a preselected skill removes it when the command completes, turning the picker into a reconciliation tool rather than an install-only interface.

Extract TerminalProgressRenderer base class from the update progress reporter and introduce SkillsInstallProgressReporter to show animated spinner progress for both install and removal steps during interactive flows. Non-interactive paths continue to emit plain text output.