### PR TITLE
refactor(skills): use metadata file as the sole managed ownership signal

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -123,7 +123,8 @@ Check whether a newer CLI release is available.
 List oo-managed skills from the local Codex skills directory.
 
 - Ownership rule: the command scans `${CODEX_HOME:-~/.codex}/skills` and keeps
-  only child directories that contain `.oo-metadata.json`.
+  only child directories whose `.oo-metadata.json` can be parsed and contains
+  a non-empty `version`.
 - Output: text output prints a summary line and one block per skill.
 - Ordering: `oo` is always listed first when present; the remaining skills are
   ordered by skill name.
@@ -235,9 +236,10 @@ directory.
   selecting one means it will be overwritten.
 - Notes: the command exits with an error when the Codex home directory does
   not exist, which indicates Codex is not installed on the current machine.
-- Notes: an existing `oo/agents/openai.yaml` is considered managed by
-  `oo` only when it contains the string `OOMOL`. Otherwise `oo` treats it as a
-  different skill and will not overwrite it.
+- Notes: an existing bundled `oo` installation is considered managed by `oo`
+  only when its `.oo-metadata.json` file can be parsed and contains a
+  non-empty `version`. Otherwise `oo` treats it as a different skill and will
+  not overwrite it.
 - Notes: on the first `oo` run, when there is no existing config, auth, or log
   data yet, `oo` silently installs the bundled managed skill automatically if
   the Codex home directory already exists.
@@ -272,14 +274,15 @@ Remove one oo-managed skill from the local Codex skills directory.
 - Alias: `oo skills remove [skill]`.
 - Arguments: `[skill]` defaults to `oo` when omitted.
 - Ownership rule: the target skill is removable only when
-  `${CODEX_HOME:-~/.codex}/skills/<skill>` contains `.oo-metadata.json`.
+  `${CODEX_HOME:-~/.codex}/skills/<skill>` has a `.oo-metadata.json` file that
+  can be parsed and contains a non-empty `version`.
 - Canonical directory removed: `<config-dir>/skills/<skill>`, where
   `<config-dir>` is the directory that contains `settings.toml`.
 - Target directory removed: `${CODEX_HOME:-~/.codex}/skills/<skill>`.
 - Path rule: `[skill]` must resolve to child directories under those local
   `skills` roots. Names that escape those roots are rejected.
-- Notes: when the target directory is missing, or it exists without
-  `.oo-metadata.json`, the command exits with an error and does not remove
+- Notes: when the target directory is missing, or its `.oo-metadata.json` file
+  is missing or invalid, the command exits with an error and does not remove
   anything.
 
 ## Logs

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -113,7 +113,7 @@
 列出本地 Codex skills 目录中由 oo 管理的 skill。
 
 - 所有权规则：命令会扫描 `${CODEX_HOME:-~/.codex}/skills`，只保留包含
-  `.oo-metadata.json` 的子目录。
+  可解析 `.oo-metadata.json` 且其中包含非空 `version` 的子目录。
 - 输出：文本输出会先打印摘要行，再为每个 skill 打印一个块。
 - 排序：如果存在 `oo`，它总是排在最前面；其余 skill 按名称排序。
 - 输出：每个 skill 块会显示 skill 名称、来源 package 或内置标记、记录的版
@@ -205,8 +205,9 @@
   只要用户仍然选择该项，就会执行覆盖。
 - 说明：当 Codex 根目录不存在时，命令会直接报错退出，这表示当前机器上没有
   安装 Codex。
-- 说明：只有当 `oo/agents/openai.yaml` 中包含 `OOMOL` 字符串时，`oo`
-  才会认为这是自己管理的内置 skill；否则会视为其他 skill，并拒绝覆盖。
+- 说明：只有当 bundled `oo` 的 `.oo-metadata.json` 可以被解析，且其中包
+  含非空的 `version` 时，`oo` 才会认为这是自己管理的内置 skill；否则会视
+  为其他 skill，并拒绝覆盖。
 - 说明：如果这是 `oo` 的首次运行，且当前还没有已有的 config、auth、log
   数据，那么只要 Codex 根目录已经存在，`oo` 就会静默自动安装这个 bundled
   受管 skill。
@@ -237,14 +238,14 @@
 - 别名：`oo skills remove [skill]`。
 - 参数：省略 `[skill]` 时，默认使用 `oo`。
 - 所有权规则：只有当
-  `${CODEX_HOME:-~/.codex}/skills/<skill>` 中存在 `.oo-metadata.json`
-  时，才允许移除该 skill。
+  `${CODEX_HOME:-~/.codex}/skills/<skill>` 中的 `.oo-metadata.json` 可
+  以被解析，且其中包含非空 `version` 时，才允许移除该 skill。
 - 会同时移除 canonical 目录：`<config-dir>/skills/<skill>`，其中
   `<config-dir>` 是 `settings.toml` 所在目录。
 - 会同时移除目标目录：`${CODEX_HOME:-~/.codex}/skills/<skill>`。
 - 路径规则：`[skill]` 解析后必须仍然落在这些本地 `skills` 根目录的子目录中。
   任何会逃出这些根目录的名称都会被拒绝。
-- 说明：如果目标目录不存在，或者目录存在但没有 `.oo-metadata.json`，
+- 说明：如果目标目录不存在，或者其 `.oo-metadata.json` 缺失或无效，
   命令会直接报错，不会删除任何内容。
 
 ## 日志

--- a/src/application/commands/skills/bundled-skill-model.test.ts
+++ b/src/application/commands/skills/bundled-skill-model.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, test } from "bun:test";
 import {
     canUninstallManagedBundledSkillInstallation,
     isBundledSkillInstallationCurrentState,
-    isManagedBundledSkillOwnershipContent,
     parseBundledSkillMetadataContent,
     readImplicitInvocationValue,
     renderBundledSkillFileContent,
@@ -75,11 +74,6 @@ describe("bundled skill model", () => {
         expect(renderSkillMetadataJson({ version: "1.2.3" })).toBe(
             "{\n  \"version\": \"1.2.3\"\n}\n",
         );
-    });
-
-    test("detects managed ownership content using the OOMOL marker", () => {
-        expect(isManagedBundledSkillOwnershipContent("# OOMOL\n")).toBeTrue();
-        expect(isManagedBundledSkillOwnershipContent("custom skill\n")).toBeFalse();
     });
 
     test("throws when the ownership policy file does not define implicit invocation", () => {

--- a/src/application/commands/skills/bundled-skill-model.ts
+++ b/src/application/commands/skills/bundled-skill-model.ts
@@ -4,7 +4,6 @@ import type { BundledSkillName } from "./embedded-assets.ts";
 import { getOoSkillImplicitInvocation } from "../../schemas/settings.ts";
 import { bundledSkillOwnershipFileRelativePath } from "./bundled-skill-paths.ts";
 
-const bundledSkillOwnershipMarker = "OOMOL";
 const bundledSkillImplicitInvocationKey = "allow_implicit_invocation";
 
 export interface BundledSkillMetadata {
@@ -80,10 +79,6 @@ export function renderBundledSkillFileContent(
         content,
         resolveBundledSkillImplicitInvocation(skillName, settings),
     );
-}
-
-export function isManagedBundledSkillOwnershipContent(content: string): boolean {
-    return content.includes(bundledSkillOwnershipMarker);
 }
 
 export function readImplicitInvocationValue(

--- a/src/application/commands/skills/bundled-skill-observation.test.ts
+++ b/src/application/commands/skills/bundled-skill-observation.test.ts
@@ -71,9 +71,10 @@ describe("bundled skill observation", () => {
         }
     });
 
-    test("reads implicit invocation and managed ownership from the ownership file", async () => {
+    test("reads implicit invocation from the ownership file and managed state from metadata", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
         const skillDirectoryPath = join(rootDirectory, "skills", "oo");
+        const metadataFilePath = join(skillDirectoryPath, ".oo-metadata.json");
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
 
         try {
@@ -93,6 +94,14 @@ describe("bundled skill observation", () => {
             );
 
             expect(await readInstalledBundledSkillImplicitInvocation(skillDirectoryPath)).toBeFalse();
+            expect(await isManagedBundledSkillInstallation(skillDirectoryPath)).toBeFalse();
+
+            await Bun.write(metadataFilePath, "not json");
+            expect(await isManagedBundledSkillInstallation(skillDirectoryPath)).toBeFalse();
+
+            await writeInstalledBundledSkillMetadata(skillDirectoryPath, {
+                version: "1.2.3",
+            });
             expect(await isManagedBundledSkillInstallation(skillDirectoryPath)).toBeTrue();
 
             await Bun.write(
@@ -106,7 +115,7 @@ describe("bundled skill observation", () => {
             );
 
             expect(await readInstalledBundledSkillImplicitInvocation(skillDirectoryPath)).toBeUndefined();
-            expect(await isManagedBundledSkillInstallation(skillDirectoryPath)).toBeFalse();
+            expect(await isManagedBundledSkillInstallation(skillDirectoryPath)).toBeTrue();
         }
         finally {
             await rm(rootDirectory, { force: true, recursive: true });
@@ -120,7 +129,10 @@ describe("bundled skill observation", () => {
 
         try {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
-            await Bun.write(ownershipFilePath, "# OOMOL\n");
+            await Bun.write(
+                ownershipFilePath,
+                "policy:\n  allow_implicit_invocation: true\n",
+            );
 
             expect(
                 await isBundledSkillInstallationCurrent(

--- a/src/application/commands/skills/bundled-skill-observation.ts
+++ b/src/application/commands/skills/bundled-skill-observation.ts
@@ -7,7 +7,6 @@ import { CliUserError } from "../../contracts/cli.ts";
 import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
 import {
     isBundledSkillInstallationCurrentState,
-    isManagedBundledSkillOwnershipContent,
     parseBundledSkillMetadataContent,
     readImplicitInvocationValue,
     renderSkillMetadataJson,
@@ -82,21 +81,7 @@ export async function readInstalledBundledSkillImplicitInvocation(
 export async function isManagedBundledSkillInstallation(
     skillDirectoryPath: string,
 ): Promise<boolean> {
-    try {
-        const content = await readFile(
-            join(skillDirectoryPath, bundledSkillOwnershipFileRelativePath),
-            "utf8",
-        );
-
-        return isManagedBundledSkillOwnershipContent(content);
-    }
-    catch (error) {
-        if (isNodeNotFoundError(error)) {
-            return false;
-        }
-
-        throw error;
-    }
+    return (await readInstalledBundledSkillMetadata(skillDirectoryPath)) !== undefined;
 }
 
 export async function readInstalledBundledSkillVersion(
@@ -142,15 +127,10 @@ export async function isBundledSkillInstallationCurrent(
     skillDirectoryPath: string,
     version: string,
 ): Promise<boolean> {
-    const managedInstallation = await isManagedBundledSkillInstallation(
-        skillDirectoryPath,
-    );
-    const hasMetadataFile = managedInstallation
-        ? await fileExists(resolveBundledSkillMetadataFilePath(skillDirectoryPath))
-        : false;
-    const installedVersion = hasMetadataFile
-        ? await readInstalledBundledSkillVersion(skillDirectoryPath)
-        : undefined;
+    const metadata = await readInstalledBundledSkillMetadata(skillDirectoryPath);
+    const managedInstallation = metadata !== undefined;
+    const hasMetadataFile = managedInstallation;
+    const installedVersion = metadata?.version;
     let hasAllBundledFiles = false;
 
     if (installedVersion === version) {

--- a/src/application/commands/skills/config/set.test.ts
+++ b/src/application/commands/skills/config/set.test.ts
@@ -6,7 +6,11 @@ import { describe, expect, test } from "bun:test";
 import { createCliSandbox } from "../../../../../__tests__/helpers.ts";
 import { resolveStorePaths } from "../../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../../config/app-config.ts";
-import { resolveCodexHomeDirectory } from "../bundled-skill-paths.ts";
+import { renderSkillMetadataJson } from "../bundled-skill-model.ts";
+import {
+    resolveBundledSkillMetadataFilePath,
+    resolveCodexHomeDirectory,
+} from "../bundled-skill-paths.ts";
 import { getBundledSkillFiles } from "../embedded-assets.ts";
 
 describe("skills config set command", () => {
@@ -48,6 +52,55 @@ describe("skills config set command", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(
+                metadataFilePath,
+                renderSkillMetadataJson({
+                    version: "9.9.9",
+                }),
+            );
+            await Bun.write(
+                ownershipFilePath,
+                await Bun.file(
+                    getBundledSkillFiles("oo").find(file => file.relativePath === "agents/openai.yaml")!.sourcePath,
+                ).text(),
+            );
+
+            const result = await sandbox.run([
+                "skills",
+                "config",
+                "set",
+                "oo",
+                "allow-implicit-invocation",
+                "false",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: false",
+            );
+            expect(await readFile(
+                resolveStorePaths({
+                    appName: APP_NAME,
+                    env: sandbox.env,
+                    platform: process.platform,
+                }).settingsFilePath,
+                "utf8",
+            )).toContain("implicit_invocation = false");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not update an installed skill without managed metadata", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
 
         try {
@@ -70,7 +123,7 @@ describe("skills config set command", () => {
 
             expect(result.exitCode).toBe(0);
             expect(await readFile(ownershipFilePath, "utf8")).toContain(
-                "allow_implicit_invocation: false",
+                "allow_implicit_invocation: true",
             );
             expect(await readFile(
                 resolveStorePaths({

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -685,16 +685,13 @@ describe("skills commands", () => {
         }
     });
 
-    test("rebuilds managed skills that do not have the metadata file yet", async () => {
+    test("does not synchronize bundled skills that do not have managed metadata", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
         const managedSkillPath = join(skillDirectoryPath, "SKILL.md");
         const managedOwnershipPath = join(skillDirectoryPath, "agents", "openai.yaml");
-        const expectedSkillContent = await Bun.file(
-            getBundledSkillFiles("oo")[0]!.sourcePath,
-        ).text();
         const expectedOwnershipContent = await Bun.file(
             getBundledSkillFiles("oo").find(file => file.relativePath === "agents/openai.yaml")!.sourcePath,
         ).text();
@@ -710,11 +707,12 @@ describe("skills commands", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
-            expect(await readFile(metadataFilePath, "utf8")).toBe(
-                formatBundledSkillMetadataContent("9.9.9"),
-            );
-            expect(await readFile(managedSkillPath, "utf8")).toBe(
-                expectedSkillContent,
+            await expect(stat(metadataFilePath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            expect(await readFile(managedSkillPath, "utf8")).toBe("stale\n");
+            expect(await readFile(managedOwnershipPath, "utf8")).toBe(
+                expectedOwnershipContent,
             );
         }
         finally {
@@ -784,12 +782,19 @@ describe("skills commands", () => {
         }
     });
 
-    test("does not synchronize a same-name skill that is not managed by OOMOL", async () => {
+    test("synchronizes a same-name bundled skill when it has managed metadata", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const managedSkillPath = join(skillDirectoryPath, "SKILL.md");
+        const expectedOwnershipContent = await Bun.file(
+            getBundledSkillFiles("oo").find(file => file.relativePath === "agents/openai.yaml")!.sourcePath,
+        ).text();
+        const expectedSkillContent = await Bun.file(
+            getBundledSkillFiles("oo")[0]!.sourcePath,
+        ).text();
 
         try {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
@@ -806,6 +811,7 @@ describe("skills commands", () => {
                     "",
                 ].join("\n"),
             );
+            await Bun.write(managedSkillPath, "stale\n");
 
             const result = await sandbox.run(["--help"], {
                 version: "9.9.9",
@@ -813,9 +819,14 @@ describe("skills commands", () => {
 
             expect(result.exitCode).toBe(0);
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                formatBundledSkillMetadataContent("0.0.1"),
+                formatBundledSkillMetadataContent("9.9.9"),
             );
-            expect(await readFile(ownershipFilePath, "utf8")).not.toContain("OOMOL");
+            expect(await readFile(ownershipFilePath, "utf8")).toBe(
+                expectedOwnershipContent,
+            );
+            expect(await readFile(managedSkillPath, "utf8")).toBe(
+                expectedSkillContent,
+            );
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -23,10 +23,10 @@ import {
 } from "./bundled-skill-model.ts";
 import {
     directoryExists,
-    fileExists,
     isBundledSkillInstallationCurrent,
     isManagedBundledSkillInstallation,
     readInstalledBundledSkillImplicitInvocation,
+    readInstalledBundledSkillMetadata,
     readInstalledBundledSkillVersion,
     requireCodexHomeDirectory,
     writeInstalledBundledSkillMetadata,
@@ -34,7 +34,6 @@ import {
 import {
     resolveBundledSkillCanonicalDirectoryPath,
     resolveBundledSkillDirectoryPath,
-    resolveBundledSkillMetadataFilePath,
     resolveCodexHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import {
@@ -340,13 +339,13 @@ export async function uninstallBundledSkill(
         skillName,
     );
     const installedSkillDirectoryExists = await directoryExists(skillDirectoryPath);
-    const installedSkillMetadataExists = installedSkillDirectoryExists
-        ? await fileExists(resolveBundledSkillMetadataFilePath(skillDirectoryPath))
-        : false;
+    const installedSkillMetadata = installedSkillDirectoryExists
+        ? await readInstalledBundledSkillMetadata(skillDirectoryPath)
+        : undefined;
 
     if (!canUninstallManagedBundledSkillInstallation({
         installedDirectoryExists: installedSkillDirectoryExists,
-        installedDirectoryManaged: installedSkillMetadataExists,
+        installedDirectoryManaged: installedSkillMetadata !== undefined,
     })) {
         context.logger.warn(
             {
@@ -362,7 +361,9 @@ export async function uninstallBundledSkill(
         });
     }
 
-    const previousVersion = await readInstalledBundledSkillVersion(skillDirectoryPath);
+    const previousVersion
+        = installedSkillMetadata?.version
+            ?? await readInstalledBundledSkillVersion(skillDirectoryPath);
 
     await Promise.all([
         removePath(skillDirectoryPath),


### PR DESCRIPTION
Replace the OOMOL marker string check in the ownership YAML file with validation of .oo-metadata.json as the single source of truth for managed skill detection. A bundled skill is now considered managed only when its metadata file can be parsed and contains a non-empty version.

This eliminates the indirect ownership marker, simplifies isBundledSkillInstallationCurrent by reading metadata once instead of multiple file checks, and aligns the uninstall path to reuse the already-read metadata for version retrieval.