### PR TITLE
refactor(i18n): consolidate duplicated i18n keys and extract shared input parsers

### DIFF
--- a/src/application/commands/auth/login.ts
+++ b/src/application/commands/auth/login.ts
@@ -64,7 +64,7 @@ export const authLoginCommand: CliCommandDefinition = {
 
         writeAuthBlock(context, {
             tone: "success",
-            summary: context.translator.t("auth.login.success", {
+            summary: context.translator.t("auth.account.loggedIn", {
                 endpoint: formatAuthStrong(context, account.endpoint),
                 name: formatAuthStrong(context, account.name),
             }),

--- a/src/application/commands/auth/status.ts
+++ b/src/application/commands/auth/status.ts
@@ -28,7 +28,7 @@ export const authStatusCommand: CliCommandDefinition = {
             if (hasStaleId) {
                 writeAuthBlock(context, {
                     tone: "danger",
-                    summary: context.translator.t("auth.status.missing"),
+                    summary: context.translator.t("auth.account.activeAccountMissing"),
                     details: [
                         {
                             label: context.translator.t("auth.status.accountId"),
@@ -50,7 +50,7 @@ export const authStatusCommand: CliCommandDefinition = {
         const statusConfig = apiKeyStatusConfig[apiKeyStatus];
         writeAuthBlock(context, {
             tone: statusConfig.tone,
-            summary: context.translator.t("auth.status.loggedIn", {
+            summary: context.translator.t("auth.account.loggedIn", {
                 endpoint: formatAuthStrong(context, currentAccount.endpoint),
                 name: formatAuthStrong(context, currentAccount.name),
             }),

--- a/src/application/commands/cloud-task/log.ts
+++ b/src/application/commands/cloud-task/log.ts
@@ -47,7 +47,7 @@ export const cloudTaskLogCommand: CliCommandDefinition<CloudTaskLogInput> = {
         const format = parseCloudTaskFormat(input.format);
         const page = parsePositiveIntegerOption(
             input.page,
-            "errors.cloudTaskLog.invalidPage",
+            "errors.shared.invalidPositiveIntegerOption",
             {
                 min: 1,
                 optionName: "--page",

--- a/src/application/commands/cloud-task/shared.ts
+++ b/src/application/commands/cloud-task/shared.ts
@@ -2,7 +2,10 @@ import type { CliExecutionContext } from "../../contracts/cli.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
+import { parseEnumOption } from "../shared/input-parsing.ts";
 import { requestText } from "../shared/request.ts";
+
+export { parsePositiveIntegerOption } from "../shared/input-parsing.ts";
 
 export const cloudTaskFormatValues = ["json"] as const;
 export const cloudTaskStatusValues = [
@@ -77,51 +80,13 @@ export type CloudTaskListResponse = z.output<typeof cloudTaskListResponseSchema>
 export function parseCloudTaskFormat(
     value: string | undefined,
 ): CloudTaskFormat | undefined {
-    return parseEnumOption(value, cloudTaskFormatValues, "errors.cloudTask.invalidFormat");
+    return parseEnumOption(value, cloudTaskFormatValues, "errors.shared.invalidFormat");
 }
 
 export function parseCloudTaskStatus(
     value: string | undefined,
 ): CloudTaskStatus | undefined {
     return parseEnumOption(value, cloudTaskStatusValues, "errors.cloudTaskList.invalidStatus");
-}
-
-export function parsePositiveIntegerOption(
-    value: string | undefined,
-    errorKey: string,
-    options: {
-        max?: number;
-        min?: number;
-        optionName: string;
-    },
-): number | undefined {
-    if (value === undefined) {
-        return undefined;
-    }
-
-    const trimmedValue = value.trim();
-
-    if (trimmedValue === "") {
-        throw new CliUserError(errorKey, 2, {
-            option: options.optionName,
-            value,
-        });
-    }
-
-    const parsedValue = Number(trimmedValue);
-
-    if (
-        !Number.isInteger(parsedValue)
-        || parsedValue < (options.min ?? 1)
-        || (options.max !== undefined && parsedValue > options.max)
-    ) {
-        throw new CliUserError(errorKey, 2, {
-            option: options.optionName,
-            value,
-        });
-    }
-
-    return parsedValue;
 }
 
 export function parseDurationOption(
@@ -312,20 +277,4 @@ function readDurationUnitMs(unit: "s" | "m" | "h"): number {
         case "h":
             return 3_600_000;
     }
-}
-
-function parseEnumOption<T extends string>(
-    value: string | undefined,
-    allowedValues: readonly T[],
-    errorKey: string,
-): T | undefined {
-    if (value === undefined) {
-        return undefined;
-    }
-
-    if (allowedValues.includes(value as T)) {
-        return value as T;
-    }
-
-    throw new CliUserError(errorKey, 2, { value });
 }

--- a/src/application/commands/file/cleanup.test.ts
+++ b/src/application/commands/file/cleanup.test.ts
@@ -61,7 +61,7 @@ describe("file cleanup command", () => {
 
         expect(error).toMatchObject({
             exitCode: 2,
-            key: "errors.file.invalidFormat",
+            key: "errors.shared.invalidFormat",
             params: {
                 value: "yaml",
             },

--- a/src/application/commands/file/shared.ts
+++ b/src/application/commands/file/shared.ts
@@ -7,7 +7,10 @@ import type { AuthAccount } from "../../schemas/auth.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
+import { parseEnumOption, parsePositiveIntegerOption } from "../shared/input-parsing.ts";
 import { performLoggedRequest, requestText } from "../shared/request.ts";
+
+export { createFormatInputError } from "../shared/input-parsing.ts";
 
 export const fileFormatValues = ["json"] as const;
 export const maxFileUploadSizeBytes = 512 * 1024 * 1024;
@@ -60,43 +63,15 @@ const finalFileUploadResponseSchema = z.object({
 export function parseFileFormat(
     value: string | undefined,
 ): FileFormat | undefined {
-    if (value === undefined) {
-        return undefined;
-    }
-
-    if (value === "json") {
-        return value;
-    }
-
-    throw new CliUserError("errors.file.invalidFormat", 2, {
-        value,
-    });
-}
-
-export function createFormatInputError(
-    rawInput: Record<string, unknown>,
-): CliUserError {
-    return new CliUserError("errors.file.invalidFormat", 2, {
-        value: String(rawInput.format ?? ""),
-    });
+    return parseEnumOption(value, fileFormatValues, "errors.shared.invalidFormat");
 }
 
 export function parseFileLimit(value: string | undefined): number | undefined {
-    if (value === undefined) {
-        return undefined;
-    }
-
-    const trimmedValue = value.trim();
-    const parsedValue = Number(trimmedValue);
-
-    if (trimmedValue === "" || !Number.isSafeInteger(parsedValue) || parsedValue <= 0) {
-        throw new CliUserError("errors.fileList.invalidLimit", 2, {
-            option: "--limit",
-            value,
-        });
-    }
-
-    return parsedValue;
+    return parsePositiveIntegerOption(
+        value,
+        "errors.shared.invalidPositiveIntegerOption",
+        { min: 1, optionName: "--limit" },
+    );
 }
 
 export function parseFileStatus(

--- a/src/application/commands/file/text.ts
+++ b/src/application/commands/file/text.ts
@@ -23,7 +23,7 @@ export function formatFileUploadRecordDetailsAsText(
         `  - ${context.translator.t("file.text.fileSize")}: ${formatFileSize(record.fileSize)}`,
         `  - ${context.translator.t("file.text.uploadedAt")}: ${record.uploadedAt}`,
         `  - ${context.translator.t("file.text.expiresAt")}: ${record.expiresAt}`,
-        `  - ${context.translator.t("file.text.status")}: ${context.translator.t(`file.status.${record.status}`)}`,
+        `  - ${context.translator.t("labels.status")}: ${context.translator.t(`file.status.${record.status}`)}`,
         `  - ${context.translator.t("file.text.downloadUrl")}: ${record.downloadUrl}`,
     ];
 }

--- a/src/application/commands/package/info.ts
+++ b/src/application/commands/package/info.ts
@@ -3,10 +3,10 @@ import type { TerminalColors } from "../../terminal-colors.ts";
 import type { PackageInfoResponse } from "./shared.ts";
 import { z } from "zod";
 import { resolveRequestLanguage } from "../../../i18n/locale.ts";
-import { CliUserError } from "../../contracts/cli.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
+import { createFormatInputError } from "../shared/input-parsing.ts";
 import {
     isPackageInfoInputHandleOptional,
     isPackageInfoSchemaObject,
@@ -43,7 +43,7 @@ export const packageInfoCommand: CliCommandDefinition<PackageInfoInput> = {
         format: z.enum(packageInfoFormatValues).optional(),
         packageSpecifier: z.string(),
     }),
-    mapInputError: (_, rawInput) => createPackageInfoInputError(rawInput),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         const account = await requireCurrentAccount(context);
         const packageSpecifier = parsePackageSpecifier(input.packageSpecifier);
@@ -62,12 +62,6 @@ export const packageInfoCommand: CliCommandDefinition<PackageInfoInput> = {
         context.stdout.write(`${formatPackageInfoResponseAsText(response, context)}\n`);
     },
 };
-
-function createPackageInfoInputError(rawInput: Record<string, unknown>): CliUserError {
-    return new CliUserError("errors.packageInfo.invalidFormat", 2, {
-        value: String(rawInput.format ?? ""),
-    });
-}
 
 function formatPackageInfoResponseAsText(
     response: PackageInfoResponse,

--- a/src/application/commands/package/search.ts
+++ b/src/application/commands/package/search.ts
@@ -12,6 +12,7 @@ import {
 import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
+import { createFormatInputError } from "../shared/input-parsing.ts";
 import { requestText } from "../shared/request.ts";
 
 const MAX_SEARCH_TEXT_LENGTH = 200;
@@ -84,7 +85,7 @@ export const packageSearchCommand: CliCommandDefinition<SearchInput> = {
         format: z.enum(searchFormatValues).optional(),
         onlyPackageId: z.boolean().optional(),
     }),
-    mapInputError: (_, rawInput) => createSearchInputError(rawInput),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         const account = await requireCurrentAccount(context);
         const query = truncateSearchText(input.text);
@@ -134,12 +135,6 @@ export const packageSearchCommand: CliCommandDefinition<SearchInput> = {
         );
     },
 };
-
-function createSearchInputError(rawInput: Record<string, unknown>): CliUserError {
-    return new CliUserError("errors.search.invalidFormat", 2, {
-        value: String(rawInput.format ?? ""),
-    });
-}
 
 function truncateSearchText(text: string): string {
     const characters = Array.from(text);
@@ -308,7 +303,7 @@ function formatSearchPackage(
     }
 
     if (pkg.blocks.length > 0) {
-        lines.push(context.translator.t("search.text.blocks"));
+        lines.push(context.translator.t("labels.blocks"));
 
         for (const block of pkg.blocks) {
             lines.push(...formatSearchBlock(block, context, colors));

--- a/src/application/commands/shared/auth-utils.test.ts
+++ b/src/application/commands/shared/auth-utils.test.ts
@@ -56,7 +56,7 @@ describe("requireCurrentAccount", () => {
 
         await expect(requireCurrentAccount(context)).rejects.toMatchObject({
             exitCode: 1,
-            key: "errors.auth.activeAccountMissing",
+            key: "auth.account.activeAccountMissing",
         });
     });
 

--- a/src/application/commands/shared/auth-utils.ts
+++ b/src/application/commands/shared/auth-utils.ts
@@ -5,7 +5,7 @@ import { CliUserError } from "../../contracts/cli.ts";
 import { readCurrentAuth } from "../auth/shared.ts";
 
 const authErrorKeys = {
-    activeAccountMissing: "errors.auth.activeAccountMissing",
+    activeAccountMissing: "auth.account.activeAccountMissing",
     required: "errors.auth.required",
 } as const;
 

--- a/src/application/commands/shared/input-parsing.test.ts
+++ b/src/application/commands/shared/input-parsing.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+
+import { CliUserError } from "../../contracts/cli.ts";
+import {
+    createFormatInputError,
+    parseEnumOption,
+    parsePositiveIntegerOption,
+} from "./input-parsing.ts";
+
+describe("parseEnumOption", () => {
+    const allowed = ["json", "csv"] as const;
+
+    test("returns undefined for undefined input", () => {
+        expect(parseEnumOption(undefined, allowed, "err")).toBeUndefined();
+    });
+
+    test("returns the value when it matches an allowed value", () => {
+        expect(parseEnumOption("json", allowed, "err")).toBe("json");
+        expect(parseEnumOption("csv", allowed, "err")).toBe("csv");
+    });
+
+    test("throws CliUserError for an invalid value", () => {
+        expect(() => parseEnumOption("xml", allowed, "err.key")).toThrowError(
+            expect.objectContaining({
+                exitCode: 2,
+                key: "err.key",
+                params: { value: "xml" },
+            }),
+        );
+    });
+});
+
+describe("parsePositiveIntegerOption", () => {
+    const opts = { optionName: "--page" };
+
+    test("returns undefined for undefined input", () => {
+        expect(parsePositiveIntegerOption(undefined, "err", opts)).toBeUndefined();
+    });
+
+    test("returns the parsed integer for a valid value", () => {
+        expect(parsePositiveIntegerOption("5", "err", opts)).toBe(5);
+    });
+
+    test("throws for an empty string", () => {
+        expect(() => parsePositiveIntegerOption("  ", "err.key", opts)).toThrowError(
+            expect.objectContaining({ exitCode: 2, key: "err.key" }),
+        );
+    });
+
+    test("throws for a non-integer value", () => {
+        expect(() => parsePositiveIntegerOption("1.5", "err.key", opts)).toThrowError(
+            expect.objectContaining({ exitCode: 2, key: "err.key" }),
+        );
+    });
+
+    test("throws for a value below min", () => {
+        expect(
+            () => parsePositiveIntegerOption("0", "err.key", { min: 1, optionName: "--n" }),
+        ).toThrowError(
+            expect.objectContaining({ exitCode: 2 }),
+        );
+    });
+
+    test("throws for a value above max", () => {
+        expect(
+            () => parsePositiveIntegerOption("101", "err.key", { max: 100, optionName: "--n" }),
+        ).toThrowError(
+            expect.objectContaining({ exitCode: 2 }),
+        );
+    });
+
+    test("accepts a value equal to min and max boundaries", () => {
+        expect(
+            parsePositiveIntegerOption("1", "err", { min: 1, max: 100, optionName: "--n" }),
+        ).toBe(1);
+        expect(
+            parsePositiveIntegerOption("100", "err", { min: 1, max: 100, optionName: "--n" }),
+        ).toBe(100);
+    });
+});
+
+describe("createFormatInputError", () => {
+    test("returns a CliUserError with the format value", () => {
+        const error = createFormatInputError({ format: "yaml" });
+
+        expect(error).toBeInstanceOf(CliUserError);
+        expect(error.exitCode).toBe(2);
+        expect(error.key).toBe("errors.shared.invalidFormat");
+        expect(error.params).toEqual({ value: "yaml" });
+    });
+
+    test("uses empty string when format is missing", () => {
+        const error = createFormatInputError({});
+
+        expect(error.params).toEqual({ value: "" });
+    });
+});

--- a/src/application/commands/shared/input-parsing.ts
+++ b/src/application/commands/shared/input-parsing.ts
@@ -1,0 +1,63 @@
+import { CliUserError } from "../../contracts/cli.ts";
+
+export function parseEnumOption<T extends string>(
+    value: string | undefined,
+    allowedValues: readonly T[],
+    errorKey: string,
+): T | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (allowedValues.includes(value as T)) {
+        return value as T;
+    }
+
+    throw new CliUserError(errorKey, 2, { value });
+}
+
+export function parsePositiveIntegerOption(
+    value: string | undefined,
+    errorKey: string,
+    options: {
+        max?: number;
+        min?: number;
+        optionName: string;
+    },
+): number | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    const trimmedValue = value.trim();
+
+    if (trimmedValue === "") {
+        throw new CliUserError(errorKey, 2, {
+            option: options.optionName,
+            value,
+        });
+    }
+
+    const parsedValue = Number(trimmedValue);
+
+    if (
+        !Number.isInteger(parsedValue)
+        || parsedValue < (options.min ?? 1)
+        || (options.max !== undefined && parsedValue > options.max)
+    ) {
+        throw new CliUserError(errorKey, 2, {
+            option: options.optionName,
+            value,
+        });
+    }
+
+    return parsedValue;
+}
+
+export function createFormatInputError(
+    rawInput: Record<string, unknown>,
+): CliUserError {
+    return new CliUserError("errors.shared.invalidFormat", 2, {
+        value: String(rawInput.format ?? ""),
+    });
+}

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -155,7 +155,7 @@ function formatManagedSkillListItem(
             colors,
         ),
         formatManagedSkillDetailLine(
-            context.translator.t("skills.list.version"),
+            context.translator.t("labels.version"),
             colors.hex(managedSkillVersionColor)(
                 skill.metadata?.version ?? context.translator.t("versionInfo.unknown"),
             ),

--- a/src/application/commands/skills/search.ts
+++ b/src/application/commands/skills/search.ts
@@ -6,6 +6,7 @@ import { CliUserError } from "../../contracts/cli.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
+import { createFormatInputError } from "../shared/input-parsing.ts";
 import { requestText } from "../shared/request.ts";
 
 const searchFormatValues = ["json"] as const;
@@ -69,7 +70,7 @@ export const skillsSearchCommand: CliCommandDefinition<SkillsSearchInput> = {
         format: z.enum(searchFormatValues).optional(),
         keywords: z.string().optional(),
     }),
-    mapInputError: (_, rawInput) => createSkillsSearchInputError(rawInput),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         const account = await requireCurrentAccount(context);
         const requestUrl = createSkillsSearchRequestUrl(
@@ -95,14 +96,6 @@ export const skillsSearchCommand: CliCommandDefinition<SkillsSearchInput> = {
         );
     },
 };
-
-function createSkillsSearchInputError(
-    rawInput: Record<string, unknown>,
-): CliUserError {
-    return new CliUserError("errors.skillsSearch.invalidFormat", 2, {
-        value: String(rawInput.format ?? ""),
-    });
-}
 
 function createSkillsSearchRequestUrl(
     endpoint: string,

--- a/src/application/config/build-info.ts
+++ b/src/application/config/build-info.ts
@@ -21,7 +21,7 @@ export function formatCliVersionText(
     const unknownValue = translator.t("versionInfo.unknown");
 
     return [
-        `${translator.t("versionInfo.version")}: ${buildInfo.version}`,
+        `${translator.t("labels.version")}: ${buildInfo.version}`,
         `${translator.t("versionInfo.buildTime")}: ${formatBuildTime(
             buildInfo.buildTimestamp,
             unknownValue,

--- a/src/i18n/catalog.test.ts
+++ b/src/i18n/catalog.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+
+import { enMessages, zhMessages } from "./catalog.ts";
+
+describe("message catalog", () => {
+    test("uses shared keys for consolidated labels and errors", () => {
+        expect(enMessages["auth.account.loggedIn"]).toBe(
+            "Logged in to {endpoint} account {name}",
+        );
+        expect(enMessages["auth.account.activeAccountMissing"]).toBe(
+            "The active account is missing from the auth store.",
+        );
+        expect(enMessages["errors.shared.invalidFormat"]).toBe(
+            "Invalid format: {value}. Use json.",
+        );
+        expect(enMessages["errors.shared.invalidPositiveIntegerOption"]).toBe(
+            "Invalid value for {option}: {value}. Use an integer greater than or equal to 1.",
+        );
+        expect(enMessages["labels.blocks"]).toBe("Blocks:");
+        expect(enMessages["labels.status"]).toBe("Status");
+        expect(enMessages["labels.version"]).toBe("Version");
+        expect(zhMessages["auth.account.loggedIn"]).toBe(
+            "已登录 {endpoint} 账号 {name}",
+        );
+        expect(zhMessages["auth.account.activeAccountMissing"]).toBe(
+            "当前激活账号不存在于认证数据中。",
+        );
+        expect(zhMessages["errors.shared.invalidFormat"]).toBe(
+            "无效的 format：{value}。请使用 json。",
+        );
+        expect(zhMessages["errors.shared.invalidPositiveIntegerOption"]).toBe(
+            "{option} 的值无效：{value}。请使用大于等于 1 的整数。",
+        );
+        expect(zhMessages["labels.blocks"]).toBe("功能块：");
+        expect(zhMessages["labels.status"]).toBe("状态");
+        expect(zhMessages["labels.version"]).toBe("版本");
+    });
+
+    test("does not keep removed duplicate keys", () => {
+        const removedKeys = [
+            "auth.login.success",
+            "auth.status.loggedIn",
+            "auth.status.missing",
+            "errors.auth.activeAccountMissing",
+            "errors.cloudTask.invalidFormat",
+            "errors.cloudTaskLog.invalidPage",
+            "errors.file.invalidFormat",
+            "errors.fileList.invalidLimit",
+            "errors.packageInfo.invalidFormat",
+            "errors.search.invalidFormat",
+            "errors.skillsSearch.invalidFormat",
+            "cloudTask.text.status",
+            "file.text.status",
+            "packageInfo.text.blocks",
+            "search.text.blocks",
+            "skills.list.version",
+            "versionInfo.version",
+        ] as const;
+
+        for (const key of removedKeys) {
+            expect(Object.hasOwn(enMessages, key)).toBeFalse();
+            expect(Object.hasOwn(zhMessages, key)).toBeFalse();
+        }
+    });
+});

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -7,7 +7,9 @@ export const enMessages = {
     "auth.login.callbackNotFound": "The requested login callback endpoint was not found.",
     "auth.login.callbackSuccess": "Login completed. You can close this tab now.",
     "auth.login.openManually": "Open this URL in your browser to continue: {url}",
-    "auth.login.success": "Logged in to {endpoint} account {name}",
+    "auth.account.activeAccountMissing":
+        "The active account is missing from the auth store.",
+    "auth.account.loggedIn": "Logged in to {endpoint} account {name}",
     "auth.login.waitingForBrowser": "Waiting for the browser login to complete...",
     "auth.logout.success": "Logged out the current account.",
     "auth.status.accountId": "Account ID",
@@ -16,9 +18,7 @@ export const enMessages = {
     "auth.status.apiKeyRequestFailed": "Request failed",
     "auth.status.apiKeyStatus": "API key status",
     "auth.status.apiKeyValid": "Valid",
-    "auth.status.loggedIn": "Logged in to {endpoint} account {name}",
     "auth.status.loggedOut": "Not logged in to any OOMOL account.",
-    "auth.status.missing": "The active account is missing from the auth store.",
     "auth.switch.success": "Switched active account for {endpoint} to {name}",
     "commands.auth.description": "Manage CLI authentication accounts.",
     "commands.auth.login.description": "Log in with an OOMOL account in the browser.",
@@ -148,8 +148,6 @@ export const enMessages = {
     "errors.commander.unknownOption": "Unknown option: {value}.",
     "errors.auth.loginTimeout":
         "Timed out waiting for the browser login callback.",
-    "errors.auth.activeAccountMissing":
-        "The active auth account is missing from the auth store.",
     "errors.auth.noSavedAccounts":
         "There are no auth accounts to switch to.",
     "errors.auth.required":
@@ -162,8 +160,10 @@ export const enMessages = {
         "Failed to read the auth file at {path}.",
     "errors.authStore.writeFailed":
         "Failed to write the auth file at {path}.",
-    "errors.cloudTask.invalidFormat":
+    "errors.shared.invalidFormat":
         "Invalid format: {value}. Use json.",
+    "errors.shared.invalidPositiveIntegerOption":
+        "Invalid value for {option}: {value}. Use an integer greater than or equal to 1.",
     "errors.cloudTask.invalidResponse":
         "The cloud task service returned an unsupported response body.",
     "errors.cloudTask.requestError":
@@ -184,8 +184,6 @@ export const enMessages = {
         "Invalid value for {option}: {value}. Use an integer between 1 and 100.",
     "errors.cloudTaskList.invalidStatus":
         "Invalid status: {value}. Use queued, scheduling, scheduled, running, success, or failed.",
-    "errors.cloudTaskLog.invalidPage":
-        "Invalid value for {option}: {value}. Use an integer greater than or equal to 1.",
     "errors.cloudTaskRun.blockIdRequired":
         "The --block-id option is required.",
     "errors.cloudTaskRun.blockNotFound":
@@ -234,8 +232,6 @@ export const enMessages = {
         "Invalid config key for skill {skill}: {value}. Use {choices}.",
     "errors.skills.config.invalidAllowImplicitInvocationValue":
         "Invalid allow-implicit-invocation value for skill {skill}: {value}. Use true or false.",
-    "errors.file.invalidFormat":
-        "Invalid format: {value}. Use json.",
     "errors.fileDownload.downloadFailed":
         "Failed to download the file at {path}: {message}",
     "errors.fileDownload.invalidExt":
@@ -252,8 +248,6 @@ export const enMessages = {
         "The download request failed: {message}",
     "errors.fileDownload.requestFailed":
         "The download request returned HTTP {status}.",
-    "errors.fileList.invalidLimit":
-        "Invalid value for {option}: {value}. Use an integer greater than or equal to 1.",
     "errors.fileList.invalidStatus":
         "Invalid status: {value}. Use active or expired.",
     "errors.fileUpload.invalidResponse":
@@ -270,24 +264,18 @@ export const enMessages = {
         "The file at {path} is {size} bytes, which exceeds the 512 MiB limit of {max} bytes.",
     "errors.lang.invalidFlag":
         "Invalid value for --lang: {value}. Use en or zh.",
-    "errors.search.invalidFormat":
-        "Invalid format: {value}. Use json.",
     "errors.search.invalidResponse":
         "The search service returned an unsupported response body.",
     "errors.search.requestError":
         "The search request failed: {message}",
     "errors.search.requestFailed":
         "The search request returned HTTP {status}.",
-    "errors.skillsSearch.invalidFormat":
-        "Invalid format: {value}. Use json.",
     "errors.skillsSearch.invalidResponse":
         "The skills search service returned an unsupported response body.",
     "errors.skillsSearch.requestError":
         "The skills search request failed: {message}",
     "errors.skillsSearch.requestFailed":
         "The skills search request returned HTTP {status}.",
-    "errors.packageInfo.invalidFormat":
-        "Invalid format: {value}. Use json.",
     "errors.packageInfo.invalidPackageSpecifier":
         "Invalid package specifier: {value}.",
     "errors.packageInfo.invalidResponse":
@@ -403,7 +391,9 @@ export const enMessages = {
     "skills.list.source.bundled": "bundled",
     "skills.list.summary":
         "Found {count} oo-managed skills.",
-    "skills.list.version": "Version",
+    "labels.blocks": "Blocks:",
+    "labels.status": "Status",
+    "labels.version": "Version",
     "skills.install.success": "Installed Codex skill {name} to {path}.",
     "skills.install.overwrite.invalid":
         "Invalid choice. Enter y/yes or n/no.",
@@ -442,7 +432,6 @@ export const enMessages = {
     "skills.update.progress.failed": "failed",
     "skills.update.success": "Updated Codex skill {name} to {path}.",
     "skills.uninstall.success": "Removed Codex skill {name} from {path}.",
-    "versionInfo.version": "Version",
     "versionInfo.buildTime": "Build Time",
     "versionInfo.commit": "Commit",
     "versionInfo.unknown": "unknown",
@@ -469,7 +458,6 @@ export const enMessages = {
     "cloudTask.text.progress": "Progress",
     "cloudTask.text.resultData": "Result data:",
     "cloudTask.text.resultUrl": "Result URL",
-    "cloudTask.text.status": "Status",
     "cloudTask.text.taskId": "Task ID",
     "cloudTask.text.createdAt": "Created",
     "cloudTask.text.updatedAt": "Updated",
@@ -494,17 +482,14 @@ export const enMessages = {
     "file.text.expiresAt": "Expires at",
     "file.text.fileSize": "File size",
     "file.text.id": "ID",
-    "file.text.status": "Status",
     "file.text.uploadedAt": "Uploaded at",
     "file.upload.success": "Uploaded {fileName}.",
-    "search.text.blocks": "Blocks:",
     "search.text.noResults": "No matching packages were found.",
     "search.text.unnamedBlock": "unnamed-block",
     "search.text.unnamedPackage": "unnamed-package",
     "skills.search.text.noResults": "No matching skills were found.",
     "skills.search.text.package": "Package",
     "skills.search.text.unnamedSkill": "unnamed-skill",
-    "packageInfo.text.blocks": "Blocks:",
     "packageInfo.text.inputHandle": "Input:",
     "packageInfo.text.outputHandle": "Output:",
     "packageInfo.text.optional": "[optional]",
@@ -518,7 +503,8 @@ export const zhMessages = {
     "auth.login.callbackNotFound": "未找到请求的登录回调地址。",
     "auth.login.callbackSuccess": "登录完成，现在可以关闭这个页面。",
     "auth.login.openManually": "请在浏览器中打开这个 URL 继续登录：{url}",
-    "auth.login.success": "已登录 {endpoint} 账号 {name}",
+    "auth.account.activeAccountMissing": "当前激活账号不存在于认证数据中。",
+    "auth.account.loggedIn": "已登录 {endpoint} 账号 {name}",
     "auth.login.waitingForBrowser": "正在等待浏览器完成登录...",
     "auth.logout.success": "已登出当前账号。",
     "auth.status.accountId": "账号 ID",
@@ -527,9 +513,7 @@ export const zhMessages = {
     "auth.status.apiKeyRequestFailed": "请求失败",
     "auth.status.apiKeyStatus": "API key 状态",
     "auth.status.apiKeyValid": "有效",
-    "auth.status.loggedIn": "已登录 {endpoint} 账号 {name}",
     "auth.status.loggedOut": "当前没有登录任何 OOMOL 账号。",
-    "auth.status.missing": "当前激活账号不存在于认证数据中。",
     "auth.switch.success": "已将 {endpoint} 的当前激活账号切换为 {name}",
     "commands.auth.description": "管理 CLI 的认证账号。",
     "commands.auth.login.description": "在浏览器中登录 OOMOL 账号。",
@@ -638,8 +622,6 @@ export const zhMessages = {
     "errors.commander.unknownCommand": "未知命令：{value}。",
     "errors.commander.unknownOption": "未知选项：{value}。",
     "errors.auth.loginTimeout": "等待浏览器登录回调超时。",
-    "errors.auth.activeAccountMissing":
-        "当前激活账号不存在于认证数据中。",
     "errors.auth.noSavedAccounts": "没有可切换的认证账号。",
     "errors.auth.required":
         "使用此命令前请先登录。",
@@ -647,8 +629,10 @@ export const zhMessages = {
     "errors.authStore.invalidSchema": "认证文件 {path} 的结构不受支持。",
     "errors.authStore.readFailed": "读取认证文件 {path} 失败。",
     "errors.authStore.writeFailed": "写入认证文件 {path} 失败。",
-    "errors.cloudTask.invalidFormat":
+    "errors.shared.invalidFormat":
         "无效的 format：{value}。请使用 json。",
+    "errors.shared.invalidPositiveIntegerOption":
+        "{option} 的值无效：{value}。请使用大于等于 1 的整数。",
     "errors.cloudTask.invalidResponse":
         "云任务服务返回了不受支持的响应内容。",
     "errors.cloudTask.requestError":
@@ -669,8 +653,6 @@ export const zhMessages = {
         "{option} 的值无效：{value}。请使用 1 到 100 之间的整数。",
     "errors.cloudTaskList.invalidStatus":
         "无效的 status：{value}。请使用 queued、scheduling、scheduled、running、success 或 failed。",
-    "errors.cloudTaskLog.invalidPage":
-        "{option} 的值无效：{value}。请使用大于等于 1 的整数。",
     "errors.cloudTaskRun.blockIdRequired":
         "--block-id 选项为必填。",
     "errors.cloudTaskRun.blockNotFound":
@@ -719,8 +701,6 @@ export const zhMessages = {
         "skill {skill} 的配置键无效：{value}。请使用 {choices}。",
     "errors.skills.config.invalidAllowImplicitInvocationValue":
         "skill {skill} 的 allow-implicit-invocation 值无效：{value}。请使用 true 或 false。",
-    "errors.file.invalidFormat":
-        "无效的 format：{value}。请使用 json。",
     "errors.fileDownload.downloadFailed":
         "下载文件到 {path} 失败：{message}",
     "errors.fileDownload.invalidExt":
@@ -737,8 +717,6 @@ export const zhMessages = {
         "下载请求失败：{message}",
     "errors.fileDownload.requestFailed":
         "下载请求返回了 HTTP {status}。",
-    "errors.fileList.invalidLimit":
-        "{option} 的值无效：{value}。请使用大于等于 1 的整数。",
     "errors.fileList.invalidStatus":
         "无效的 status：{value}。请使用 active 或 expired。",
     "errors.fileUpload.invalidResponse":
@@ -755,24 +733,18 @@ export const zhMessages = {
         "文件 {path} 的大小为 {size} 字节，超出了 512 MiB 上限 {max} 字节。",
     "errors.lang.invalidFlag":
         "--lang 的值无效：{value}。请使用 en 或 zh。",
-    "errors.search.invalidFormat":
-        "无效的 format：{value}。请使用 json。",
     "errors.search.invalidResponse":
         "搜索服务返回了不受支持的响应内容。",
     "errors.search.requestError":
         "搜索请求失败：{message}",
     "errors.search.requestFailed":
         "搜索请求返回了 HTTP {status}。",
-    "errors.skillsSearch.invalidFormat":
-        "无效的 format：{value}。请使用 json。",
     "errors.skillsSearch.invalidResponse":
         "skills 搜索服务返回了不受支持的响应内容。",
     "errors.skillsSearch.requestError":
         "skills 搜索请求失败：{message}",
     "errors.skillsSearch.requestFailed":
         "skills 搜索请求返回了 HTTP {status}。",
-    "errors.packageInfo.invalidFormat":
-        "无效的 format：{value}。请使用 json。",
     "errors.packageInfo.invalidPackageSpecifier":
         "无效的包标识：{value}。",
     "errors.packageInfo.invalidResponse":
@@ -882,7 +854,9 @@ export const zhMessages = {
     "skills.list.source.bundled": "内置",
     "skills.list.summary":
         "找到 {count} 个由 oo 管理的 skill。",
-    "skills.list.version": "版本",
+    "labels.blocks": "功能块：",
+    "labels.status": "状态",
+    "labels.version": "版本",
     "skills.install.success": "已将 Codex skill {name} 安装到 {path}。",
     "skills.install.overwrite.invalid":
         "输入无效。请输入 y/yes 或 n/no。",
@@ -921,7 +895,6 @@ export const zhMessages = {
     "skills.update.progress.failed": "失败",
     "skills.update.success": "已将 Codex skill {name} 更新到 {path}。",
     "skills.uninstall.success": "已从 {path} 移除 Codex skill {name}。",
-    "versionInfo.version": "版本",
     "versionInfo.buildTime": "构建时间",
     "versionInfo.commit": "提交",
     "versionInfo.unknown": "未知",
@@ -948,7 +921,6 @@ export const zhMessages = {
     "cloudTask.text.progress": "进度",
     "cloudTask.text.resultData": "结果数据：",
     "cloudTask.text.resultUrl": "结果 URL",
-    "cloudTask.text.status": "状态",
     "cloudTask.text.taskId": "任务 ID",
     "cloudTask.text.createdAt": "创建时间",
     "cloudTask.text.updatedAt": "更新时间",
@@ -970,17 +942,14 @@ export const zhMessages = {
     "file.text.expiresAt": "过期时间",
     "file.text.fileSize": "文件大小",
     "file.text.id": "ID",
-    "file.text.status": "状态",
     "file.text.uploadedAt": "上传时间",
     "file.upload.success": "已上传 {fileName}。",
-    "search.text.blocks": "功能块：",
     "search.text.noResults": "未找到匹配的包。",
     "search.text.unnamedBlock": "未命名功能块",
     "search.text.unnamedPackage": "未命名包",
     "skills.search.text.noResults": "未找到匹配的 skill。",
     "skills.search.text.package": "包",
     "skills.search.text.unnamedSkill": "未命名 skill",
-    "packageInfo.text.blocks": "功能块：",
     "packageInfo.text.inputHandle": "输入：",
     "packageInfo.text.outputHandle": "输出：",
     "packageInfo.text.optional": "[可选]",


### PR DESCRIPTION
Unify per-command i18n keys into shared namespaces:
- errors.{file,cloudTaskLog,packageInfo,search}.invalidFormat → errors.shared.invalidFormat
- errors.cloudTaskLog.invalidPage → errors.shared.invalidPositiveIntegerOption
- auth.{login,status} success/missing → auth.account.{loggedIn,activeAccountMissing}
- file.text.status → labels.status, search.text.blocks → labels.blocks

Extract parseEnumOption, parsePositiveIntegerOption, and createFormatInputError from cloud-task/shared and file/shared into a dedicated shared/input-parsing module to eliminate duplication across command domains.