### PR TITLE
test: add unit tests and document test quality rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,58 @@ function writeLine(stream: Writer, msg: string) {
 }
 ```
 
+### DRY in Tests — Extract Repeated Setup
+
+When the same mock, stub, or setup object appears in multiple tests within the same file, extract it into a local factory function at the bottom of the file. Copy-pasted test setup is still copy-paste.
+
+```typescript
+// BAD - identical 15-line mock in every test
+test("case A", () => {
+    const translator = { t: (key) => { switch (key) { case "x": return "X"; /* 10 more */ } } };
+    // ...
+});
+test("case B", () => {
+    const translator = { t: (key) => { switch (key) { case "x": return "X"; /* same 10 */ } } };
+    // ...
+});
+
+// GOOD - one factory, all tests share it
+test("case A", () => {
+    const translator = createTranslatorStub();
+    // ...
+});
+test("case B", () => {
+    const translator = createTranslatorStub();
+    // ...
+});
+
+function createTranslatorStub() {
+    return { t: (key: string) => { switch (key) { case "x": return "X"; /* ... */ default: return key; } } };
+}
+```
+
+### `try/finally` over `try/catch/rethrow` for Cleanup
+
+When the only purpose of a `catch` block is to clean up and rethrow, use `finally` instead. It eliminates the duplicate cleanup call and removes dead code in the success path.
+
+```typescript
+// BAD - cleanup duplicated, catch block only rethrows
+try {
+    doWork();
+} catch (error) {
+    cleanup();
+    throw error;
+}
+cleanup();
+
+// GOOD
+try {
+    doWork();
+} finally {
+    cleanup();
+}
+```
+
 ## Testing
 
 - Any modification must include sufficient tests

--- a/CODE_QUALITY_RULES.md
+++ b/CODE_QUALITY_RULES.md
@@ -252,3 +252,55 @@ function writeLine(stream: Writer, msg: string) {
     stream.write(`${msg}\n`);
 }
 ```
+
+## DRY in Tests — Extract Repeated Setup
+
+When the same mock, stub, or setup object appears in multiple tests within the same file, extract it into a local factory function at the bottom of the file. Copy-pasted test setup is still copy-paste.
+
+```typescript
+// BAD - identical 15-line mock in every test
+test("case A", () => {
+    const translator = { t: (key) => { switch (key) { case "x": return "X"; /* 10 more */ } } };
+    // ...
+});
+test("case B", () => {
+    const translator = { t: (key) => { switch (key) { case "x": return "X"; /* same 10 */ } } };
+    // ...
+});
+
+// GOOD - one factory, all tests share it
+test("case A", () => {
+    const translator = createTranslatorStub();
+    // ...
+});
+test("case B", () => {
+    const translator = createTranslatorStub();
+    // ...
+});
+
+function createTranslatorStub() {
+    return { t: (key: string) => { switch (key) { case "x": return "X"; /* ... */ default: return key; } } };
+}
+```
+
+## `try/finally` over `try/catch/rethrow` for Cleanup
+
+When the only purpose of a `catch` block is to clean up and rethrow, use `finally` instead. It eliminates the duplicate cleanup call and removes dead code in the success path.
+
+```typescript
+// BAD - cleanup duplicated, catch block only rethrows
+try {
+    doWork();
+} catch (error) {
+    cleanup();
+    throw error;
+}
+cleanup();
+
+// GOOD
+try {
+    doWork();
+} finally {
+    cleanup();
+}
+```

--- a/src/adapters/store/file-store-utils.test.ts
+++ b/src/adapters/store/file-store-utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    isFileAlreadyExistsError,
+    isFileMissingError,
+} from "./file-store-utils.ts";
+
+describe("file store utils", () => {
+    test("detects missing-file errors by ENOENT", () => {
+        const missingError = new Error("missing") as NodeJS.ErrnoException;
+        missingError.code = "ENOENT";
+
+        expect(isFileMissingError(missingError)).toBe(true);
+        expect(isFileMissingError(new Error("other"))).toBe(false);
+        expect(isFileMissingError({
+            code: "ENOENT",
+        })).toBe(false);
+    });
+
+    test("detects existing-file errors by EEXIST", () => {
+        const existsError = new Error("exists") as NodeJS.ErrnoException;
+        existsError.code = "EEXIST";
+
+        expect(isFileAlreadyExistsError(existsError)).toBe(true);
+        expect(isFileAlreadyExistsError(new Error("other"))).toBe(false);
+    });
+});

--- a/src/application/commands/completion.test.ts
+++ b/src/application/commands/completion.test.ts
@@ -1,0 +1,64 @@
+import type {
+    CliCatalog,
+    CliExecutionContext,
+    SupportedShell,
+} from "../contracts/cli.ts";
+
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+
+import { createTextBuffer } from "../../../__tests__/helpers.ts";
+import { completionCommand } from "./completion.ts";
+
+describe("completion command", () => {
+    test("renders completion output for the requested shell", () => {
+        const stdout = createTextBuffer();
+        const catalog: CliCatalog = {
+            commands: [],
+            descriptionKey: "catalog.description",
+            globalOptions: [],
+            name: "oo",
+        };
+        let renderedShell: string | undefined;
+        let renderedCatalog: unknown;
+
+        completionCommand.handler!(
+            {
+                shell: "fish",
+            },
+            {
+                catalog,
+                completionRenderer: {
+                    render(shell: SupportedShell, currentCatalog: CliCatalog) {
+                        renderedShell = shell;
+                        renderedCatalog = currentCatalog;
+
+                        return "complete -c oo\n";
+                    },
+                },
+                stdout: stdout.writer,
+            } as unknown as CliExecutionContext,
+        );
+
+        expect(renderedShell).toBe("fish");
+        expect(renderedCatalog).toBe(catalog);
+        expect(stdout.read()).toBe("complete -c oo\n");
+    });
+
+    test("maps invalid shell input to a user-facing error", () => {
+        const error = completionCommand.mapInputError!(
+            new z.ZodError([]),
+            {
+                shell: "pwsh",
+            },
+        );
+
+        expect(error).toMatchObject({
+            exitCode: 2,
+            key: "errors.completion.invalidShell",
+            params: {
+                value: "pwsh",
+            },
+        });
+    });
+});

--- a/src/application/commands/file/cleanup.test.ts
+++ b/src/application/commands/file/cleanup.test.ts
@@ -1,0 +1,70 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+
+import { createTextBuffer } from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
+import { fileCleanupCommand } from "./cleanup.ts";
+
+describe("file cleanup command", () => {
+    test("writes a localized text summary when json output is not requested", () => {
+        const stdout = createTextBuffer();
+        let deletedAt: number | undefined;
+
+        fileCleanupCommand.handler!(
+            {},
+            {
+                fileUploadStore: {
+                    deleteExpired(now: number) {
+                        deletedAt = now;
+                        return 3;
+                    },
+                },
+                stdout: stdout.writer,
+                translator: createTranslator("en"),
+            } as unknown as CliExecutionContext,
+        );
+
+        expect(typeof deletedAt).toBe("number");
+        expect(stdout.read()).toBe("Deleted 3 expired upload records.\n");
+    });
+
+    test("writes json output when the format is json", () => {
+        const stdout = createTextBuffer();
+
+        fileCleanupCommand.handler!(
+            {
+                format: "json",
+            },
+            {
+                fileUploadStore: {
+                    deleteExpired() {
+                        return 2;
+                    },
+                },
+                stdout: stdout.writer,
+                translator: createTranslator("en"),
+            } as unknown as CliExecutionContext,
+        );
+
+        expect(stdout.read()).toBe("{\"deletedCount\":2}\n");
+    });
+
+    test("maps invalid format input to a user-facing error", () => {
+        const error = fileCleanupCommand.mapInputError!(
+            new z.ZodError([]),
+            {
+                format: "yaml",
+            },
+        );
+
+        expect(error).toMatchObject({
+            exitCode: 2,
+            key: "errors.file.invalidFormat",
+            params: {
+                value: "yaml",
+            },
+        });
+    });
+});

--- a/src/application/commands/skills/install-progress.test.ts
+++ b/src/application/commands/skills/install-progress.test.ts
@@ -13,26 +13,7 @@ describe("skills install progress reporter", () => {
         });
         const reporter = new SkillsInstallProgressReporter(
             stdout.writer,
-            {
-                t: (key) => {
-                    switch (key) {
-                        case "skills.install.progress.installing.start":
-                            return "Installing selected skills...";
-                        case "skills.install.progress.installing.complete":
-                            return "Installed";
-                        case "skills.install.progress.installing.failed":
-                            return "Installing selected skills failed";
-                        case "skills.install.progress.removing.start":
-                            return "Removing deselected skills...";
-                        case "skills.install.progress.removing.complete":
-                            return "Removed";
-                        case "skills.install.progress.removing.failed":
-                            return "Removing deselected skills failed";
-                        default:
-                            return key;
-                    }
-                },
-            },
+            createTranslatorStub(),
         );
 
         reporter.startInstalling(["audit", "frontend-design"]);
@@ -61,13 +42,71 @@ describe("skills install progress reporter", () => {
         reporter.completeRemoving(["clarify"]);
         reporter.stop();
 
-        const finalOutput = stripVTControlCharacters(stdout.read()).replaceAll(
-            "\r",
-            "",
-        );
+        const finalOutput = normalizeOutput(stdout.read());
 
         expect(finalOutput).toContain("  frontend-design\n\n◆ Removed");
         expect(finalOutput).toContain("◆ Removed");
         expect(finalOutput).toContain("  clarify");
     });
+
+    test("renders failure summaries for installing and removing steps", () => {
+        const stdout = createTextBuffer({
+            hasColors: true,
+            isTTY: true,
+        });
+        const reporter = new SkillsInstallProgressReporter(
+            stdout.writer,
+            createTranslatorStub(),
+        );
+
+        reporter.startInstalling(["audit"]);
+        const installingStartOutput = stdout.read();
+        reporter.failInstalling();
+        const installingFailureOutput = normalizeOutput(
+            stdout.read().slice(installingStartOutput.length),
+        );
+
+        reporter.startRemoving(["clarify"]);
+        const removingStartOutput = stdout.read();
+        reporter.failRemoving();
+        reporter.stop();
+        const removingFailureOutput = normalizeOutput(
+            stdout.read().slice(removingStartOutput.length),
+        );
+
+        const output = normalizeOutput(stdout.read());
+
+        expect(installingFailureOutput).toContain("◆ Installing selected skills failed");
+        expect(installingFailureOutput).not.toContain("  audit");
+        expect(removingFailureOutput).toContain("◆ Removing deselected skills failed");
+        expect(removingFailureOutput).not.toContain("  clarify");
+        expect(output).toContain("◆ Installing selected skills failed\n\n◆ Removing deselected skills failed");
+    });
 });
+
+function normalizeOutput(text: string): string {
+    return stripVTControlCharacters(text).replaceAll("\r", "");
+}
+
+function createTranslatorStub() {
+    return {
+        t: (key: string) => {
+            switch (key) {
+                case "skills.install.progress.installing.start":
+                    return "Installing selected skills...";
+                case "skills.install.progress.installing.complete":
+                    return "Installed";
+                case "skills.install.progress.installing.failed":
+                    return "Installing selected skills failed";
+                case "skills.install.progress.removing.start":
+                    return "Removing deselected skills...";
+                case "skills.install.progress.removing.complete":
+                    return "Removed";
+                case "skills.install.progress.removing.failed":
+                    return "Removing deselected skills failed";
+                default:
+                    return key;
+            }
+        },
+    };
+}

--- a/src/application/commands/skills/progress-renderer.test.ts
+++ b/src/application/commands/skills/progress-renderer.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { createTextBuffer } from "../../../../__tests__/helpers.ts";
+import {
+    createTextBuffer,
+    waitForOutputText,
+} from "../../../../__tests__/helpers.ts";
 import { TerminalProgressRenderer } from "./progress-renderer.ts";
 
 describe("terminal progress renderer", () => {
@@ -20,6 +23,28 @@ describe("terminal progress renderer", () => {
             + "\u001B[?25h",
         );
     });
+
+    test("updates spinner output when the interval ticks", async () => {
+        const stdout = createTextBuffer({
+            isTTY: true,
+        });
+        const renderer = new SpinnerTerminalProgressRenderer(stdout.writer);
+
+        try {
+            renderer.start("Loading selected skills...");
+            renderer.rerender();
+
+            const initialOutput = stdout.read();
+
+            expect(initialOutput).toContain("| Loading selected skills...");
+            expect(stdout.read()).toBe(initialOutput);
+
+            await waitForOutputText(stdout, "/ Loading selected skills...");
+        }
+        finally {
+            renderer.stop();
+        }
+    });
 });
 
 class TestTerminalProgressRenderer extends TerminalProgressRenderer {
@@ -27,6 +52,24 @@ class TestTerminalProgressRenderer extends TerminalProgressRenderer {
 
     setLines(lines: readonly string[]): void {
         this.lines = [...lines];
+        this.render();
+    }
+
+    protected renderLines(): string[] {
+        return this.lines;
+    }
+}
+
+class SpinnerTerminalProgressRenderer extends TerminalProgressRenderer {
+    private lines: string[] = [];
+
+    start(message: string): void {
+        this.startSpinner(() => {
+            this.lines = [`${this.currentFrame} ${message}`];
+        });
+    }
+
+    rerender(): void {
         this.render();
     }
 


### PR DESCRIPTION
- Add tests for file-store-utils, completion command, and file cleanup command
- Refactor skills install-progress tests: extract shared translator stub and normalizeOutput helper to reduce duplication
- Add failure summary and spinner interval tick test cases
- Document "DRY in Tests" and "try/finally over try/catch/rethrow" rules in AGENTS.md and CODE_QUALITY_RULES.md