### PR TITLE
refactor: extract terminal control sequences into shared module

### DIFF
--- a/src/application/commands/file/download/progress.test.ts
+++ b/src/application/commands/file/download/progress.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import { formatByteCount } from "./progress.ts";
+import { createTextBuffer } from "../../../../../__tests__/helpers.ts";
+import { createDownloadProgressReporter, formatByteCount } from "./progress.ts";
 
 describe("formatByteCount", () => {
     test("keeps byte-sized values in bytes", () => {
@@ -15,5 +16,32 @@ describe("formatByteCount", () => {
         expect(formatByteCount(1024 * 1024)).toBe("1 MB");
         expect(formatByteCount(5.5 * 1024 * 1024)).toBe("5.5 MB");
         expect(formatByteCount(3 * 1024 * 1024 * 1024)).toBe("3 GB");
+    });
+});
+
+describe("createDownloadProgressReporter", () => {
+    test("returns undefined for non-tty writers", () => {
+        const stderr = createTextBuffer({
+            isTTY: false,
+        });
+
+        expect(createDownloadProgressReporter(stderr.writer, 4)).toBeUndefined();
+    });
+
+    test("rewrites the previous line when progress output changes", () => {
+        const stderr = createTextBuffer({
+            isTTY: true,
+        });
+        const reporter = createDownloadProgressReporter(stderr.writer, 4);
+
+        expect(reporter).toBeDefined();
+
+        reporter!.render(1);
+        reporter!.complete(4);
+
+        expect(stderr.read()).toBe(
+            "Downloading 1 B / 4 B (25%)\n"
+            + "\u001B[1A\r\u001B[2KDownloaded 4 B / 4 B (100%)\n",
+        );
     });
 });

--- a/src/application/commands/file/download/progress.ts
+++ b/src/application/commands/file/download/progress.ts
@@ -1,5 +1,10 @@
 import type { CliExecutionContext } from "../../../contracts/cli.ts";
 
+import {
+    moveCursorUp,
+    rewriteTerminalLine,
+} from "../../../terminal-control.ts";
+
 export function createDownloadProgressReporter(
     writer: CliExecutionContext["stderr"],
     totalBytes: number | undefined,
@@ -72,7 +77,7 @@ export class DownloadProgressReporter {
         }
 
         this.lastRenderedLine = line;
-        this.writer.write(`\u001B[1A\r\u001B[2K${line}\n`);
+        this.writer.write(`${moveCursorUp(1)}${rewriteTerminalLine(line)}\n`);
     }
 }
 

--- a/src/application/commands/skills/progress-renderer.test.ts
+++ b/src/application/commands/skills/progress-renderer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { createTextBuffer } from "../../../../__tests__/helpers.ts";
+import { TerminalProgressRenderer } from "./progress-renderer.ts";
+
+describe("terminal progress renderer", () => {
+    test("uses shared terminal control sequences to redraw output and restore the cursor", () => {
+        const stdout = createTextBuffer({
+            isTTY: true,
+        });
+        const renderer = new TestTerminalProgressRenderer(stdout.writer);
+
+        renderer.setLines(["first", "second"]);
+        renderer.setLines(["next", "value"]);
+        renderer.stop();
+
+        expect(stdout.read()).toBe(
+            "\u001B[?25lfirst\nsecond\n"
+            + "\u001B[2A\r\u001B[2Knext\n\r\u001B[2Kvalue\n"
+            + "\u001B[?25h",
+        );
+    });
+});
+
+class TestTerminalProgressRenderer extends TerminalProgressRenderer {
+    private lines: string[] = [];
+
+    setLines(lines: readonly string[]): void {
+        this.lines = [...lines];
+        this.render();
+    }
+
+    protected renderLines(): string[] {
+        return this.lines;
+    }
+}

--- a/src/application/commands/skills/progress-renderer.ts
+++ b/src/application/commands/skills/progress-renderer.ts
@@ -1,5 +1,11 @@
 import type { Writer } from "../../contracts/cli.ts";
 
+import {
+    moveCursorUp,
+    rewriteTerminalLines,
+    terminalControl,
+} from "../../terminal-control.ts";
+
 const spinnerFrames = ["|", "/", "-", "\\"] as const;
 
 export abstract class TerminalProgressRenderer {
@@ -20,7 +26,7 @@ export abstract class TerminalProgressRenderer {
         }
 
         this.render();
-        this.writer.write("\u001B[?25h");
+        this.writer.write(terminalControl.showCursor);
     }
 
     protected get currentFrame(): string {
@@ -55,7 +61,7 @@ export abstract class TerminalProgressRenderer {
         }
 
         if (this.renderedLineCount === 0) {
-            this.writer.write("\u001B[?25l");
+            this.writer.write(terminalControl.hideCursor);
             this.writer.write(`${nextOutput}\n`);
             this.renderedLineCount = nextOutput.split("\n").length;
             this.renderedOutput = nextOutput;
@@ -63,12 +69,10 @@ export abstract class TerminalProgressRenderer {
         }
 
         const renderedLines = nextOutput.split("\n");
-        const rewrittenContent = renderedLines.map(
-            line => `\r\u001B[2K${line}`,
-        ).join("\n");
+        const rewrittenContent = rewriteTerminalLines(renderedLines);
 
         this.writer.write(
-            `\u001B[${this.renderedLineCount}A${rewrittenContent}\n`,
+            `${moveCursorUp(this.renderedLineCount)}${rewrittenContent}\n`,
         );
         this.renderedLineCount = renderedLines.length;
         this.renderedOutput = nextOutput;

--- a/src/application/terminal-control.test.ts
+++ b/src/application/terminal-control.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    moveCursorUp,
+    rewriteTerminalLine,
+    rewriteTerminalLines,
+} from "./terminal-control.ts";
+
+describe("terminal control", () => {
+    test("formats cursor-up sequences for non-negative line counts", () => {
+        expect(moveCursorUp(0)).toBe("");
+        expect(moveCursorUp(3)).toBe("\u001B[3A");
+        expect(() => moveCursorUp(-1)).toThrow(
+            "lineCount must be a non-negative integer.",
+        );
+        expect(() => moveCursorUp(1.5)).toThrow(
+            "lineCount must be a non-negative integer.",
+        );
+    });
+
+    test("rewrites one or more rendered lines with carriage return and clear line", () => {
+        expect(rewriteTerminalLine("Downloading")).toBe("\r\u001B[2KDownloading");
+        expect(rewriteTerminalLines(["first", "second"])).toBe(
+            "\r\u001B[2Kfirst\n\r\u001B[2Ksecond",
+        );
+    });
+});

--- a/src/application/terminal-control.ts
+++ b/src/application/terminal-control.ts
@@ -1,0 +1,28 @@
+const controlSequencePrefix = "\u001B[";
+const carriageReturn = "\r";
+const clearLine = `${controlSequencePrefix}2K`;
+
+export const terminalControl = {
+    hideCursor: `${controlSequencePrefix}?25l`,
+    showCursor: `${controlSequencePrefix}?25h`,
+} as const;
+
+export function moveCursorUp(lineCount: number): string {
+    if (!Number.isInteger(lineCount) || lineCount < 0) {
+        throw new TypeError("lineCount must be a non-negative integer.");
+    }
+
+    if (lineCount === 0) {
+        return "";
+    }
+
+    return `${controlSequencePrefix}${lineCount}A`;
+}
+
+export function rewriteTerminalLine(line: string): string {
+    return `${carriageReturn}${clearLine}${line}`;
+}
+
+export function rewriteTerminalLines(lines: readonly string[]): string {
+    return lines.map(rewriteTerminalLine).join("\n");
+}


### PR DESCRIPTION
Replace inline ANSI escape sequences scattered across progress-renderer and download progress with shared utility functions from a new terminal-control module.

Add tests for the shared module and existing progress reporters.