### PR TITLE
feat(connector): add connector search and run commands

### DIFF
--- a/__tests__/helpers.test.ts
+++ b/__tests__/helpers.test.ts
@@ -30,6 +30,7 @@ describe("test helpers", () => {
                 stdout: [
                     "C:\\Users\\Tester\\.config\\oo-cli\\settings.toml",
                     outputFilePath,
+                    `{"schemaPath":"C:\\\\Users\\\\Tester\\\\.config\\\\oo-cli\\\\connector-actions\\\\gmail\\\\send_mail.json"}`,
                 ].join("\r\n"),
                 stderr: `${colors.green("ok")} ${outputFilePath}\r`,
             },
@@ -48,6 +49,7 @@ describe("test helpers", () => {
             stdout: [
                 "<XDG_CONFIG_HOME>/oo-cli/settings.toml",
                 "<OUTPUT_FILE>",
+                "{\"schemaPath\":\"<XDG_CONFIG_HOME>/oo-cli/connector-actions/gmail/send_mail.json\"}",
             ].join("\n"),
             stderr: "ok <OUTPUT_FILE>\n",
         });

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -576,6 +576,11 @@ function normalizeSnapshotText(
             replacement.value,
             replacement.placeholder,
         );
+        normalized = replaceSnapshotValue(
+            normalized,
+            JSON.stringify(replacement.value).slice(1, -1),
+            replacement.placeholder,
+        );
 
         const portableValue = replacement.value
             .split("\\")
@@ -587,10 +592,15 @@ function normalizeSnapshotText(
                 portableValue,
                 replacement.placeholder,
             );
+            normalized = replaceSnapshotValue(
+                normalized,
+                JSON.stringify(portableValue).slice(1, -1),
+                replacement.placeholder,
+            );
         }
     }
 
-    return normalized.split("\\").join("/");
+    return normalizeBackslashRunsToSlash(normalized);
 }
 
 function replaceSnapshotValue(
@@ -599,6 +609,31 @@ function replaceSnapshotValue(
     replacementValue: string,
 ): string {
     return value.split(searchValue).join(replacementValue);
+}
+
+function normalizeBackslashRunsToSlash(
+    value: string,
+): string {
+    let normalized = "";
+    let index = 0;
+
+    while (index < value.length) {
+        const char = value[index];
+
+        if (char !== "\\") {
+            normalized += char;
+            index += 1;
+            continue;
+        }
+
+        normalized += "/";
+
+        while (value[index] === "\\") {
+            index += 1;
+        }
+    }
+
+    return normalized;
 }
 
 function resolveSnapshotReplacements(

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -477,6 +477,38 @@ export function readAuthLoginUrlPrefix(endpoint: string): string {
     return `https://api.${endpoint}/v1/auth/redirect?`;
 }
 
+export interface ConnectorActionFixtureOverrides {
+    description?: string;
+    inputSchema?: Record<string, unknown>;
+    name?: string;
+    outputSchema?: Record<string, unknown>;
+    service?: string;
+}
+
+export interface ConnectorActionFixture {
+    description: string;
+    inputSchema: Record<string, unknown>;
+    name: string;
+    outputSchema: Record<string, unknown>;
+    service: string;
+}
+
+export function createConnectorActionFixture(
+    overrides: ConnectorActionFixtureOverrides = {},
+): ConnectorActionFixture {
+    return {
+        description: overrides.description ?? "Send a Gmail message.",
+        inputSchema: overrides.inputSchema ?? {
+            type: "object",
+        },
+        name: overrides.name ?? "send_mail",
+        outputSchema: overrides.outputSchema ?? {
+            type: "object",
+        },
+        service: overrides.service ?? "gmail",
+    };
+}
+
 export function toRequest(input: string | URL | Request, init?: RequestInit): Request {
     if (input instanceof Request) {
         return new Request(input, init);

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -121,6 +121,40 @@ Check whether a newer CLI release is available.
 - Notes: when the registry is temporarily unavailable, the CLI prints a
   retry-later message instead of exiting with an error.
 
+## Connector
+
+### `oo connector search <text>`
+
+Search connector actions with free-form text.
+
+- Arguments: `<text>` is the semantic search text.
+- Options: `--keywords <keywords>` sends a comma-separated keyword list after
+  trimming empty and duplicate entries.
+- Options: `--format=json` and `--json` print a JSON array of matching action
+  entries.
+- Output: every match is enriched with `authenticated` and `schemaPath`.
+- Output: JSON entries include the stable CLI fields `service`, `name`,
+  `description`, `authenticated`, and `schemaPath`.
+- Output: text output prints one block per action with the service/action
+  label, optional description, authenticated state, and schema cache path.
+- Notes: the command writes one schema cache file per result under the
+  persisted CLI configuration root in `connector-actions/`, alongside `data/`.
+
+### `oo connector run <serviceName>`
+
+Validate input data and run one connector action synchronously.
+
+- Arguments: `<serviceName>` is the service name.
+- Options: `-a, --action <action>` selects the action name and is required.
+- Options: `-d, --data <data>` accepts inline JSON or `@path` to a JSON file.
+- Options: `--dry-run` validates the payload without executing the action.
+- Options: `--format=json` and `--json` print a JSON object.
+- Output: non-dry-run JSON output mirrors the stable response shape
+  `{ data, meta: { executionId } }`.
+- Output: dry-run JSON output returns `{ dryRun, ok, schemaPath }`.
+- Notes: when the local schema cache is missing or invalid, the command fetches
+  action metadata, rewrites the schema cache, and then validates the payload.
+
 ## Codex Skills
 
 ### `oo skills list`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -137,8 +137,8 @@ Search connector actions with free-form text.
   `description`, `authenticated`, and `schemaPath`.
 - Output: text output prints one block per action with the service/action
   label, optional description, authenticated state, and schema cache path.
-- Notes: the command writes one schema cache file per result under the
-  persisted CLI configuration root in `connector-actions/`, alongside `data/`.
+- Notes: the command caches discovered action schemas locally and reports the
+  cache path for each result.
 
 ### `oo connector run <serviceName>`
 
@@ -152,8 +152,8 @@ Validate input data and run one connector action synchronously.
 - Output: non-dry-run JSON output mirrors the stable response shape
   `{ data, meta: { executionId } }`.
 - Output: dry-run JSON output returns `{ dryRun, ok, schemaPath }`.
-- Notes: when the local schema cache is missing or invalid, the command fetches
-  action metadata, rewrites the schema cache, and then validates the payload.
+- Notes: when local schema cache is unavailable or unusable, the command
+  refreshes it automatically before validating and running.
 
 ## Codex Skills
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -126,8 +126,8 @@
   `authenticated`、`schemaPath`。
 - 输出：文本输出会为每个 action 打印一个块，包含 service/action 标识、可选
   描述、认证状态和 schema cache 路径。
-- 说明：命令会为每条结果在持久化 CLI 配置根目录下的 `connector-actions/`
-  中写入一个 schema cache 文件，该目录与 `data/` 平级。
+- 说明：命令会在本地缓存已发现的 action schema，并在输出中返回对应的缓存
+  路径。
 
 ### `oo connector run <serviceName>`
 
@@ -141,8 +141,8 @@
 - 输出：非 dry-run 的 JSON 输出会保持稳定结构
   `{ data, meta: { executionId } }`。
 - 输出：dry-run 的 JSON 输出返回 `{ dryRun, ok, schemaPath }`。
-- 说明：如果本地 schema cache 缺失或无效，命令会先拉取 action 元数据，重写
-  schema cache，再继续做 payload 校验。
+- 说明：如果本地 schema cache 不可用或无法使用，命令会自动刷新后再继续校验
+  和运行。
 
 ## Codex Skill
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -111,6 +111,39 @@
   registry 拉取最新版本信息。
 - 说明：如果注册表暂时不可用，CLI 会输出稍后重试的提示，而不是直接报错退出。
 
+## Connector
+
+### `oo connector search <text>`
+
+使用自由文本搜索 connector action。
+
+- 参数：`<text>` 为语义搜索文本。
+- 选项：`--keywords <keywords>` 接收逗号分隔的关键词列表，去掉空项和重复项
+  后发送。
+- 选项：`--format=json` 和 `--json` 会输出匹配 action 条目的 JSON 数组。
+- 输出：每条结果都会附加 `authenticated` 和 `schemaPath`。
+- 输出：JSON 条目只包含稳定的 CLI 字段：`service`、`name`、`description`、
+  `authenticated`、`schemaPath`。
+- 输出：文本输出会为每个 action 打印一个块，包含 service/action 标识、可选
+  描述、认证状态和 schema cache 路径。
+- 说明：命令会为每条结果在持久化 CLI 配置根目录下的 `connector-actions/`
+  中写入一个 schema cache 文件，该目录与 `data/` 平级。
+
+### `oo connector run <serviceName>`
+
+校验输入数据，并同步运行一个 connector action。
+
+- 参数：`<serviceName>` 为服务名。
+- 选项：`-a, --action <action>` 用于指定 action 名称，且为必填。
+- 选项：`-d, --data <data>` 支持直接传入 JSON，或使用 `@路径` 读取 JSON 文件。
+- 选项：`--dry-run` 只做 payload 校验，不真正执行 action。
+- 选项：`--format=json` 和 `--json` 会输出 JSON 对象。
+- 输出：非 dry-run 的 JSON 输出会保持稳定结构
+  `{ data, meta: { executionId } }`。
+- 输出：dry-run 的 JSON 输出返回 `{ dryRun, ok, schemaPath }`。
+- 说明：如果本地 schema cache 缺失或无效，命令会先拉取 action 元数据，重写
+  schema cache，再继续做 payload 校验。
+
 ## Codex Skill
 
 ### `oo skills list`

--- a/src/adapters/completion/static-completion-renderer.test.ts
+++ b/src/adapters/completion/static-completion-renderer.test.ts
@@ -13,6 +13,7 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain("auth");
         expect(output).toContain("completion");
         expect(output).toContain("config");
+        expect(output).toContain("connector");
         expect(output).toContain("login");
         expect(output).toContain("logout");
         expect(output).toContain("packages");
@@ -27,6 +28,7 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain(`#compdef ${APP_NAME}`);
         expect(output).toContain("auth switch");
         expect(output).toContain("config set");
+        expect(output).toContain("connector run");
         expect(output).toContain("packages search");
         expect(output).toContain(`compdef _${APP_NAME} ${APP_NAME}`);
     });
@@ -40,6 +42,7 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain("__fish_seen_subcommand_from auth");
         expect(output).toContain("completion");
         expect(output).toContain("config");
+        expect(output).toContain("connector");
         expect(output).toContain("login");
         expect(output).toContain("logout");
         expect(output).toContain("__fish_seen_subcommand_from packages");

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -43,6 +43,7 @@ Commands:
   auth                Manage CLI authentication
   check-update        Check for CLI updates
   cloud-task          Manage cloud tasks
+  connector           Manage connector actions
   file                Manage temporary file transfers
   login               Log in with a browser flow (alias for auth login)
   logout              Log out the current account (alias for auth logout)
@@ -74,6 +75,7 @@ Commands:
   auth                Manage CLI authentication
   check-update        Check for CLI updates
   cloud-task          Manage cloud tasks
+  connector           Manage connector actions
   file                Manage temporary file transfers
   login               Log in with a browser flow (alias for auth login)
   logout              Log out the current account (alias for auth logout)
@@ -108,6 +110,7 @@ Commands:
   auth                Manage CLI authentication
   check-update        Check for CLI updates
   cloud-task          Manage cloud tasks
+  connector           Manage connector actions
   file                Manage temporary file transfers
   login               Log in with a browser flow (alias for auth login)
   logout              Log out the current account (alias for auth logout)
@@ -140,6 +143,7 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
   auth                管理 CLI 认证
   check-update        检查 CLI 更新
   cloud-task          管理云任务
+  connector           管理 connector action
   file                管理临时文件传输
   login               通过浏览器登录（auth login 的别名）
   logout              登出当前账号（auth logout 的别名）
@@ -168,6 +172,7 @@ Commands:
   auth                Manage CLI authentication
   check-update        Check for CLI updates
   cloud-task          Manage cloud tasks
+  connector           Manage connector actions
   file                Manage temporary file transfers
   login               Log in with a browser flow (alias for auth login)
   logout              Log out the current account (alias for auth logout)
@@ -200,6 +205,7 @@ Commands:
   auth                Manage CLI authentication
   check-update        Check for CLI updates
   cloud-task          Manage cloud tasks
+  connector           Manage connector actions
   file                Manage temporary file transfers
   login               Log in with a browser flow (alias for auth login)
   logout              Log out the current account (alias for auth logout)

--- a/src/application/commands/catalog.ts
+++ b/src/application/commands/catalog.ts
@@ -6,6 +6,7 @@ import { checkUpdateCommand } from "./check-update.ts";
 import { cloudTaskCommand } from "./cloud-task/index.ts";
 import { completionCommand } from "./completion.ts";
 import { configCommand } from "./config/index.ts";
+import { connectorCommand } from "./connector/index.ts";
 import { fileCommand } from "./file/index.ts";
 import { logCommand } from "./log/index.ts";
 import { loginCommand } from "./login.ts";
@@ -38,6 +39,7 @@ export function createCliCatalog(): CliCatalog {
             authCommand,
             checkUpdateCommand,
             cloudTaskCommand,
+            connectorCommand,
             fileCommand,
             loginCommand,
             logoutCommand,

--- a/src/application/commands/cloud-task/run.ts
+++ b/src/application/commands/cloud-task/run.ts
@@ -1,14 +1,15 @@
-import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
-import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
 import { z } from "zod";
 import { resolveRequestLanguage } from "../../../i18n/locale.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { loadPackageInfo, parsePackageSpecifier } from "../package/shared.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
-import { isPlainObject } from "../shared/schema-utils.ts";
+import {
+    readJsonInputValue,
+    requireJsonObjectInput,
+} from "../shared/json-input.ts";
 import {
     createCloudTaskTasksUrl,
     parseCloudTaskCreateResponse,
@@ -24,6 +25,12 @@ interface CloudTaskRunInput {
     format?: string;
     packageSpecifier: string;
 }
+
+const cloudTaskRunDataErrorKeys = {
+    dataFilePathRequired: "errors.cloudTaskRun.dataFilePathRequired",
+    dataReadFailed: "errors.cloudTaskRun.dataReadFailed",
+    invalidDataJson: "errors.cloudTaskRun.invalidDataJson",
+} as const;
 
 export const cloudTaskRunCommand: CliCommandDefinition<CloudTaskRunInput> = {
     name: "run",
@@ -80,8 +87,15 @@ export const cloudTaskRunCommand: CliCommandDefinition<CloudTaskRunInput> = {
             requireSemver: true,
             requireVersion: true,
         });
-        const rawInputValues = await readInputValuesSource(input.data, context);
-        const inputValues = parseInputValues(rawInputValues);
+        const inputValues = requireJsonObjectInput(
+            await readJsonInputValue(
+                input.data,
+                context,
+                cloudTaskRunDataErrorKeys,
+                {},
+            ),
+            "errors.cloudTaskRun.invalidPayloadShape",
+        );
         const packageInfo = await loadPackageInfo(
             packageSpecifier,
             account,
@@ -141,59 +155,3 @@ export const cloudTaskRunCommand: CliCommandDefinition<CloudTaskRunInput> = {
         );
     },
 };
-
-async function readInputValuesSource(
-    value: string | undefined,
-    context: Pick<CliExecutionContext, "cwd">,
-): Promise<string> {
-    if (value === undefined || value.trim() === "") {
-        return "{}";
-    }
-
-    if (!value.startsWith("@")) {
-        return value;
-    }
-
-    const relativePath = value.slice(1);
-
-    if (relativePath.trim() === "") {
-        throw new CliUserError("errors.cloudTaskRun.dataFilePathRequired", 2);
-    }
-
-    const resolvedPath = resolve(context.cwd, relativePath);
-
-    try {
-        return await readFile(resolvedPath, "utf8");
-    }
-    catch (error) {
-        throw new CliUserError("errors.cloudTaskRun.dataReadFailed", 1, {
-            message: error instanceof Error ? error.message : String(error),
-            path: resolvedPath,
-        });
-    }
-}
-
-function parseInputValues(
-    rawInputValues: string,
-): Record<string, unknown> {
-    const normalizedInput = rawInputValues.charCodeAt(0) === 0xFEFF
-        ? rawInputValues.slice(1)
-        : rawInputValues;
-
-    let parsedValue: unknown;
-
-    try {
-        parsedValue = JSON.parse(normalizedInput) as unknown;
-    }
-    catch (error) {
-        throw new CliUserError("errors.cloudTaskRun.invalidDataJson", 2, {
-            message: error instanceof Error ? error.message : String(error),
-        });
-    }
-
-    if (!isPlainObject(parsedValue)) {
-        throw new CliUserError("errors.cloudTaskRun.invalidPayloadShape", 2);
-    }
-
-    return parsedValue;
-}

--- a/src/application/commands/cloud-task/validation.ts
+++ b/src/application/commands/cloud-task/validation.ts
@@ -1,17 +1,15 @@
-import type { ErrorObject, ValidateFunction } from "ajv";
-
 import type { Translator } from "../../contracts/translator.ts";
 import type { PackageInfoResponse } from "../package/shared.ts";
-import Ajv from "ajv";
-import addFormats from "ajv-formats";
-import ajvEN from "ajv-i18n/localize/en/index.js";
-import ajvZH from "ajv-i18n/localize/zh/index.js";
 import { CliUserError } from "../../contracts/cli.ts";
 import { isPackageInfoInputHandleOptional } from "../package/shared.ts";
 import { patchHandleSchema } from "../shared/handle-schema.ts";
+import {
+    compileJsonSchema,
+    formatJsonSchemaErrors,
+    validateCompiledJsonSchema,
+} from "../shared/json-schema-validation.ts";
 import { isPlainObject, readWidgetName } from "../shared/schema-utils.ts";
 
-const ajv = createAjv();
 const oomolStoragePathPrefix = "/oomol-driver/oomol-storage/";
 type ValidationTranslator = Pick<Translator, "locale" | "t">;
 
@@ -149,23 +147,6 @@ export function validateCloudTaskInputValues(
     }
 }
 
-function createAjv(): Ajv {
-    const instance = new Ajv({
-        addUsedSchema: false,
-        allErrors: true,
-        strict: false,
-        verbose: true,
-    });
-
-    addFormats(instance);
-    instance.addFormat("hex-color", {
-        type: "string",
-        validate: value => isHexColorString(value),
-    });
-
-    return instance;
-}
-
 function validateHandleValue(
     value: unknown,
     def: PackageInfoResponse["blocks"][number]["inputHandle"][string],
@@ -195,7 +176,7 @@ function validateHandleValue(
         return normalizedSchema.error;
     }
 
-    const [validator, compileError] = compile(normalizedSchema.schema);
+    const [validator, compileError] = compileJsonSchema(normalizedSchema.schema);
 
     if (compileError !== undefined) {
         return {
@@ -233,12 +214,16 @@ function validateHandleValue(
         };
     }
 
-    const validationErrors = validate(validator, value, translator.locale);
+    const validationErrors = validateCompiledJsonSchema(
+        validator,
+        value,
+        translator.locale,
+    );
 
     if (validationErrors && validationErrors.length > 0) {
         return {
             code: "validation",
-            message: ajv.errorsText(validationErrors),
+            message: formatJsonSchemaErrors(validationErrors),
         };
     }
 
@@ -300,44 +285,6 @@ function normalizeHandleSchema(
     return {
         schema: patchHandleSchema(normalizedSchema, ext),
     };
-}
-
-function compile(
-    schema?: unknown,
-): [ValidateFunction | undefined, Error | undefined] {
-    if (schema === undefined) {
-        return [undefined, undefined];
-    }
-
-    try {
-        return [ajv.compile(schema as object | boolean), undefined];
-    }
-    catch (error) {
-        return [undefined, error as Error];
-    }
-}
-
-function validate(
-    validator: ValidateFunction | undefined,
-    data: unknown,
-    locale?: string,
-): ErrorObject[] | null | undefined {
-    if (validator === undefined) {
-        return [];
-    }
-
-    if (validator(data)) {
-        return [];
-    }
-
-    if (locale?.startsWith("zh")) {
-        ajvZH(validator.errors);
-    }
-    else {
-        ajvEN(validator.errors);
-    }
-
-    return validator.errors;
 }
 
 function typeOfSchema(schema: unknown): WidgetType {
@@ -424,29 +371,6 @@ function inferPrimitiveType(value: unknown): PrimitiveType {
     }
 
     return typeof value;
-}
-
-function isHexColorString(value: string): boolean {
-    if (!value.startsWith("#")) {
-        return false;
-    }
-
-    if (value.length !== 7 && value.length !== 9) {
-        return false;
-    }
-
-    for (let index = 1; index < value.length; index += 1) {
-        const charCode = value.charCodeAt(index);
-        const isDigit = charCode >= 48 && charCode <= 57;
-        const isUpperHex = charCode >= 65 && charCode <= 70;
-        const isLowerHex = charCode >= 97 && charCode <= 102;
-
-        if (!isDigit && !isUpperHex && !isLowerHex) {
-            return false;
-        }
-    }
-
-    return true;
 }
 
 function isOomolStoragePath(value: string): boolean {

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -29,6 +29,7 @@ Commands:
   auth                Manage CLI authentication
   check-update        Check for CLI updates
   cloud-task          Manage cloud tasks
+  connector           Manage connector actions
   file                Manage temporary file transfers
   login               Log in with a browser flow (alias for auth login)
   logout              Log out the current account (alias for auth logout)
@@ -57,6 +58,7 @@ Commands:
   auth                管理 CLI 认证
   check-update        检查 CLI 更新
   cloud-task          管理云任务
+  connector           管理 connector action
   file                管理临时文件传输
   login               通过浏览器登录（auth login 的别名）
   logout              登出当前账号（auth logout 的别名）

--- a/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
@@ -1,0 +1,135 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`connectorCommand CLI supports connector search with text output and writes schema caches 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"gmail.send_mail
+Send a Gmail message.
+Authenticated: yes
+Schema path: <XDG_CONFIG_HOME>/oo/connector-actions/gmail.send_mail.json
+"
+,
+}
+`;
+
+exports[`connectorCommand CLI supports connector search with json output and omits schemas 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"[{"authenticated":false,"description":"Send a Gmail message.","name":"send_mail","schemaPath":"<XDG_CONFIG_HOME>/oo/connector-actions/gmail.send_mail.json","service":"gmail"}]
+"
+,
+}
+`;
+
+exports[`connectorCommand CLI renders connector search output with field-specific colors 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"gmail.send_mail
+Send a Gmail message.
+Authenticated: yes
+Schema path: <XDG_CONFIG_HOME>/oo/connector-actions/gmail.send_mail.json
+"
+,
+}
+`;
+
+exports[`connectorCommand CLI validates the connector search format option 1`] = `
+{
+  "exitCode": 2,
+  "stderr": 
+"Invalid format: yaml. Use json.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`connectorCommand CLI renders connector search help when text argument is omitted 1`] = `
+{
+  "expectedHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Search connector actions and cache their schemas locally.
+
+Arguments:
+  text                   Search text
+
+Options:
+  --format <format>      Specify output format (use json for structured output)
+  --json                 Alias for --format=json
+  --keywords <keywords>  Specify comma-separated keywords to refine the
+                         connector action search
+  -h, --help             Show help for command
+
+Global Options:
+  -V, --version          Show the current version
+  --debug                Print the current log file path when the CLI exits
+  --lang <lang>          Specify the display language
+"
+,
+  },
+  "result": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Search connector actions and cache their schemas locally.
+
+Arguments:
+  text                   Search text
+
+Options:
+  --format <format>      Specify output format (use json for structured output)
+  --json                 Alias for --format=json
+  --keywords <keywords>  Specify comma-separated keywords to refine the
+                         connector action search
+  -h, --help             Show help for command
+
+Global Options:
+  -V, --version          Show the current version
+  --debug                Print the current log file path when the CLI exits
+  --lang <lang>          Specify the display language
+"
+,
+  },
+}
+`;
+
+exports[`connectorCommand CLI supports connector run with cached schema and json output 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"{"data":{"messageId":"message-1"},"meta":{"executionId":"exec-1"}}
+"
+,
+}
+`;
+
+exports[`connectorCommand CLI loads connector action metadata and supports dry-run when the schema cache is missing 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"{"dryRun":true,"ok":true,"schemaPath":"<XDG_CONFIG_HOME>/oo/connector-actions/gmail.send_mail.json"}
+"
+,
+}
+`;
+
+exports[`connectorCommand CLI validates connector run payloads before sending the action request 1`] = `
+{
+  "exitCode": 2,
+  "stderr": 
+"The connector action input payload is invalid: data/to must match format "email"
+"
+,
+  "stdout": "",
+}
+`;

--- a/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
@@ -8,7 +8,7 @@ exports[`connectorCommand CLI supports connector search with text output and wri
 "gmail.send_mail
 Send a Gmail message.
 Authenticated: yes
-Schema path: <XDG_CONFIG_HOME>/oo/connector-actions/gmail.send_mail.json
+Schema path: <XDG_CONFIG_HOME>/oo/connector-actions/gmail/send_mail.json
 "
 ,
 }
@@ -19,7 +19,7 @@ exports[`connectorCommand CLI supports connector search with json output and omi
   "exitCode": 0,
   "stderr": "",
   "stdout": 
-"[{"authenticated":false,"description":"Send a Gmail message.","name":"send_mail","schemaPath":"<XDG_CONFIG_HOME>/oo/connector-actions/gmail.send_mail.json","service":"gmail"}]
+"[{"authenticated":false,"description":"Send a Gmail message.","name":"send_mail","schemaPath":"<XDG_CONFIG_HOME>/oo/connector-actions/gmail/send_mail.json","service":"gmail"}]
 "
 ,
 }
@@ -33,7 +33,7 @@ exports[`connectorCommand CLI renders connector search output with field-specifi
 "gmail.send_mail
 Send a Gmail message.
 Authenticated: yes
-Schema path: <XDG_CONFIG_HOME>/oo/connector-actions/gmail.send_mail.json
+Schema path: <XDG_CONFIG_HOME>/oo/connector-actions/gmail/send_mail.json
 "
 ,
 }
@@ -117,7 +117,7 @@ exports[`connectorCommand CLI loads connector action metadata and supports dry-r
   "exitCode": 0,
   "stderr": "",
   "stdout": 
-"{"dryRun":true,"ok":true,"schemaPath":"<XDG_CONFIG_HOME>/oo/connector-actions/gmail.send_mail.json"}
+"{"dryRun":true,"ok":true,"schemaPath":"<XDG_CONFIG_HOME>/oo/connector-actions/gmail/send_mail.json"}
 "
 ,
 }

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "bun:test";
 import {
     createCliSandbox,
     createCliSnapshot,
+    createConnectorActionFixture,
     readLatestLogContent,
     toRequest,
     writeAuthFile,
@@ -15,9 +16,10 @@ import {
     renderConnectorActionSchemaCache,
     resolveConnectorActionSchemaPath,
 } from "./schema-cache.ts";
-
-const connectorActionColor = "#59F78D";
-const connectorServiceColor = "#CAA8FA";
+import {
+    connectorSearchActionColor,
+    connectorSearchServiceColor,
+} from "./search.ts";
 
 describe("connectorCommand CLI", () => {
     test("supports connector search with text output and writes schema caches", async () => {
@@ -236,7 +238,7 @@ describe("connectorCommand CLI", () => {
                 stripAnsi: true,
             })).toMatchSnapshot();
             expect(result.stdout).toContain(
-                `${colors.hex(connectorServiceColor)("gmail")}.${colors.hex(connectorActionColor)("send_mail")}`,
+                `${colors.hex(connectorSearchServiceColor)("gmail")}.${colors.hex(connectorSearchActionColor)("send_mail")}`,
             );
             expect(result.stdout).toContain(`Authenticated: ${colors.green("yes")}`);
         }
@@ -371,6 +373,69 @@ describe("connectorCommand CLI", () => {
                     to: "foo@bar.com",
                 },
             });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("trims connector action names before cache lookup and request", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const schemaPath = await seedConnectorActionSchema(
+                sandbox,
+                createConnectorActionFixture(),
+            );
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    " send_mail ",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(JSON.parse(result.stdout)).toEqual({
+                data: {
+                    messageId: "message-1",
+                },
+                meta: {
+                    executionId: "exec-1",
+                },
+            });
+            expect(schemaPath).toBe(
+                resolveConnectorActionSchemaPath(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
+                    "gmail",
+                    "send_mail",
+                ),
+            );
+            expect(requests[0]?.url).toBe(
+                "https://connector.oomol.com/v1/actions/gmail.send_mail",
+            );
         }
         finally {
             await sandbox.cleanup();
@@ -669,10 +734,27 @@ describe("connectorCommand CLI", () => {
             expect(content).toContain("\"responseMessage\":\"Invalid id value\"");
             expect(content).toContain("\"errorCode\":\"invalid_input\"");
             expect(content).toContain("\"executionId\":\"exec-1\"");
-            expect(content).toContain("\"responseBody\":\"{\\\"errorCode\\\":\\\"invalid_input\\\"");
+            expect(content).not.toContain("\"responseBody\":");
         }
         finally {
             await sandbox.cleanup();
         }
     });
 });
+
+async function seedConnectorActionSchema(
+    sandbox: {
+        env: Record<string, string | undefined>;
+    },
+    action = createConnectorActionFixture(),
+): Promise<string> {
+    const schemaPath = resolveConnectorActionSchemaPath(
+        join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
+        action.service,
+        action.name,
+    );
+
+    await Bun.write(schemaPath, renderConnectorActionSchemaCache(action));
+
+    return schemaPath;
+}

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -1,0 +1,678 @@
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    createCliSandbox,
+    createCliSnapshot,
+    readLatestLogContent,
+    toRequest,
+    writeAuthFile,
+} from "../../../../__tests__/helpers.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import { createTerminalColors } from "../../terminal-colors.ts";
+import {
+    renderConnectorActionSchemaCache,
+    resolveConnectorActionSchemaPath,
+} from "./schema-cache.ts";
+
+const connectorActionColor = "#59F78D";
+const connectorServiceColor = "#CAA8FA";
+
+describe("connectorCommand CLI", () => {
+    test("supports connector search with text output and writes schema caches", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["connector", "search", "send mail", "--keywords=gmail,email,gmail"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.url.startsWith("https://search.")) {
+                            return new Response(JSON.stringify({
+                                data: [
+                                    {
+                                        description: "Send a Gmail message.",
+                                        inputSchema: {
+                                            properties: {
+                                                to: {
+                                                    format: "email",
+                                                    type: "string",
+                                                },
+                                            },
+                                            required: ["to"],
+                                            type: "object",
+                                        },
+                                        name: "send_mail",
+                                        outputSchema: {
+                                            properties: {
+                                                messageId: {
+                                                    type: "string",
+                                                },
+                                            },
+                                            required: ["messageId"],
+                                            type: "object",
+                                        },
+                                        service: "gmail",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: ["gmail"],
+                        }));
+                    },
+                },
+            );
+            const schemaPath = resolveConnectorActionSchemaPath(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
+                "gmail",
+                "send_mail",
+            );
+
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain("gmail.send_mail");
+            expect(result.stdout).toContain("Send a Gmail message.");
+            expect(result.stdout).toContain("Authenticated: yes");
+            expect(result.stdout).toContain(`Schema path: ${schemaPath}`);
+            expect(requests).toHaveLength(2);
+            expect(requests[0]?.url).toBe(
+                "https://search.oomol.com/v1/connector-actions?q=send+mail&keywords=gmail%2Cemail",
+            );
+            expect(requests[1]?.url).toBe(
+                "https://connector.oomol.com/v1/apps/authenticated?service=gmail",
+            );
+            await expect(Bun.file(schemaPath).text()).resolves.toBe(
+                [
+                    "{",
+                    "  \"description\": \"Send a Gmail message.\",",
+                    "  \"inputSchema\": {",
+                    "    \"properties\": {",
+                    "      \"to\": {",
+                    "        \"format\": \"email\",",
+                    "        \"type\": \"string\"",
+                    "      }",
+                    "    },",
+                    "    \"required\": [",
+                    "      \"to\"",
+                    "    ],",
+                    "    \"type\": \"object\"",
+                    "  },",
+                    "  \"name\": \"send_mail\",",
+                    "  \"outputSchema\": {",
+                    "    \"properties\": {",
+                    "      \"messageId\": {",
+                    "        \"type\": \"string\"",
+                    "      }",
+                    "    },",
+                    "    \"required\": [",
+                    "      \"messageId\"",
+                    "    ],",
+                    "    \"type\": \"object\"",
+                    "  },",
+                    "  \"service\": \"gmail\"",
+                    "}",
+                    "",
+                ].join("\n"),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports connector search with json output and omits schemas", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["connector", "search", "send mail", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.startsWith("https://search.")) {
+                            return new Response(JSON.stringify({
+                                data: [
+                                    {
+                                        description: "Send a Gmail message.",
+                                        inputSchema: {
+                                            type: "object",
+                                        },
+                                        name: "send_mail",
+                                        outputSchema: {
+                                            type: "object",
+                                        },
+                                        service: "gmail",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: [],
+                        }));
+                    },
+                },
+            );
+
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
+            expect(JSON.parse(result.stdout)).toEqual([
+                {
+                    authenticated: false,
+                    description: "Send a Gmail message.",
+                    name: "send_mail",
+                    schemaPath: resolveConnectorActionSchemaPath(
+                        join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
+                        "gmail",
+                        "send_mail",
+                    ),
+                    service: "gmail",
+                },
+            ]);
+            expect(result.stdout).not.toContain("inputSchema");
+            expect(result.stdout).not.toContain("outputSchema");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders connector search output with field-specific colors", async () => {
+        const sandbox = await createCliSandbox();
+        const colors = createTerminalColors(true);
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["connector", "search", "send mail"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.startsWith("https://search.")) {
+                            return new Response(JSON.stringify({
+                                data: [
+                                    {
+                                        description: "Send a Gmail message.",
+                                        inputSchema: {
+                                            type: "object",
+                                        },
+                                        name: "send_mail",
+                                        outputSchema: {
+                                            type: "object",
+                                        },
+                                        service: "gmail",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: ["gmail"],
+                        }));
+                    },
+                    stdout: {
+                        hasColors: true,
+                    },
+                },
+            );
+
+            expect(createCliSnapshot(result, {
+                sandbox,
+                stripAnsi: true,
+            })).toMatchSnapshot();
+            expect(result.stdout).toContain(
+                `${colors.hex(connectorServiceColor)("gmail")}.${colors.hex(connectorActionColor)("send_mail")}`,
+            );
+            expect(result.stdout).toContain(`Authenticated: ${colors.green("yes")}`);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("validates the connector search format option", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run([
+                "connector",
+                "search",
+                "send mail",
+                "--format=yaml",
+            ]);
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders connector search help when text argument is omitted", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const expectedHelp = await sandbox.run(["connector", "search", "--help"]);
+            const result = await sandbox.run(["connector", "search"]);
+
+            expect({
+                expectedHelp: createCliSnapshot(expectedHelp),
+                result: createCliSnapshot(result),
+            }).toMatchSnapshot();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports connector run with cached schema and json output", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const schemaPath = resolveConnectorActionSchemaPath(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
+                "gmail",
+                "send_mail",
+            );
+
+            await Bun.write(
+                schemaPath,
+                renderConnectorActionSchemaCache({
+                    description: "Send a Gmail message.",
+                    inputSchema: {
+                        properties: {
+                            to: {
+                                format: "email",
+                                type: "string",
+                            },
+                        },
+                        required: ["to"],
+                        type: "object",
+                    },
+                    name: "send_mail",
+                    outputSchema: {
+                        properties: {
+                            messageId: {
+                                type: "string",
+                            },
+                        },
+                        required: ["messageId"],
+                        type: "object",
+                    },
+                    service: "gmail",
+                }),
+            );
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                            message: "ok",
+                            success: true,
+                        }));
+                    },
+                },
+            );
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+            expect(JSON.parse(result.stdout)).toEqual({
+                data: {
+                    messageId: "message-1",
+                },
+                meta: {
+                    executionId: "exec-1",
+                },
+            });
+            expect(result.stdout).not.toContain("\"success\"");
+            expect(result.stdout).not.toContain("\"message\"");
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.url).toBe(
+                "https://connector.oomol.com/v1/actions/gmail.send_mail",
+            );
+            expect(requests[0]?.method).toBe("POST");
+            await expect(requests[0]?.json()).resolves.toEqual({
+                input: {
+                    to: "foo@bar.com",
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders connector run text output with clear result-data emphasis", async () => {
+        const sandbox = await createCliSandbox();
+        const colors = createTerminalColors(true);
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const schemaPath = resolveConnectorActionSchemaPath(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
+                "gmail",
+                "send_mail",
+            );
+
+            await Bun.write(
+                schemaPath,
+                renderConnectorActionSchemaCache({
+                    description: "Send a Gmail message.",
+                    inputSchema: {
+                        properties: {
+                            to: {
+                                format: "email",
+                                type: "string",
+                            },
+                        },
+                        required: ["to"],
+                        type: "object",
+                    },
+                    name: "send_mail",
+                    outputSchema: {
+                        type: "object",
+                    },
+                    service: "gmail",
+                }),
+            );
+
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                ],
+                {
+                    fetcher: async () => new Response(JSON.stringify({
+                        data: {
+                            body: "Hello",
+                            messageId: "message-1",
+                        },
+                        meta: {
+                            executionId: "exec-1",
+                        },
+                    })),
+                    stdout: {
+                        hasColors: true,
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain(colors.hex("#59F78D")("exec-1"));
+            expect(result.stdout).toContain(colors.bold("Result data:"));
+            expect(result.stdout).toContain("\u001B[36m{\n");
+            expect(result.stdout).toContain("\"messageId\": \"message-1\"");
+            expect(result.stdout).not.toContain(colors.gray("{"));
+            expect(result.stdout).not.toContain("\u001B[90m");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("loads connector action metadata and supports dry-run when the schema cache is missing", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--dry-run",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                description: "Send a Gmail message.",
+                                id: "action-1",
+                                inputSchema: {
+                                    properties: {
+                                        to: {
+                                            format: "email",
+                                            type: "string",
+                                        },
+                                    },
+                                    required: ["to"],
+                                    type: "object",
+                                },
+                                name: "send_mail",
+                                outputSchema: {
+                                    type: "object",
+                                },
+                                providerPermissions: [],
+                                requiredScopes: [],
+                                service: "gmail",
+                            },
+                        }));
+                    },
+                },
+            );
+            const schemaPath = resolveConnectorActionSchemaPath(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
+                "gmail",
+                "send_mail",
+            );
+
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
+            expect(JSON.parse(result.stdout)).toEqual({
+                dryRun: true,
+                ok: true,
+                schemaPath,
+            });
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.url).toBe(
+                "https://connector.oomol.com/v1/actions/gmail.send_mail",
+            );
+            await expect(Bun.file(schemaPath).text()).resolves.toContain(
+                "\"service\": \"gmail\"",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("validates connector run payloads before sending the action request", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const schemaPath = resolveConnectorActionSchemaPath(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
+                "gmail",
+                "send_mail",
+            );
+
+            await Bun.write(
+                schemaPath,
+                renderConnectorActionSchemaCache({
+                    description: "Send a Gmail message.",
+                    inputSchema: {
+                        properties: {
+                            to: {
+                                format: "email",
+                                type: "string",
+                            },
+                        },
+                        required: ["to"],
+                        type: "object",
+                    },
+                    name: "send_mail",
+                    outputSchema: {
+                        type: "object",
+                    },
+                    service: "gmail",
+                }),
+            );
+
+            let requestCount = 0;
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"not-an-email\"}",
+                ],
+                {
+                    fetcher: async () => {
+                        requestCount += 1;
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+            expect(result.exitCode).toBe(2);
+            expect(requestCount).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("logs connector run failure details and surfaces the server message", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const schemaPath = resolveConnectorActionSchemaPath(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
+                "gmail",
+                "get_message",
+            );
+
+            await Bun.write(
+                schemaPath,
+                renderConnectorActionSchemaCache({
+                    description: "Get a Gmail message by id.",
+                    inputSchema: {
+                        properties: {
+                            messageId: {
+                                type: "string",
+                            },
+                        },
+                        required: ["messageId"],
+                        type: "object",
+                    },
+                    name: "get_message",
+                    outputSchema: {
+                        type: "object",
+                    },
+                    service: "gmail",
+                }),
+            );
+
+            const result = await sandbox.run(
+                [
+                    "--debug",
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "get_message",
+                    "-d",
+                    "{\"messageId\":\"invalid-id\"}",
+                ],
+                {
+                    fetcher: async () => new Response(JSON.stringify({
+                        errorCode: "invalid_input",
+                        message: "Invalid id value",
+                        meta: {
+                            actionId: "gmail.get_message",
+                            executionId: "exec-1",
+                        },
+                        success: false,
+                    }), {
+                        status: 400,
+                    }),
+                },
+            );
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toContain(
+                "The connector action run request returned HTTP 400: Invalid id value",
+            );
+            expect(content).toContain(
+                "\"msg\":\"Connector action run request returned a non-success status.\"",
+            );
+            expect(content).toContain("\"responseMessage\":\"Invalid id value\"");
+            expect(content).toContain("\"errorCode\":\"invalid_input\"");
+            expect(content).toContain("\"executionId\":\"exec-1\"");
+            expect(content).toContain("\"responseBody\":\"{\\\"errorCode\\\":\\\"invalid_input\\\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/connector/index.ts
+++ b/src/application/commands/connector/index.ts
@@ -1,0 +1,14 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { connectorRunCommand } from "./run.ts";
+import { connectorSearchCommand } from "./search.ts";
+
+export const connectorCommand: CliCommandDefinition = {
+    name: "connector",
+    summaryKey: "commands.connector.summary",
+    descriptionKey: "commands.connector.description",
+    children: [
+        connectorSearchCommand,
+        connectorRunCommand,
+    ],
+};

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -75,7 +75,9 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        if (input.action === undefined || input.action.trim() === "") {
+        const actionName = input.action?.trim();
+
+        if (actionName === undefined || actionName === "") {
             throw new CliUserError("errors.connectorRun.actionRequired", 2);
         }
 
@@ -88,7 +90,7 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
         );
         const actionReference = await ensureConnectorActionSchemaReference(
             {
-                actionName: input.action,
+                actionName,
                 apiKey: account.apiKey,
                 endpoint: account.endpoint,
                 serviceName: input.serviceName,
@@ -120,7 +122,7 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
 
         const response = await runConnectorAction(
             {
-                actionName: input.action,
+                actionName,
                 apiKey: account.apiKey,
                 endpoint: account.endpoint,
                 inputData,

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -1,0 +1,161 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { createWriterColors } from "../../terminal-colors.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
+import { createFormatInputError } from "../shared/input-parsing.ts";
+import { readJsonInputValue } from "../shared/json-input.ts";
+import { ensureConnectorActionSchemaReference } from "./schema-cache.ts";
+import {
+    connectorFormatValues,
+    runConnectorAction,
+} from "./shared.ts";
+import { validateConnectorActionInput } from "./validation.ts";
+
+const connectorRunExecutionIdColor = "#59F78D";
+
+const connectorRunDataErrorKeys = {
+    dataFilePathRequired: "errors.connectorRun.dataFilePathRequired",
+    dataReadFailed: "errors.connectorRun.dataReadFailed",
+    invalidDataJson: "errors.connectorRun.invalidDataJson",
+} as const;
+
+type ConnectorRunTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
+
+interface ConnectorRunInput {
+    action?: string;
+    data?: string;
+    dryRun?: boolean;
+    format?: (typeof connectorFormatValues)[number];
+    serviceName: string;
+}
+
+export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
+    name: "run",
+    summaryKey: "commands.connector.run.summary",
+    descriptionKey: "commands.connector.run.description",
+    missingArgumentBehavior: "showHelp",
+    arguments: [
+        {
+            name: "serviceName",
+            descriptionKey: "arguments.serviceName",
+            required: true,
+        },
+    ],
+    options: [
+        {
+            name: "action",
+            longFlag: "--action",
+            shortFlag: "-a",
+            valueName: "action",
+            descriptionKey: "options.action",
+        },
+        {
+            name: "data",
+            longFlag: "--data",
+            shortFlag: "-d",
+            valueName: "data",
+            descriptionKey: "options.data",
+        },
+        {
+            name: "dryRun",
+            longFlag: "--dry-run",
+            descriptionKey: "options.dryRun",
+        },
+        ...jsonOutputOptions,
+    ],
+    inputSchema: z.object({
+        action: z.string().optional(),
+        data: z.string().optional(),
+        dryRun: z.boolean().optional(),
+        format: z.enum(connectorFormatValues).optional(),
+        serviceName: z.string(),
+    }),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+    handler: async (input, context) => {
+        if (input.action === undefined || input.action.trim() === "") {
+            throw new CliUserError("errors.connectorRun.actionRequired", 2);
+        }
+
+        const account = await requireCurrentAccount(context);
+        const inputData = await readJsonInputValue(
+            input.data,
+            context,
+            connectorRunDataErrorKeys,
+            {},
+        );
+        const actionReference = await ensureConnectorActionSchemaReference(
+            {
+                actionName: input.action,
+                apiKey: account.apiKey,
+                endpoint: account.endpoint,
+                serviceName: input.serviceName,
+            },
+            context,
+        );
+
+        validateConnectorActionInput(
+            inputData,
+            actionReference.inputSchema,
+            context.translator,
+        );
+
+        if (input.dryRun === true) {
+            if (input.format === "json") {
+                writeJsonOutput(context.stdout, {
+                    dryRun: true,
+                    ok: true,
+                    schemaPath: actionReference.schemaPath,
+                });
+                return;
+            }
+
+            context.stdout.write(
+                `${context.translator.t("connector.run.text.dryRunPassed")}\n`,
+            );
+            return;
+        }
+
+        const response = await runConnectorAction(
+            {
+                actionName: input.action,
+                apiKey: account.apiKey,
+                endpoint: account.endpoint,
+                inputData,
+                serviceName: input.serviceName,
+            },
+            context,
+        );
+
+        if (input.format === "json") {
+            writeJsonOutput(context.stdout, response);
+            return;
+        }
+
+        context.stdout.write(
+            `${formatConnectorRunResponseAsText(response, context)}\n`,
+        );
+    },
+};
+
+function formatConnectorRunResponseAsText(
+    response: Awaited<ReturnType<typeof runConnectorAction>>,
+    context: ConnectorRunTextContext,
+): string {
+    const colors = createWriterColors(context.stdout);
+
+    return [
+        `${context.translator.t("connector.run.text.executionId")}: ${colors.hex(connectorRunExecutionIdColor)(response.meta.executionId)}`,
+        colors.bold(`${context.translator.t("connector.run.text.resultData")}:`),
+        formatConnectorRunResultData(response.data, colors),
+    ].join("\n");
+}
+
+function formatConnectorRunResultData(
+    value: unknown,
+    colors: ReturnType<typeof createWriterColors>,
+): string {
+    return colors.cyan(JSON.stringify(value, null, 2) ?? "null");
+}

--- a/src/application/commands/connector/schema-cache.test.ts
+++ b/src/application/commands/connector/schema-cache.test.ts
@@ -1,0 +1,212 @@
+import type { AppSettings } from "../../schemas/settings.ts";
+import { rm } from "node:fs/promises";
+
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+import pino from "pino";
+
+import { createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
+import {
+    ensureConnectorActionSchemaReference,
+    persistConnectorActionSchemaCache,
+    renderConnectorActionSchemaCache,
+    resolveConnectorActionSchemaPath,
+} from "./schema-cache.ts";
+
+describe("connector schema cache", () => {
+    test("resolveConnectorActionSchemaPath places schema files alongside the data directory", () => {
+        expect(resolveConnectorActionSchemaPath(
+            join("/tmp", "oo", "settings.toml"),
+            "gmail",
+            "send_mail",
+        )).toBe(join("/tmp", "oo", "connector-actions", "gmail.send_mail.json"));
+    });
+
+    test("persistConnectorActionSchemaCache writes the cache file to the connector-actions directory", async () => {
+        const rootPath = await createTemporaryDirectory("connector-schema-cache");
+
+        try {
+            const schemaPath = await persistConnectorActionSchemaCache(
+                {
+                    description: "Send a Gmail message.",
+                    inputSchema: {
+                        type: "object",
+                    },
+                    name: "send_mail",
+                    outputSchema: {
+                        type: "object",
+                    },
+                    service: "gmail",
+                },
+                createCacheContext(rootPath),
+            );
+
+            expect(schemaPath).toBe(
+                join(rootPath, "connector-actions", "gmail.send_mail.json"),
+            );
+            await expect(Bun.file(schemaPath).text()).resolves.toBe(
+                renderConnectorActionSchemaCache({
+                    description: "Send a Gmail message.",
+                    inputSchema: {
+                        type: "object",
+                    },
+                    name: "send_mail",
+                    outputSchema: {
+                        type: "object",
+                    },
+                    service: "gmail",
+                }),
+            );
+        }
+        finally {
+            await rm(rootPath, { force: true, recursive: true });
+        }
+    });
+
+    test("ensureConnectorActionSchemaReference reuses a cached schema without fetching", async () => {
+        const rootPath = await createTemporaryDirectory("connector-schema-cache");
+
+        try {
+            const schemaPath = resolveConnectorActionSchemaPath(
+                join(rootPath, "settings.toml"),
+                "gmail",
+                "send_mail",
+            );
+
+            await Bun.write(
+                schemaPath,
+                renderConnectorActionSchemaCache({
+                    description: "Cached schema.",
+                    inputSchema: {
+                        type: "object",
+                    },
+                    name: "send_mail",
+                    outputSchema: {
+                        type: "object",
+                    },
+                    service: "gmail",
+                }),
+            );
+
+            let fetchCount = 0;
+            const reference = await ensureConnectorActionSchemaReference(
+                {
+                    actionName: "send_mail",
+                    apiKey: "secret-1",
+                    endpoint: "oomol.com",
+                    serviceName: "gmail",
+                },
+                createCacheContext(rootPath, {
+                    fetcher: async () => {
+                        fetchCount += 1;
+
+                        return new Response("unexpected");
+                    },
+                }),
+            );
+
+            expect(reference).toEqual({
+                description: "Cached schema.",
+                inputSchema: {
+                    type: "object",
+                },
+                name: "send_mail",
+                outputSchema: {
+                    type: "object",
+                },
+                schemaPath,
+                service: "gmail",
+            });
+            expect(fetchCount).toBe(0);
+        }
+        finally {
+            await rm(rootPath, { force: true, recursive: true });
+        }
+    });
+
+    test("ensureConnectorActionSchemaReference refreshes invalid cache content from metadata", async () => {
+        const rootPath = await createTemporaryDirectory("connector-schema-cache");
+
+        try {
+            const schemaPath = resolveConnectorActionSchemaPath(
+                join(rootPath, "settings.toml"),
+                "gmail",
+                "get_message",
+            );
+
+            await Bun.write(schemaPath, "{");
+
+            const reference = await ensureConnectorActionSchemaReference(
+                {
+                    actionName: "get_message",
+                    apiKey: "secret-1",
+                    endpoint: "oomol.com",
+                    serviceName: "gmail",
+                },
+                createCacheContext(rootPath, {
+                    fetcher: async () => new Response(JSON.stringify({
+                        data: {
+                            description: "Get one Gmail message.",
+                            id: "action-1",
+                            inputSchema: {
+                                type: "object",
+                            },
+                            name: "get_message",
+                            outputSchema: {
+                                type: "object",
+                            },
+                            providerPermissions: [],
+                            requiredScopes: [],
+                            service: "gmail",
+                        },
+                    })),
+                }),
+            );
+
+            expect(reference).toEqual({
+                description: "Get one Gmail message.",
+                inputSchema: {
+                    type: "object",
+                },
+                name: "get_message",
+                outputSchema: {
+                    type: "object",
+                },
+                schemaPath,
+                service: "gmail",
+            });
+            await expect(Bun.file(schemaPath).text()).resolves.toContain(
+                "\"name\": \"get_message\"",
+            );
+        }
+        finally {
+            await rm(rootPath, { force: true, recursive: true });
+        }
+    });
+});
+
+function createCacheContext(
+    rootPath: string,
+    options: {
+        fetcher?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+    } = {},
+) {
+    const emptySettings = {} as AppSettings;
+
+    return {
+        fetcher: options.fetcher ?? (async () => {
+            throw new Error("Unexpected fetch");
+        }),
+        logger: pino({
+            enabled: false,
+        }),
+        settingsStore: {
+            getFilePath: () => join(rootPath, "settings.toml"),
+            read: async () => emptySettings,
+            update: async (updater: (settings: AppSettings) => AppSettings) =>
+                updater(emptySettings),
+            write: async (value: AppSettings) => value,
+        },
+    };
+}

--- a/src/application/commands/connector/schema-cache.test.ts
+++ b/src/application/commands/connector/schema-cache.test.ts
@@ -6,7 +6,10 @@ import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import pino from "pino";
 
-import { createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
+import {
+    createConnectorActionFixture,
+    createTemporaryDirectory,
+} from "../../../../__tests__/helpers.ts";
 import {
     ensureConnectorActionSchemaReference,
     persistConnectorActionSchemaCache,
@@ -20,7 +23,19 @@ describe("connector schema cache", () => {
             join("/tmp", "oo", "settings.toml"),
             "gmail",
             "send_mail",
-        )).toBe(join("/tmp", "oo", "connector-actions", "gmail.send_mail.json"));
+        )).toBe(join("/tmp", "oo", "connector-actions", "gmail", "send_mail.json"));
+    });
+
+    test("resolveConnectorActionSchemaPath keeps service and action names unambiguous", () => {
+        expect(resolveConnectorActionSchemaPath(
+            join("/tmp", "oo", "settings.toml"),
+            "foo.bar",
+            "baz",
+        )).not.toBe(resolveConnectorActionSchemaPath(
+            join("/tmp", "oo", "settings.toml"),
+            "foo",
+            "bar.baz",
+        ));
     });
 
     test("persistConnectorActionSchemaCache writes the cache file to the connector-actions directory", async () => {
@@ -28,35 +43,15 @@ describe("connector schema cache", () => {
 
         try {
             const schemaPath = await persistConnectorActionSchemaCache(
-                {
-                    description: "Send a Gmail message.",
-                    inputSchema: {
-                        type: "object",
-                    },
-                    name: "send_mail",
-                    outputSchema: {
-                        type: "object",
-                    },
-                    service: "gmail",
-                },
+                createConnectorActionFixture(),
                 createCacheContext(rootPath),
             );
 
             expect(schemaPath).toBe(
-                join(rootPath, "connector-actions", "gmail.send_mail.json"),
+                join(rootPath, "connector-actions", "gmail", "send_mail.json"),
             );
             await expect(Bun.file(schemaPath).text()).resolves.toBe(
-                renderConnectorActionSchemaCache({
-                    description: "Send a Gmail message.",
-                    inputSchema: {
-                        type: "object",
-                    },
-                    name: "send_mail",
-                    outputSchema: {
-                        type: "object",
-                    },
-                    service: "gmail",
-                }),
+                renderConnectorActionSchemaCache(createConnectorActionFixture()),
             );
         }
         finally {
@@ -76,17 +71,9 @@ describe("connector schema cache", () => {
 
             await Bun.write(
                 schemaPath,
-                renderConnectorActionSchemaCache({
+                renderConnectorActionSchemaCache(createConnectorActionFixture({
                     description: "Cached schema.",
-                    inputSchema: {
-                        type: "object",
-                    },
-                    name: "send_mail",
-                    outputSchema: {
-                        type: "object",
-                    },
-                    service: "gmail",
-                }),
+                })),
             );
 
             let fetchCount = 0;

--- a/src/application/commands/connector/schema-cache.ts
+++ b/src/application/commands/connector/schema-cache.ts
@@ -3,18 +3,10 @@ import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { ConnectorActionDefinition } from "./shared.ts";
 import { mkdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import { getConnectorActionMetadata } from "./shared.ts";
+import { connectorActionDefinitionSchema, getConnectorActionMetadata } from "./shared.ts";
 
 const connectorActionSchemaCacheDirectoryName = "connector-actions";
-const connectorActionSchemaCacheEntrySchema = z.object({
-    description: z.string().optional().default(""),
-    inputSchema: z.unknown(),
-    name: z.string().min(1),
-    outputSchema: z.unknown(),
-    service: z.string().min(1),
-});
 
 export interface ConnectorActionSchemaReference
     extends ConnectorActionDefinition {
@@ -86,7 +78,8 @@ export function resolveConnectorActionSchemaPath(
     return join(
         dirname(settingsFilePath),
         connectorActionSchemaCacheDirectoryName,
-        `${encodeURIComponent(serviceName)}.${encodeURIComponent(actionName)}.json`,
+        encodeURIComponent(serviceName),
+        `${encodeURIComponent(actionName)}.json`,
     );
 }
 
@@ -111,7 +104,7 @@ async function tryReadConnectorActionSchemaCache(
     }
 
     try {
-        return connectorActionSchemaCacheEntrySchema.parse(
+        return connectorActionDefinitionSchema.parse(
             JSON.parse(content) as unknown,
         );
     }

--- a/src/application/commands/connector/schema-cache.ts
+++ b/src/application/commands/connector/schema-cache.ts
@@ -1,0 +1,150 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+
+import type { ConnectorActionDefinition } from "./shared.ts";
+import { mkdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { getConnectorActionMetadata } from "./shared.ts";
+
+const connectorActionSchemaCacheDirectoryName = "connector-actions";
+const connectorActionSchemaCacheEntrySchema = z.object({
+    description: z.string().optional().default(""),
+    inputSchema: z.unknown(),
+    name: z.string().min(1),
+    outputSchema: z.unknown(),
+    service: z.string().min(1),
+});
+
+export interface ConnectorActionSchemaReference
+    extends ConnectorActionDefinition {
+    schemaPath: string;
+}
+
+export async function ensureConnectorActionSchemaReference(
+    options: {
+        actionName: string;
+        apiKey: string;
+        endpoint: string;
+        serviceName: string;
+    },
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "settingsStore">,
+): Promise<ConnectorActionSchemaReference> {
+    const schemaPath = resolveConnectorActionSchemaPath(
+        context.settingsStore.getFilePath(),
+        options.serviceName,
+        options.actionName,
+    );
+    const cachedSchema = await tryReadConnectorActionSchemaCache(
+        schemaPath,
+        context,
+    );
+
+    if (cachedSchema !== undefined) {
+        return {
+            ...cachedSchema,
+            schemaPath,
+        };
+    }
+
+    const metadata = await getConnectorActionMetadata(options, context);
+
+    await writeConnectorActionSchemaCache(schemaPath, metadata);
+
+    return {
+        ...metadata,
+        schemaPath,
+    };
+}
+
+export async function persistConnectorActionSchemaCache(
+    action: ConnectorActionDefinition,
+    context: Pick<CliExecutionContext, "settingsStore">,
+): Promise<string> {
+    const schemaPath = resolveConnectorActionSchemaPath(
+        context.settingsStore.getFilePath(),
+        action.service,
+        action.name,
+    );
+
+    await writeConnectorActionSchemaCache(schemaPath, action);
+
+    return schemaPath;
+}
+
+export function renderConnectorActionSchemaCache(
+    action: ConnectorActionDefinition,
+): string {
+    return `${JSON.stringify(action, null, 2)}\n`;
+}
+
+export function resolveConnectorActionSchemaPath(
+    settingsFilePath: string,
+    serviceName: string,
+    actionName: string,
+): string {
+    return join(
+        dirname(settingsFilePath),
+        connectorActionSchemaCacheDirectoryName,
+        `${encodeURIComponent(serviceName)}.${encodeURIComponent(actionName)}.json`,
+    );
+}
+
+async function tryReadConnectorActionSchemaCache(
+    schemaPath: string,
+    context: Pick<CliExecutionContext, "logger">,
+): Promise<ConnectorActionDefinition | undefined> {
+    let content: string;
+
+    try {
+        content = await readFile(schemaPath, "utf8");
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return undefined;
+        }
+
+        throw new CliUserError("errors.connectorSchema.readFailed", 1, {
+            message: error instanceof Error ? error.message : String(error),
+            path: schemaPath,
+        });
+    }
+
+    try {
+        return connectorActionSchemaCacheEntrySchema.parse(
+            JSON.parse(content) as unknown,
+        );
+    }
+    catch {
+        context.logger.warn(
+            {
+                path: schemaPath,
+            },
+            "Connector action schema cache was invalid and will be refreshed.",
+        );
+
+        return undefined;
+    }
+}
+
+async function writeConnectorActionSchemaCache(
+    schemaPath: string,
+    action: ConnectorActionDefinition,
+): Promise<void> {
+    try {
+        await mkdir(dirname(schemaPath), { recursive: true });
+        await Bun.write(schemaPath, renderConnectorActionSchemaCache(action));
+    }
+    catch (error) {
+        throw new CliUserError("errors.connectorSchema.writeFailed", 1, {
+            message: error instanceof Error ? error.message : String(error),
+            path: schemaPath,
+        });
+    }
+}
+
+function isNodeNotFoundError(
+    error: unknown,
+): error is NodeJS.ErrnoException {
+    return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/src/application/commands/connector/search.ts
+++ b/src/application/commands/connector/search.ts
@@ -1,0 +1,176 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+
+import type { TerminalColors } from "../../terminal-colors.ts";
+import { z } from "zod";
+import { createWriterColors } from "../../terminal-colors.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
+import { createFormatInputError } from "../shared/input-parsing.ts";
+import { persistConnectorActionSchemaCache } from "./schema-cache.ts";
+import {
+    connectorFormatValues,
+    listAuthenticatedConnectorServices,
+    parseConnectorSearchKeywords,
+    searchConnectorActions,
+} from "./shared.ts";
+
+const connectorSearchActionColor = "#59F78D";
+const connectorSearchServiceColor = "#CAA8FA";
+
+type ConnectorSearchTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
+
+interface ConnectorSearchResult {
+    authenticated: boolean;
+    description: string;
+    name: string;
+    schemaPath: string;
+    service: string;
+}
+
+interface ConnectorSearchInput {
+    format?: (typeof connectorFormatValues)[number];
+    keywords?: string;
+    text: string;
+}
+
+export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> = {
+    name: "search",
+    summaryKey: "commands.connector.search.summary",
+    descriptionKey: "commands.connector.search.description",
+    missingArgumentBehavior: "showHelp",
+    arguments: [
+        {
+            name: "text",
+            descriptionKey: "arguments.text",
+            required: true,
+        },
+    ],
+    options: [
+        ...jsonOutputOptions,
+        {
+            name: "keywords",
+            longFlag: "--keywords",
+            valueName: "keywords",
+            descriptionKey: "options.connectorKeywords",
+        },
+    ],
+    inputSchema: z.object({
+        format: z.enum(connectorFormatValues).optional(),
+        keywords: z.string().optional(),
+        text: z.string(),
+    }),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+    handler: async (input, context) => {
+        const account = await requireCurrentAccount(context);
+        const keywords = parseConnectorSearchKeywords(input.keywords);
+        const actions = await searchConnectorActions(
+            {
+                apiKey: account.apiKey,
+                endpoint: account.endpoint,
+                keywords,
+                text: input.text,
+            },
+            context,
+        );
+
+        if (actions.length === 0) {
+            if (input.format === "json") {
+                writeJsonOutput(context.stdout, []);
+                return;
+            }
+
+            context.stdout.write(
+                `${context.translator.t("connector.search.text.noResults")}\n`,
+            );
+            return;
+        }
+
+        const authenticatedServices = await listAuthenticatedConnectorServices(
+            {
+                apiKey: account.apiKey,
+                endpoint: account.endpoint,
+                services: uniqueServices(actions),
+            },
+            context,
+        );
+        const results = await Promise.all(actions.map(async action => ({
+            authenticated: authenticatedServices.has(action.service),
+            description: action.description,
+            name: action.name,
+            schemaPath: await persistConnectorActionSchemaCache(action, context),
+            service: action.service,
+        })));
+
+        if (input.format === "json") {
+            writeJsonOutput(context.stdout, results);
+            return;
+        }
+
+        context.stdout.write(
+            `${formatConnectorSearchResultsAsText(results, context)}\n`,
+        );
+    },
+};
+
+function uniqueServices(
+    actions: readonly Pick<ConnectorSearchResult, "service">[],
+): string[] {
+    const services: string[] = [];
+    const seen = new Set<string>();
+
+    for (const action of actions) {
+        if (seen.has(action.service)) {
+            continue;
+        }
+
+        seen.add(action.service);
+        services.push(action.service);
+    }
+
+    return services;
+}
+
+function formatConnectorSearchResultsAsText(
+    results: readonly ConnectorSearchResult[],
+    context: ConnectorSearchTextContext,
+): string {
+    const colors = createWriterColors(context.stdout);
+
+    return results
+        .map(result => formatConnectorSearchResult(result, context, colors))
+        .join("\n\n");
+}
+
+function formatConnectorSearchResult(
+    result: ConnectorSearchResult,
+    context: ConnectorSearchTextContext,
+    colors: TerminalColors,
+): string {
+    const lines = [
+        `${colors.hex(connectorSearchServiceColor)(result.service)}.${colors.hex(connectorSearchActionColor)(result.name)}`,
+        `${context.translator.t("connector.search.text.authenticated")}: ${formatConnectorAuthenticationLabel(result.authenticated, context, colors)}`,
+        `${context.translator.t("connector.search.text.schemaPath")}: ${colors.gray(result.schemaPath)}`,
+    ];
+
+    if (result.description !== "") {
+        lines.splice(1, 0, result.description);
+    }
+
+    return lines.join("\n");
+}
+
+function formatConnectorAuthenticationLabel(
+    authenticated: boolean,
+    context: Pick<CliExecutionContext, "translator">,
+    colors: TerminalColors,
+): string {
+    if (authenticated) {
+        return colors.green(
+            context.translator.t("connector.search.text.authenticated.yes"),
+        );
+    }
+
+    return colors.yellow(
+        context.translator.t("connector.search.text.authenticated.no"),
+    );
+}

--- a/src/application/commands/connector/search.ts
+++ b/src/application/commands/connector/search.ts
@@ -14,8 +14,8 @@ import {
     searchConnectorActions,
 } from "./shared.ts";
 
-const connectorSearchActionColor = "#59F78D";
-const connectorSearchServiceColor = "#CAA8FA";
+export const connectorSearchActionColor = "#59F78D";
+export const connectorSearchServiceColor = "#CAA8FA";
 
 type ConnectorSearchTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
 

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -1,0 +1,200 @@
+import type { Fetcher } from "../../contracts/cli.ts";
+
+import { describe, expect, test } from "bun:test";
+import pino from "pino";
+
+import { toRequest } from "../../../../__tests__/helpers.ts";
+import {
+    getConnectorActionMetadata,
+    listAuthenticatedConnectorServices,
+    parseConnectorSearchKeywords,
+    runConnectorAction,
+    searchConnectorActions,
+} from "./shared.ts";
+
+describe("parseConnectorSearchKeywords", () => {
+    test("trims empty values and removes duplicates", () => {
+        expect(parseConnectorSearchKeywords(" gmail, email ,,gmail, inbox ")).toEqual([
+            "gmail",
+            "email",
+            "inbox",
+        ]);
+    });
+
+    test("returns an empty list when the option is omitted", () => {
+        expect(parseConnectorSearchKeywords(undefined)).toEqual([]);
+    });
+});
+
+describe("connector shared requests", () => {
+    test("searchConnectorActions sends the expected request and parses actions", async () => {
+        const requests: Request[] = [];
+        const actions = await searchConnectorActions(
+            {
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                keywords: ["gmail", "email"],
+                text: "send mail",
+            },
+            createRequestContext({
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+
+                    return new Response(JSON.stringify({
+                        data: [
+                            {
+                                description: "Send a Gmail message.",
+                                inputSchema: {
+                                    type: "object",
+                                },
+                                name: "send_mail",
+                                outputSchema: {
+                                    type: "object",
+                                },
+                                service: "gmail",
+                            },
+                        ],
+                    }));
+                },
+            }),
+        );
+
+        expect(actions).toEqual([
+            {
+                description: "Send a Gmail message.",
+                inputSchema: {
+                    type: "object",
+                },
+                name: "send_mail",
+                outputSchema: {
+                    type: "object",
+                },
+                service: "gmail",
+            },
+        ]);
+        expect(requests).toHaveLength(1);
+        expect(requests[0]?.url).toBe(
+            "https://search.oomol.com/v1/connector-actions?q=send+mail&keywords=gmail%2Cemail",
+        );
+        expect(requests[0]?.headers.get("Authorization")).toBe("secret-1");
+    });
+
+    test("listAuthenticatedConnectorServices avoids a request when no services are provided", async () => {
+        let fetchCount = 0;
+        const services = await listAuthenticatedConnectorServices(
+            {
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                services: [],
+            },
+            createRequestContext({
+                fetcher: async () => {
+                    fetchCount += 1;
+
+                    return new Response("[]");
+                },
+            }),
+        );
+
+        expect([...services]).toEqual([]);
+        expect(fetchCount).toBe(0);
+    });
+
+    test("getConnectorActionMetadata strips metadata-only fields", async () => {
+        const action = await getConnectorActionMetadata(
+            {
+                actionName: "get_message",
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                serviceName: "gmail",
+            },
+            createRequestContext({
+                fetcher: async () => new Response(JSON.stringify({
+                    data: {
+                        description: "Get one Gmail message.",
+                        id: "action-1",
+                        inputSchema: {
+                            type: "object",
+                        },
+                        name: "get_message",
+                        outputSchema: {
+                            type: "object",
+                        },
+                        providerPermissions: ["gmail.readonly"],
+                        requiredScopes: ["gmail.readonly"],
+                        service: "gmail",
+                    },
+                })),
+            }),
+        );
+
+        expect(action).toEqual({
+            description: "Get one Gmail message.",
+            inputSchema: {
+                type: "object",
+            },
+            name: "get_message",
+            outputSchema: {
+                type: "object",
+            },
+            service: "gmail",
+        });
+    });
+
+    test("runConnectorAction wraps request input and strips success fields from json output", async () => {
+        const requests: Request[] = [];
+        const response = await runConnectorAction(
+            {
+                actionName: "send_mail",
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                inputData: {
+                    to: "foo@bar.com",
+                },
+                serviceName: "gmail",
+            },
+            createRequestContext({
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+
+                    return new Response(JSON.stringify({
+                        data: {
+                            messageId: "message-1",
+                        },
+                        message: "ok",
+                        meta: {
+                            executionId: "exec-1",
+                        },
+                        success: true,
+                    }));
+                },
+            }),
+        );
+
+        expect(response).toEqual({
+            data: {
+                messageId: "message-1",
+            },
+            meta: {
+                executionId: "exec-1",
+            },
+        });
+        expect(requests).toHaveLength(1);
+        await expect(requests[0]?.json()).resolves.toEqual({
+            input: {
+                to: "foo@bar.com",
+            },
+        });
+    });
+});
+
+function createRequestContext(options: {
+    fetcher: Fetcher;
+}) {
+    return {
+        fetcher: options.fetcher,
+        logger: pino({
+            enabled: false,
+        }),
+    };
+}

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -5,7 +5,7 @@ import { CliUserError } from "../../contracts/cli.ts";
 import { withRequestTarget } from "../../logging/log-fields.ts";
 import { requestText } from "../shared/request.ts";
 
-const connectorActionDefinitionSchema = z.object({
+export const connectorActionDefinitionSchema = z.object({
     description: z.string().optional().default(""),
     inputSchema: z.unknown(),
     name: z.string().min(1),
@@ -323,8 +323,9 @@ export async function runConnectorAction(
                     errorCode: failureResponse?.errorCode,
                     executionId: failureResponse?.meta?.executionId,
                     method: "POST",
-                    responseBody: truncateConnectorResponseBodyForLogs(rawResponse),
-                    responseMessage: failureResponse?.message,
+                    responseMessage: sanitizeConnectorFailureMessage(
+                        failureResponse?.message,
+                    ),
                     serviceName: options.serviceName,
                     status: response.status,
                 },
@@ -417,14 +418,19 @@ function parseConnectorFailureResponse(
     }
 }
 
-function truncateConnectorResponseBodyForLogs(
-    responseBody: string,
-): string {
-    const maxLength = 1000;
-
-    if (responseBody.length <= maxLength) {
-        return responseBody;
+function sanitizeConnectorFailureMessage(
+    message: string | undefined,
+): string | undefined {
+    if (message === undefined) {
+        return undefined;
     }
 
-    return `${responseBody.slice(0, maxLength)}...`;
+    const singleLineMessage = message.replaceAll("\r", " ").replaceAll("\n", " ");
+    const maxLength = 200;
+
+    if (singleLineMessage.length <= maxLength) {
+        return singleLineMessage;
+    }
+
+    return `${singleLineMessage.slice(0, maxLength)}...`;
 }

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -1,0 +1,430 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { withRequestTarget } from "../../logging/log-fields.ts";
+import { requestText } from "../shared/request.ts";
+
+const connectorActionDefinitionSchema = z.object({
+    description: z.string().optional().default(""),
+    inputSchema: z.unknown(),
+    name: z.string().min(1),
+    outputSchema: z.unknown(),
+    service: z.string().min(1),
+});
+
+const connectorActionSearchResponseSchema = z.object({
+    data: z.array(connectorActionDefinitionSchema).optional().default([]),
+});
+
+const authenticatedConnectorServicesResponseSchema = z.object({
+    data: z.array(z.string()).optional().default([]),
+});
+
+const connectorActionMetadataResponseSchema = z.object({
+    data: z.object({
+        description: z.string().optional().default(""),
+        id: z.string(),
+        inputSchema: z.unknown(),
+        name: z.string().min(1),
+        outputSchema: z.unknown(),
+        providerPermissions: z.array(z.string()),
+        requiredScopes: z.array(z.string()),
+        service: z.string().min(1),
+    }).transform(action => ({
+        description: action.description,
+        inputSchema: action.inputSchema,
+        name: action.name,
+        outputSchema: action.outputSchema,
+        service: action.service,
+    })),
+});
+
+const connectorActionRunResponseSchema = z.object({
+    data: z.unknown(),
+    meta: z.object({
+        executionId: z.string().min(1),
+    }).passthrough(),
+}).passthrough().transform(({
+    message: _message,
+    success: _success,
+    ...response
+}) => response);
+
+const connectorActionFailureResponseSchema = z.object({
+    errorCode: z.string().optional(),
+    message: z.string().optional(),
+    meta: z.object({
+        actionId: z.string().optional(),
+        executionId: z.string().optional(),
+    }).partial().optional(),
+}).passthrough();
+
+export const connectorFormatValues = ["json"] as const;
+
+export type ConnectorActionDefinition = z.output<typeof connectorActionDefinitionSchema>;
+export type ConnectorActionRunResponse = z.output<typeof connectorActionRunResponseSchema>;
+
+export function parseConnectorSearchKeywords(
+    value: string | undefined,
+): string[] {
+    if (value === undefined) {
+        return [];
+    }
+
+    const keywords: string[] = [];
+    const seen = new Set<string>();
+
+    for (const segment of value.split(",")) {
+        const keyword = segment.trim();
+
+        if (keyword === "" || seen.has(keyword)) {
+            continue;
+        }
+
+        seen.add(keyword);
+        keywords.push(keyword);
+    }
+
+    return keywords;
+}
+
+export async function searchConnectorActions(
+    options: {
+        apiKey: string;
+        endpoint: string;
+        keywords: readonly string[];
+        text: string;
+    },
+    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+): Promise<ConnectorActionDefinition[]> {
+    const requestUrl = new URL(
+        `https://search.${options.endpoint}/v1/connector-actions`,
+    );
+
+    requestUrl.searchParams.set("q", options.text);
+
+    if (options.keywords.length > 0) {
+        requestUrl.searchParams.set("keywords", options.keywords.join(","));
+    }
+
+    const rawResponse = await requestText({
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.connectorSearch.requestFailed",
+            1,
+            {
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.connectorSearch.requestError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            start: {
+                keywordCount: options.keywords.length,
+                textLength: options.text.length,
+            },
+        },
+        init: {
+            headers: {
+                Authorization: options.apiKey,
+            },
+        },
+        requestLabel: "Connector action search",
+        requestUrl,
+    });
+
+    try {
+        return connectorActionSearchResponseSchema.parse(
+            JSON.parse(rawResponse) as unknown,
+        ).data;
+    }
+    catch {
+        throw new CliUserError("errors.connectorSearch.invalidResponse", 1);
+    }
+}
+
+export async function listAuthenticatedConnectorServices(
+    options: {
+        apiKey: string;
+        endpoint: string;
+        services: readonly string[];
+    },
+    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+): Promise<Set<string>> {
+    if (options.services.length === 0) {
+        return new Set<string>();
+    }
+
+    const requestUrl = new URL(
+        `https://connector.${options.endpoint}/v1/apps/authenticated`,
+    );
+
+    for (const service of options.services) {
+        requestUrl.searchParams.append("service", service);
+    }
+
+    const rawResponse = await requestText({
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.connectorAuthenticated.requestFailed",
+            1,
+            {
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.connectorAuthenticated.requestError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            start: {
+                serviceCount: options.services.length,
+            },
+        },
+        init: {
+            headers: {
+                Authorization: options.apiKey,
+            },
+        },
+        requestLabel: "Authenticated connector services",
+        requestUrl,
+    });
+
+    try {
+        return new Set(
+            authenticatedConnectorServicesResponseSchema.parse(
+                JSON.parse(rawResponse) as unknown,
+            ).data,
+        );
+    }
+    catch {
+        throw new CliUserError("errors.connectorAuthenticated.invalidResponse", 1);
+    }
+}
+
+export async function getConnectorActionMetadata(
+    options: {
+        actionName: string;
+        apiKey: string;
+        endpoint: string;
+        serviceName: string;
+    },
+    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+): Promise<ConnectorActionDefinition> {
+    const requestUrl = createConnectorActionRequestUrl(
+        options.endpoint,
+        options.serviceName,
+        options.actionName,
+    );
+    const rawResponse = await requestText({
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.connectorMetadata.requestFailed",
+            1,
+            {
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.connectorMetadata.requestError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            start: {
+                actionName: options.actionName,
+                serviceName: options.serviceName,
+            },
+        },
+        init: {
+            headers: {
+                Authorization: options.apiKey,
+            },
+        },
+        requestLabel: "Connector action metadata",
+        requestUrl,
+    });
+
+    try {
+        return connectorActionMetadataResponseSchema.parse(
+            JSON.parse(rawResponse) as unknown,
+        ).data;
+    }
+    catch {
+        throw new CliUserError("errors.connectorMetadata.invalidResponse", 1);
+    }
+}
+
+export async function runConnectorAction(
+    options: {
+        actionName: string;
+        apiKey: string;
+        endpoint: string;
+        inputData: unknown;
+        serviceName: string;
+    },
+    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+): Promise<ConnectorActionRunResponse> {
+    const requestUrl = createConnectorActionRequestUrl(
+        options.endpoint,
+        options.serviceName,
+        options.actionName,
+    );
+    const requestBody = JSON.stringify({
+        input: options.inputData,
+    });
+    const requestStartedAt = Date.now();
+
+    context.logger.debug(
+        {
+            ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+            actionName: options.actionName,
+            bodyLength: requestBody.length,
+            method: "POST",
+            serviceName: options.serviceName,
+        },
+        "Connector action run request started.",
+    );
+
+    let rawResponse: string;
+
+    try {
+        const response = await context.fetcher(requestUrl, {
+            body: requestBody,
+            headers: {
+                "Authorization": options.apiKey,
+                "Content-Type": "application/json",
+            },
+            method: "POST",
+        });
+        const durationMs = Date.now() - requestStartedAt;
+
+        rawResponse = await response.text();
+
+        if (!response.ok) {
+            const failureResponse = parseConnectorFailureResponse(rawResponse);
+
+            context.logger.warn(
+                {
+                    ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+                    actionName: options.actionName,
+                    durationMs,
+                    errorCode: failureResponse?.errorCode,
+                    executionId: failureResponse?.meta?.executionId,
+                    method: "POST",
+                    responseBody: truncateConnectorResponseBodyForLogs(rawResponse),
+                    responseMessage: failureResponse?.message,
+                    serviceName: options.serviceName,
+                    status: response.status,
+                },
+                "Connector action run request returned a non-success status.",
+            );
+
+            if (failureResponse?.message) {
+                throw new CliUserError(
+                    "errors.connectorRun.requestFailedWithMessage",
+                    1,
+                    {
+                        message: failureResponse.message,
+                        status: response.status,
+                    },
+                );
+            }
+
+            throw new CliUserError("errors.connectorRun.requestFailed", 1, {
+                status: response.status,
+            });
+        }
+
+        context.logger.debug(
+            {
+                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+                actionName: options.actionName,
+                durationMs,
+                method: "POST",
+                serviceName: options.serviceName,
+                status: response.status,
+            },
+            "Connector action run request completed.",
+        );
+    }
+    catch (error) {
+        if (error instanceof CliUserError) {
+            throw error;
+        }
+
+        context.logger.warn(
+            {
+                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+                actionName: options.actionName,
+                durationMs: Date.now() - requestStartedAt,
+                err: error,
+                method: "POST",
+                serviceName: options.serviceName,
+            },
+            "Connector action run request failed unexpectedly.",
+        );
+
+        throw new CliUserError("errors.connectorRun.requestError", 1, {
+            message: error instanceof Error ? error.message : String(error),
+        });
+    }
+
+    try {
+        return connectorActionRunResponseSchema.parse(
+            JSON.parse(rawResponse) as unknown,
+        );
+    }
+    catch {
+        throw new CliUserError("errors.connectorRun.invalidResponse", 1);
+    }
+}
+
+function createConnectorActionRequestUrl(
+    endpoint: string,
+    serviceName: string,
+    actionName: string,
+): URL {
+    const qualifiedActionName
+        = `${encodeURIComponent(serviceName)}.${encodeURIComponent(actionName)}`;
+
+    return new URL(
+        `https://connector.${endpoint}/v1/actions/${qualifiedActionName}`,
+    );
+}
+
+function parseConnectorFailureResponse(
+    rawResponse: string,
+): z.output<typeof connectorActionFailureResponseSchema> | undefined {
+    try {
+        return connectorActionFailureResponseSchema.parse(
+            JSON.parse(rawResponse) as unknown,
+        );
+    }
+    catch {
+        return undefined;
+    }
+}
+
+function truncateConnectorResponseBodyForLogs(
+    responseBody: string,
+): string {
+    const maxLength = 1000;
+
+    if (responseBody.length <= maxLength) {
+        return responseBody;
+    }
+
+    return `${responseBody.slice(0, maxLength)}...`;
+}

--- a/src/application/commands/connector/validation.test.ts
+++ b/src/application/commands/connector/validation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import { createTranslator } from "../../../i18n/translator.ts";
+import { validateConnectorActionInput } from "./validation.ts";
+
+const englishTranslator = createTranslator("en");
+
+describe("validateConnectorActionInput", () => {
+    test("accepts valid input payloads", () => {
+        expect(() =>
+            validateConnectorActionInput(
+                {
+                    to: "foo@bar.com",
+                },
+                {
+                    properties: {
+                        to: {
+                            format: "email",
+                            type: "string",
+                        },
+                    },
+                    required: ["to"],
+                    type: "object",
+                },
+                englishTranslator,
+            )).not.toThrow();
+    });
+
+    test("rejects invalid payloads with the connector invalid-payload error", () => {
+        expect(() =>
+            validateConnectorActionInput(
+                {
+                    to: "not-an-email",
+                },
+                {
+                    properties: {
+                        to: {
+                            format: "email",
+                            type: "string",
+                        },
+                    },
+                    required: ["to"],
+                    type: "object",
+                },
+                englishTranslator,
+            )).toThrow("errors.connectorRun.invalidPayload");
+    });
+
+    test("rejects invalid schemas with the connector invalid-schema error", () => {
+        expect(() =>
+            validateConnectorActionInput(
+                {
+                    to: "foo@bar.com",
+                },
+                {
+                    $ref: "missing-schema",
+                },
+                englishTranslator,
+            )).toThrow("errors.connectorRun.invalidActionSchema");
+    });
+});

--- a/src/application/commands/connector/validation.test.ts
+++ b/src/application/commands/connector/validation.test.ts
@@ -12,16 +12,7 @@ describe("validateConnectorActionInput", () => {
                 {
                     to: "foo@bar.com",
                 },
-                {
-                    properties: {
-                        to: {
-                            format: "email",
-                            type: "string",
-                        },
-                    },
-                    required: ["to"],
-                    type: "object",
-                },
+                createEmailSchema(),
                 englishTranslator,
             )).not.toThrow();
     });
@@ -32,16 +23,7 @@ describe("validateConnectorActionInput", () => {
                 {
                     to: "not-an-email",
                 },
-                {
-                    properties: {
-                        to: {
-                            format: "email",
-                            type: "string",
-                        },
-                    },
-                    required: ["to"],
-                    type: "object",
-                },
+                createEmailSchema(),
                 englishTranslator,
             )).toThrow("errors.connectorRun.invalidPayload");
     });
@@ -59,3 +41,16 @@ describe("validateConnectorActionInput", () => {
             )).toThrow("errors.connectorRun.invalidActionSchema");
     });
 });
+
+function createEmailSchema(): Record<string, unknown> {
+    return {
+        properties: {
+            to: {
+                format: "email",
+                type: "string",
+            },
+        },
+        required: ["to"],
+        type: "object",
+    };
+}

--- a/src/application/commands/connector/validation.ts
+++ b/src/application/commands/connector/validation.ts
@@ -1,0 +1,34 @@
+import type { Translator } from "../../contracts/translator.ts";
+
+import { CliUserError } from "../../contracts/cli.ts";
+import {
+    compileJsonSchema,
+    formatJsonSchemaErrors,
+    validateCompiledJsonSchema,
+} from "../shared/json-schema-validation.ts";
+
+export function validateConnectorActionInput(
+    inputValue: unknown,
+    schema: unknown,
+    translator: Pick<Translator, "locale">,
+): void {
+    const [validator, compileError] = compileJsonSchema(schema);
+
+    if (compileError !== undefined) {
+        throw new CliUserError("errors.connectorRun.invalidActionSchema", 1, {
+            message: String(compileError.message ?? compileError),
+        });
+    }
+
+    const validationErrors = validateCompiledJsonSchema(
+        validator,
+        inputValue,
+        translator.locale,
+    );
+
+    if (validationErrors && validationErrors.length > 0) {
+        throw new CliUserError("errors.connectorRun.invalidPayload", 2, {
+            message: formatJsonSchemaErrors(validationErrors),
+        });
+    }
+}

--- a/src/application/commands/shared/json-input.ts
+++ b/src/application/commands/shared/json-input.ts
@@ -1,0 +1,74 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { CliUserError } from "../../contracts/cli.ts";
+import { isPlainObject } from "./schema-utils.ts";
+
+interface JsonInputErrorKeys {
+    dataFilePathRequired: string;
+    dataReadFailed: string;
+    invalidDataJson: string;
+}
+
+export async function readJsonInputValue(
+    value: string | undefined,
+    context: Pick<CliExecutionContext, "cwd">,
+    errorKeys: JsonInputErrorKeys,
+    defaultValue: unknown,
+): Promise<unknown> {
+    if (value === undefined || value.trim() === "") {
+        return defaultValue;
+    }
+
+    const rawInput = value.startsWith("@")
+        ? await readJsonInputFile(value, context, errorKeys)
+        : value;
+    const normalizedInput = rawInput.charCodeAt(0) === 0xFEFF
+        ? rawInput.slice(1)
+        : rawInput;
+
+    try {
+        return JSON.parse(normalizedInput) as unknown;
+    }
+    catch (error) {
+        throw new CliUserError(errorKeys.invalidDataJson, 2, {
+            message: error instanceof Error ? error.message : String(error),
+        });
+    }
+}
+
+export function requireJsonObjectInput(
+    value: unknown,
+    errorKey: string,
+): Record<string, unknown> {
+    if (!isPlainObject(value)) {
+        throw new CliUserError(errorKey, 2);
+    }
+
+    return value;
+}
+
+async function readJsonInputFile(
+    value: string,
+    context: Pick<CliExecutionContext, "cwd">,
+    errorKeys: JsonInputErrorKeys,
+): Promise<string> {
+    const relativePath = value.slice(1);
+
+    if (relativePath.trim() === "") {
+        throw new CliUserError(errorKeys.dataFilePathRequired, 2);
+    }
+
+    const resolvedPath = resolve(context.cwd, relativePath);
+
+    try {
+        return await readFile(resolvedPath, "utf8");
+    }
+    catch (error) {
+        throw new CliUserError(errorKeys.dataReadFailed, 1, {
+            message: error instanceof Error ? error.message : String(error),
+            path: resolvedPath,
+        });
+    }
+}

--- a/src/application/commands/shared/json-schema-validation.test.ts
+++ b/src/application/commands/shared/json-schema-validation.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./json-schema-validation.ts";
 
 describe("json schema validation", () => {
-    test("strips $schema declarations before compiling", () => {
+    test("strips the root $schema declaration before compiling", () => {
         const schema = {
             $schema: "https://json-schema.org/draft/2020-12/schema",
             properties: {
@@ -27,9 +27,10 @@ describe("json schema validation", () => {
             },
             "en",
         )).toEqual([]);
+        expect(schema.$schema).toBe("https://json-schema.org/draft/2020-12/schema");
     });
 
-    test("does not mutate the original schema while stripping $schema", () => {
+    test("compiles schemas with nested $schema declarations without mutating the input", () => {
         const schema = {
             properties: {
                 payload: {

--- a/src/application/commands/shared/json-schema-validation.test.ts
+++ b/src/application/commands/shared/json-schema-validation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    compileJsonSchema,
+    validateCompiledJsonSchema,
+} from "./json-schema-validation.ts";
+
+describe("json schema validation", () => {
+    test("strips $schema declarations before compiling", () => {
+        const schema = {
+            $schema: "https://json-schema.org/draft/2020-12/schema",
+            properties: {
+                messageId: {
+                    type: "string",
+                },
+            },
+            required: ["messageId"],
+            type: "object",
+        };
+        const [validator, error] = compileJsonSchema(schema);
+
+        expect(error).toBeUndefined();
+        expect(validateCompiledJsonSchema(
+            validator,
+            {
+                messageId: "foo",
+            },
+            "en",
+        )).toEqual([]);
+    });
+
+    test("does not mutate the original schema while stripping $schema", () => {
+        const schema = {
+            properties: {
+                payload: {
+                    $schema: "https://json-schema.org/draft/2020-12/schema",
+                    type: "string",
+                },
+            },
+            type: "object",
+        };
+        const [validator, error] = compileJsonSchema(schema);
+
+        expect(error).toBeUndefined();
+        expect(validateCompiledJsonSchema(
+            validator,
+            {
+                payload: "ok",
+            },
+            "en",
+        )).toEqual([]);
+        expect(schema.properties.payload.$schema).toBe(
+            "https://json-schema.org/draft/2020-12/schema",
+        );
+    });
+});

--- a/src/application/commands/shared/json-schema-validation.ts
+++ b/src/application/commands/shared/json-schema-validation.ts
@@ -1,0 +1,120 @@
+import type { ErrorObject, ValidateFunction } from "ajv";
+
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import ajvEN from "ajv-i18n/localize/en/index.js";
+import ajvZH from "ajv-i18n/localize/zh/index.js";
+import { isPlainObject } from "./schema-utils.ts";
+
+const ajv = createAjv();
+
+export function compileJsonSchema(
+    schema?: unknown,
+): [ValidateFunction | undefined, Error | undefined] {
+    if (schema === undefined) {
+        return [undefined, undefined];
+    }
+
+    try {
+        return [
+            ajv.compile(stripSchemaDialectDeclaration(schema) as object | boolean),
+            undefined,
+        ];
+    }
+    catch (error) {
+        return [undefined, error as Error];
+    }
+}
+
+export function validateCompiledJsonSchema(
+    validator: ValidateFunction | undefined,
+    data: unknown,
+    locale?: string,
+): ErrorObject[] | null | undefined {
+    if (validator === undefined) {
+        return [];
+    }
+
+    if (validator(data)) {
+        return [];
+    }
+
+    if (locale?.startsWith("zh")) {
+        ajvZH(validator.errors);
+    }
+    else {
+        ajvEN(validator.errors);
+    }
+
+    return validator.errors;
+}
+
+export function formatJsonSchemaErrors(
+    errors: ErrorObject[] | null | undefined,
+): string {
+    return ajv.errorsText(errors);
+}
+
+function createAjv(): Ajv {
+    const instance = new Ajv({
+        addUsedSchema: false,
+        allErrors: true,
+        strict: false,
+        verbose: true,
+    });
+
+    addFormats(instance);
+    instance.addFormat("hex-color", {
+        type: "string",
+        validate: value => isHexColorString(value),
+    });
+
+    return instance;
+}
+
+function stripSchemaDialectDeclaration(
+    value: unknown,
+): unknown {
+    if (Array.isArray(value)) {
+        return value.map(item => stripSchemaDialectDeclaration(item));
+    }
+
+    if (!isPlainObject(value)) {
+        return value;
+    }
+
+    const entries: [string, unknown][] = [];
+
+    for (const [key, entryValue] of Object.entries(value)) {
+        if (key === "$schema") {
+            continue;
+        }
+
+        entries.push([key, stripSchemaDialectDeclaration(entryValue)]);
+    }
+
+    return Object.fromEntries(entries);
+}
+
+function isHexColorString(value: string): boolean {
+    if (!value.startsWith("#")) {
+        return false;
+    }
+
+    if (value.length !== 7 && value.length !== 9) {
+        return false;
+    }
+
+    for (let index = 1; index < value.length; index += 1) {
+        const charCode = value.charCodeAt(index);
+        const isDigit = charCode >= 48 && charCode <= 57;
+        const isUpperHex = charCode >= 65 && charCode <= 70;
+        const isLowerHex = charCode >= 97 && charCode <= 102;
+
+        if (!isDigit && !isUpperHex && !isLowerHex) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/application/commands/shared/json-schema-validation.ts
+++ b/src/application/commands/shared/json-schema-validation.ts
@@ -75,25 +75,13 @@ function createAjv(): Ajv {
 function stripSchemaDialectDeclaration(
     value: unknown,
 ): unknown {
-    if (Array.isArray(value)) {
-        return value.map(item => stripSchemaDialectDeclaration(item));
-    }
-
     if (!isPlainObject(value)) {
         return value;
     }
 
-    const entries: [string, unknown][] = [];
+    const { $schema: _schemaDialect, ...schemaWithoutDialect } = value;
 
-    for (const [key, entryValue] of Object.entries(value)) {
-        if (key === "$schema") {
-            continue;
-        }
-
-        entries.push([key, stripSchemaDialectDeclaration(entryValue)]);
-    }
-
-    return Object.fromEntries(entries);
+    return schemaWithoutDialect;
 }
 
 function isHexColorString(value: string): boolean {

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -22,133 +22,6 @@ exports[`skills CLI treats the removed allow-implicit-invocation subcommand as u
 }
 `;
 
-exports[`skills CLI silently installs the managed Codex skill on the first run 1`] = `
-{
-  "exitCode": 0,
-  "stderr": "",
-  "stdout": 
-"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
-
-Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
-
-Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
-"
-,
-}
-`;
-
-exports[`skills CLI does not auto-install the managed Codex skill during local development runs 1`] = `
-{
-  "exitCode": 0,
-  "stderr": "",
-  "stdout": 
-"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
-
-Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
-
-Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
-"
-,
-}
-`;
-
-exports[`skills CLI does not auto-install the managed Codex skill for skills subcommands 1`] = `
-{
-  "exitCode": 1,
-  "stderr": 
-"Codex skill oo is not installed at <HOME>/.codex/skills/oo.
-"
-,
-  "stdout": "",
-}
-`;
-
-exports[`skills CLI synchronizes the managed Codex skill policy from persisted settings 1`] = `
-{
-  "exitCode": 0,
-  "stderr": "",
-  "stdout": 
-"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
-
-Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
-
-Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
-"
-,
-}
-`;
-
-exports[`skills CLI writes explicit skills install and uninstall logs 1`] = `
-{
-  "installResult": {
-    "exitCode": 0,
-    "stderr": "",
-    "stdout": 
-"Installed skill oo to <HOME>/.codex/skills/oo.
-Installed skill oo-find-skills to <HOME>/.codex/skills/oo-find-skills.
-"
-,
-  },
-  "uninstallResult": {
-    "exitCode": 0,
-    "stderr": "",
-    "stdout": 
-"Removed skill oo from <HOME>/.codex/skills/oo.
-Removed skill oo-find-skills from <HOME>/.codex/skills/oo-find-skills.
-"
-,
-  },
-}
-`;
-
 exports[`skills CLI silently installs the managed bundled skill on the first run 1`] = `
 {
   "exitCode": 0,
@@ -166,6 +39,7 @@ Commands:
   auth                Manage CLI authentication
   check-update        Check for CLI updates
   cloud-task          Manage cloud tasks
+  connector           Manage connector actions
   file                Manage temporary file transfers
   login               Log in with a browser flow (alias for auth login)
   logout              Log out the current account (alias for auth logout)
@@ -197,6 +71,7 @@ Commands:
   auth                Manage CLI authentication
   check-update        Check for CLI updates
   cloud-task          Manage cloud tasks
+  connector           Manage connector actions
   file                Manage temporary file transfers
   login               Log in with a browser flow (alias for auth login)
   logout              Log out the current account (alias for auth logout)
@@ -239,6 +114,7 @@ Commands:
   auth                Manage CLI authentication
   check-update        Check for CLI updates
   cloud-task          Manage cloud tasks
+  connector           Manage connector actions
   file                Manage temporary file transfers
   login               Log in with a browser flow (alias for auth login)
   logout              Log out the current account (alias for auth logout)
@@ -270,6 +146,7 @@ Commands:
   auth                Manage CLI authentication
   check-update        Check for CLI updates
   cloud-task          Manage cloud tasks
+  connector           Manage connector actions
   file                Manage temporary file transfers
   login               Log in with a browser flow (alias for auth login)
   logout              Log out the current account (alias for auth logout)
@@ -281,5 +158,28 @@ Commands:
   help [command]      Show help for a command
 "
 ,
+}
+`;
+
+exports[`skills CLI writes explicit skills install and uninstall logs 1`] = `
+{
+  "installResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Installed skill oo to <HOME>/.codex/skills/oo.
+Installed skill oo-find-skills to <HOME>/.codex/skills/oo-find-skills.
+"
+,
+  },
+  "uninstallResult": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Removed skill oo from <HOME>/.codex/skills/oo.
+Removed skill oo-find-skills from <HOME>/.codex/skills/oo-find-skills.
+"
+,
+  },
 }
 `;

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -47,6 +47,15 @@ export const enMessages = {
         "Wait for a cloud task to finish by polling its result.",
     "commands.cloudTask.wait.summary": "Wait for cloud task completion",
     "commands.cloudTask.summary": "Manage cloud tasks",
+    "commands.connector.description":
+        "Search connector actions and run authenticated connector operations.",
+    "commands.connector.summary": "Manage connector actions",
+    "commands.connector.search.description":
+        "Search connector actions and cache their schemas locally.",
+    "commands.connector.search.summary": "Search connector actions",
+    "commands.connector.run.description":
+        "Validate input data and run one connector action synchronously.",
+    "commands.connector.run.summary": "Run a connector action",
     "commands.completion.description":
         "Output a shell completion script for a supported shell.",
     "commands.completion.summary": "Generate shell completion scripts",
@@ -214,6 +223,48 @@ export const enMessages = {
         "The handle {handle} is not defined by block {blockId}.",
     "errors.cloudTaskRun.unsupportedContentMediaType":
         "The handle {handle} uses unsupported contentMediaType {contentMediaType}.",
+    "errors.connectorAuthenticated.invalidResponse":
+        "The authenticated connector services response body is unsupported.",
+    "errors.connectorAuthenticated.requestError":
+        "The authenticated connector services request failed: {message}",
+    "errors.connectorAuthenticated.requestFailed":
+        "The authenticated connector services request returned HTTP {status}.",
+    "errors.connectorMetadata.invalidResponse":
+        "The connector action metadata response body is unsupported.",
+    "errors.connectorMetadata.requestError":
+        "The connector action metadata request failed: {message}",
+    "errors.connectorMetadata.requestFailed":
+        "The connector action metadata request returned HTTP {status}.",
+    "errors.connectorRun.actionRequired":
+        "The --action option is required.",
+    "errors.connectorRun.dataFilePathRequired":
+        "The @data file path cannot be empty.",
+    "errors.connectorRun.dataReadFailed":
+        "Failed to read input data from {path}: {message}",
+    "errors.connectorRun.invalidActionSchema":
+        "The connector action input schema is invalid: {message}",
+    "errors.connectorRun.invalidDataJson":
+        "The --data value is not valid JSON: {message}",
+    "errors.connectorRun.invalidPayload":
+        "The connector action input payload is invalid: {message}",
+    "errors.connectorRun.invalidResponse":
+        "The connector action run response body is unsupported.",
+    "errors.connectorRun.requestError":
+        "The connector action run request failed: {message}",
+    "errors.connectorRun.requestFailed":
+        "The connector action run request returned HTTP {status}.",
+    "errors.connectorRun.requestFailedWithMessage":
+        "The connector action run request returned HTTP {status}: {message}",
+    "errors.connectorSchema.readFailed":
+        "Failed to read the connector action schema cache at {path}: {message}",
+    "errors.connectorSchema.writeFailed":
+        "Failed to write the connector action schema cache at {path}: {message}",
+    "errors.connectorSearch.invalidResponse":
+        "The connector action search response body is unsupported.",
+    "errors.connectorSearch.requestError":
+        "The connector action search request failed: {message}",
+    "errors.connectorSearch.requestFailed":
+        "The connector action search request returned HTTP {status}.",
     "errors.completion.invalidShell":
         "Unsupported shell: {value}. Use bash, zsh, or fish.",
     "errors.checkUpdate.failed": "Failed to check for CLI updates.",
@@ -355,7 +406,10 @@ export const enMessages = {
         "{appName} is {companyName}'s CLI toolkit. Everything can be done in the CLI.",
     "help.usage": "Usage:",
     "options.blockId": "Specify the target block id",
+    "options.action": "Specify the target action name",
     "options.blockName": "Alias for --block-id",
+    "options.connectorKeywords":
+        "Specify comma-separated keywords to refine the connector action search",
     "options.data": "Provide JSON input values or @path to a JSON file",
     "options.dryRun": "Validate the request without creating a task",
     "options.debug": "Print the current log file path when the CLI exits",
@@ -445,6 +499,7 @@ export const enMessages = {
     "arguments.outDir": "Output directory",
     "arguments.packageName": "Package name",
     "arguments.packageSpecifier": "Package specifier",
+    "arguments.serviceName": "Service name",
     "arguments.shell": "Target shell",
     "arguments.skill": "Skill name",
     "arguments.skillConfigKey": "Skill configuration key",
@@ -474,6 +529,15 @@ export const enMessages = {
     "cloudTask.status.scheduling": "scheduling",
     "cloudTask.status.success": "success",
     "cloudTask.status.queued": "queued",
+    "connector.search.text.authenticated": "Authenticated",
+    "connector.search.text.authenticated.no": "no",
+    "connector.search.text.authenticated.yes": "yes",
+    "connector.search.text.noResults":
+        "No matching connector actions were found.",
+    "connector.search.text.schemaPath": "Schema path",
+    "connector.run.text.dryRunPassed": "Validation passed.",
+    "connector.run.text.executionId": "Execution ID",
+    "connector.run.text.resultData": "Result data",
     "file.cleanup.success":
         "Deleted {deletedCount} expired upload records.",
     "file.download.savedTo": "Saved to: {path}",
@@ -543,6 +607,17 @@ export const zhMessages = {
     "commands.cloudTask.wait.description": "通过轮询任务结果等待云任务结束。",
     "commands.cloudTask.wait.summary": "等待云任务完成",
     "commands.cloudTask.summary": "管理云任务",
+    "commands.connector.description":
+        "搜索 connector action，并运行已认证的 connector 操作。",
+    "commands.connector.summary": "管理 connector action",
+    "commands.connector.search.description":
+        "搜索 connector action，并将 schema 缓存到本地。",
+    "commands.connector.search.summary":
+        "搜索 connector action",
+    "commands.connector.run.description":
+        "校验输入数据，并同步运行一个 connector action。",
+    "commands.connector.run.summary":
+        "运行 connector action",
     "commands.completion.description": "输出受支持 shell 的补全脚本。",
     "commands.completion.summary": "生成 shell 补全脚本",
     "commands.config.description": "读取并更新持久化的用户配置。",
@@ -687,6 +762,48 @@ export const zhMessages = {
         "Block {blockId} 未定义 handle {handle}。",
     "errors.cloudTaskRun.unsupportedContentMediaType":
         "Handle {handle} 使用了暂不支持的 contentMediaType {contentMediaType}。",
+    "errors.connectorAuthenticated.invalidResponse":
+        "已认证 connector 服务列表返回了不受支持的响应内容。",
+    "errors.connectorAuthenticated.requestError":
+        "获取已认证 connector 服务列表失败：{message}",
+    "errors.connectorAuthenticated.requestFailed":
+        "获取已认证 connector 服务列表返回了 HTTP {status}。",
+    "errors.connectorMetadata.invalidResponse":
+        "connector action 元数据返回了不受支持的响应内容。",
+    "errors.connectorMetadata.requestError":
+        "获取 connector action 元数据失败：{message}",
+    "errors.connectorMetadata.requestFailed":
+        "获取 connector action 元数据返回了 HTTP {status}。",
+    "errors.connectorRun.actionRequired":
+        "--action 选项为必填。",
+    "errors.connectorRun.dataFilePathRequired":
+        "@data 文件路径不能为空。",
+    "errors.connectorRun.dataReadFailed":
+        "读取 {path} 中的输入数据失败：{message}",
+    "errors.connectorRun.invalidActionSchema":
+        "connector action 的输入 schema 无效：{message}",
+    "errors.connectorRun.invalidDataJson":
+        "--data 的值不是合法 JSON：{message}",
+    "errors.connectorRun.invalidPayload":
+        "connector action 的输入 payload 无效：{message}",
+    "errors.connectorRun.invalidResponse":
+        "connector action 运行返回了不受支持的响应内容。",
+    "errors.connectorRun.requestError":
+        "运行 connector action 失败：{message}",
+    "errors.connectorRun.requestFailed":
+        "运行 connector action 返回了 HTTP {status}。",
+    "errors.connectorRun.requestFailedWithMessage":
+        "运行 connector action 返回了 HTTP {status}：{message}",
+    "errors.connectorSchema.readFailed":
+        "读取 {path} 的 connector action schema cache 失败：{message}",
+    "errors.connectorSchema.writeFailed":
+        "写入 {path} 的 connector action schema cache 失败：{message}",
+    "errors.connectorSearch.invalidResponse":
+        "connector action 搜索返回了不受支持的响应内容。",
+    "errors.connectorSearch.requestError":
+        "connector action 搜索请求失败：{message}",
+    "errors.connectorSearch.requestFailed":
+        "connector action 搜索请求返回了 HTTP {status}。",
     "errors.completion.invalidShell":
         "不支持的 shell：{value}。请使用 bash、zsh 或 fish。",
     "errors.checkUpdate.failed": "检查 CLI 更新失败。",
@@ -823,7 +940,10 @@ export const zhMessages = {
         "{appName} 是 {companyName} 的 CLI 工具集，一切均可在 CLI 中完成",
     "help.usage": "用法：",
     "options.blockId": "指定目标 block id",
+    "options.action": "指定目标 action 名称",
     "options.blockName": "--block-id 的别名",
+    "options.connectorKeywords":
+        "指定用于细化 connector action 搜索的逗号分隔关键词",
     "options.data": "提供 JSON 输入值，或使用 @路径 读取 JSON 文件",
     "options.dryRun": "仅校验请求，不真正创建任务",
     "options.debug": "在 CLI 退出时打印当前日志文件路径",
@@ -912,6 +1032,7 @@ export const zhMessages = {
     "arguments.outDir": "输出目录",
     "arguments.packageName": "包名",
     "arguments.packageSpecifier": "包标识",
+    "arguments.serviceName": "服务名",
     "arguments.shell": "目标 shell",
     "arguments.skill": "skill 名称",
     "arguments.skillConfigKey": "skill 配置键",
@@ -940,6 +1061,14 @@ export const zhMessages = {
     "cloudTask.status.scheduling": "调度中",
     "cloudTask.status.success": "成功",
     "cloudTask.status.queued": "排队中",
+    "connector.search.text.authenticated": "已认证",
+    "connector.search.text.authenticated.no": "否",
+    "connector.search.text.authenticated.yes": "是",
+    "connector.search.text.noResults": "未找到匹配的 connector action。",
+    "connector.search.text.schemaPath": "Schema 路径",
+    "connector.run.text.dryRunPassed": "校验通过。",
+    "connector.run.text.executionId": "执行 ID",
+    "connector.run.text.resultData": "结果数据",
     "file.cleanup.success": "已删除 {deletedCount} 条过期上传记录。",
     "file.download.savedTo": "已保存到：{path}",
     "file.list.noResults": "未找到任何上传记录。",


### PR DESCRIPTION
Introduce the `oo connector` command group with `search` for free-form action discovery and `run` for synchronous action execution with payload validation and dry-run support. Each search result writes a schema cache file under the CLI config root so subsequent runs can validate inputs offline and transparently refetch when the cache is missing or invalid.

Extract the JSON input reader and AJV-based schema validation helpers out of cloud-task into shared modules so connector and cloud-task share one implementation instead of duplicating the file/inline JSON parsing and validator compilation logic.