### PR TITLE
feat(skills): add oo-find-skills bundled skill and generalize per-skill settings

### DIFF
--- a/README-ZH_CN.md
+++ b/README-ZH_CN.md
@@ -31,9 +31,9 @@ $oo 帮我生成 OOMOL 字符串的二维码
 
 ## Codex Skill
 
-首次打开 `oo`，或者执行 `oo skills install`（等价于
-`oo skills install oo`）之后，Codex 中会生成内置的 `oo` skill，位置在
-`${CODEX_HOME:-~/.codex}/skills/oo`。
+首次打开 `oo` 之后，Codex 中会生成内置的 `oo` skill，位置在
+`${CODEX_HOME:-~/.codex}/skills/oo`；同时还会生成 `oo-find-skills`
+辅助 skill，位置在 `${CODEX_HOME:-~/.codex}/skills/oo-find-skills`。
 
 然后你就可以在 Codex 中这样使用：
 
@@ -41,10 +41,16 @@ $oo 帮我生成 OOMOL 字符串的二维码
 $oo 帮我生成 OOMOL 字符串的二维码
 ```
 
-也可以手动执行安装：
+也可以手动安装全部内置 skills：
 
 ```bash
 oo skills install
+```
+
+如果你想单独安装搜索辅助 skill，也可以执行：
+
+```bash
+oo skills install oo-find-skills
 ```
 
 ## 文档

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ $oo generate a QR code for the string OOMOL
 
 ## Codex Skills
 
-On the first `oo` launch, or after running `oo skills install` (equivalent to
-`oo skills install oo`), Codex will get the bundled `oo` skill under
-`${CODEX_HOME:-~/.codex}/skills/oo`.
+On the first `oo` launch, Codex will get the bundled `oo` skill under
+`${CODEX_HOME:-~/.codex}/skills/oo` and the bundled `oo-find-skills` helper
+under `${CODEX_HOME:-~/.codex}/skills/oo-find-skills`.
 
 Then you can use it in Codex, for example:
 
@@ -43,10 +43,16 @@ Then you can use it in Codex, for example:
 $oo generate a QR code for the string OOMOL
 ```
 
-You can also install it explicitly with:
+You can also install all bundled skills explicitly with:
 
 ```bash
 oo skills install
+```
+
+And you can install the search helper explicitly with:
+
+```bash
+oo skills install oo-find-skills
 ```
 
 ## Documentation

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -25,6 +25,7 @@ import {
     executeCli as executeCliInvocation,
 } from "../src/application/bootstrap/run-cli.ts";
 import { APP_NAME } from "../src/application/config/app-config.ts";
+import { defaultSettings, renderSettingsFile } from "../src/application/schemas/settings.ts";
 import { createTerminalColors } from "../src/application/terminal-colors.ts";
 
 export interface TextBuffer {
@@ -131,27 +132,7 @@ export const platformTest = createPlatformScope(test);
 
 export const platformDescribe = createPlatformScope(describe);
 
-export const defaultSettingsFileContent = [
-    "# lang controls the CLI display language for help text, messages, and errors.",
-    "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
-    "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
-    "# lang = \"en\"",
-    "",
-    "# file.download.out_dir controls the default output directory used by `oo file download` when [outDir] is omitted.",
-    "# Default: ~/Downloads.",
-    "# Supported values: any non-empty path string.",
-    "# Relative values resolve from the current working directory when the command runs.",
-    "# A leading `~` expands to the current user's home directory.",
-    "# [file.download]",
-    "# out_dir = \"~/Downloads\"",
-    "",
-    "# skills.oo.implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
-    "# Supported values: true, false.",
-    "# Default: true.",
-    "# [skills.oo]",
-    "# implicit_invocation = false",
-    "",
-].join("\n");
+export const defaultSettingsFileContent = renderSettingsFile(defaultSettings);
 
 export function createNoopFileUploadStore(): FileUploadRecordStore {
     return {

--- a/contrib/skills/oo-find-skills/SKILL.md
+++ b/contrib/skills/oo-find-skills/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: oo-find-skills
+description: >-
+  Use when the user wants to search the published OOMOL or oo skill catalog,
+  compare candidate skills, and install one or two chosen results. Do not use
+  for generic skill discovery outside the oo or OOMOL ecosystem.
+---
+
+# oo Find Skills
+
+Use this skill only when you are acting as ChatGPT 5.4 in Codex and the user
+wants to discover and install existing published skills from the OOMOL or
+`oo` skill catalog through `oo skills search` and `oo skills install`.
+
+Read [references/oo-cli-contract.md](references/oo-cli-contract.md) when you
+need exact `oo skills search` or `oo skills install` command forms, JSON
+expectations, output-shape rules, or failure-handling details.
+
+## Workflow
+
+### 1. Normalize the request into English search terms
+
+Convert the user request into:
+
+- one short internal intent statement
+- one concise English sentence for the search text
+- `0` to `3` English keywords or short phrases for the optional `--keywords`
+  filter
+
+Rules:
+
+- The sentence and keywords must always be in English, regardless of the
+  user's language.
+- The sentence should describe only the user's need itself.
+- Prefer a short sentence built from task + capability + domain or constraint.
+- Do not add meta words such as `skill`, `skills`, `search`, `install`, or
+  `Codex` unless the user's actual need depends on those words.
+- Avoid filler words.
+- Use keywords only when they add extra filtering signal that the sentence does
+  not already capture.
+- Prefer `0` to `3` keywords. Do not exceed `3`.
+
+Examples:
+
+- Sentence: `translate scanned images from Japanese to English`
+  Keywords: `Japanese`, `image translation`
+- Sentence: `generate a QR code from text`
+  Keywords: `QR code`
+- Sentence: `convert speech to text`
+  Keywords: `transcription`
+- Sentence: `write Markdown more effectively`
+  Keywords: `Markdown`, `writing`
+
+Use the sentence as the main search text. Add `--keywords` only when the extra
+keywords help narrow the search.
+
+### 2. Search for candidate skills
+
+Run:
+
+```bash
+oo skills search "<english query>" --json
+```
+
+Or, when helpful:
+
+```bash
+oo skills search "<english sentence>" --keywords "<comma-separated keywords>" --json
+```
+
+Then:
+
+- Rank only from the returned JSON array.
+- Prefer semantic matches between the original user goal and the returned
+  `description`, `skillDisplayName`, or `name`.
+- Keep one primary skill.
+- Keep one fallback skill only if it is genuinely plausible.
+
+If the returned array is empty, tell the user there is no matching skill
+available right now and stop. Do not present a menu.
+
+### 3. Filter installable results
+
+- Treat a search item as installable only when it includes both `packageName`
+  and `name`.
+- If the JSON array is non-empty but no installable items exist, stop and tell
+  the user that no installable skill could be derived from the search results.
+  Do not present a menu.
+
+### 4. Rank the installable results
+
+6. Rank the installable JSON items using only the fields in the response.
+7. Pick one primary skill and, only if credible, one fallback skill.
+
+### 5. Ask the user to choose
+
+8. Only when at least one installable result exists, ask the user to choose
+   between the available actions.
+   Do not stop at a plain existence summary when installable results exist.
+   Even if the user first asks whether a matching skill exists, this skill
+   should still continue into the chooser step after confirming the matches.
+
+Interaction rules:
+
+- If a credible fallback exists, offer these actions:
+  1. Install the primary skill as `primarySkillName (primaryPackageName)`
+  2. Install the fallback skill as `fallbackSkillName (fallbackPackageName)`
+  3. Install both
+  4. Install neither
+- If no credible fallback exists, offer only these actions:
+  1. Install the primary skill as `primarySkillName (primaryPackageName)`
+  2. Install neither
+- First, try to use the `request_user_input` tool with one short multiple-choice
+  question that includes only the actions that are actually available.
+- If the `request_user_input` tool is unavailable in the current mode or the
+  tool call fails, fall back to plain text.
+- If the `request_user_input` UI returns `None of the above`, treat that as
+  the same outcome as `Install neither`.
+- In either UI or text form, the label for every install action must include
+  the concrete `skillName (packageName)` text.
+
+Fallback text format:
+
+```text
+1. Install <skillName> (<packageName>)
+2. Install <skillName2> (<packageName2>)
+3. Install both
+4. Install neither
+
+Reply with: 1, 2, 3, or 4
+```
+
+If no credible fallback exists, use:
+
+```text
+1. Install <skillName> (<packageName>)
+2. Install neither
+
+Reply with: 1 or 2
+```
+
+If the user reply is not one of the explicit numbers that correspond to the
+currently available options, do not install anything. Ask the user to reply
+with one of the displayed numbers.
+
+### 6. Install after confirmation
+
+9. After the user chooses, install only the selected skill or skills with
+   `oo skills install`.
+   If the user chooses `Install neither` or the UI returns `None of the above`,
+   do not install anything. Reply with exactly one short acknowledgement in the
+   user's language that no skill was installed, then stop. Do not continue with
+   extra result explanation, matched-result recap, ranking recap, package names,
+   skill names, descriptions, or repeated summaries.
+10. Batch by package:
+   - If both selected skills come from the same package, install them with one
+     command and multiple `-s` flags.
+   - If they come from different packages, run one install command per package.
+   If `Install both` requires multiple `oo skills install` commands across
+   different packages and a later command fails after an earlier one succeeded,
+   report the partial completion accurately: say which package/skill
+   installation(s) succeeded, say which command failed, say that no rollback
+   was attempted, and then stop.
+
+Install examples:
+
+- Single skill install:
+
+```bash
+oo skills install "<packageName>" -s "<skillName>" -y
+```
+
+- Two skills from the same package:
+
+```bash
+oo skills install "<packageName>" -s "<skillName1>" -s "<skillName2>" -y
+```
+
+- Two skills from different packages:
+
+```bash
+oo skills install "<packageName1>" -s "<skillName1>" -y
+oo skills install "<packageName2>" -s "<skillName2>" -y
+```
+
+11. Use each search result's `name` field as the `-s` value. Use
+   `skillDisplayName` only for display text.
+12. Never invent package names, skill names, versions, or extra metadata.
+13. If `oo skills search` or `oo skills install` fails for any reason other
+   than the explicit HTTP `402` billing case, stop immediately and report the
+   exact command failure. Do not invent recommendations, do not claim an
+   install succeeded, and do not continue silently.
+14. If the command output shows HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`,
+   stop immediately, tell the user their current account has insufficient
+   credit or is overdue, and direct them to
+   `https://console.oomol.com/billing/recharge` before retrying.
+
+## Behavior Notes
+
+- `oo skills search --json` returns at most `5` results because that is the CLI
+  behavior for this command; do not try to enforce or emulate a different
+  limit in the skill text.
+- Use `skillDisplayName` when present, otherwise fall back to `name`.
+- Prefer the closest semantic match for the primary skill.
+- Break ranking ties deterministically by preferring the result whose
+  `description` or display text more directly matches the same user request.
+- Prefer non-duplicate results over near-duplicates.
+- If the semantic match is still tied, prefer the result with clearer install
+  identifiers (`packageName` plus `name`) and richer explanatory text.
+- You may compare response text fields against the original user request, but
+  you must not use external metadata or guessed fields to break ties.
+- Treat a fallback as credible only when it is the next-best result that still
+  plausibly solves the same user request, not merely a loosely related or
+  duplicate-looking match.
+- Do not install anything before the user explicitly chooses one of the four
+  options.

--- a/contrib/skills/oo-find-skills/agents/openai.yaml
+++ b/contrib/skills/oo-find-skills/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: oo Find Skills
+  short_description: Search OOMOL/oo skills for installation
+  default_prompt: "Use $oo-find-skills when I want to search the OOMOL or oo skill catalog, compare likely matches for my current need, and install the selected published skill or skills."
+
+policy:
+  allow_implicit_invocation: true

--- a/contrib/skills/oo-find-skills/references/oo-cli-contract.md
+++ b/contrib/skills/oo-find-skills/references/oo-cli-contract.md
@@ -1,0 +1,106 @@
+# oo CLI Contract for Skill Discovery
+
+Use this reference when you need the concrete `oo` command forms for finding
+and installing skills.
+
+## `oo skills search`
+
+Canonical form:
+
+```bash
+oo skills search "<text>" --json
+```
+
+Optional keyword-refined form:
+
+```bash
+oo skills search "<text>" --keywords "<comma-separated keywords>" --json
+```
+
+Facts:
+
+- `--json` is an alias for `--format=json`.
+- `--keywords` is optional and accepts a comma-separated list.
+- The command returns a raw JSON array.
+- Search results may include `description`, `name`, `packageName`,
+  `packageVersion`, and `skillDisplayName`.
+- The CLI returns at most `5` results for this command.
+- Treat an empty array as no matching capability.
+- An item is installable only when it includes both `packageName` and `name`.
+- If the JSON array is non-empty but no items are installable, stop and explain
+  that no installable skill could be derived from the search results.
+
+## `oo skills install`
+
+Canonical forms:
+
+```bash
+oo skills install <packageName> -s "<skillName>" -y
+```
+
+```bash
+oo skills install <packageName> -s "<skillName1>" -s "<skillName2>" -y
+```
+
+Facts:
+
+- Bundled skill names can be installed directly by package name.
+- When both chosen skills come from the same package, install them with one
+  command and multiple `-s` flags.
+- When the chosen skills come from different packages, run one install command
+  per package.
+- If `Install both` requires multiple `oo skills install` commands across
+  different packages and a later command fails after an earlier one succeeded,
+  report the partial completion accurately: say which package/skill
+  installation(s) succeeded, say which command failed, say that no rollback was
+  attempted, and then stop.
+- Use only the package and `name` fields returned by `oo skills search --json`.
+- Use `skillDisplayName` only for user-facing labels, never as a `-s` value.
+- If the `request_user_input` UI returns `None of the above`, treat that as
+  the same outcome as `Install neither`.
+- If the user reply is not one of the explicit numbers that correspond to the
+  currently displayed options, do not install anything. Ask the user to reply
+  with one of the displayed numbers.
+- Every install option label must include the concrete
+  `skillName (packageName)` text.
+
+Output shape:
+
+- When a credible fallback exists, show four numbered choices:
+  `Install <primarySkillName> (<primaryPackageName>)`,
+  `Install <fallbackSkillName> (<fallbackPackageName>)`,
+  `Install both`, `Install neither`.
+- Do not stop at a plain existence confirmation when installable results exist.
+  Even if the user's first question is only whether a matching skill exists,
+  continue into the chooser step after confirming the matches.
+- When no credible fallback exists, show only two numbered choices:
+
+```text
+1. Install <skillName> (<packageName>)
+2. Install neither
+```
+
+Ranking guidance:
+
+- Prefer the installable result whose `description` or display text more
+  directly matches the same user request.
+- Prefer non-duplicate results over near-duplicates.
+- If the semantic match is tied, prefer the result with clearer install
+  identifiers (`packageName` plus `name`) and richer explanatory text.
+- You may compare response text fields against the original user request, but
+  you must not use external metadata or guessed fields to break ties.
+
+Failure handling:
+
+- If `oo skills search` or `oo skills install` fails for any reason other than
+  the explicit HTTP `402` billing case, stop immediately and report the exact
+  command failure. Do not invent recommendations, do not claim an install
+  succeeded, and do not continue silently.
+- If the user chooses `Install neither` or the UI returns `None of the above`,
+  do not install anything. Reply with exactly one short acknowledgement in the
+  user's language that no skill was installed, then stop without extra result
+  recap, package names, skill names, or descriptions.
+- If any `oo` output shows HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`, stop
+  immediately, tell the user their current account has insufficient credit or
+  is overdue, and direct them to
+  `https://console.oomol.com/billing/recharge` before retrying.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -73,7 +73,8 @@ List persisted configuration values that are currently set.
 Read one persisted configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported values:
-  `lang`, `file.download.out_dir`, `skills.oo.implicit_invocation`.
+  `lang`, `file.download.out_dir`, `skills.oo.implicit_invocation`,
+  `skills.oo-find-skills.implicit_invocation`.
 
 ### `oo config path`
 
@@ -84,7 +85,8 @@ Print the path to the persisted configuration file.
 Persist one configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported values:
-  `lang`, `file.download.out_dir`, `skills.oo.implicit_invocation`.
+  `lang`, `file.download.out_dir`, `skills.oo.implicit_invocation`,
+  `skills.oo-find-skills.implicit_invocation`.
 - Arguments: `<value>` is the value for the selected key.
 - Value rules: for `lang`, supported values are `en` and `zh`.
 - Value rules: for `file.download.out_dir`, use any non-empty path string. Relative
@@ -92,13 +94,16 @@ Persist one configuration value.
   leading `~` expands to the current user's home directory.
 - Value rules: for `skills.oo.implicit_invocation`, supported values are
   `true` and `false`.
+- Value rules: for `skills.oo-find-skills.implicit_invocation`, supported
+  values are `true` and `false`.
 
 ### `oo config unset <key>`
 
 Remove one persisted configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported values:
-  `lang`, `file.download.out_dir`, `skills.oo.implicit_invocation`.
+  `lang`, `file.download.out_dir`, `skills.oo.implicit_invocation`,
+  `skills.oo-find-skills.implicit_invocation`.
 
 ## Updates
 
@@ -183,10 +188,9 @@ directory.
 
 - Alias: `oo skills add [packageName]`.
 - Arguments: `[packageName]` is optional.
-- Arguments: when omitted, the command behaves the same as
-  `oo skills install oo`.
-- Arguments: when `[packageName]` is `oo`, the command installs the
-  bundled `oo` skill.
+- Arguments: when omitted, the command installs all bundled skills.
+- Arguments: when `[packageName]` is `oo` or `oo-find-skills`, the command
+  installs the corresponding bundled skill.
 - Arguments: when `[packageName]` is a published package name, the command
   installs skills from that package.
 - Options: `-s, --skill <skills...>` installs one or more named published
@@ -204,8 +208,8 @@ directory.
 - Notes: in the interactive picker, skills already installed from the same
   package start selected. Clearing such a selection removes that installed
   skill when the command completes.
-- Canonical directory: bundled `oo` is materialized to
-  `<config-dir>/skills/oo`, where `<config-dir>` is the directory that
+- Canonical directory: bundled skills are materialized to
+  `<config-dir>/skills/<skill-id>`, where `<config-dir>` is the directory that
   contains `settings.toml`.
 - Canonical directory: published skills are materialized to
   `<config-dir>/skills/<skill-id>`.
@@ -217,14 +221,14 @@ directory.
   canonical directory when the current platform and environment allow it. When
   symlink creation fails, `oo` falls back to copying the canonical files into
   the Codex skills directory.
-- Metadata: bundled `oo` writes a hidden `.oo-metadata.json` file whose
+- Metadata: bundled skills write a hidden `.oo-metadata.json` file whose
   `version` field matches the current `oo` version.
 - Metadata: published skills write a hidden `.oo-metadata.json` file whose
   `version` field matches the package version and whose `packageName` field
   records the source package.
-- Metadata: `agents/openai.yaml` in bundled `oo` uses the persisted
-  `skills.oo.implicit_invocation` value when configured, otherwise the
-  bundled default is used.
+- Metadata: `agents/openai.yaml` in bundled `oo` and `oo-find-skills` uses
+  the persisted skill-specific `implicit_invocation` value when configured;
+  otherwise the bundled default is used.
 - Notes: all registry requests for published skills send the active account's
   `Authorization` header.
 - Notes: when a package publishes multiple skills and the command runs outside
@@ -236,16 +240,16 @@ directory.
   selecting one means it will be overwritten.
 - Notes: the command exits with an error when the Codex home directory does
   not exist, which indicates Codex is not installed on the current machine.
-- Notes: an existing bundled `oo` installation is considered managed by `oo`
+- Notes: an existing bundled skill installation is considered managed by `oo`
   only when its `.oo-metadata.json` file can be parsed and contains a
   non-empty `version`. Otherwise `oo` treats it as a different skill and will
   not overwrite it.
 - Notes: on the first `oo` run, when there is no existing config, auth, or log
-  data yet, `oo` silently installs the bundled managed skill automatically if
-  the Codex home directory already exists.
-- Notes: when the bundled `oo` skill is already installed, every `oo` startup
-  checks whether the recorded metadata `version` matches the current CLI
-  version and silently refreshes the installed files when needed.
+  data yet, `oo` silently installs missing bundled managed skills
+  automatically if the Codex home directory already exists.
+- Notes: when a bundled skill is already installed, every `oo` startup checks
+  whether the recorded metadata `version` matches the current CLI version and
+  silently refreshes the installed files when needed.
 
 ### `oo skills update [skills...]`
 
@@ -255,8 +259,9 @@ Update installed oo-managed Codex skills.
   published skill.
 - Arguments: when one or more skill names are provided, only those named skills
   are checked and updated.
-- Bundled skills: the bundled `oo` skill is excluded from this command because
-  the CLI synchronizes it automatically during startup when needed.
+- Bundled skills: bundled skills such as `oo` and `oo-find-skills` are
+  excluded from this command because the CLI synchronizes them automatically
+  during startup when needed.
 - Published skills: registry-backed skills derive their package identity from
   `.oo-metadata.json`, then fetch package info without an explicit version to
   determine the latest available package version.
@@ -272,7 +277,7 @@ Update installed oo-managed Codex skills.
 Remove one oo-managed skill from the local Codex skills directory.
 
 - Alias: `oo skills remove [skill]`.
-- Arguments: `[skill]` defaults to `oo` when omitted.
+- Arguments: when `[skill]` is omitted, the command removes all bundled skills.
 - Ownership rule: the target skill is removable only when
   `${CODEX_HOME:-~/.codex}/skills/<skill>` has a `.oo-metadata.json` file that
   can be parsed and contains a non-empty `version`.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -66,7 +66,8 @@
 读取一个持久化配置值。
 
 - 参数：`<key>` 为配置键。目前支持
-  `lang`、`file.download.out_dir`、`skills.oo.implicit_invocation`。
+  `lang`、`file.download.out_dir`、`skills.oo.implicit_invocation`、
+  `skills.oo-find-skills.implicit_invocation`。
 
 ### `oo config path`
 
@@ -77,7 +78,8 @@
 写入一个持久化配置值。
 
 - 参数：`<key>` 为配置键。目前支持
-  `lang`、`file.download.out_dir`、`skills.oo.implicit_invocation`。
+  `lang`、`file.download.out_dir`、`skills.oo.implicit_invocation`、
+  `skills.oo-find-skills.implicit_invocation`。
 - 参数：`<value>` 为对应配置值。
 - 取值规则：当 `<key>` 为 `lang` 时，支持的值为 `en` 和 `zh`。
 - 取值规则：当 `<key>` 为 `file.download.out_dir` 时，支持任意非空路径字符串。
@@ -85,13 +87,16 @@
   开头，则会展开为当前用户的 home 目录。
 - 取值规则：当 `<key>` 为 `skills.oo.implicit_invocation` 时，支持的
   值为 `true` 和 `false`。
+- 取值规则：当 `<key>` 为 `skills.oo-find-skills.implicit_invocation` 时，
+  支持的值为 `true` 和 `false`。
 
 ### `oo config unset <key>`
 
 删除一个持久化配置值。
 
 - 参数：`<key>` 为配置键。目前支持
-  `lang`、`file.download.out_dir`、`skills.oo.implicit_invocation`。
+  `lang`、`file.download.out_dir`、`skills.oo.implicit_invocation`、
+  `skills.oo-find-skills.implicit_invocation`。
 
 ## 更新
 
@@ -164,8 +169,9 @@
 
 - 别名：`oo skills add [packageName]`。
 - 参数：`[packageName]` 可选。
-- 参数：未提供时，该命令等价于 `oo skills install oo`。
-- 参数：当 `[packageName]` 为 `oo` 时，命令安装内置的 `oo` skill。
+- 参数：未提供时，该命令会安装全部内置 skill。
+- 参数：当 `[packageName]` 为 `oo` 或 `oo-find-skills` 时，命令安装对应
+  的内置 skill。
 - 参数：当 `[packageName]` 为已发布 package 名称时，命令从该 package 中
   安装 skill。
 - 选项：`-s, --skill <skills...>` 用于安装 package 中一个或多个指定的
@@ -180,7 +186,7 @@
   `-y`，命令会在 TTY 中打开交互选择页面。
 - 说明：在交互选择页面中，同一 package 下已安装的 skill 会默认保持勾选；
   如果用户取消这些勾选，命令完成时会移除对应已安装 skill。
-- canonical 目录：内置 `oo` 的文件会先释放到 `<config-dir>/skills/oo`，
+- canonical 目录：内置 skill 会先释放到 `<config-dir>/skills/<skill-id>`，
   其中 `<config-dir>` 是 `settings.toml` 所在目录。
 - canonical 目录：已发布 skill 会先释放到 `<config-dir>/skills/<skill-id>`。
 - 目标目录：所有已安装 skill 都会发布到
@@ -188,13 +194,14 @@
 - 安装方式：`oo` 会优先将目标目录发布为指向 canonical 目录的软连接。
   如果当前平台或环境下创建软连接失败，则会回退为把 canonical 目录内容复制
   到 Codex skills 目录。
-- 元数据：内置 `oo` 会写入一个隐藏的 `.oo-metadata.json` 文件，其中
+- 元数据：内置 skill 会写入一个隐藏的 `.oo-metadata.json` 文件，其中
   `version` 字段记录当前 `oo` 版本。
 - 元数据：已发布 skill 也会写入一个隐藏的 `.oo-metadata.json` 文件，
   其中 `version` 字段记录 package 版本，`packageName` 字段记录来源
   package。
-- 元数据：当存在持久化的 `skills.oo.implicit_invocation` 配置时，
-  bundled `oo` 的 `agents/openai.yaml` 会使用该值；否则使用内置默认值。
+- 元数据：当存在持久化的 `implicit_invocation` 配置时，bundled `oo`
+  和 `oo-find-skills` 的 `agents/openai.yaml` 都会使用各自的配置值；
+  否则使用内置默认值。
 - 说明：安装已发布 skill 时，所有 registry 请求都会携带当前激活账号的
   `Authorization` header。
 - 说明：如果 package 下有多个 skill，且当前不是交互终端，则必须提供
@@ -205,15 +212,15 @@
   只要用户仍然选择该项，就会执行覆盖。
 - 说明：当 Codex 根目录不存在时，命令会直接报错退出，这表示当前机器上没有
   安装 Codex。
-- 说明：只有当 bundled `oo` 的 `.oo-metadata.json` 可以被解析，且其中包
+- 说明：只有当 bundled skill 的 `.oo-metadata.json` 可以被解析，且其中包
   含非空的 `version` 时，`oo` 才会认为这是自己管理的内置 skill；否则会视
   为其他 skill，并拒绝覆盖。
 - 说明：如果这是 `oo` 的首次运行，且当前还没有已有的 config、auth、log
-  数据，那么只要 Codex 根目录已经存在，`oo` 就会静默自动安装这个 bundled
-  受管 skill。
-- 说明：如果 bundled `oo` 已经安装，`oo` 每次启动都会检查其记录版本是否
-  与当前 CLI 版本一致；这里的版本来自元数据文件中的 `version` 字段。不一
-  致时会静默刷新已安装的文件。
+  数据，那么只要 Codex 根目录已经存在，`oo` 就会静默自动安装缺失的
+  bundled 受管 skills。
+- 说明：如果某个 bundled skill 已经安装，`oo` 每次启动都会检查其记录版本
+  是否与当前 CLI 版本一致；这里的版本来自元数据文件中的 `version` 字段。
+  不一致时会静默刷新已安装的文件。
 
 ### `oo skills update [skills...]`
 
@@ -221,8 +228,8 @@
 
 - 参数：省略时，会检查所有已安装且由 oo 管理的已发布 skill。
 - 参数：提供一个或多个 skill 名称时，只会检查并更新这些指定 skill。
-- 内置 skill：bundled `oo` 不在此命令处理范围内，因为 CLI 启动时会在需要时
-  自动同步它。
+- 内置 skill：bundled `oo`、`oo-find-skills` 等内置 skill 不在此命令处理
+  范围内，因为 CLI 启动时会在需要时自动同步它们。
 - 已发布 skill：registry skill 会从 `.oo-metadata.json` 读取所属包名，再通过
   不带显式版本的 package info 请求判断最新可用版本。
 - 更新顺序：命令会先刷新 canonical 目录
@@ -236,7 +243,7 @@
 从本地 Codex skills 目录移除一个由 oo 管理的 skill。
 
 - 别名：`oo skills remove [skill]`。
-- 参数：省略 `[skill]` 时，默认使用 `oo`。
+- 参数：省略 `[skill]` 时，命令会移除全部内置 skill。
 - 所有权规则：只有当
   `${CODEX_HOME:-~/.codex}/skills/<skill>` 中的 `.oo-metadata.json` 可
   以被解析，且其中包含非空 `version` 时，才允许移除该 skill。

--- a/src/adapters/store/file-settings-store.test.ts
+++ b/src/adapters/store/file-settings-store.test.ts
@@ -7,31 +7,10 @@ import { describe, expect, test } from "bun:test";
 import {
     createLogCapture,
     createTemporaryDirectory,
+    defaultSettingsFileContent,
 } from "../../../__tests__/helpers.ts";
 import { APP_NAME } from "../../application/config/app-config.ts";
 import { FileSettingsStore } from "./file-settings-store.ts";
-
-const defaultSettingsFileContent = [
-    "# lang controls the CLI display language for help text, messages, and errors.",
-    "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
-    "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
-    "# lang = \"en\"",
-    "",
-    "# file.download.out_dir controls the default output directory used by `oo file download` when [outDir] is omitted.",
-    "# Default: ~/Downloads.",
-    "# Supported values: any non-empty path string.",
-    "# Relative values resolve from the current working directory when the command runs.",
-    "# A leading `~` expands to the current user's home directory.",
-    "# [file.download]",
-    "# out_dir = \"~/Downloads\"",
-    "",
-    "# skills.oo.implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
-    "# Supported values: true, false.",
-    "# Default: true.",
-    "# [skills.oo]",
-    "# implicit_invocation = false",
-    "",
-].join("\n");
 
 describe("FileSettingsStore", () => {
     test("returns default settings when the file does not exist", async () => {
@@ -68,29 +47,9 @@ describe("FileSettingsStore", () => {
 
         expect(store.getFilePath()).toEndWith("settings.toml");
         expect(await readFile(store.getFilePath(), "utf8")).toBe(
-            [
-                "# lang controls the CLI display language for help text, messages, and errors.",
-                "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
-                "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
-                "# lang = \"en\"",
-                "",
-                "# file.download.out_dir controls the default output directory used by `oo file download` when [outDir] is omitted.",
-                "# Default: ~/Downloads.",
-                "# Supported values: any non-empty path string.",
-                "# Relative values resolve from the current working directory when the command runs.",
-                "# A leading `~` expands to the current user's home directory.",
-                "# [file.download]",
-                "# out_dir = \"~/Downloads\"",
-                "",
-                "# skills.oo.implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
-                "# Supported values: true, false.",
-                "# Default: true.",
-                "# [skills.oo]",
-                "# implicit_invocation = false",
-                "",
+            createExpectedSettingsFileContent([
                 "lang = \"zh\"",
-                "",
-            ].join("\n"),
+            ]),
         );
         expect(await store.read()).toEqual({
             lang: "zh",
@@ -117,34 +76,48 @@ describe("FileSettingsStore", () => {
         });
 
         expect(await readFile(store.getFilePath(), "utf8")).toBe(
-            [
-                "# lang controls the CLI display language for help text, messages, and errors.",
-                "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
-                "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
-                "# lang = \"en\"",
-                "",
-                "# file.download.out_dir controls the default output directory used by `oo file download` when [outDir] is omitted.",
-                "# Default: ~/Downloads.",
-                "# Supported values: any non-empty path string.",
-                "# Relative values resolve from the current working directory when the command runs.",
-                "# A leading `~` expands to the current user's home directory.",
-                "# [file.download]",
-                "# out_dir = \"~/Downloads\"",
-                "",
-                "# skills.oo.implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
-                "# Supported values: true, false.",
-                "# Default: true.",
-                "# [skills.oo]",
-                "# implicit_invocation = false",
-                "",
+            createExpectedSettingsFileContent([
                 "[skills.oo]",
                 "implicit_invocation = false",
-                "",
-            ].join("\n"),
+            ]),
         );
         expect(await store.read()).toEqual({
             skills: {
                 oo: {
+                    implicit_invocation: false,
+                },
+            },
+        });
+    });
+
+    test("writes and reads persisted oo-find-skills settings", async () => {
+        const root = await createTemporaryDirectory("store-find-skills-write");
+        const store = new FileSettingsStore({
+            appName: APP_NAME,
+            env: {
+                HOME: root,
+                XDG_CONFIG_HOME: root,
+            },
+            platform: "linux",
+        });
+
+        await store.write({
+            skills: {
+                "oo-find-skills": {
+                    implicit_invocation: false,
+                },
+            },
+        });
+
+        expect(await readFile(store.getFilePath(), "utf8")).toBe(
+            createExpectedSettingsFileContent([
+                "[skills.oo-find-skills]",
+                "implicit_invocation = false",
+            ]),
+        );
+        expect(await store.read()).toEqual({
+            skills: {
+                "oo-find-skills": {
                     implicit_invocation: false,
                 },
             },
@@ -171,30 +144,10 @@ describe("FileSettingsStore", () => {
         });
 
         expect(await readFile(store.getFilePath(), "utf8")).toBe(
-            [
-                "# lang controls the CLI display language for help text, messages, and errors.",
-                "# Supported values: \"en\" (English), \"zh\" (Simplified Chinese).",
-                "# Default: auto-detect from LC_ALL, LC_MESSAGES, LANG, then system locale.",
-                "# lang = \"en\"",
-                "",
-                "# file.download.out_dir controls the default output directory used by `oo file download` when [outDir] is omitted.",
-                "# Default: ~/Downloads.",
-                "# Supported values: any non-empty path string.",
-                "# Relative values resolve from the current working directory when the command runs.",
-                "# A leading `~` expands to the current user's home directory.",
-                "# [file.download]",
-                "# out_dir = \"~/Downloads\"",
-                "",
-                "# skills.oo.implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
-                "# Supported values: true, false.",
-                "# Default: true.",
-                "# [skills.oo]",
-                "# implicit_invocation = false",
-                "",
+            createExpectedSettingsFileContent([
                 "[file.download]",
                 "out_dir = \"~/Downloads\"",
-                "",
-            ].join("\n"),
+            ]),
         );
         expect(await store.read()).toEqual({
             file: {
@@ -243,6 +196,9 @@ describe("FileSettingsStore", () => {
                 "lang = \"zh\"",
                 "updateNotifier = false",
                 "",
+                "[skills.oo-find-skills]",
+                "implicit_invocation = false",
+                "",
                 "[skills.oo]",
                 "implicit_invocation = false",
                 "extra = true",
@@ -254,7 +210,10 @@ describe("FileSettingsStore", () => {
         await expect(store.read()).resolves.toEqual({
             lang: "zh",
             skills: {
-                oo: {
+                "oo-find-skills": {
+                    implicit_invocation: false,
+                },
+                "oo": {
                     implicit_invocation: false,
                 },
             },
@@ -327,3 +286,13 @@ describe("FileSettingsStore", () => {
         } satisfies Partial<CliUserError>);
     });
 });
+
+function createExpectedSettingsFileContent(
+    persistedLines: string[],
+): string {
+    if (persistedLines.length === 0) {
+        return defaultSettingsFileContent;
+    }
+
+    return `${defaultSettingsFileContent}\n${persistedLines.join("\n")}\n`;
+}

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -140,8 +140,24 @@ exports[`config CLI supports config path list get set and unset 1`] = `
 }
 `;
 
-exports[`config CLI supports the oo skill implicit invocation config key 1`] = `
+exports[`config CLI supports bundled skill implicit invocation config keys 1`] = `
 {
+  "findGet": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"false
+"
+,
+  },
+  "findSet": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Set skills.oo-find-skills.implicit_invocation to false.
+"
+,
+  },
   "get": {
     "exitCode": 0,
     "stderr": "",
@@ -235,12 +251,34 @@ exports[`config CLI config set immediately synchronizes the installed managed sk
 }
 `;
 
+exports[`config CLI config set immediately synchronizes the installed oo-find-skills policy 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Set skills.oo-find-skills.implicit_invocation to false.
+"
+,
+}
+`;
+
 exports[`config CLI config unset immediately restores the installed managed skill policy default 1`] = `
 {
   "exitCode": 0,
   "stderr": "",
   "stdout": 
 "Removed skills.oo.implicit_invocation.
+"
+,
+}
+`;
+
+exports[`config CLI config unset immediately restores the installed oo-find-skills policy default 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Removed skills.oo-find-skills.implicit_invocation.
 "
 ,
 }
@@ -360,7 +398,7 @@ exports[`config CLI returns usage errors for invalid config inputs 1`] = `
   "invalidSkillPolicyValue": {
     "exitCode": 2,
     "stderr": 
-"Invalid skills.oo.implicit_invocation value: maybe. Use true or false.
+"Invalid skills.oo-find-skills.implicit_invocation value: maybe. Use true or false.
 "
 ,
     "stdout": "",

--- a/src/application/commands/config/index.cli.test.ts
+++ b/src/application/commands/config/index.cli.test.ts
@@ -90,7 +90,7 @@ describe("config CLI", () => {
         }
     });
 
-    test("supports the oo skill implicit invocation config key", async () => {
+    test("supports bundled skill implicit invocation config keys", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -116,8 +116,21 @@ describe("config CLI", () => {
                 "get",
                 "skills.oo.implicit_invocation",
             ]);
+            const findSetResult = await sandbox.run([
+                "config",
+                "set",
+                "skills.oo-find-skills.implicit_invocation",
+                "false",
+            ]);
+            const findGetResult = await sandbox.run([
+                "config",
+                "get",
+                "skills.oo-find-skills.implicit_invocation",
+            ]);
 
             expect({
+                findGet: createCliSnapshot(findGetResult),
+                findSet: createCliSnapshot(findSetResult),
                 get: createCliSnapshot(getResult),
                 getAfterUnset: createCliSnapshot(getAfterUnsetResult),
                 list: createCliSnapshot(listResult),
@@ -209,6 +222,52 @@ describe("config CLI", () => {
         }
     });
 
+    test("config set immediately synchronizes the installed oo-find-skills policy", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(
+                metadataFilePath,
+                renderSkillMetadataJson({ version: "9.9.9" }),
+            );
+            await Bun.write(
+                ownershipFilePath,
+                await Bun.file(
+                    join(
+                        process.cwd(),
+                        "contrib",
+                        "skills",
+                        "oo-find-skills",
+                        "agents",
+                        "openai.yaml",
+                    ),
+                ).text(),
+            );
+
+            const result = await sandbox.run([
+                "config",
+                "set",
+                "skills.oo-find-skills.implicit_invocation",
+                "false",
+            ], {
+                version: "9.9.9",
+            });
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: false",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("config unset immediately restores the installed managed skill policy default", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -255,6 +314,66 @@ describe("config CLI", () => {
                 "config",
                 "unset",
                 "skills.oo.implicit_invocation",
+            ], {
+                version: "9.9.9",
+            });
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: true",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("config unset immediately restores the installed oo-find-skills policy default", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const settingsFilePath = join(
+            sandbox.env.XDG_CONFIG_HOME!,
+            APP_NAME,
+            "settings.toml",
+        );
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(
+                metadataFilePath,
+                renderSkillMetadataJson({ version: "9.9.9" }),
+            );
+            await Bun.write(
+                ownershipFilePath,
+                [
+                    "interface:",
+                    "  display_name: oo Find Skills",
+                    "  short_description: Search and install likely oo skills",
+                    "  default_prompt: \"Use $oo-find-skills when I need to search the OO skill catalog from a user request, pick a primary and fallback match, show four install choices, and then install the selected skill or skills with `oo skills install`.\"",
+                    "",
+                    "policy:",
+                    "  allow_implicit_invocation: false",
+                    "",
+                    "# OOMOL",
+                    "",
+                ].join("\n"),
+            );
+            await Bun.write(
+                settingsFilePath,
+                [
+                    "[skills.oo-find-skills]",
+                    "implicit_invocation = false",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run([
+                "config",
+                "unset",
+                "skills.oo-find-skills.implicit_invocation",
             ], {
                 version: "9.9.9",
             });
@@ -333,7 +452,7 @@ describe("config CLI", () => {
             const invalidSkillPolicyValue = await sandbox.run([
                 "config",
                 "set",
-                "skills.oo.implicit_invocation",
+                "skills.oo-find-skills.implicit_invocation",
                 "maybe",
             ]);
 
@@ -348,7 +467,7 @@ describe("config CLI", () => {
             expect(invalidConfigValue.stderr).toContain("Invalid lang value");
 
             expect(invalidSkillPolicyValue.stderr).toContain(
-                "Invalid skills.oo.implicit_invocation value",
+                "Invalid skills.oo-find-skills.implicit_invocation value",
             );
         }
         finally {

--- a/src/application/commands/config/set.ts
+++ b/src/application/commands/config/set.ts
@@ -11,7 +11,7 @@ import {
     configKeySchema,
     createInvalidConfigKeyError,
     isConfigKey,
-    ooSkillImplicitInvocationConfigKey,
+    isSkillImplicitInvocationConfigKey,
 } from "./shared.ts";
 
 interface ResolvedConfigSetInput {
@@ -78,7 +78,7 @@ export const configSetCommand: CliCommandDefinition<ResolvedConfigSetInput> = {
             settings => input.definition.setValue(settings, input.value),
         );
 
-        if (input.key === ooSkillImplicitInvocationConfigKey) {
+        if (isSkillImplicitInvocationConfigKey(input.key)) {
             await maybeSynchronizeInstalledBundledSkills(context, {
                 settings: nextSettings,
             });

--- a/src/application/commands/config/shared.ts
+++ b/src/application/commands/config/shared.ts
@@ -1,6 +1,6 @@
 import type { ZodType } from "zod";
 import type { SupportedLocale } from "../../contracts/cli.ts";
-import type { AppSettings } from "../../schemas/settings.ts";
+import type { AppSettings, BundledSkillSettingsKey } from "../../schemas/settings.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
@@ -9,14 +9,14 @@ import {
     booleanConfigValueSchema,
     fileDownloadOutDirConfigValueSchema,
     getConfiguredFileDownloadOutDir,
-    getConfiguredOoSkillImplicitInvocation,
+    getConfiguredSkillImplicitInvocation,
     localeSchema,
     parseBooleanConfigValue,
     setFileDownloadOutDir,
-    setOoSkillImplicitInvocation,
+    setSkillImplicitInvocation,
     stringifyBooleanConfigValue,
     unsetFileDownloadOutDir,
-    unsetOoSkillImplicitInvocation,
+    unsetSkillImplicitInvocation,
 } from "../../schemas/settings.ts";
 
 interface ConfigDefinition<TValue extends string> {
@@ -38,7 +38,54 @@ function createValueErrorFactory(translationKey: string) {
 
 export const ooSkillImplicitInvocationConfigKey
     = "skills.oo.implicit_invocation" as const;
+export const ooFindSkillsImplicitInvocationConfigKey
+    = "skills.oo-find-skills.implicit_invocation" as const;
 export const fileDownloadOutDirConfigKey = "file.download.out_dir" as const;
+
+const skillImplicitInvocationConfigKeys: ReadonlySet<string> = new Set([
+    ooSkillImplicitInvocationConfigKey,
+    ooFindSkillsImplicitInvocationConfigKey,
+]);
+
+export function isSkillImplicitInvocationConfigKey(key: string): boolean {
+    return skillImplicitInvocationConfigKeys.has(key);
+}
+
+function createSkillImplicitInvocationConfigDefinition(
+    skillName: BundledSkillSettingsKey,
+): ConfigDefinition<"false" | "true"> {
+    return {
+        createInvalidValueError(rawValue: unknown): CliUserError {
+            return new CliUserError(
+                "errors.config.invalidSkillImplicitInvocationValue",
+                2,
+                {
+                    skill: skillName,
+                    value: String(rawValue ?? ""),
+                },
+            );
+        },
+        getValue(settings: AppSettings): "false" | "true" | undefined {
+            const configuredValue = getConfiguredSkillImplicitInvocation(settings, skillName);
+
+            return configuredValue === undefined
+                ? undefined
+                : stringifyBooleanConfigValue(configuredValue);
+        },
+        setValue(settings: AppSettings, value: "false" | "true"): AppSettings {
+            return setSkillImplicitInvocation(
+                settings,
+                skillName,
+                parseBooleanConfigValue(value),
+            );
+        },
+        unsetValue(settings: AppSettings): AppSettings {
+            return unsetSkillImplicitInvocation(settings, skillName);
+        },
+        valueChoices: booleanConfigValueChoices,
+        valueSchema: booleanConfigValueSchema,
+    };
+}
 
 export const configDefinitions = {
     lang: {
@@ -76,28 +123,10 @@ export const configDefinitions = {
         valueChoices: [],
         valueSchema: fileDownloadOutDirConfigValueSchema,
     } satisfies ConfigDefinition<string>,
-    [ooSkillImplicitInvocationConfigKey]: {
-        createInvalidValueError: createValueErrorFactory("errors.config.invalidSkillsOoImplicitInvocationValue"),
-        getValue(settings: AppSettings): "false" | "true" | undefined {
-            const configuredValue
-                = getConfiguredOoSkillImplicitInvocation(settings);
-
-            return configuredValue === undefined
-                ? undefined
-                : stringifyBooleanConfigValue(configuredValue);
-        },
-        setValue(settings: AppSettings, value: "false" | "true"): AppSettings {
-            return setOoSkillImplicitInvocation(
-                settings,
-                parseBooleanConfigValue(value),
-            );
-        },
-        unsetValue(settings: AppSettings): AppSettings {
-            return unsetOoSkillImplicitInvocation(settings);
-        },
-        valueChoices: booleanConfigValueChoices,
-        valueSchema: booleanConfigValueSchema,
-    } satisfies ConfigDefinition<"false" | "true">,
+    [ooSkillImplicitInvocationConfigKey]:
+        createSkillImplicitInvocationConfigDefinition("oo"),
+    [ooFindSkillsImplicitInvocationConfigKey]:
+        createSkillImplicitInvocationConfigDefinition("oo-find-skills"),
 } as const;
 
 export type ConfigKey = keyof typeof configDefinitions;

--- a/src/application/commands/config/unset.ts
+++ b/src/application/commands/config/unset.ts
@@ -9,7 +9,7 @@ import {
     configKeyChoices,
     configKeySchema,
     createInvalidConfigKeyError,
-    ooSkillImplicitInvocationConfigKey,
+    isSkillImplicitInvocationConfigKey,
 } from "./shared.ts";
 
 export const configUnsetCommand: CliCommandDefinition<ConfigKeyInput> = {
@@ -33,7 +33,7 @@ export const configUnsetCommand: CliCommandDefinition<ConfigKeyInput> = {
             configDefinitions[input.key].unsetValue(settings),
         );
 
-        if (input.key === ooSkillImplicitInvocationConfigKey) {
+        if (isSkillImplicitInvocationConfigKey(input.key)) {
             await maybeSynchronizeInstalledBundledSkills(context, {
                 settings: nextSettings,
             });

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -133,6 +133,7 @@ exports[`skills CLI writes explicit skills install and uninstall logs 1`] = `
     "stderr": "",
     "stdout": 
 "Installed Codex skill oo to <HOME>/.codex/skills/oo.
+Installed Codex skill oo-find-skills to <HOME>/.codex/skills/oo-find-skills.
 "
 ,
   },
@@ -141,6 +142,7 @@ exports[`skills CLI writes explicit skills install and uninstall logs 1`] = `
     "stderr": "",
     "stdout": 
 "Removed Codex skill oo from <HOME>/.codex/skills/oo.
+Removed Codex skill oo-find-skills from <HOME>/.codex/skills/oo-find-skills.
 "
 ,
   },

--- a/src/application/commands/skills/__snapshots__/search.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/search.cli.test.ts.snap
@@ -35,6 +35,19 @@ exports[`skills search CLI supports skills search with the --json alias 1`] = `
 }
 `;
 
+exports[`skills search CLI renders skills search output with field-specific colors 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Text Generation (text-generation)
+Generate text using AI models
+Package: @oomol/ai-tools@1.0.0
+"
+,
+}
+`;
+
 exports[`skills search CLI validates the skills search format option 1`] = `
 {
   "exitCode": 2,
@@ -94,18 +107,5 @@ Global Options:
 "
 ,
   },
-}
-`;
-
-exports[`skills search CLI renders skills search output with field-specific colors 1`] = `
-{
-  "exitCode": 0,
-  "stderr": "",
-  "stdout": 
-"Text Generation (text-generation)
-Generate text using AI models
-Package: @oomol/ai-tools@1.0.0
-"
-,
 }
 `;

--- a/src/application/commands/skills/bundled-skill-model.test.ts
+++ b/src/application/commands/skills/bundled-skill-model.test.ts
@@ -17,7 +17,10 @@ describe("bundled skill model", () => {
     test("renders the ownership policy file with the configured implicit invocation value", () => {
         const settings: AppSettings = {
             skills: {
-                oo: {
+                "oo-find-skills": {
+                    implicit_invocation: false,
+                },
+                "oo": {
                     implicit_invocation: false,
                 },
             },
@@ -39,6 +42,14 @@ describe("bundled skill model", () => {
         expect(
             renderBundledSkillFileContent("oo", "SKILL.md", "skill\n", settings),
         ).toBe("skill\n");
+        expect(
+            renderBundledSkillFileContent(
+                "oo-find-skills",
+                "agents/openai.yaml",
+                content,
+                settings,
+            ),
+        ).toContain("allow_implicit_invocation: false");
     });
 
     test("reads and writes the implicit invocation value while preserving CRLF formatting", () => {

--- a/src/application/commands/skills/bundled-skill-model.ts
+++ b/src/application/commands/skills/bundled-skill-model.ts
@@ -1,7 +1,7 @@
 import type { AppSettings } from "../../schemas/settings.ts";
 
 import type { BundledSkillName } from "./embedded-assets.ts";
-import { getOoSkillImplicitInvocation } from "../../schemas/settings.ts";
+import { getSkillImplicitInvocation } from "../../schemas/settings.ts";
 import { bundledSkillOwnershipFileRelativePath } from "./bundled-skill-paths.ts";
 import { parseSkillMetadataWithVersion } from "./skill-metadata.ts";
 
@@ -60,10 +60,7 @@ export function resolveBundledSkillImplicitInvocation(
     skillName: BundledSkillName,
     settings: AppSettings,
 ): boolean {
-    switch (skillName) {
-        case "oo":
-            return getOoSkillImplicitInvocation(settings);
-    }
+    return getSkillImplicitInvocation(settings, skillName);
 }
 
 export function renderBundledSkillFileContent(

--- a/src/application/commands/skills/config/__snapshots__/get.cli.test.ts.snap
+++ b/src/application/commands/skills/config/__snapshots__/get.cli.test.ts.snap
@@ -11,6 +11,17 @@ exports[`skills config get CLI reads the effective oo skill config value for a k
 }
 `;
 
+exports[`skills config get CLI reads the effective oo-find-skills config value for a key 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"true
+"
+,
+}
+`;
+
 exports[`skills config get CLI lists all known effective values when the key is omitted 1`] = `
 {
   "exitCode": 0,
@@ -27,7 +38,7 @@ exports[`skills config get CLI validates skills config get input 1`] = `
   "invalidKey": {
     "exitCode": 2,
     "stderr": 
-"Invalid config key for skill oo: missing. Use allow-implicit-invocation.
+"Invalid config key for skill oo-find-skills: missing. Use allow-implicit-invocation.
 "
 ,
     "stdout": "",
@@ -35,7 +46,7 @@ exports[`skills config get CLI validates skills config get input 1`] = `
   "invalidSkill": {
     "exitCode": 2,
     "stderr": 
-"Unsupported skill: missing. Use oo.
+"Unsupported skill: missing. Use oo, oo-find-skills.
 "
 ,
     "stdout": "",

--- a/src/application/commands/skills/config/__snapshots__/set.cli.test.ts.snap
+++ b/src/application/commands/skills/config/__snapshots__/set.cli.test.ts.snap
@@ -11,6 +11,17 @@ exports[`skills config set CLI supports skills config set for the oo skill impli
 }
 `;
 
+exports[`skills config set CLI supports skills config set for the oo-find-skills implicit invocation policy 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Set Codex skill oo-find-skills allow-implicit-invocation to false.
+"
+,
+}
+`;
+
 exports[`skills config set CLI validates skills config set input 1`] = `
 {
   "invalidKey": {
@@ -24,7 +35,7 @@ exports[`skills config set CLI validates skills config set input 1`] = `
   "invalidSkill": {
     "exitCode": 2,
     "stderr": 
-"Unsupported skill: missing. Use oo.
+"Unsupported skill: missing. Use oo, oo-find-skills.
 "
 ,
     "stdout": "",
@@ -32,7 +43,7 @@ exports[`skills config set CLI validates skills config set input 1`] = `
   "invalidValue": {
     "exitCode": 2,
     "stderr": 
-"Invalid allow-implicit-invocation value for skill oo: disabled. Use true or false.
+"Invalid allow-implicit-invocation value for skill oo-find-skills: disabled. Use true or false.
 "
 ,
     "stdout": "",

--- a/src/application/commands/skills/config/get.cli.test.ts
+++ b/src/application/commands/skills/config/get.cli.test.ts
@@ -22,6 +22,25 @@ describe("skills config get CLI", () => {
         }
     });
 
+    test("reads the effective oo-find-skills config value for a key", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "config",
+                "get",
+                "oo-find-skills",
+                "allow-implicit-invocation",
+            ]);
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("lists all known effective values when the key is omitted", async () => {
         const sandbox = await createCliSandbox();
 
@@ -54,7 +73,7 @@ describe("skills config get CLI", () => {
                 "skills",
                 "config",
                 "get",
-                "oo",
+                "oo-find-skills",
                 "missing",
             ]);
 

--- a/src/application/commands/skills/config/get.test.ts
+++ b/src/application/commands/skills/config/get.test.ts
@@ -59,4 +59,32 @@ describe("skills config get command", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("reads oo-find-skills configured values after skills config set", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const setResult = await sandbox.run([
+                "skills",
+                "config",
+                "set",
+                "oo-find-skills",
+                "allow-implicit-invocation",
+                "false",
+            ]);
+            const getResult = await sandbox.run([
+                "skills",
+                "config",
+                "get",
+                "oo-find-skills",
+            ]);
+
+            expect(setResult.exitCode).toBe(0);
+            expect(getResult.exitCode).toBe(0);
+            expect(getResult.stdout).toBe("allow-implicit-invocation=false\n");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });

--- a/src/application/commands/skills/config/get.ts
+++ b/src/application/commands/skills/config/get.ts
@@ -1,6 +1,5 @@
 import type { CliCommandDefinition } from "../../../contracts/cli.ts";
-import type { BundledSkillName } from "../embedded-assets.ts";
-
+import type { ConfigurableBundledSkillName } from "./shared.ts";
 import { z } from "zod";
 import {
     createInvalidSkillConfigKeyError,
@@ -13,7 +12,7 @@ import {
 
 interface SkillsConfigGetInput {
     key?: string;
-    skill: BundledSkillName;
+    skill: ConfigurableBundledSkillName;
 }
 
 const skillsConfigGetInputSchema = z.object({

--- a/src/application/commands/skills/config/set.cli.test.ts
+++ b/src/application/commands/skills/config/set.cli.test.ts
@@ -23,6 +23,26 @@ describe("skills config set CLI", () => {
         }
     });
 
+    test("supports skills config set for the oo-find-skills implicit invocation policy", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "config",
+                "set",
+                "oo-find-skills",
+                "allow-implicit-invocation",
+                "false",
+            ]);
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("validates skills config set input", async () => {
         const sandbox = await createCliSandbox();
 
@@ -47,7 +67,7 @@ describe("skills config set CLI", () => {
                 "skills",
                 "config",
                 "set",
-                "oo",
+                "oo-find-skills",
                 "allow-implicit-invocation",
                 "disabled",
             ]);

--- a/src/application/commands/skills/config/set.test.ts
+++ b/src/application/commands/skills/config/set.test.ts
@@ -138,4 +138,53 @@ describe("skills config set command", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("updates the installed oo-find-skills managed skill when the config changes", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(
+                metadataFilePath,
+                renderSkillMetadataJson({
+                    version: "9.9.9",
+                }),
+            );
+            await Bun.write(
+                ownershipFilePath,
+                await Bun.file(
+                    getBundledSkillFiles("oo-find-skills").find(file => file.relativePath === "agents/openai.yaml")!.sourcePath,
+                ).text(),
+            );
+
+            const result = await sandbox.run([
+                "skills",
+                "config",
+                "set",
+                "oo-find-skills",
+                "allow-implicit-invocation",
+                "false",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: false",
+            );
+            expect(await readFile(
+                resolveStorePaths({
+                    appName: APP_NAME,
+                    env: sandbox.env,
+                    platform: process.platform,
+                }).settingsFilePath,
+                "utf8",
+            )).toContain("[skills.oo-find-skills]");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });

--- a/src/application/commands/skills/config/set.ts
+++ b/src/application/commands/skills/config/set.ts
@@ -1,7 +1,6 @@
 import type { CliCommandDefinition } from "../../../contracts/cli.ts";
 import type { AppSettings } from "../../../schemas/settings.ts";
-import type { BundledSkillName } from "../embedded-assets.ts";
-
+import type { ConfigurableBundledSkillName } from "./shared.ts";
 import { z } from "zod";
 import { maybeSynchronizeInstalledBundledSkills } from "../shared.ts";
 import {
@@ -16,7 +15,7 @@ interface ResolvedSkillsConfigSetInput {
         setValue: (settings: AppSettings, value: string) => AppSettings;
     };
     key: string;
-    skill: BundledSkillName;
+    skill: ConfigurableBundledSkillName;
     value: string;
 }
 

--- a/src/application/commands/skills/config/shared.test.ts
+++ b/src/application/commands/skills/config/shared.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { defaultSettings } from "../../../schemas/settings.ts";
+import { availableBundledSkillNames } from "../embedded-assets.ts";
 import {
     getSkillConfigDefinition,
     getSkillConfigDefinitionByRawInput,
@@ -10,32 +11,47 @@ import {
 } from "./shared.ts";
 
 describe("skills config shared contracts", () => {
+    test("keeps the bundled skill registry aligned with the config registry", () => {
+        expect(availableBundledSkillNames).toEqual(["oo", "oo-find-skills"]);
+        expect(skillConfigSkillChoices).toEqual(["oo", "oo-find-skills"]);
+    });
+
     test("keeps the bundled skill config registry aligned with the public contract", () => {
-        expect(skillConfigSkillChoices).toEqual(["oo"]);
+        expect(skillConfigSkillChoices).toEqual(["oo", "oo-find-skills"]);
         expect(getSkillConfigKeyChoices("oo")).toEqual([
+            "allow-implicit-invocation",
+        ]);
+        expect(getSkillConfigKeyChoices("oo-find-skills")).toEqual([
             "allow-implicit-invocation",
         ]);
         expect(listSkillConfigValues(defaultSettings, "oo")).toEqual([
             "allow-implicit-invocation=true",
         ]);
+        expect(listSkillConfigValues(defaultSettings, "oo-find-skills")).toEqual([
+            "allow-implicit-invocation=true",
+        ]);
     });
 
-    test("keeps the oo skill config value contract aligned with the public contract", () => {
-        const definition = getSkillConfigDefinition(
-            "oo",
-            "allow-implicit-invocation",
-        );
+    test("keeps bundled skill config value contracts aligned with the public contract", () => {
+        for (const skillName of skillConfigSkillChoices) {
+            const definition = getSkillConfigDefinition(
+                skillName,
+                "allow-implicit-invocation",
+            );
 
-        expect(definition.valueChoices).toEqual(["true", "false"]);
+            expect(definition.valueChoices).toEqual(["true", "false"]);
+        }
     });
 
     test("keeps skill config lookup helpers aligned with key choices", () => {
-        const [key] = getSkillConfigKeyChoices("oo");
+        for (const skillName of skillConfigSkillChoices) {
+            const [key] = getSkillConfigKeyChoices(skillName);
 
-        expect(key).toBe("allow-implicit-invocation");
-        expect(getSkillConfigDefinitionByRawInput("oo", key)).toBe(
-            getSkillConfigDefinition("oo", key!),
-        );
-        expect(getSkillConfigDefinitionByRawInput("oo", "missing")).toBeUndefined();
+            expect(key).toBe("allow-implicit-invocation");
+            expect(getSkillConfigDefinitionByRawInput(skillName, key)).toBe(
+                getSkillConfigDefinition(skillName, key!),
+            );
+            expect(getSkillConfigDefinitionByRawInput(skillName, "missing")).toBeUndefined();
+        }
     });
 });

--- a/src/application/commands/skills/config/shared.ts
+++ b/src/application/commands/skills/config/shared.ts
@@ -1,24 +1,23 @@
 import type { ZodType } from "zod";
 import type { AppSettings } from "../../../schemas/settings.ts";
-import type { BundledSkillName } from "../embedded-assets.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../../contracts/cli.ts";
 import {
     booleanConfigValueChoices,
     booleanConfigValueSchema,
-    getOoSkillImplicitInvocation,
+    getSkillImplicitInvocation,
     parseBooleanConfigValue,
-    setOoSkillImplicitInvocation,
+    setSkillImplicitInvocation,
     stringifyBooleanConfigValue,
 } from "../../../schemas/settings.ts";
-import {
-    availableBundledSkillNames,
-} from "../embedded-assets.ts";
+
+export const skillConfigSkillChoices = ["oo", "oo-find-skills"] as const;
+export type ConfigurableBundledSkillName = (typeof skillConfigSkillChoices)[number];
 
 interface SkillConfigDefinition {
     createInvalidValueError: (
-        skillName: BundledSkillName,
+        skillName: ConfigurableBundledSkillName,
         rawValue: unknown,
     ) => CliUserError;
     getValue: (settings: AppSettings) => string;
@@ -27,45 +26,54 @@ interface SkillConfigDefinition {
     valueSchema: ZodType<string>;
 }
 
-const skillConfigDefinitions: Record<
-    BundledSkillName,
-    Record<string, SkillConfigDefinition>
-> = {
-    oo: {
-        "allow-implicit-invocation": {
-            createInvalidValueError(skillName, rawValue) {
-                return new CliUserError(
-                    "errors.skills.config.invalidAllowImplicitInvocationValue",
-                    2,
-                    {
-                        skill: skillName,
-                        value: String(rawValue ?? ""),
-                    },
-                );
-            },
-            getValue(settings) {
-                return stringifyBooleanConfigValue(
-                    getOoSkillImplicitInvocation(settings),
-                );
-            },
-            setValue(settings, value) {
-                return setOoSkillImplicitInvocation(
-                    settings,
-                    parseBooleanConfigValue(
-                        booleanConfigValueSchema.parse(value),
-                    ),
-                );
-            },
-            valueChoices: booleanConfigValueChoices,
-            valueSchema: booleanConfigValueSchema,
-        } satisfies SkillConfigDefinition,
-    },
-};
+function createAllowImplicitInvocationDefinition(
+    skillName: ConfigurableBundledSkillName,
+): SkillConfigDefinition {
+    return {
+        createInvalidValueError(displaySkillName, rawValue) {
+            return new CliUserError(
+                "errors.skills.config.invalidAllowImplicitInvocationValue",
+                2,
+                {
+                    skill: displaySkillName,
+                    value: String(rawValue ?? ""),
+                },
+            );
+        },
+        getValue(settings) {
+            return stringifyBooleanConfigValue(
+                getSkillImplicitInvocation(settings, skillName),
+            );
+        },
+        setValue(settings, value) {
+            return setSkillImplicitInvocation(
+                settings,
+                skillName,
+                parseBooleanConfigValue(
+                    booleanConfigValueSchema.parse(value),
+                ),
+            );
+        },
+        valueChoices: booleanConfigValueChoices,
+        valueSchema: booleanConfigValueSchema,
+    };
+}
 
-export const skillConfigSkillChoices = availableBundledSkillNames;
+const skillConfigDefinitions = Object.fromEntries(
+    skillConfigSkillChoices.map(skillName => [
+        skillName,
+        {
+            "allow-implicit-invocation":
+                createAllowImplicitInvocationDefinition(skillName),
+        } satisfies Record<string, SkillConfigDefinition>,
+    ]),
+) as unknown as Record<ConfigurableBundledSkillName, Record<string, SkillConfigDefinition>>;
+
 export const skillConfigSkillSchema = z.enum(skillConfigSkillChoices);
 
-export function isBundledSkillName(value: unknown): value is BundledSkillName {
+export function isBundledSkillName(
+    value: unknown,
+): value is ConfigurableBundledSkillName {
     return typeof value === "string" && value in skillConfigDefinitions;
 }
 
@@ -93,13 +101,13 @@ export function createInvalidSkillConfigKeyError(
 }
 
 export function getSkillConfigKeyChoices(
-    skillName: BundledSkillName,
+    skillName: ConfigurableBundledSkillName,
 ): readonly string[] {
     return Object.keys(getSkillConfigDefinitions(skillName));
 }
 
 export function getSkillConfigDefinition(
-    skillName: BundledSkillName,
+    skillName: ConfigurableBundledSkillName,
     key: string,
 ): SkillConfigDefinition {
     return getSkillConfigDefinitions(skillName)[key]!;
@@ -107,7 +115,7 @@ export function getSkillConfigDefinition(
 
 export function getSkillConfigValue(
     settings: AppSettings,
-    skillName: BundledSkillName,
+    skillName: ConfigurableBundledSkillName,
     key: string,
 ): string {
     return getSkillConfigDefinition(skillName, key).getValue(settings);
@@ -115,7 +123,7 @@ export function getSkillConfigValue(
 
 export function listSkillConfigValues(
     settings: AppSettings,
-    skillName: BundledSkillName,
+    skillName: ConfigurableBundledSkillName,
 ): string[] {
     return getSkillConfigKeyChoices(skillName).map(
         key => `${key}=${getSkillConfigValue(settings, skillName, key)}`,
@@ -140,7 +148,7 @@ export function getSkillConfigDefinitionByRawInput(
 }
 
 function getSkillConfigDefinitions(
-    skillName: BundledSkillName,
+    skillName: ConfigurableBundledSkillName,
 ): Record<string, SkillConfigDefinition> {
     return skillConfigDefinitions[skillName];
 }

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+
+import { availableBundledSkillNames, getBundledSkillFiles } from "./embedded-assets.ts";
+
+describe("embedded skill assets", () => {
+    test("keeps the bundled skill file registry aligned with the bundled skill names", () => {
+        expect(availableBundledSkillNames).toEqual(["oo", "oo-find-skills"]);
+        expect(getBundledSkillFiles("oo").map(file => file.relativePath)).toEqual([
+            "SKILL.md",
+            "agents/openai.yaml",
+            "references/oo-cli-contract.md",
+        ]);
+        expect(getBundledSkillFiles("oo-find-skills").map(file => file.relativePath)).toEqual([
+            "SKILL.md",
+            "agents/openai.yaml",
+            "references/oo-cli-contract.md",
+        ]);
+    });
+});

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -1,8 +1,11 @@
+import ooFindSkillsOpenAIAgentPath from "../../../../contrib/skills/oo-find-skills/agents/openai.yaml" with { type: "file" };
+import ooFindSkillsCliContractPath from "../../../../contrib/skills/oo-find-skills/references/oo-cli-contract.md" with { type: "file" };
+import ooFindSkillsSkillPath from "../../../../contrib/skills/oo-find-skills/SKILL.md" with { type: "file" };
 import ooOpenAIAgentPath from "../../../../contrib/skills/oo/agents/openai.yaml" with { type: "file" };
 import ooCliContractPath from "../../../../contrib/skills/oo/references/oo-cli-contract.md" with { type: "file" };
 import ooSkillPath from "../../../../contrib/skills/oo/SKILL.md" with { type: "file" };
 
-export const availableBundledSkillNames = ["oo"] as const;
+export const availableBundledSkillNames = ["oo", "oo-find-skills"] as const;
 
 export type BundledSkillName = (typeof availableBundledSkillNames)[number];
 
@@ -28,6 +31,21 @@ const bundledSkillFiles = [
         relativePath: "references/oo-cli-contract.md",
         skillName: "oo",
         sourcePath: ooCliContractPath,
+    },
+    {
+        relativePath: "SKILL.md",
+        skillName: "oo-find-skills",
+        sourcePath: ooFindSkillsSkillPath,
+    },
+    {
+        relativePath: "agents/openai.yaml",
+        skillName: "oo-find-skills",
+        sourcePath: ooFindSkillsOpenAIAgentPath,
+    },
+    {
+        relativePath: "references/oo-cli-contract.md",
+        skillName: "oo-find-skills",
+        sourcePath: ooFindSkillsCliContractPath,
     },
 ] as const satisfies readonly BundledSkillFile[];
 

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -14,6 +14,7 @@ import {
     resolveBundledSkillMetadataFilePath,
     resolveCodexHomeDirectory,
 } from "./bundled-skill-paths.ts";
+import { getBundledSkillFiles } from "./embedded-assets.ts";
 import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 describe("skills CLI", () => {
@@ -52,12 +53,20 @@ describe("skills CLI", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
         const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
             join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
             "oo",
         );
+        const canonicalFindSkillsDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
+            "oo-find-skills",
+        );
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
         const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const findSkillsMetadataFilePath = resolveBundledSkillMetadataFilePath(
+            findSkillsDirectoryPath,
+        );
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -81,12 +90,27 @@ describe("skills CLI", () => {
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: "9.9.9" }),
             );
+            expect(await realpath(findSkillsDirectoryPath)).toBe(
+                await realpath(canonicalFindSkillsDirectoryPath),
+            );
+            for (const file of getBundledSkillFiles("oo-find-skills")) {
+                expect(
+                    await readFile(
+                        join(findSkillsDirectoryPath, file.relativePath),
+                        "utf8",
+                    ),
+                ).toBe(await Bun.file(file.sourcePath).text());
+            }
+            expect(await readFile(findSkillsMetadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson({ version: "9.9.9" }),
+            );
             expect(content).toContain(`"msg":"CLI first-run detection completed."`);
             expect(content).toContain(`"isFirstRun":true`);
             expect(content).toContain(`"shouldInstallMissingBundledSkills":true`);
             expect(content).toContain(
                 `"msg":"Bundled Codex skill installed during first-run bootstrap."`,
             );
+            expect(content).toContain(`"skillName":"oo-find-skills"`);
         }
         finally {
             await sandbox.cleanup();
@@ -145,7 +169,8 @@ describe("skills CLI", () => {
     test("supports skills remove as an alias for uninstall", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -157,7 +182,11 @@ describe("skills CLI", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
-                `Removed Codex skill oo from ${skillDirectoryPath}.\n`,
+                [
+                    `Removed Codex skill oo from ${ooSkillDirectoryPath}.`,
+                    `Removed Codex skill oo-find-skills from ${findSkillsDirectoryPath}.`,
+                    "",
+                ].join("\n"),
             );
             expect(result.stderr).toBe("");
         }
@@ -169,7 +198,8 @@ describe("skills CLI", () => {
     test("supports skills add as an alias for install", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -180,7 +210,11 @@ describe("skills CLI", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
-                `Installed Codex skill oo to ${skillDirectoryPath}.\n`,
+                [
+                    `Installed Codex skill oo to ${ooSkillDirectoryPath}.`,
+                    `Installed Codex skill oo-find-skills to ${findSkillsDirectoryPath}.`,
+                    "",
+                ].join("\n"),
             );
             expect(result.stderr).toBe("");
         }
@@ -239,8 +273,10 @@ describe("skills CLI", () => {
     test("writes explicit skills install and uninstall logs", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
-        const serializedSkillDirectoryPath = JSON.stringify(skillDirectoryPath);
+        const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
+        const serializedOoSkillDirectoryPath = JSON.stringify(ooSkillDirectoryPath);
+        const serializedFindSkillsDirectoryPath = JSON.stringify(findSkillsDirectoryPath);
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -260,14 +296,16 @@ describe("skills CLI", () => {
                 `"msg":"Bundled Codex skill installed explicitly."`,
             );
             expect(installContent).toContain(`"skillName":"oo"`);
-            expect(installContent).toContain(`"path":${serializedSkillDirectoryPath}`);
+            expect(installContent).toContain(`"skillName":"oo-find-skills"`);
+            expect(installContent).toContain(`"path":${serializedOoSkillDirectoryPath}`);
+            expect(installContent).toContain(`"path":${serializedFindSkillsDirectoryPath}`);
             expect(installContent).toContain(`"version":"9.9.9"`);
 
             expect(uninstallContent).toContain(
                 `"msg":"Bundled Codex skill removed explicitly."`,
             );
             expect(uninstallContent).toContain(`"skillName":"oo"`);
-            expect(uninstallContent).toContain(`"path":${serializedSkillDirectoryPath}`);
+            expect(uninstallContent).toContain(`"path":${serializedOoSkillDirectoryPath}`);
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -36,21 +36,34 @@ import { renderSkillMetadataJson } from "./skill-metadata.ts";
 describe("skills commands", () => {
     const guidance = renderOoPackageExecutionGuidance();
 
-    test("installs the default bundled Codex skill when no skill name is provided", async () => {
+    test("installs all bundled Codex skills when no skill name is provided", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
             platform: process.platform,
         });
-        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+        const ooCanonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
             storePaths.settingsFilePath,
             "oo",
         );
-        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
-        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const findSkillsCanonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo-find-skills",
+        );
+        const ooOwnershipFilePath = join(ooSkillDirectoryPath, "agents", "openai.yaml");
+        const ooMetadataFilePath = resolveBundledSkillMetadataFilePath(ooSkillDirectoryPath);
+        const findSkillsOwnershipFilePath = join(
+            findSkillsDirectoryPath,
+            "agents",
+            "openai.yaml",
+        );
+        const findSkillsMetadataFilePath = resolveBundledSkillMetadataFilePath(
+            findSkillsDirectoryPath,
+        );
         const resultVersion = "9.9.9";
 
         try {
@@ -62,22 +75,40 @@ describe("skills commands", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
-                `Installed Codex skill oo to ${skillDirectoryPath}.\n`,
+                [
+                    `Installed Codex skill oo to ${ooSkillDirectoryPath}.`,
+                    `Installed Codex skill oo-find-skills to ${findSkillsDirectoryPath}.`,
+                    "",
+                ].join("\n"),
             );
             expect(result.stderr).toBe("");
-            expect(await realpath(skillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
+            expect(await realpath(ooSkillDirectoryPath)).toBe(
+                await realpath(ooCanonicalSkillDirectoryPath),
+            );
+            expect(await realpath(findSkillsDirectoryPath)).toBe(
+                await realpath(findSkillsCanonicalSkillDirectoryPath),
             );
 
             for (const file of getBundledSkillFiles("oo")) {
                 expect(
-                    await readFile(join(skillDirectoryPath, file.relativePath), "utf8"),
+                    await readFile(join(ooSkillDirectoryPath, file.relativePath), "utf8"),
                 ).toBe(await Bun.file(file.sourcePath).text());
             }
-            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+            for (const file of getBundledSkillFiles("oo-find-skills")) {
+                expect(
+                    await readFile(join(findSkillsDirectoryPath, file.relativePath), "utf8"),
+                ).toBe(await Bun.file(file.sourcePath).text());
+            }
+            expect(await readFile(ooOwnershipFilePath, "utf8")).toContain(
                 "allow_implicit_invocation: true",
             );
-            expect(await readFile(metadataFilePath, "utf8")).toBe(
+            expect(await readFile(findSkillsOwnershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: true",
+            );
+            expect(await readFile(ooMetadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson({ version: resultVersion }),
+            );
+            expect(await readFile(findSkillsMetadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: resultVersion }),
             );
         }
@@ -126,11 +157,57 @@ describe("skills commands", () => {
         }
     });
 
+    test("installs the oo-find-skills bundled Codex skill by explicit name", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo-find-skills",
+        );
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const resultVersion = "9.9.9";
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "install", "oo-find-skills"], {
+                version: resultVersion,
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Installed Codex skill oo-find-skills to ${skillDirectoryPath}.\n`,
+            );
+            expect(result.stderr).toBe("");
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson({ version: resultVersion }),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("installs the bundled Codex skill with the persisted implicit invocation policy", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
-        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
+        const ooOwnershipFilePath = join(ooSkillDirectoryPath, "agents", "openai.yaml");
+        const findSkillsOwnershipFilePath = join(
+            findSkillsDirectoryPath,
+            "agents",
+            "openai.yaml",
+        );
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
@@ -145,6 +222,9 @@ describe("skills commands", () => {
                     "[skills.oo]",
                     "implicit_invocation = false",
                     "",
+                    "[skills.oo-find-skills]",
+                    "implicit_invocation = false",
+                    "",
                 ].join("\n"),
             );
 
@@ -153,7 +233,10 @@ describe("skills commands", () => {
             });
 
             expect(result.exitCode).toBe(0);
-            expect(await readFile(ownershipFilePath, "utf8")).toContain(
+            expect(await readFile(ooOwnershipFilePath, "utf8")).toContain(
+                "allow_implicit_invocation: false",
+            );
+            expect(await readFile(findSkillsOwnershipFilePath, "utf8")).toContain(
                 "allow_implicit_invocation: false",
             );
         }
@@ -259,18 +342,23 @@ describe("skills commands", () => {
         }
     });
 
-    test("uninstalls a bundled Codex skill from the Codex skills directory", async () => {
+    test("uninstalls all bundled Codex skills from the Codex skills directory when no skill name is provided", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
             platform: process.platform,
         });
-        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+        const ooCanonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
             storePaths.settingsFilePath,
             "oo",
+        );
+        const findSkillsCanonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo-find-skills",
         );
 
         try {
@@ -283,13 +371,23 @@ describe("skills commands", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
-                `Removed Codex skill oo from ${skillDirectoryPath}.\n`,
+                [
+                    `Removed Codex skill oo from ${ooSkillDirectoryPath}.`,
+                    `Removed Codex skill oo-find-skills from ${findSkillsDirectoryPath}.`,
+                    "",
+                ].join("\n"),
             );
             expect(result.stderr).toBe("");
-            await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
+            await expect(stat(ooSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
-            await expect(stat(canonicalSkillDirectoryPath)).rejects.toMatchObject({
+            await expect(stat(findSkillsDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(ooCanonicalSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(findSkillsCanonicalSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
         }
@@ -399,35 +497,30 @@ describe("skills commands", () => {
     test("supports skills remove as an alias for uninstall", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-        const skillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
-        const storePaths = resolveStorePaths({
-            appName: APP_NAME,
-            env: sandbox.env,
-            platform: process.platform,
-        });
-        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
-            storePaths.settingsFilePath,
-            "chatgpt",
-        );
-        const metadataFilePath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
+        const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
 
         try {
-            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
-            await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
-                recursive: true,
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
             });
-            await Bun.write(metadataFilePath, renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }));
-            await Bun.write(join(skillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
-            await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
 
-            const result = await sandbox.run(["skills", "remove", "chatgpt"]);
+            const result = await sandbox.run(["skills", "remove"]);
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
-                `Removed Codex skill chatgpt from ${skillDirectoryPath}.\n`,
+                [
+                    `Removed Codex skill oo from ${ooSkillDirectoryPath}.`,
+                    `Removed Codex skill oo-find-skills from ${findSkillsDirectoryPath}.`,
+                    "",
+                ].join("\n"),
             );
             expect(result.stderr).toBe("");
-            await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
+            await expect(stat(ooSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(findSkillsDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
         }
@@ -454,7 +547,7 @@ describe("skills commands", () => {
                 ].join("\n"),
             );
 
-            const result = await sandbox.run(["skills", "uninstall"]);
+            const result = await sandbox.run(["skills", "uninstall", "oo"]);
 
             expect(result.exitCode).toBe(1);
             expect(result.stdout).toBe("");
@@ -557,7 +650,7 @@ describe("skills commands", () => {
                 ].join("\n"),
             );
 
-            const result = await sandbox.run(["skills", "uninstall"]);
+            const result = await sandbox.run(["skills", "uninstall", "oo"]);
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -2,6 +2,7 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import type { BundledSkillName } from "./embedded-assets.ts";
 
 import { z } from "zod";
+import { availableBundledSkillNames } from "./embedded-assets.ts";
 import { installRegistrySkills } from "./registry-skill-install.ts";
 import { installBundledSkill, isBundledSkillName } from "./shared.ts";
 
@@ -11,8 +12,6 @@ interface SkillsInstallInput {
     skill?: string[];
     yes?: boolean;
 }
-
-const defaultBundledSkillName = "oo" as const;
 
 export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
     name: "install",
@@ -53,13 +52,16 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         yes: z.boolean().optional(),
     }),
     handler: async (input, context) => {
-        if (
-            input.packageName === undefined
-            || isBundledSkillName(input.packageName)
-        ) {
+        if (input.packageName === undefined) {
+            for (const skillName of availableBundledSkillNames) {
+                await installBundledSkill(skillName, context);
+            }
+            return;
+        }
+
+        if (isBundledSkillName(input.packageName)) {
             await installBundledSkill(
-                (input.packageName as BundledSkillName | undefined)
-                ?? defaultBundledSkillName,
+                input.packageName as BundledSkillName,
                 context,
             );
             return;

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -41,7 +41,7 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 2 oo-managed skills.",
+                    "✓ Found 3 oo-managed skills.",
                     "",
                     "oo",
                     "  Source: bundled",
@@ -50,6 +50,10 @@ describe("skills list CLI", () => {
                     "alpha-skill",
                     "  Source: @oomol/alpha",
                     "  Version: 1.2.3",
+                    "",
+                    "oo-find-skills",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
                     "",
                 ].join("\n"),
             );

--- a/src/application/commands/skills/uninstall.ts
+++ b/src/application/commands/skills/uninstall.ts
@@ -1,9 +1,8 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
+import { availableBundledSkillNames } from "./embedded-assets.ts";
 import { uninstallManagedSkill } from "./shared.ts";
-
-const bundledSkillName = "oo" as const;
 
 interface SkillsUninstallInput {
     skill?: string;
@@ -25,6 +24,13 @@ export const skillsUninstallCommand: CliCommandDefinition<SkillsUninstallInput> 
         skill: z.string().optional(),
     }),
     handler: async (input, context) => {
-        await uninstallManagedSkill(input.skill ?? bundledSkillName, context);
+        if (input.skill === undefined) {
+            for (const skillName of availableBundledSkillNames) {
+                await uninstallManagedSkill(skillName, context);
+            }
+            return;
+        }
+
+        await uninstallManagedSkill(input.skill, context);
     },
 };

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -84,6 +84,26 @@ describe("skills update command", () => {
         }
     });
 
+    test("rejects the bundled oo-find-skills skill as an explicit update target", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "update", "oo-find-skills"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Codex skill oo-find-skills is synchronized automatically and cannot be updated with skills update.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("updates a published managed skill to the latest version", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);

--- a/src/application/schemas/settings.ts
+++ b/src/application/schemas/settings.ts
@@ -31,18 +31,20 @@ const ooSkillSettingsShape = {
     implicit_invocation: z.boolean().optional(),
 };
 
-const ooSkillSettingsReadSchema = z.object(ooSkillSettingsShape);
-const ooSkillSettingsSchema = z.object(ooSkillSettingsShape).strict();
+const skillImplicitInvocationReadSchema = z.object(ooSkillSettingsShape);
+const skillImplicitInvocationSchema = z.object(ooSkillSettingsShape).strict();
 
 const skillsSettingsReadSchema = z.object({
-    oo: ooSkillSettingsReadSchema.optional(),
+    "oo-find-skills": skillImplicitInvocationReadSchema.optional(),
+    "oo": skillImplicitInvocationReadSchema.optional(),
 });
 
 const skillsSettingsSchema = z.object({
-    oo: ooSkillSettingsSchema.optional(),
+    "oo-find-skills": skillImplicitInvocationSchema.optional(),
+    "oo": skillImplicitInvocationSchema.optional(),
 }).strict();
 
-export const defaultOoSkillImplicitInvocation = true;
+export const defaultBundledSkillImplicitInvocation = true;
 
 export const settingsFileReadSchema = z.object({
     file: fileSettingsReadSchema.optional(),
@@ -58,6 +60,7 @@ export const settingsFileSchema = z.object({
 
 export type AppSettings = z.output<typeof settingsFileSchema>;
 export type BooleanConfigValue = z.output<typeof booleanConfigValueSchema>;
+export type BundledSkillSettingsKey = keyof NonNullable<AppSettings["skills"]>;
 export const defaultFileDownloadOutDir = "~/Downloads";
 
 export const defaultSettings: AppSettings = {};
@@ -78,13 +81,13 @@ const defaultSettingsCommentBlocks = [
         "# [file.download]",
         `# out_dir = "${defaultFileDownloadOutDir}"`,
     ],
-    [
-        "# skills.oo.implicit_invocation controls whether Codex may invoke the bundled oo skill without an explicit mention.",
+    ...["oo", "oo-find-skills"].map(skillName => [
+        `# skills.${skillName}.implicit_invocation controls whether Codex may invoke the bundled ${skillName} skill without an explicit mention.`,
         "# Supported values: true, false.",
-        `# Default: ${stringifyBooleanConfigValue(defaultOoSkillImplicitInvocation)}.`,
-        "# [skills.oo]",
+        `# Default: ${stringifyBooleanConfigValue(defaultBundledSkillImplicitInvocation)}.`,
+        `# [skills.${skillName}]`,
         "# implicit_invocation = false",
-    ],
+    ]),
 ] as const;
 
 export function renderSettingsFile(settings: AppSettings): string {
@@ -105,10 +108,20 @@ export function renderSettingsFile(settings: AppSettings): string {
         };
     }
 
-    if (parsedSettings.skills?.oo?.implicit_invocation !== undefined) {
-        persistedSettings.skills = {
-            oo: { implicit_invocation: parsedSettings.skills.oo.implicit_invocation },
-        };
+    const persistedSkillSettings: Record<string, unknown> = {};
+
+    for (const skillName of Object.keys(parsedSettings.skills ?? {})) {
+        const skillSettings = parsedSettings.skills?.[skillName as BundledSkillSettingsKey];
+
+        if (skillSettings?.implicit_invocation !== undefined) {
+            persistedSkillSettings[skillName] = {
+                implicit_invocation: skillSettings.implicit_invocation,
+            };
+        }
+    }
+
+    if (Object.keys(persistedSkillSettings).length > 0) {
+        persistedSettings.skills = persistedSkillSettings;
     }
 
     const serializedSettings = stringifyToml(persistedSettings).trimEnd();
@@ -167,43 +180,50 @@ export function unsetFileDownloadOutDir(
     return deleteNestedProperty(settings, ["file", "download", "out_dir"]);
 }
 
-export function getConfiguredOoSkillImplicitInvocation(
+export function getConfiguredSkillImplicitInvocation(
     settings: AppSettings,
+    skillName: BundledSkillSettingsKey,
 ): boolean | undefined {
-    return settings.skills?.oo?.implicit_invocation;
+    return settings.skills?.[skillName]?.implicit_invocation;
 }
 
-export function getOoSkillImplicitInvocation(
+export function getSkillImplicitInvocation(
     settings: AppSettings,
+    skillName: BundledSkillSettingsKey,
 ): boolean {
-    return getConfiguredOoSkillImplicitInvocation(settings)
-        ?? defaultOoSkillImplicitInvocation;
+    return getConfiguredSkillImplicitInvocation(settings, skillName)
+        ?? defaultBundledSkillImplicitInvocation;
 }
 
-export function setOoSkillImplicitInvocation(
+export function setSkillImplicitInvocation(
     settings: AppSettings,
+    skillName: BundledSkillSettingsKey,
     value: boolean,
 ): AppSettings {
     return {
         ...settings,
         skills: {
             ...settings.skills,
-            oo: {
-                ...settings.skills?.oo,
+            [skillName]: {
+                ...settings.skills?.[skillName],
                 implicit_invocation: value,
             },
         },
     };
 }
 
-export function unsetOoSkillImplicitInvocation(
+export function unsetSkillImplicitInvocation(
     settings: AppSettings,
+    skillName: BundledSkillSettingsKey,
 ): AppSettings {
-    if (settings.skills?.oo?.implicit_invocation === undefined) {
+    if (settings.skills?.[skillName]?.implicit_invocation === undefined) {
         return settings;
     }
 
-    return deleteNestedProperty(settings, ["skills", "oo", "implicit_invocation"]);
+    return deleteNestedProperty(
+        settings,
+        ["skills", skillName, "implicit_invocation"],
+    );
 }
 
 // Shallow-clones each level of a nested object along the given path,

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -224,8 +224,8 @@ export const enMessages = {
         "Invalid lang value: {value}. Use en or zh.",
     "errors.config.invalidFileDownloadOutDirValue":
         "Invalid file.download.out_dir value: {value}. Use a non-empty path.",
-    "errors.config.invalidSkillsOoImplicitInvocationValue":
-        "Invalid skills.oo.implicit_invocation value: {value}. Use true or false.",
+    "errors.config.invalidSkillImplicitInvocationValue":
+        "Invalid skills.{skill}.implicit_invocation value: {value}. Use true or false.",
     "errors.skills.invalidName":
         "Unsupported skill: {value}. Use {choices}.",
     "errors.skills.invalidPath":
@@ -709,8 +709,8 @@ export const zhMessages = {
         "无效的 lang 值：{value}。请使用 en 或 zh。",
     "errors.config.invalidFileDownloadOutDirValue":
         "无效的 file.download.out_dir 值：{value}。请使用非空路径。",
-    "errors.config.invalidSkillsOoImplicitInvocationValue":
-        "无效的 skills.oo.implicit_invocation 值：{value}。请使用 true 或 false。",
+    "errors.config.invalidSkillImplicitInvocationValue":
+        "无效的 skills.{skill}.implicit_invocation 值：{value}。请使用 true 或 false。",
     "errors.skills.invalidName":
         "不支持的 skill：{value}。请使用 {choices}。",
     "errors.skills.invalidPath":


### PR DESCRIPTION
Add the oo-find-skills bundled skill for discovering and installing published OOMOL skills from within Codex. Generalize the settings schema and config commands so that implicit_invocation is no longer hardcoded to a single skill — each bundled skill now has its own configurable entry.

- Register oo-find-skills as a bundled skill with SKILL.md, agent config, and CLI contract reference
- Replace oo-specific settings helpers (getOoSkillImplicitInvocation, setOoSkillImplicitInvocation, etc.) with generic per-skill variants
- Make bare `oo skills install` and `oo skills uninstall` operate on all bundled skills instead of defaulting to oo only
- Add config key skills.oo-find-skills.implicit_invocation
- Update docs, READMEs, i18n catalog, and tests