### PR TITLE
feat(skills): rewrite oo::self references to published package name

### DIFF
--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -877,7 +877,12 @@ describe("skills commands", () => {
 
                         if (request.url.endsWith("/openai/-/meta/openai-0.0.3.tgz")) {
                             return new Response(await createRegistrySkillArchiveBytes({
-                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
+                                "package/package/skills/chatgpt/SKILL.md": [
+                                    "# ChatGPT",
+                                    "",
+                                    "Use `oo::self::chat` for the remote workflow.",
+                                    "",
+                                ].join("\n"),
                                 "package/package/skills/chatgpt/agents/openai.yaml":
                                     "agent\n",
                             }));
@@ -909,6 +914,8 @@ describe("skills commands", () => {
                     "# ChatGPT",
                     "",
                     guidance,
+                    "",
+                    "Use `oo::openai::chat` for the remote workflow.",
                     "",
                 ].join("\n"),
             );

--- a/src/application/commands/skills/registry-skill-markdown.test.ts
+++ b/src/application/commands/skills/registry-skill-markdown.test.ts
@@ -161,4 +161,49 @@ describe("registry skill markdown", () => {
             ].join("\n"),
         );
     });
+
+    test("rewrites backticked oo self references to the published package name", () => {
+        const content = [
+            "---",
+            "name: chatgpt",
+            "description: \"Mention oo::self::summarize in prose.\"",
+            "---",
+            "",
+            "# ChatGPT",
+            "",
+            "Use `oo::self::summarize` for the primary workflow.",
+            "Mention oo::self::summarize in prose.",
+            "Keep `oo::text-tools::chat` unchanged.",
+            "",
+        ].join("\n");
+
+        const result = normalizeInstalledRegistrySkillMarkdown(
+            content,
+            {
+                description: "Chat with a model",
+                name: "chatgpt",
+                title: "ChatGPT",
+            },
+            "@oomol/text-tools",
+        );
+
+        expect(result).toBe(
+            [
+                "---",
+                "name: chatgpt",
+                "description: \"Mention oo::self::summarize in prose.\"",
+                `compatibility: ${JSON.stringify(installedRegistrySkillCompatibility)}`,
+                "---",
+                "",
+                "# ChatGPT",
+                "",
+                guidance,
+                "",
+                "Use `oo::@oomol/text-tools::summarize` for the primary workflow.",
+                "Mention oo::self::summarize in prose.",
+                "Keep `oo::text-tools::chat` unchanged.",
+                "",
+            ].join("\n"),
+        );
+    });
 });

--- a/src/application/commands/skills/registry-skill-markdown.ts
+++ b/src/application/commands/skills/registry-skill-markdown.ts
@@ -37,7 +37,10 @@ export function normalizeInstalledRegistrySkillMarkdown(
     skill: RegistrySkillSummary,
     packageName: string,
 ): string {
-    const normalizedContent = normalizeLineEndings(content);
+    const normalizedContent = resolveOoSelfReferences(
+        normalizeLineEndings(content),
+        packageName,
+    );
     const splitFrontmatter = trySplitFrontmatter(normalizedContent);
 
     if (splitFrontmatter === undefined) {
@@ -57,6 +60,13 @@ function normalizeLineEndings(content: string): string {
     return content
         .replaceAll("\r\n", "\n")
         .replaceAll("\r", "\n");
+}
+
+function resolveOoSelfReferences(content: string, packageName: string): string {
+    return content.replaceAll(
+        "`oo::self::",
+        `\`oo::${packageName}::`,
+    );
 }
 
 function trySplitFrontmatter(content: string): SplitFrontmatterResult | undefined {


### PR DESCRIPTION
Skill authors can now use backtick-wrapped `oo::self::<skill>` in their SKILL.md during development. On install, these are resolved to the actual package name (e.g. `oo::@oomol/text-tools::<skill>`), so cross-skill references remain correct after publication.

Only backtick-delimited occurrences are rewritten; prose mentions of oo::self are left untouched.