### PR TITLE
refactor(skills): extract shared metadata parsing into dedicated module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,6 +304,30 @@ function createTranslatorStub() {
 }
 ```
 
+## Complete the Extraction — Propagate to Tests
+
+When extracting a shared utility from production code, also replace any test helpers or inline expressions that duplicate the same logic. An extraction is incomplete if test files still contain local functions or raw inline code doing the same thing under a different name.
+
+```typescript
+// BAD - shared utility extracted, but tests still duplicate it
+// skill-metadata.ts (shared module)
+export function renderSkillMetadataJson(metadata: object): string {
+    return `${JSON.stringify(metadata, null, 2)}\n`;
+}
+
+// index.test.ts (local helper duplicates the shared utility)
+function formatBundledSkillMetadataContent(version: string): string {
+    return `${JSON.stringify({ version }, null, 2)}\n`;
+}
+
+// update.test.ts (inline expression duplicates the shared utility)
+await Bun.write(path, `${JSON.stringify({ version: "1.0.0" }, null, 2)}\n`);
+
+// GOOD - tests import the shared utility directly
+import { renderSkillMetadataJson } from "./skill-metadata.ts";
+await Bun.write(path, renderSkillMetadataJson({ version: "1.0.0" }));
+```
+
 ### `try/finally` over `try/catch/rethrow` for Cleanup
 
 When the only purpose of a `catch` block is to clean up and rethrow, use `finally` instead. It eliminates the duplicate cleanup call and removes dead code in the success path.

--- a/CODE_QUALITY_RULES.md
+++ b/CODE_QUALITY_RULES.md
@@ -283,6 +283,30 @@ function createTranslatorStub() {
 }
 ```
 
+## Complete the Extraction — Propagate to Tests
+
+When extracting a shared utility from production code, also replace any test helpers or inline expressions that duplicate the same logic. An extraction is incomplete if test files still contain local functions or raw inline code doing the same thing under a different name.
+
+```typescript
+// BAD - shared utility extracted, but tests still duplicate it
+// skill-metadata.ts (shared module)
+export function renderSkillMetadataJson(metadata: object): string {
+    return `${JSON.stringify(metadata, null, 2)}\n`;
+}
+
+// index.test.ts (local helper duplicates the shared utility)
+function formatBundledSkillMetadataContent(version: string): string {
+    return `${JSON.stringify({ version }, null, 2)}\n`;
+}
+
+// update.test.ts (inline expression duplicates the shared utility)
+await Bun.write(path, `${JSON.stringify({ version: "1.0.0" }, null, 2)}\n`);
+
+// GOOD - tests import the shared utility directly
+import { renderSkillMetadataJson } from "./skill-metadata.ts";
+await Bun.write(path, renderSkillMetadataJson({ version: "1.0.0" }));
+```
+
 ## `try/finally` over `try/catch/rethrow` for Cleanup
 
 When the only purpose of a `catch` block is to clean up and rethrow, use `finally` instead. It eliminates the duplicate cleanup call and removes dead code in the success path.

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -674,13 +674,6 @@ interface ResolvedSnapshotReplacement {
     readonly value: string;
 }
 
-export function formatManagedSkillMetadataContent(
-    packageName: string,
-    version: string,
-): string {
-    return `${JSON.stringify({ packageName, version }, null, 2)}\n`;
-}
-
 export async function createRegistrySkillArchiveBytes(
     files: Record<string, string>,
 ): Promise<Uint8Array<ArrayBuffer>> {

--- a/src/application/commands/config/index.cli.test.ts
+++ b/src/application/commands/config/index.cli.test.ts
@@ -14,6 +14,7 @@ import {
     resolveBundledSkillMetadataFilePath,
     resolveCodexHomeDirectory,
 } from "../skills/bundled-skill-paths.ts";
+import { renderSkillMetadataJson } from "../skills/skill-metadata.ts";
 
 describe("config CLI", () => {
     test("writes settings-store and config mutation logs", async () => {
@@ -180,7 +181,7 @@ describe("config CLI", () => {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
             await Bun.write(
                 metadataFilePath,
-                formatBundledSkillMetadataContent("9.9.9"),
+                renderSkillMetadataJson({ version: "9.9.9" }),
             );
             await Bun.write(
                 ownershipFilePath,
@@ -224,7 +225,7 @@ describe("config CLI", () => {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
             await Bun.write(
                 metadataFilePath,
-                formatBundledSkillMetadataContent("9.9.9"),
+                renderSkillMetadataJson({ version: "9.9.9" }),
             );
             await Bun.write(
                 ownershipFilePath,
@@ -434,7 +435,3 @@ describe("config CLI", () => {
         }
     });
 });
-
-function formatBundledSkillMetadataContent(version: string): string {
-    return `${JSON.stringify({ version }, null, 2)}\n`;
-}

--- a/src/application/commands/skills/bundled-skill-model.test.ts
+++ b/src/application/commands/skills/bundled-skill-model.test.ts
@@ -8,7 +8,6 @@ import {
     parseBundledSkillMetadataContent,
     readImplicitInvocationValue,
     renderBundledSkillFileContent,
-    renderSkillMetadataJson,
     resolveBundledSkillInstallConflict,
     resolveBundledSkillManagedSynchronizationAction,
     writeImplicitInvocationValue,
@@ -62,7 +61,7 @@ describe("bundled skill model", () => {
         );
     });
 
-    test("parses and renders bundled skill metadata content", () => {
+    test("parses bundled skill metadata content", () => {
         expect(parseBundledSkillMetadataContent("{\"version\":\" 1.2.3 \"}\n")).toEqual({
             version: "1.2.3",
         });
@@ -71,9 +70,6 @@ describe("bundled skill model", () => {
         expect(parseBundledSkillMetadataContent("[]")).toBeUndefined();
         expect(parseBundledSkillMetadataContent("{}")).toBeUndefined();
         expect(parseBundledSkillMetadataContent("{\"version\":1}")).toBeUndefined();
-        expect(renderSkillMetadataJson({ version: "1.2.3" })).toBe(
-            "{\n  \"version\": \"1.2.3\"\n}\n",
-        );
     });
 
     test("throws when the ownership policy file does not define implicit invocation", () => {

--- a/src/application/commands/skills/bundled-skill-model.ts
+++ b/src/application/commands/skills/bundled-skill-model.ts
@@ -3,6 +3,7 @@ import type { AppSettings } from "../../schemas/settings.ts";
 import type { BundledSkillName } from "./embedded-assets.ts";
 import { getOoSkillImplicitInvocation } from "../../schemas/settings.ts";
 import { bundledSkillOwnershipFileRelativePath } from "./bundled-skill-paths.ts";
+import { parseSkillMetadataWithVersion } from "./skill-metadata.ts";
 
 const bundledSkillImplicitInvocationKey = "allow_implicit_invocation";
 
@@ -143,44 +144,15 @@ export function writeImplicitInvocationValue(
 export function parseBundledSkillMetadataContent(
     content: string,
 ): BundledSkillMetadata | undefined {
-    let parsedContent: unknown;
+    const parsedMetadata = parseSkillMetadataWithVersion(content);
 
-    try {
-        parsedContent = JSON.parse(content);
-    }
-    catch {
-        return undefined;
-    }
-
-    if (
-        typeof parsedContent !== "object"
-        || parsedContent === null
-        || Array.isArray(parsedContent)
-    ) {
-        return undefined;
-    }
-
-    const rawVersion = (parsedContent as Record<string, unknown>).version;
-
-    if (typeof rawVersion !== "string") {
-        return undefined;
-    }
-
-    const version = rawVersion.trim();
-
-    if (version === "") {
+    if (parsedMetadata === undefined) {
         return undefined;
     }
 
     return {
-        version,
+        version: parsedMetadata.version,
     };
-}
-
-export function renderSkillMetadataJson(
-    metadata: object,
-): string {
-    return `${JSON.stringify(metadata, null, 2)}\n`;
 }
 
 export function isBundledSkillInstallationCurrentState(input: {

--- a/src/application/commands/skills/bundled-skill-observation.test.ts
+++ b/src/application/commands/skills/bundled-skill-observation.test.ts
@@ -8,6 +8,7 @@ import {
     directoryExists,
     fileExists,
     isBundledSkillInstallationCurrent,
+    isBundledSkillInstallationCurrentFromMetadata,
     isManagedBundledSkillInstallation,
     readInstalledBundledSkillImplicitInvocation,
     readInstalledBundledSkillMetadata,
@@ -175,6 +176,52 @@ describe("bundled skill observation", () => {
                 await isBundledSkillInstallationCurrent(
                     "oo",
                     skillDirectoryPath,
+                    "1.2.3",
+                ),
+            ).toBeTrue();
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("evaluates current installations from preloaded metadata", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const skillDirectoryPath = join(rootDirectory, "skills", "oo");
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+
+            expect(
+                await isBundledSkillInstallationCurrentFromMetadata(
+                    "oo",
+                    skillDirectoryPath,
+                    undefined,
+                    "1.2.3",
+                ),
+            ).toBeFalse();
+
+            expect(
+                await isBundledSkillInstallationCurrentFromMetadata(
+                    "oo",
+                    skillDirectoryPath,
+                    { version: "1.2.3" },
+                    "1.2.3",
+                ),
+            ).toBeFalse();
+
+            for (const file of getBundledSkillFiles("oo")) {
+                const filePath = join(skillDirectoryPath, file.relativePath);
+
+                await mkdir(join(filePath, ".."), { recursive: true });
+                await Bun.write(filePath, await Bun.file(file.sourcePath).text());
+            }
+
+            expect(
+                await isBundledSkillInstallationCurrentFromMetadata(
+                    "oo",
+                    skillDirectoryPath,
+                    { version: "1.2.3" },
                     "1.2.3",
                 ),
             ).toBeTrue();

--- a/src/application/commands/skills/bundled-skill-observation.ts
+++ b/src/application/commands/skills/bundled-skill-observation.ts
@@ -9,7 +9,6 @@ import {
     isBundledSkillInstallationCurrentState,
     parseBundledSkillMetadataContent,
     readImplicitInvocationValue,
-    renderSkillMetadataJson,
 } from "./bundled-skill-model.ts";
 import {
     bundledSkillOwnershipFileRelativePath,
@@ -17,6 +16,7 @@ import {
     resolveCodexHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { getBundledSkillFiles } from "./embedded-assets.ts";
+import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 export async function requireCodexHomeDirectory(
     context: Pick<{ env: Record<string, string | undefined> }, "env">,
@@ -128,8 +128,22 @@ export async function isBundledSkillInstallationCurrent(
     version: string,
 ): Promise<boolean> {
     const metadata = await readInstalledBundledSkillMetadata(skillDirectoryPath);
+
+    return isBundledSkillInstallationCurrentFromMetadata(
+        skillName,
+        skillDirectoryPath,
+        metadata,
+        version,
+    );
+}
+
+export async function isBundledSkillInstallationCurrentFromMetadata(
+    skillName: BundledSkillName,
+    skillDirectoryPath: string,
+    metadata: BundledSkillMetadata | undefined,
+    version: string,
+): Promise<boolean> {
     const managedInstallation = metadata !== undefined;
-    const hasMetadataFile = managedInstallation;
     const installedVersion = metadata?.version;
     let hasAllBundledFiles = false;
 
@@ -146,7 +160,7 @@ export async function isBundledSkillInstallationCurrent(
 
     return isBundledSkillInstallationCurrentState({
         hasAllBundledFiles,
-        hasMetadataFile,
+        hasMetadataFile: managedInstallation,
         installedVersion,
         isManagedInstallation: managedInstallation,
         version,

--- a/src/application/commands/skills/config/set.test.ts
+++ b/src/application/commands/skills/config/set.test.ts
@@ -6,12 +6,12 @@ import { describe, expect, test } from "bun:test";
 import { createCliSandbox } from "../../../../../__tests__/helpers.ts";
 import { resolveStorePaths } from "../../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../../config/app-config.ts";
-import { renderSkillMetadataJson } from "../bundled-skill-model.ts";
 import {
     resolveBundledSkillMetadataFilePath,
     resolveCodexHomeDirectory,
 } from "../bundled-skill-paths.ts";
 import { getBundledSkillFiles } from "../embedded-assets.ts";
+import { renderSkillMetadataJson } from "../skill-metadata.ts";
 
 describe("skills config set command", () => {
     test("persists the oo skill config without requiring Codex", async () => {

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -14,6 +14,7 @@ import {
     resolveBundledSkillMetadataFilePath,
     resolveCodexHomeDirectory,
 } from "./bundled-skill-paths.ts";
+import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 describe("skills CLI", () => {
     test("requires login before installing published skills", async () => {
@@ -78,7 +79,7 @@ describe("skills CLI", () => {
                 "allow_implicit_invocation: true",
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                formatBundledSkillMetadataContent("9.9.9"),
+                renderSkillMetadataJson({ version: "9.9.9" }),
             );
             expect(content).toContain(`"msg":"CLI first-run detection completed."`);
             expect(content).toContain(`"isFirstRun":true`);
@@ -204,7 +205,7 @@ describe("skills CLI", () => {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
             await Bun.write(
                 metadataFilePath,
-                formatBundledSkillMetadataContent("9.9.9"),
+                renderSkillMetadataJson({ version: "9.9.9" }),
             );
             await Bun.write(
                 ownershipFilePath,
@@ -273,7 +274,3 @@ describe("skills CLI", () => {
         }
     });
 });
-
-function formatBundledSkillMetadataContent(version: string): string {
-    return `${JSON.stringify({ version }, null, 2)}\n`;
-}

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -10,7 +10,6 @@ import {
     createInteractiveInput,
     createRegistrySkillArchiveBytes,
     createTextBuffer,
-    formatManagedSkillMetadataContent,
     toRequest,
     waitForOutputText,
     writeAuthFile,
@@ -32,6 +31,7 @@ import {
     installedRegistrySkillCompatibility,
     renderOoPackageExecutionGuidance,
 } from "./registry-skill-markdown.ts";
+import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 describe("skills commands", () => {
     const guidance = renderOoPackageExecutionGuidance();
@@ -78,7 +78,7 @@ describe("skills commands", () => {
                 "allow_implicit_invocation: true",
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                formatBundledSkillMetadataContent(resultVersion),
+                renderSkillMetadataJson({ version: resultVersion }),
             );
         }
         finally {
@@ -118,7 +118,7 @@ describe("skills commands", () => {
                 await realpath(canonicalSkillDirectoryPath),
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                formatBundledSkillMetadataContent(resultVersion),
+                renderSkillMetadataJson({ version: resultVersion }),
             );
         }
         finally {
@@ -318,7 +318,7 @@ describe("skills commands", () => {
             await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
                 recursive: true,
             });
-            await Bun.write(metadataFilePath, formatManagedSkillMetadataContent("openai", "0.0.3"));
+            await Bun.write(metadataFilePath, renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }));
             await Bun.write(join(skillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
             await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
 
@@ -372,7 +372,7 @@ describe("skills commands", () => {
             await mkdir(escapedCanonicalSkillDirectoryPath, { recursive: true });
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(escapedSkillDirectoryPath),
-                formatManagedSkillMetadataContent("openai", "0.0.3"),
+                renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
             );
             await Bun.write(installedSentinelPath, "installed\n");
             await Bun.write(canonicalSentinelPath, "canonical\n");
@@ -416,7 +416,7 @@ describe("skills commands", () => {
             await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
                 recursive: true,
             });
-            await Bun.write(metadataFilePath, formatManagedSkillMetadataContent("openai", "0.0.3"));
+            await Bun.write(metadataFilePath, renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }));
             await Bun.write(join(skillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
             await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
 
@@ -544,7 +544,7 @@ describe("skills commands", () => {
             });
             await Bun.write(
                 metadataFilePath,
-                formatBundledSkillMetadataContent("9.9.9"),
+                renderSkillMetadataJson({ version: "9.9.9" }),
             );
             await Bun.write(ownershipFilePath, "# OOMOL\n");
             await Bun.write(
@@ -595,7 +595,7 @@ describe("skills commands", () => {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
             await Bun.write(
                 metadataFilePath,
-                formatBundledSkillMetadataContent("0.0.1"),
+                renderSkillMetadataJson({ version: "0.0.1" }),
             );
             await Bun.write(managedSkillPath, "stale\n");
             await Bun.write(managedOwnershipPath, expectedOwnershipContent);
@@ -608,7 +608,7 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                formatBundledSkillMetadataContent("9.9.9"),
+                renderSkillMetadataJson({ version: "9.9.9" }),
             );
             expect(await readFile(managedSkillPath, "utf8")).toBe(
                 expectedSkillContent,
@@ -653,7 +653,7 @@ describe("skills commands", () => {
             });
             await Bun.write(
                 metadataFilePath,
-                formatBundledSkillMetadataContent("0.0.1"),
+                renderSkillMetadataJson({ version: "0.0.1" }),
             );
             await Bun.write(managedOwnershipPath, expectedOwnershipContent);
             await Bun.write(
@@ -673,7 +673,7 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                formatBundledSkillMetadataContent("9.9.9"),
+                renderSkillMetadataJson({ version: "9.9.9" }),
             );
             expect(await readFile(canonicalOwnershipPath, "utf8")).toContain("OOMOL");
             expect(await readFile(canonicalOwnershipPath, "utf8")).not.toContain(
@@ -735,7 +735,7 @@ describe("skills commands", () => {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
             await Bun.write(
                 metadataFilePath,
-                formatBundledSkillMetadataContent("0.0.1"),
+                renderSkillMetadataJson({ version: "0.0.1" }),
             );
             await Bun.write(managedSkillPath, "stale\n");
             await Bun.write(managedOwnershipPath, expectedOwnershipContent);
@@ -745,7 +745,7 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                formatBundledSkillMetadataContent("0.0.1"),
+                renderSkillMetadataJson({ version: "0.0.1" }),
             );
             expect(await readFile(managedSkillPath, "utf8")).toBe("stale\n");
         }
@@ -800,7 +800,7 @@ describe("skills commands", () => {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
             await Bun.write(
                 metadataFilePath,
-                formatBundledSkillMetadataContent("0.0.1"),
+                renderSkillMetadataJson({ version: "0.0.1" }),
             );
             await Bun.write(
                 ownershipFilePath,
@@ -819,7 +819,7 @@ describe("skills commands", () => {
 
             expect(result.exitCode).toBe(0);
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                formatBundledSkillMetadataContent("9.9.9"),
+                renderSkillMetadataJson({ version: "9.9.9" }),
             );
             expect(await readFile(ownershipFilePath, "utf8")).toBe(
                 expectedOwnershipContent,
@@ -913,7 +913,7 @@ describe("skills commands", () => {
                 ].join("\n"),
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                formatManagedSkillMetadataContent("openai", "0.0.3"),
+                renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
             );
             expect(requests).toHaveLength(2);
             expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
@@ -1096,11 +1096,11 @@ describe("skills commands", () => {
             });
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
-                formatManagedSkillMetadataContent("openai", "0.0.3"),
+                renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
             );
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath),
-                formatManagedSkillMetadataContent("openai", "0.0.3"),
+                renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
             );
             await Bun.write(join(installedSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
             await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
@@ -1355,7 +1355,3 @@ describe("skills commands", () => {
         }
     });
 });
-
-function formatBundledSkillMetadataContent(version: string): string {
-    return `${JSON.stringify({ version }, null, 2)}\n`;
-}

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -5,8 +5,8 @@ import { describe, expect, test } from "bun:test";
 
 import { createCliSandbox } from "../../../../__tests__/helpers.ts";
 import { createTerminalColors } from "../../terminal-colors.ts";
-import { renderSkillMetadataJson } from "./bundled-skill-model.ts";
 import { resolveCodexHomeDirectory } from "./bundled-skill-paths.ts";
+import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 const managedSkillNameColor = "#59F78D";
 const managedSkillSourceColor = "#CAA8FA";

--- a/src/application/commands/skills/list.test.ts
+++ b/src/application/commands/skills/list.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import { createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
-import { renderSkillMetadataJson } from "./bundled-skill-model.ts";
 import { listManagedSkillInstallations } from "./list.ts";
+import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 describe("skills list command helpers", () => {
     test("lists managed skills and keeps oo before the remaining sorted names", async () => {

--- a/src/application/commands/skills/managed-skill-metadata.test.ts
+++ b/src/application/commands/skills/managed-skill-metadata.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { renderSkillMetadataJson } from "./bundled-skill-model.ts";
 import {
     parseManagedSkillMetadataContent,
 } from "./managed-skill-metadata.ts";
+import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 describe("managed skill metadata", () => {
     test("parses version-only metadata", () => {
@@ -38,6 +38,17 @@ describe("managed skill metadata", () => {
             parseManagedSkillMetadataContent(
                 JSON.stringify({
                     version: "",
+                }),
+            ),
+        ).toBeUndefined();
+    });
+
+    test("rejects metadata with an empty packageName", () => {
+        expect(
+            parseManagedSkillMetadataContent(
+                JSON.stringify({
+                    packageName: "  ",
+                    version: "1.2.3",
                 }),
             ),
         ).toBeUndefined();

--- a/src/application/commands/skills/managed-skill-metadata.ts
+++ b/src/application/commands/skills/managed-skill-metadata.ts
@@ -1,8 +1,10 @@
 import { readFile } from "node:fs/promises";
 import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
-import { renderSkillMetadataJson } from "./bundled-skill-model.ts";
-
 import { resolveManagedSkillMetadataFilePath } from "./managed-skill-paths.ts";
+import {
+    parseSkillMetadataWithVersion,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
 
 export interface ManagedSkillMetadata {
     packageName?: string;
@@ -12,30 +14,12 @@ export interface ManagedSkillMetadata {
 export function parseManagedSkillMetadataContent(
     content: string,
 ): ManagedSkillMetadata | undefined {
-    let parsedContent: unknown;
+    const parsedMetadata = parseSkillMetadataWithVersion(content);
 
-    try {
-        parsedContent = JSON.parse(content);
-    }
-    catch {
+    if (parsedMetadata === undefined) {
         return undefined;
     }
-
-    if (
-        typeof parsedContent !== "object"
-        || parsedContent === null
-        || Array.isArray(parsedContent)
-    ) {
-        return undefined;
-    }
-
-    const rawVersion = (parsedContent as Record<string, unknown>).version;
-
-    if (typeof rawVersion !== "string" || rawVersion.trim() === "") {
-        return undefined;
-    }
-
-    const rawPackageName = (parsedContent as Record<string, unknown>).packageName;
+    const rawPackageName = parsedMetadata.fields.packageName;
     let packageName: string | undefined;
 
     if (rawPackageName !== undefined) {
@@ -48,7 +32,7 @@ export function parseManagedSkillMetadataContent(
 
     return {
         packageName,
-        version: rawVersion.trim(),
+        version: parsedMetadata.version,
     };
 }
 

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -23,7 +23,7 @@ import {
 } from "./bundled-skill-model.ts";
 import {
     directoryExists,
-    isBundledSkillInstallationCurrent,
+    isBundledSkillInstallationCurrentFromMetadata,
     isManagedBundledSkillInstallation,
     readInstalledBundledSkillImplicitInvocation,
     readInstalledBundledSkillMetadata,
@@ -216,9 +216,10 @@ export async function maybeSynchronizeInstalledBundledSkills(
                 continue;
             }
 
-            const managedInstallation = await isManagedBundledSkillInstallation(
+            const installedSkillMetadata = await readInstalledBundledSkillMetadata(
                 skillDirectoryPath,
             );
+            const managedInstallation = installedSkillMetadata !== undefined;
 
             if (!managedInstallation) {
                 context.logger.debug(
@@ -231,11 +232,13 @@ export async function maybeSynchronizeInstalledBundledSkills(
                 continue;
             }
 
-            const isCurrentInstallation = await isBundledSkillInstallationCurrent(
-                skillName,
-                skillDirectoryPath,
-                context.version,
-            );
+            const isCurrentInstallation
+                = await isBundledSkillInstallationCurrentFromMetadata(
+                    skillName,
+                    skillDirectoryPath,
+                    installedSkillMetadata,
+                    context.version,
+                );
             const desiredImplicitInvocation = resolveBundledSkillImplicitInvocation(
                 skillName,
                 settings,
@@ -265,8 +268,7 @@ export async function maybeSynchronizeInstalledBundledSkills(
                     continue;
                 }
                 case "sync-installation": {
-                    const previousVersion
-                        = await readInstalledBundledSkillVersion(skillDirectoryPath);
+                    const previousVersion = installedSkillMetadata.version;
                     const installation = await writeBundledSkillInstallation({
                         codexHomeDirectory,
                         settings,

--- a/src/application/commands/skills/skill-metadata.test.ts
+++ b/src/application/commands/skills/skill-metadata.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    parseSkillMetadataWithVersion,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
+
+describe("skill metadata", () => {
+    test("parses metadata when version is present and trims surrounding whitespace", () => {
+        expect(parseSkillMetadataWithVersion("{\"version\":\" 1.2.3 \"}\n")).toEqual({
+            fields: {
+                version: " 1.2.3 ",
+            },
+            version: "1.2.3",
+        });
+    });
+
+    test("rejects metadata without a non-empty string version", () => {
+        expect(parseSkillMetadataWithVersion("not json")).toBeUndefined();
+        expect(parseSkillMetadataWithVersion("[]")).toBeUndefined();
+        expect(parseSkillMetadataWithVersion("{}")).toBeUndefined();
+        expect(parseSkillMetadataWithVersion("{\"version\":1}")).toBeUndefined();
+        expect(parseSkillMetadataWithVersion("{\"version\":\"\"}")).toBeUndefined();
+    });
+
+    test("renders metadata as formatted JSON with a trailing newline", () => {
+        expect(renderSkillMetadataJson({ version: "1.2.3" })).toBe(
+            "{\n  \"version\": \"1.2.3\"\n}\n",
+        );
+    });
+});

--- a/src/application/commands/skills/skill-metadata.ts
+++ b/src/application/commands/skills/skill-metadata.ts
@@ -1,0 +1,49 @@
+export interface ParsedSkillMetadataWithVersion {
+    fields: Readonly<Record<string, unknown>>;
+    version: string;
+}
+
+export function parseSkillMetadataWithVersion(
+    content: string,
+): ParsedSkillMetadataWithVersion | undefined {
+    let parsedContent: unknown;
+
+    try {
+        parsedContent = JSON.parse(content);
+    }
+    catch {
+        return undefined;
+    }
+
+    if (
+        typeof parsedContent !== "object"
+        || parsedContent === null
+        || Array.isArray(parsedContent)
+    ) {
+        return undefined;
+    }
+
+    const fields = parsedContent as Record<string, unknown>;
+    const rawVersion = fields.version;
+
+    if (typeof rawVersion !== "string") {
+        return undefined;
+    }
+
+    const version = rawVersion.trim();
+
+    if (version === "") {
+        return undefined;
+    }
+
+    return {
+        fields,
+        version,
+    };
+}
+
+export function renderSkillMetadataJson(
+    metadata: object,
+): string {
+    return `${JSON.stringify(metadata, null, 2)}\n`;
+}

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -9,7 +9,6 @@ import {
     createInteractiveInput,
     createRegistrySkillArchiveBytes,
     createTextBuffer,
-    formatManagedSkillMetadataContent,
     toRequest,
     waitForOutputText,
     writeAuthFile,
@@ -22,6 +21,7 @@ import {
     resolveManagedSkillCanonicalDirectoryPath,
     resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
+import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 describe("skills update command", () => {
     test("skips bundled oo when no explicit skill names are provided", async () => {
@@ -46,11 +46,11 @@ describe("skills update command", () => {
             await Bun.write(join(ooInstalledDirectoryPath, "SKILL.md"), "# oo\n");
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(ooCanonicalDirectoryPath),
-                `${JSON.stringify({ version: "1.0.0" }, null, 2)}\n`,
+                renderSkillMetadataJson({ version: "1.0.0" }),
             );
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(ooInstalledDirectoryPath),
-                `${JSON.stringify({ version: "1.0.0" }, null, 2)}\n`,
+                renderSkillMetadataJson({ version: "1.0.0" }),
             );
 
             const result = await sandbox.run(["skills", "update"]);
@@ -148,7 +148,7 @@ describe("skills update command", () => {
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
                 "utf8",
-            )).toBe(formatManagedSkillMetadataContent("openai", "0.0.4"));
+            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }));
             expect(await readFile(join(installedSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
                 "# ChatGPT fresh",
             );
@@ -364,11 +364,11 @@ describe("skills update command", () => {
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(chatgptInstalledDirectoryPath),
                 "utf8",
-            )).toBe(formatManagedSkillMetadataContent("openai", "0.0.4"));
+            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }));
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(visionInstalledDirectoryPath),
                 "utf8",
-            )).toBe(formatManagedSkillMetadataContent("openai", "0.0.3"));
+            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }));
         }
         finally {
             await sandbox.cleanup();
@@ -492,11 +492,11 @@ describe("skills update command", () => {
             );
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath),
-                `${JSON.stringify({ version: "1.0.0" }, null, 2)}\n`,
+                renderSkillMetadataJson({ version: "1.0.0" }),
             );
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
-                `${JSON.stringify({ version: "1.0.0" }, null, 2)}\n`,
+                renderSkillMetadataJson({ version: "1.0.0" }),
             );
 
             const result = await sandbox.run(["skills", "update", "custom"]);
@@ -534,10 +534,10 @@ async function writeManagedRegistrySkillInstallation(options: {
     );
     await Bun.write(
         resolveManagedSkillMetadataFilePath(options.canonicalSkillDirectoryPath),
-        formatManagedSkillMetadataContent(options.packageName, options.version),
+        renderSkillMetadataJson({ packageName: options.packageName, version: options.version }),
     );
     await Bun.write(
         resolveManagedSkillMetadataFilePath(options.installedSkillDirectoryPath),
-        formatManagedSkillMetadataContent(options.packageName, options.version),
+        renderSkillMetadataJson({ packageName: options.packageName, version: options.version }),
     );
 }


### PR DESCRIPTION
Introduce skill-metadata.ts with renderSkillMetadataJson and parseSkillMetadataWithVersion to consolidate duplicated JSON serialization and parsing logic scattered across bundled-skill-model, managed-skill-metadata, and multiple test helpers.

- Simplify parseBundledSkillMetadataContent and parseManagedSkillMetadataContent by delegating to the shared parser
- Replace local formatBundledSkillMetadataContent and formatManagedSkillMetadataContent helpers in tests with the shared renderSkillMetadataJson utility
- Extract isBundledSkillInstallationCurrentFromMetadata to support preloaded metadata evaluation
- Document "Complete the Extraction" rule in quality guidelines