### PR TITLE
refactor(auth): consolidate per-command auth error keys into shared c…

### DIFF
--- a/src/application/commands/cloud-task/list.ts
+++ b/src/application/commands/cloud-task/list.ts
@@ -3,6 +3,7 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import {
     createCloudTaskTasksUrl,
     parseCloudTaskFormat,
@@ -10,7 +11,6 @@ import {
     parseCloudTaskStatus,
     parsePositiveIntegerOption,
     requestCloudTask,
-    requireCurrentCloudTaskAccount,
 } from "./shared.ts";
 import { formatCloudTaskListAsText } from "./text.ts";
 
@@ -113,7 +113,7 @@ export const cloudTaskListCommand: CliCommandDefinition<CloudTaskListInput> = {
             throw new CliUserError("errors.cloudTaskList.blockIdRequiresPackageId", 2);
         }
 
-        const account = await requireCurrentCloudTaskAccount(context);
+        const account = await requireCurrentAccount(context);
         const requestUrl = createCloudTaskTasksUrl(account.endpoint);
 
         if (size !== undefined) {

--- a/src/application/commands/cloud-task/log.ts
+++ b/src/application/commands/cloud-task/log.ts
@@ -2,13 +2,13 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import {
     createCloudTaskTaskUrl,
     parseCloudTaskFormat,
     parseCloudTaskLogResponse,
     parsePositiveIntegerOption,
     requestCloudTask,
-    requireCurrentCloudTaskAccount,
 } from "./shared.ts";
 
 interface CloudTaskLogInput {
@@ -53,7 +53,7 @@ export const cloudTaskLogCommand: CliCommandDefinition<CloudTaskLogInput> = {
                 optionName: "--page",
             },
         );
-        const account = await requireCurrentCloudTaskAccount(context);
+        const account = await requireCurrentAccount(context);
         const requestUrl = createCloudTaskTaskUrl(
             account.endpoint,
             input.taskId,

--- a/src/application/commands/cloud-task/result.ts
+++ b/src/application/commands/cloud-task/result.ts
@@ -2,12 +2,12 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import {
     createCloudTaskTaskUrl,
     parseCloudTaskFormat,
     parseCloudTaskResultResponse,
     requestCloudTask,
-    requireCurrentCloudTaskAccount,
 } from "./shared.ts";
 import { formatCloudTaskResultAsText } from "./text.ts";
 
@@ -35,7 +35,7 @@ export const cloudTaskResultCommand: CliCommandDefinition<CloudTaskResultInput> 
     }),
     handler: async (input, context) => {
         const format = parseCloudTaskFormat(input.format);
-        const account = await requireCurrentCloudTaskAccount(context);
+        const account = await requireCurrentAccount(context);
         const response = parseCloudTaskResultResponse(
             await requestCloudTask(
                 createCloudTaskTaskUrl(account.endpoint, input.taskId, "result"),

--- a/src/application/commands/cloud-task/run.ts
+++ b/src/application/commands/cloud-task/run.ts
@@ -7,13 +7,13 @@ import { resolveRequestLanguage } from "../../../i18n/locale.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { loadPackageInfo, parsePackageSpecifier } from "../package/shared.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { isPlainObject } from "../shared/schema-utils.ts";
 import {
     createCloudTaskTasksUrl,
     parseCloudTaskCreateResponse,
     parseCloudTaskFormat,
     requestCloudTask,
-    requireCurrentCloudTaskAccount,
 } from "./shared.ts";
 import { validateCloudTaskInputValues } from "./validation.ts";
 
@@ -74,7 +74,7 @@ export const cloudTaskRunCommand: CliCommandDefinition<CloudTaskRunInput> = {
         }
 
         const blockId = input.blockId;
-        const account = await requireCurrentCloudTaskAccount(context);
+        const account = await requireCurrentAccount(context);
         const packageSpecifier = parsePackageSpecifier(input.packageSpecifier, {
             errorKey: "errors.cloudTaskRun.invalidPackageSpecifier",
             requireSemver: true,

--- a/src/application/commands/cloud-task/shared.ts
+++ b/src/application/commands/cloud-task/shared.ts
@@ -1,9 +1,7 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
-import type { AuthAccount } from "../../schemas/auth.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { requestText } from "../shared/request.ts";
 
 export const cloudTaskFormatValues = ["json"] as const;
@@ -75,16 +73,6 @@ export type CloudTaskResultResponse = z.output<
 >;
 export type CloudTaskLogResponse = z.output<typeof cloudTaskLogResponseSchema>;
 export type CloudTaskListResponse = z.output<typeof cloudTaskListResponseSchema>;
-
-export async function requireCurrentCloudTaskAccount(
-    context: CliExecutionContext,
-): Promise<AuthAccount> {
-    return requireCurrentAccount(
-        context,
-        "errors.cloudTask.authRequired",
-        "errors.cloudTask.activeAccountMissing",
-    );
-}
 
 export function parseCloudTaskFormat(
     value: string | undefined,

--- a/src/application/commands/cloud-task/wait.ts
+++ b/src/application/commands/cloud-task/wait.ts
@@ -5,12 +5,12 @@ import type {
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import {
     createCloudTaskTaskUrl,
     parseCloudTaskResultResponse,
     parseDurationOption,
     requestCloudTask,
-    requireCurrentCloudTaskAccount,
 } from "./shared.ts";
 import {
     formatCloudTaskDuration,
@@ -76,7 +76,7 @@ export function createCloudTaskWaitHandler(
 ): CliCommandHandler<CloudTaskWaitInput> {
     return async (input, context) => {
         const timeoutMs = parseCloudTaskWaitTimeout(input.timeout);
-        const account = await requireCurrentCloudTaskAccount(context);
+        const account = await requireCurrentAccount(context);
         const requestUrl = createCloudTaskTaskUrl(
             account.endpoint,
             input.taskId,

--- a/src/application/commands/file/upload.ts
+++ b/src/application/commands/file/upload.ts
@@ -43,7 +43,7 @@ export const fileUploadCommand: CliCommandDefinition<FileUploadInput> = {
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         const format = parseFileFormat(input.format);
-        const account = await requireCurrentAccount(context, "errors.fileUpload.authRequired", "errors.fileUpload.activeAccountMissing");
+        const account = await requireCurrentAccount(context);
         const sourceFile = await readSourceFile(input.filePath, context.cwd);
         const uploadSession = await initFileUpload(
             account,

--- a/src/application/commands/package/info.ts
+++ b/src/application/commands/package/info.ts
@@ -1,5 +1,4 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
-import type { AuthAccount } from "../../schemas/auth.ts";
 import type { TerminalColors } from "../../terminal-colors.ts";
 import type { PackageInfoResponse } from "./shared.ts";
 import { z } from "zod";
@@ -46,7 +45,7 @@ export const packageInfoCommand: CliCommandDefinition<PackageInfoInput> = {
     }),
     mapInputError: (_, rawInput) => createPackageInfoInputError(rawInput),
     handler: async (input, context) => {
-        const account = await requireCurrentPackageInfoAccount(context);
+        const account = await requireCurrentAccount(context);
         const packageSpecifier = parsePackageSpecifier(input.packageSpecifier);
         const response = await loadPackageInfo(
             packageSpecifier,
@@ -68,16 +67,6 @@ function createPackageInfoInputError(rawInput: Record<string, unknown>): CliUser
     return new CliUserError("errors.packageInfo.invalidFormat", 2, {
         value: String(rawInput.format ?? ""),
     });
-}
-
-async function requireCurrentPackageInfoAccount(
-    context: CliExecutionContext,
-): Promise<AuthAccount> {
-    return requireCurrentAccount(
-        context,
-        "errors.packageInfo.authRequired",
-        "errors.packageInfo.activeAccountMissing",
-    );
 }
 
 function formatPackageInfoResponseAsText(

--- a/src/application/commands/package/search.ts
+++ b/src/application/commands/package/search.ts
@@ -86,7 +86,7 @@ export const packageSearchCommand: CliCommandDefinition<SearchInput> = {
     }),
     mapInputError: (_, rawInput) => createSearchInputError(rawInput),
     handler: async (input, context) => {
-        const account = await requireCurrentSearchAccount(context);
+        const account = await requireCurrentAccount(context);
         const query = truncateSearchText(input.text);
         const requestUrl = new URL(
             `https://search.${account.endpoint}/v1/packages/-/intent-search`,
@@ -139,16 +139,6 @@ function createSearchInputError(rawInput: Record<string, unknown>): CliUserError
     return new CliUserError("errors.search.invalidFormat", 2, {
         value: String(rawInput.format ?? ""),
     });
-}
-
-async function requireCurrentSearchAccount(
-    context: CliExecutionContext,
-): Promise<AuthAccount> {
-    return requireCurrentAccount(
-        context,
-        "errors.search.authRequired",
-        "errors.search.activeAccountMissing",
-    );
 }
 
 function truncateSearchText(text: string): string {

--- a/src/application/commands/shared/auth-utils.test.ts
+++ b/src/application/commands/shared/auth-utils.test.ts
@@ -1,0 +1,92 @@
+import type {
+    CliCatalog,
+    CliExecutionContext,
+    InteractiveInput,
+} from "../../contracts/cli.ts";
+import type { Translator } from "../../contracts/translator.ts";
+import type { AuthFile } from "../../schemas/auth.ts";
+
+import { describe, expect, test } from "bun:test";
+import pino from "pino";
+
+import {
+    createAuthStore,
+    createCacheStore,
+    createNoopFileDownloadSessionStore,
+    createNoopFileUploadStore,
+    createSettingsStore,
+    createTextBuffer,
+} from "../../../../__tests__/helpers.ts";
+import { requireCurrentAccount } from "./auth-utils.ts";
+
+const emptyCatalog: CliCatalog = {
+    name: "oo",
+    descriptionKey: "catalog.description",
+    globalOptions: [],
+    commands: [],
+};
+const translator: Translator = {
+    locale: "en",
+    t: key => key,
+    resolveLocale: () => "en",
+};
+const stdin: InteractiveInput = {
+    on() {},
+    off() {},
+};
+
+describe("requireCurrentAccount", () => {
+    test("uses the shared auth-required key when no account is active", async () => {
+        const context = createAuthContext({
+            auth: [],
+            id: "",
+        });
+
+        await expect(requireCurrentAccount(context)).rejects.toMatchObject({
+            exitCode: 1,
+            key: "errors.auth.required",
+        });
+    });
+
+    test("uses the shared missing-account key when the active id is stale", async () => {
+        const context = createAuthContext({
+            auth: [],
+            id: "user-1",
+        });
+
+        await expect(requireCurrentAccount(context)).rejects.toMatchObject({
+            exitCode: 1,
+            key: "errors.auth.activeAccountMissing",
+        });
+    });
+});
+
+function createAuthContext(authFile: AuthFile): CliExecutionContext {
+    const stdout = createTextBuffer();
+    const stderr = createTextBuffer();
+
+    return {
+        authStore: createAuthStore(authFile),
+        cacheStore: createCacheStore(),
+        currentLogFilePath: "",
+        fetcher: async () => new Response(null),
+        cwd: process.cwd(),
+        env: {},
+        fileDownloadSessionStore: createNoopFileDownloadSessionStore(),
+        fileUploadStore: createNoopFileUploadStore(),
+        stdin,
+        logger: pino({
+            enabled: false,
+        }),
+        packageName: "@oomol-lab/oo-cli",
+        settingsStore: createSettingsStore({}),
+        stdout: stdout.writer,
+        stderr: stderr.writer,
+        translator,
+        completionRenderer: {
+            render: () => "",
+        },
+        catalog: emptyCatalog,
+        version: "0.1.0",
+    };
+}

--- a/src/application/commands/shared/auth-utils.ts
+++ b/src/application/commands/shared/auth-utils.ts
@@ -4,10 +4,13 @@ import type { AuthAccount } from "../../schemas/auth.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { readCurrentAuth } from "../auth/shared.ts";
 
+const authErrorKeys = {
+    activeAccountMissing: "errors.auth.activeAccountMissing",
+    required: "errors.auth.required",
+} as const;
+
 export async function requireCurrentAccount(
     context: CliExecutionContext,
-    authRequiredKey: string,
-    accountMissingKey: string,
 ): Promise<AuthAccount> {
     const { authFile, currentAccount } = await readCurrentAuth(context);
 
@@ -15,6 +18,8 @@ export async function requireCurrentAccount(
         return currentAccount;
     }
 
-    const errorKey = authFile.id === "" ? authRequiredKey : accountMissingKey;
+    const errorKey = authFile.id === ""
+        ? authErrorKeys.required
+        : authErrorKeys.activeAccountMissing;
     throw new CliUserError(errorKey, 1);
 }

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -4,7 +4,7 @@ exports[`skills CLI requires login before installing published skills 1`] = `
 {
   "exitCode": 1,
   "stderr": 
-"You must log in before installing published skills.
+"You must log in before using this command.
 "
 ,
   "stdout": "",

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -5,6 +5,7 @@ import type { RegistryPackageSkillInfo, RegistrySkillSummary } from "./registry-
 import { CliUserError } from "../../contracts/cli.ts";
 import { withPackageIdentity } from "../../logging/log-fields.ts";
 
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { writeLine } from "../shared/output.ts";
 import { directoryExists, requireCodexHomeDirectory } from "./bundled-skill-observation.ts";
 import { SkillsInstallProgressReporter } from "./install-progress.ts";
@@ -28,7 +29,6 @@ import {
 import {
     downloadRegistryPackageTarball,
     loadRegistryPackageSkillInfo,
-    requireCurrentSkillsInstallAccount,
 } from "./registry-skill-source.ts";
 import { uninstallManagedSkill } from "./shared.ts";
 
@@ -67,7 +67,7 @@ export async function installRegistrySkills(
     request: RegistrySkillInstallRequest,
     context: CliExecutionContext,
 ): Promise<void> {
-    const account = await requireCurrentSkillsInstallAccount(context);
+    const account = await requireCurrentAccount(context);
     const codexHomeDirectory = await requireCodexHomeDirectory(context);
     const packageInfo = await loadRegistryPackageSkillInfo(
         request.packageName,

--- a/src/application/commands/skills/registry-skill-source.ts
+++ b/src/application/commands/skills/registry-skill-source.ts
@@ -4,7 +4,6 @@ import type { AuthAccount } from "../../schemas/auth.ts";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { withPackageIdentity } from "../../logging/log-fields.ts";
-import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { performLoggedRequest, requestText } from "../shared/request.ts";
 
 const registrySkillSchema = z.object({
@@ -30,12 +29,6 @@ export interface RegistryPackageSkillInfo {
     packageName: string;
     packageVersion: string;
     skills: RegistrySkillSummary[];
-}
-
-export async function requireCurrentSkillsInstallAccount(
-    context: CliExecutionContext,
-): Promise<AuthAccount> {
-    return requireCurrentAccount(context, "errors.skills.install.authRequired", "errors.skills.install.activeAccountMissing");
 }
 
 export function createRegistryPackageInfoRequestUrl(

--- a/src/application/commands/skills/search.ts
+++ b/src/application/commands/skills/search.ts
@@ -71,7 +71,7 @@ export const skillsSearchCommand: CliCommandDefinition<SkillsSearchInput> = {
     }),
     mapInputError: (_, rawInput) => createSkillsSearchInputError(rawInput),
     handler: async (input, context) => {
-        const account = await requireCurrentAccount(context, "errors.skillsSearch.authRequired", "errors.skillsSearch.activeAccountMissing");
+        const account = await requireCurrentAccount(context);
         const requestUrl = createSkillsSearchRequestUrl(
             account.endpoint,
             input.text,

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -5,6 +5,7 @@ import type { PreparedRegistrySkillPublication } from "./registry-skill-publicat
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { writeLine } from "../shared/output.ts";
 import {
     directoryExists,
@@ -29,7 +30,6 @@ import {
 import {
     downloadRegistryPackageTarball,
     loadRegistryPackageSkillInfo,
-    requireCurrentSkillsInstallAccount,
 } from "./registry-skill-source.ts";
 import { isBundledSkillName } from "./shared.ts";
 import { SkillsUpdateProgressReporter } from "./update-progress.ts";
@@ -131,7 +131,7 @@ export async function updateManagedSkills(
 
     try {
         const account = registrySkillGroups.length > 0
-            ? await requireCurrentSkillsInstallAccount(context)
+            ? await requireCurrentAccount(context)
             : undefined;
         const unresolvedSkillFailures: SkillPreparationResult[] = unresolvedSkills.map(skill => ({
             events: [

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -148,8 +148,12 @@ export const enMessages = {
     "errors.commander.unknownOption": "Unknown option: {value}.",
     "errors.auth.loginTimeout":
         "Timed out waiting for the browser login callback.",
+    "errors.auth.activeAccountMissing":
+        "The active auth account is missing from the auth store.",
     "errors.auth.noSavedAccounts":
         "There are no auth accounts to switch to.",
+    "errors.auth.required":
+        "You must log in before using this command.",
     "errors.authStore.invalidToml":
         "The auth file at {path} is not valid TOML.",
     "errors.authStore.invalidSchema":
@@ -158,10 +162,6 @@ export const enMessages = {
         "Failed to read the auth file at {path}.",
     "errors.authStore.writeFailed":
         "Failed to write the auth file at {path}.",
-    "errors.cloudTask.activeAccountMissing":
-        "The active auth account is missing from the auth store.",
-    "errors.cloudTask.authRequired":
-        "You must log in before using cloud-task commands.",
     "errors.cloudTask.invalidFormat":
         "Invalid format: {value}. Use json.",
     "errors.cloudTask.invalidResponse":
@@ -256,10 +256,6 @@ export const enMessages = {
         "Invalid value for {option}: {value}. Use an integer greater than or equal to 1.",
     "errors.fileList.invalidStatus":
         "Invalid status: {value}. Use active or expired.",
-    "errors.fileUpload.activeAccountMissing":
-        "The active auth account is missing from the auth store.",
-    "errors.fileUpload.authRequired":
-        "You must log in before using the file upload command.",
     "errors.fileUpload.invalidResponse":
         "The file upload service returned an unsupported response body.",
     "errors.fileUpload.pathNotFile":
@@ -274,10 +270,6 @@ export const enMessages = {
         "The file at {path} is {size} bytes, which exceeds the 512 MiB limit of {max} bytes.",
     "errors.lang.invalidFlag":
         "Invalid value for --lang: {value}. Use en or zh.",
-    "errors.search.activeAccountMissing":
-        "The active auth account is missing from the auth store.",
-    "errors.search.authRequired":
-        "You must log in before using the packages search command.",
     "errors.search.invalidFormat":
         "Invalid format: {value}. Use json.",
     "errors.search.invalidResponse":
@@ -286,10 +278,6 @@ export const enMessages = {
         "The search request failed: {message}",
     "errors.search.requestFailed":
         "The search request returned HTTP {status}.",
-    "errors.skillsSearch.activeAccountMissing":
-        "The active auth account is missing from the auth store.",
-    "errors.skillsSearch.authRequired":
-        "You must log in before using the skills search command.",
     "errors.skillsSearch.invalidFormat":
         "Invalid format: {value}. Use json.",
     "errors.skillsSearch.invalidResponse":
@@ -298,10 +286,6 @@ export const enMessages = {
         "The skills search request failed: {message}",
     "errors.skillsSearch.requestFailed":
         "The skills search request returned HTTP {status}.",
-    "errors.packageInfo.activeAccountMissing":
-        "The active auth account is missing from the auth store.",
-    "errors.packageInfo.authRequired":
-        "You must log in before using the packages info command.",
     "errors.packageInfo.invalidFormat":
         "Invalid format: {value}. Use json.",
     "errors.packageInfo.invalidPackageSpecifier":
@@ -314,10 +298,6 @@ export const enMessages = {
         "The package info request returned HTTP {status}.",
     "errors.skills.codexNotInstalled":
         "Codex is not installed. Expected the Codex home directory at {path}.",
-    "errors.skills.install.activeAccountMissing":
-        "The active auth account is missing from the auth store.",
-    "errors.skills.install.authRequired":
-        "You must log in before installing published skills.",
     "errors.skills.install.confirmationRequired":
         "Skill {name} already exists and requires interactive confirmation.",
     "errors.skills.install.invalidArchive":
@@ -658,15 +638,15 @@ export const zhMessages = {
     "errors.commander.unknownCommand": "未知命令：{value}。",
     "errors.commander.unknownOption": "未知选项：{value}。",
     "errors.auth.loginTimeout": "等待浏览器登录回调超时。",
+    "errors.auth.activeAccountMissing":
+        "当前激活账号不存在于认证数据中。",
     "errors.auth.noSavedAccounts": "没有可切换的认证账号。",
+    "errors.auth.required":
+        "使用此命令前请先登录。",
     "errors.authStore.invalidToml": "认证文件 {path} 不是有效的 TOML。",
     "errors.authStore.invalidSchema": "认证文件 {path} 的结构不受支持。",
     "errors.authStore.readFailed": "读取认证文件 {path} 失败。",
     "errors.authStore.writeFailed": "写入认证文件 {path} 失败。",
-    "errors.cloudTask.activeAccountMissing":
-        "当前激活账号不存在于认证数据中。",
-    "errors.cloudTask.authRequired":
-        "使用 cloud-task 命令前请先登录。",
     "errors.cloudTask.invalidFormat":
         "无效的 format：{value}。请使用 json。",
     "errors.cloudTask.invalidResponse":
@@ -761,10 +741,6 @@ export const zhMessages = {
         "{option} 的值无效：{value}。请使用大于等于 1 的整数。",
     "errors.fileList.invalidStatus":
         "无效的 status：{value}。请使用 active 或 expired。",
-    "errors.fileUpload.activeAccountMissing":
-        "当前激活账号不存在于认证数据中。",
-    "errors.fileUpload.authRequired":
-        "使用 file upload 命令前请先登录。",
     "errors.fileUpload.invalidResponse":
         "文件上传服务返回了不受支持的响应内容。",
     "errors.fileUpload.pathNotFile":
@@ -779,10 +755,6 @@ export const zhMessages = {
         "文件 {path} 的大小为 {size} 字节，超出了 512 MiB 上限 {max} 字节。",
     "errors.lang.invalidFlag":
         "--lang 的值无效：{value}。请使用 en 或 zh。",
-    "errors.search.activeAccountMissing":
-        "当前激活账号不存在于认证数据中。",
-    "errors.search.authRequired":
-        "使用 packages search 命令前请先登录。",
     "errors.search.invalidFormat":
         "无效的 format：{value}。请使用 json。",
     "errors.search.invalidResponse":
@@ -791,10 +763,6 @@ export const zhMessages = {
         "搜索请求失败：{message}",
     "errors.search.requestFailed":
         "搜索请求返回了 HTTP {status}。",
-    "errors.skillsSearch.activeAccountMissing":
-        "当前激活账号不存在于认证数据中。",
-    "errors.skillsSearch.authRequired":
-        "使用 skills search 命令前请先登录。",
     "errors.skillsSearch.invalidFormat":
         "无效的 format：{value}。请使用 json。",
     "errors.skillsSearch.invalidResponse":
@@ -803,10 +771,6 @@ export const zhMessages = {
         "skills 搜索请求失败：{message}",
     "errors.skillsSearch.requestFailed":
         "skills 搜索请求返回了 HTTP {status}。",
-    "errors.packageInfo.activeAccountMissing":
-        "当前激活账号不存在于认证数据中。",
-    "errors.packageInfo.authRequired":
-        "使用 packages info 命令前请先登录。",
     "errors.packageInfo.invalidFormat":
         "无效的 format：{value}。请使用 json。",
     "errors.packageInfo.invalidPackageSpecifier":
@@ -819,10 +783,6 @@ export const zhMessages = {
         "包信息请求返回了 HTTP {status}。",
     "errors.skills.codexNotInstalled":
         "未检测到 Codex 安装。期望的 Codex 根目录为 {path}。",
-    "errors.skills.install.activeAccountMissing":
-        "当前激活账号不存在于认证数据中。",
-    "errors.skills.install.authRequired":
-        "安装已发布 skill 前请先登录。",
     "errors.skills.install.confirmationRequired":
         "Skill {name} 已存在，且需要在交互终端中确认覆盖。",
     "errors.skills.install.invalidArchive":


### PR DESCRIPTION
…onstants

Each command module (cloud-task, package, skills, file) maintained its own wrapper around `requireCurrentAccount` solely to pass domain-specific i18n error keys. Since every wrapper conveys the same two outcomes (not logged in / active account missing), replace them with two shared keys (`errors.auth.required`, `errors.auth.activeAccountMissing`) and remove the custom parameters from `requireCurrentAccount`.

This eliminates six wrapper functions across four modules, the redundant i18n catalog entries they referenced, and adds unit tests for the simplified auth utility.