### PR TITLE
refactor(skills): filter search JSON output to stable CLI fields only

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -140,6 +140,8 @@ Search published skills with free-form text.
   repeated `keywords` query parameters after trimming empty entries.
 - Options: `--format=json` and `--json` print a JSON array of matching skill
   entries.
+- Output: JSON entries include only the stable CLI fields `description`,
+  `name`, `packageName`, `packageVersion`, and `skillDisplayName` when present.
 - Output: text output prints one block per skill with its title or name,
   optional description, and source package reference when available.
 - Notes: every invocation requests at most `5` results.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -128,6 +128,8 @@
 - 选项：`--keywords <keywords>` 接收逗号分隔的关键词列表，去掉空项后以
   重复的 `keywords` 查询参数发送。
 - 选项：`--format=json` 和 `--json` 会输出匹配 skill 条目的 JSON 数组。
+- 输出：JSON 条目只包含稳定的 CLI 字段：`description`、`name`、
+  `packageName`、`packageVersion`、`skillDisplayName`；不会暴露服务端专有字段。
 - 输出：文本输出会为每个 skill 打印一个块，包含标题或名称、可选描述，以及
   在可用时显示来源包标识。
 - 说明：每次调用最多请求 `5` 条结果。

--- a/src/application/commands/skills/__snapshots__/search.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/search.cli.test.ts.snap
@@ -18,7 +18,18 @@ exports[`skills search CLI supports skills find alias with json output and keywo
   "exitCode": 0,
   "stderr": "",
   "stdout": 
-"[{"description":"Generate text using AI models","icon":"https://example.com/text-generation.png","name":"text-generation","packageName":"@oomol/ai-tools","packageVersion":"1.0.0","title":"Text Generation"}]
+"[{"description":"Generate text using AI models","name":"text-generation","packageName":"@oomol/ai-tools","packageVersion":"1.0.0","skillDisplayName":"Text Generation"}]
+"
+,
+}
+`;
+
+exports[`skills search CLI supports skills search with the --json alias 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"[{"description":"Generate text using AI models","name":"text-generation","packageName":"@oomol/ai-tools","packageVersion":"1.0.0","skillDisplayName":"Text Generation"}]
 "
 ,
 }

--- a/src/application/commands/skills/search.cli.test.ts
+++ b/src/application/commands/skills/search.cli.test.ts
@@ -8,8 +8,23 @@ import {
 } from "../../../../__tests__/helpers.ts";
 import { createTerminalColors } from "../../terminal-colors.ts";
 
-const skillSearchTitleColor = "#59F78D";
+const skillSearchDisplayNameColor = "#59F78D";
 const skillSearchPackageColor = "#CAA8FA";
+
+const fullServerResponse = {
+    data: [
+        {
+            description: "Generate text using AI models",
+            icon: "https://example.com/text-generation.png",
+            name: "text-generation",
+            owner: "0195f082-f87a-7772-80a9-9a2e4245d4d5",
+            packageName: "@oomol/ai-tools",
+            packageVersion: "1.0.0",
+            title: "Text Generation",
+            when: "Use this when the user asks for text generation.",
+        },
+    ],
+};
 
 describe("skills search CLI", () => {
     test("supports skills search command with text output", async () => {
@@ -25,20 +40,7 @@ describe("skills search CLI", () => {
                     fetcher: async (input, init) => {
                         requests.push(toRequest(input, init));
 
-                        return new Response(JSON.stringify({
-                            data: [
-                                {
-                                    description: "Generate text using AI models",
-                                    icon: "https://example.com/text-generation.png",
-                                    name: "text-generation",
-                                    owner: "0195f082-f87a-7772-80a9-9a2e4245d4d5",
-                                    packageName: "@oomol/ai-tools",
-                                    packageVersion: "1.0.0",
-                                    title: "Text Generation",
-                                    when: "Use this when the user asks for text generation.",
-                                },
-                            ],
-                        }));
+                        return new Response(JSON.stringify(fullServerResponse));
                     },
                 },
             );
@@ -100,14 +102,15 @@ describe("skills search CLI", () => {
             expect(JSON.parse(result.stdout)).toEqual([
                 {
                     description: "Generate text using AI models",
-                    icon: "https://example.com/text-generation.png",
                     name: "text-generation",
                     packageName: "@oomol/ai-tools",
                     packageVersion: "1.0.0",
-                    title: "Text Generation",
+                    skillDisplayName: "Text Generation",
                 },
             ]);
+            expect(result.stdout).not.toContain("\"icon\"");
             expect(result.stdout).not.toContain("\"owner\"");
+            expect(result.stdout).not.toContain("\"title\"");
             expect(result.stdout).not.toContain("\"when\"");
             expect(requests).toHaveLength(1);
             expect(new URL(requests[0]!.url).searchParams.get("text")).toBe(
@@ -116,6 +119,51 @@ describe("skills search CLI", () => {
             expect(
                 new URL(requests[0]!.url).searchParams.getAll("keywords"),
             ).toEqual(["bar", "baz"]);
+            expect(new URL(requests[0]!.url).searchParams.get("size")).toBe("5");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports skills search with the --json alias", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["skills", "search", "text generation", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify(fullServerResponse));
+                    },
+                },
+            );
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(JSON.parse(result.stdout)).toEqual([
+                {
+                    description: "Generate text using AI models",
+                    name: "text-generation",
+                    packageName: "@oomol/ai-tools",
+                    packageVersion: "1.0.0",
+                    skillDisplayName: "Text Generation",
+                },
+            ]);
+            expect(result.stdout).not.toContain("\"icon\"");
+            expect(result.stdout).not.toContain("\"owner\"");
+            expect(result.stdout).not.toContain("\"title\"");
+            expect(result.stdout).not.toContain("\"when\"");
+            expect(requests).toHaveLength(1);
+            expect(new URL(requests[0]!.url).searchParams.get("text")).toBe(
+                "text generation",
+            );
             expect(new URL(requests[0]!.url).searchParams.get("size")).toBe("5");
         }
         finally {
@@ -154,7 +202,7 @@ describe("skills search CLI", () => {
                 stripAnsi: true,
             })).toMatchSnapshot();
             expect(result.stdout).toContain(
-                `${colors.hex(skillSearchTitleColor)("Text Generation")} (text-generation)`,
+                `${colors.hex(skillSearchDisplayNameColor)("Text Generation")} (text-generation)`,
             );
             expect(result.stdout).toContain(
                 `Package: ${colors.hex(skillSearchPackageColor)("@oomol/ai-tools@1.0.0")}`,

--- a/src/application/commands/skills/search.test.ts
+++ b/src/application/commands/skills/search.test.ts
@@ -32,6 +32,20 @@ const activeAuthFile: AuthFile = {
         },
     ],
 };
+const fullServerResponse = {
+    data: [
+        {
+            description: "Generate text using AI models",
+            icon: "https://example.com/text-generation.png",
+            name: "text-generation",
+            owner: "0195f082-f87a-7772-80a9-9a2e4245d4d5",
+            packageName: "@oomol/ai-tools",
+            packageVersion: "1.0.0",
+            title: "Text Generation",
+            when: "Use this when the user asks for text generation.",
+        },
+    ],
+};
 const emptyCatalog: CliCatalog = {
     name: "oo",
     descriptionKey: "catalog.description",
@@ -103,6 +117,24 @@ describe("skillsSearchCommand", () => {
         );
 
         expect(context.stdoutBuffer.read()).toBe("No matching skills were found.\n");
+    });
+
+    test("writes json output without service-only fields", async () => {
+        const context = createSearchContext({
+            fetcher: async () => new Response(JSON.stringify(fullServerResponse)),
+        });
+
+        await searchHandler(
+            {
+                text: "text generation",
+                format: "json",
+            },
+            context,
+        );
+
+        expect(context.stdoutBuffer.read()).toBe(
+            "[{\"description\":\"Generate text using AI models\",\"name\":\"text-generation\",\"packageName\":\"@oomol/ai-tools\",\"packageVersion\":\"1.0.0\",\"skillDisplayName\":\"Text Generation\"}]\n",
+        );
     });
 
     test("rejects unsupported skills search responses", async () => {

--- a/src/application/commands/skills/search.ts
+++ b/src/application/commands/skills/search.ts
@@ -10,23 +10,30 @@ import { requestText } from "../shared/request.ts";
 
 const searchFormatValues = ["json"] as const;
 const skillSearchResultLimit = 5;
-const skillSearchTitleColor = "#59F78D";
+const skillSearchDisplayNameColor = "#59F78D";
 const skillSearchPackageColor = "#CAA8FA";
 
 const skillSearchItemSchema = z.object({
     description: z.string().optional().default(""),
-    icon: z.string().optional().default(""),
     name: z.string().optional().default(""),
     packageName: z.string().optional().default(""),
     packageVersion: z.string().optional().default(""),
     title: z.string().optional().default(""),
-});
+}).transform(item => ({
+    description: item.description,
+    name: item.name,
+    packageName: item.packageName,
+    packageVersion: item.packageVersion,
+    skillDisplayName: item.title,
+}));
 
 const skillSearchResponseSchema = z.object({
     data: z.array(skillSearchItemSchema).optional().default([]),
-}).passthrough();
+});
 
+type SkillSearchItem = z.output<typeof skillSearchItemSchema>;
 type SkillSearchResponse = z.output<typeof skillSearchResponseSchema>;
+
 type SkillSearchTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
 
 interface SkillsSearchInput {
@@ -203,7 +210,7 @@ function formatSkillsSearchResponseAsText(
 }
 
 function formatSkillsSearchItem(
-    item: SkillSearchResponse["data"][number],
+    item: SkillSearchItem,
     context: SkillSearchTextContext,
     colors: TerminalColors,
 ): string {
@@ -225,29 +232,31 @@ function formatSkillsSearchItem(
 }
 
 function readSkillsSearchItemLabel(
-    item: SkillSearchResponse["data"][number],
+    item: SkillSearchItem,
     context: SkillSearchTextContext,
     colors: TerminalColors,
 ): string {
-    if (item.title !== "") {
-        const title = colors.hex(skillSearchTitleColor)(item.title);
+    if (item.skillDisplayName !== "") {
+        const skillDisplayName = colors.hex(skillSearchDisplayNameColor)(
+            item.skillDisplayName,
+        );
 
-        if (item.name !== "" && item.title !== item.name) {
-            return `${title} (${item.name})`;
+        if (item.name !== "" && item.skillDisplayName !== item.name) {
+            return `${skillDisplayName} (${item.name})`;
         }
 
-        return title;
+        return skillDisplayName;
     }
 
     if (item.name !== "") {
-        return colors.hex(skillSearchTitleColor)(item.name);
+        return colors.hex(skillSearchDisplayNameColor)(item.name);
     }
 
     return context.translator.t("skills.search.text.unnamedSkill");
 }
 
 function readSkillsSearchPackageLabel(
-    item: SkillSearchResponse["data"][number],
+    item: SkillSearchItem,
 ): string {
     if (item.packageName === "") {
         return "";


### PR DESCRIPTION
Transform the skill search schema to expose only stable CLI fields (description, name, packageName, packageVersion, skillDisplayName) and drop server-internal fields (icon, owner, when).

- Rename `title` to `skillDisplayName` in JSON output via zod transform
- Remove `.passthrough()` to prevent leaking unknown server fields
- Add test coverage for `--json` alias and field filtering
- Update documentation to describe the stable output contract