### PR TITLE
feat(search): add unified `oo search` command for packages and connectors

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -155,6 +155,26 @@ Validate input data and run one connector action synchronously.
 - Notes: when local schema cache is unavailable or unusable, the command
   refreshes it automatically before validating and running.
 
+## Search
+
+### `oo search <text>`
+
+Search packages and connector actions with one free-form query.
+
+- Arguments: `<text>` is the search text sent to both discovery sources.
+- Options: `--keywords <keywords>` sends a comma-separated keyword list after
+  trimming empty and duplicate entries when searching connector actions.
+- Options: `--format=json` and `--json` print one JSON array that mixes
+  `package` and `connector` items and uses `kind` as the discriminator.
+- Output: package JSON entries include the stable CLI fields `kind`,
+  `packageId`, `displayName`, `description`, and `blocks`.
+- Output: connector JSON entries include the stable CLI fields `kind`,
+  `service`, `name`, `description`, `authenticated`, and `schemaPath`.
+- Output: text output prints one block per result and includes a `Kind` line
+  for each block instead of source section headers.
+- Notes: connector matches still cache their schemas locally and report the
+  cache path in text and JSON output.
+
 ## Codex Skills
 
 ### `oo skills list`

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -144,6 +144,26 @@
 - 说明：如果本地 schema cache 不可用或无法使用，命令会自动刷新后再继续校验
   和运行。
 
+## Search
+
+### `oo search <text>`
+
+使用一个自由文本查询同时搜索 package 与 connector action。
+
+- 参数：`<text>` 会同时发送到两个搜索来源。
+- 选项：`--keywords <keywords>` 会在搜索 connector action 时发送一个逗号分隔
+  的关键词列表，并移除空项与重复项。
+- 选项：`--format=json` 和 `--json` 会输出一个混合 `package` 与
+  `connector` 条目的 JSON 数组，并使用 `kind` 作为区分字段。
+- 输出：package JSON 条目包含稳定 CLI 字段 `kind`、`packageId`、
+  `displayName`、`description` 和 `blocks`。
+- 输出：connector JSON 条目包含稳定 CLI 字段 `kind`、`service`、
+  `name`、`description`、`authenticated` 和 `schemaPath`。
+- 输出：文本输出会为每个结果打印一个块，并额外包含一行 `类型` 字段，而不
+  再输出来源分组标题。
+- 说明：connector 命中结果仍会在本地缓存 schema，并在文本与 JSON 输出中
+  报告其缓存路径。
+
 ## Codex Skill
 
 ### `oo skills list`

--- a/src/adapters/completion/static-completion-renderer.test.ts
+++ b/src/adapters/completion/static-completion-renderer.test.ts
@@ -17,6 +17,7 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain("login");
         expect(output).toContain("logout");
         expect(output).toContain("packages");
+        expect(output).toContain("search");
         expect(output).toContain("--lang");
         expect(output).toContain("en zh");
     });
@@ -30,6 +31,7 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain("config set");
         expect(output).toContain("connector run");
         expect(output).toContain("packages search");
+        expect(output).toContain("search");
         expect(output).toContain(`compdef _${APP_NAME} ${APP_NAME}`);
     });
 
@@ -46,6 +48,7 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain("login");
         expect(output).toContain("logout");
         expect(output).toContain("__fish_seen_subcommand_from packages");
+        expect(output).toContain("__fish_seen_subcommand_from search");
         expect(output).toContain("en zh");
     });
 });

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -34,25 +34,26 @@ exports[`runCli bootstrap creates the sqlite cache file during cli startup 1`] =
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  connector           Manage connector actions
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  help [command]           Show help for a command
 "
 ,
 }
@@ -66,25 +67,26 @@ exports[`runCli bootstrap writes debug logs to the log directory during cli star
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  connector           Manage connector actions
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  help [command]           Show help for a command
 "
 ,
 }
@@ -101,25 +103,26 @@ exports[`runCli bootstrap prints the current log file path to stderr when --debu
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  connector           Manage connector actions
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  help [command]           Show help for a command
 "
 ,
 }
@@ -134,25 +137,26 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
 "oo 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成
 
 选项：
-  -V, --version       显示当前版本
-  --debug             在 CLI 退出时打印当前日志文件路径
-  --lang <lang>       指定显示语言
-  -h, --help          显示命令帮助
+  -V, --version            显示当前版本
+  --debug                  在 CLI 退出时打印当前日志文件路径
+  --lang <lang>            指定显示语言
+  -h, --help               显示命令帮助
 
 命令：
-  auth                管理 CLI 认证
-  check-update        检查 CLI 更新
-  cloud-task          管理云任务
-  connector           管理 connector action
-  file                管理临时文件传输
-  login               通过浏览器登录（auth login 的别名）
-  logout              登出当前账号（auth logout 的别名）
-  completion <shell>  生成 shell 补全脚本
-  config              管理持久化配置
-  skills              管理 Codex skill
-  log                 管理持久化 debug 日志
-  packages            包相关工具
-  help [command]      显示命令帮助
+  auth                     管理 CLI 认证
+  check-update             检查 CLI 更新
+  cloud-task               管理云任务
+  connector                管理 connector action
+  file                     管理临时文件传输
+  login                    通过浏览器登录（auth login 的别名）
+  logout                   登出当前账号（auth logout 的别名）
+  completion <shell>       生成 shell 补全脚本
+  config                   管理持久化配置
+  skills                   管理 Codex skill
+  log                      管理持久化 debug 日志
+  search [options] <text>  搜索 package 与 connector action
+  packages                 包相关工具
+  help [command]           显示命令帮助
 "
 ,
   },
@@ -163,25 +167,26 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  connector           Manage connector actions
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  help [command]           Show help for a command
 "
 ,
   },
@@ -196,25 +201,26 @@ exports[`runCli bootstrap renders branded colors in help when stdout supports co
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  connector           Manage connector actions
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  help [command]           Show help for a command
 "
 ,
 }

--- a/src/application/commands/__snapshots__/search.cli.test.ts.snap
+++ b/src/application/commands/__snapshots__/search.cli.test.ts.snap
@@ -1,0 +1,115 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`mixedSearchCommand CLI supports mixed search with text output and groups results by source 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Mail Tools (@oomol/mail-tools@1.2.3)
+Email automation package.
+Kind: package
+Blocks:
+- Send Email (send-email)
+  Send templated emails.
+
+gmail.send_mail
+Send a Gmail message.
+Kind: connector
+Authenticated: yes
+Schema path: <XDG_CONFIG_HOME>/oo/connector-actions/gmail/send_mail.json
+"
+,
+}
+`;
+
+exports[`mixedSearchCommand CLI supports mixed search with json output 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"[{"blocks":[{"description":"","name":"","title":"Send Email"}],"description":"Email automation package.","displayName":"Mail Tools","kind":"package","packageId":"@oomol/mail-tools@1.2.3"},{"authenticated":false,"description":"Send a Gmail message.","kind":"connector","name":"send_mail","schemaPath":"<XDG_CONFIG_HOME>/oo/connector-actions/gmail/send_mail.json","service":"gmail"}]
+"
+,
+}
+`;
+
+exports[`mixedSearchCommand CLI renders kind lines after descriptions with field-specific colors 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Mail Tools (@oomol/mail-tools@1.2.3)
+Email automation package.
+Kind: package
+
+gmail.send_mail
+Send a Gmail message.
+Kind: connector
+Authenticated: no
+Schema path: <XDG_CONFIG_HOME>/oo/connector-actions/gmail/send_mail.json
+"
+,
+}
+`;
+
+exports[`mixedSearchCommand CLI renders mixed search no-results output when both providers are empty 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"No matching packages or connector actions were found.
+"
+,
+}
+`;
+
+exports[`mixedSearchCommand CLI renders mixed search help when text argument is omitted 1`] = `
+{
+  "expectedHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Search packages and connector actions with one free-form query.
+
+Arguments:
+  text                   Search text
+
+Options:
+  --format <format>      Specify output format (use json for structured output)
+  --json                 Alias for --format=json
+  --keywords <keywords>  Specify comma-separated keywords to refine the
+                         connector action search
+  -h, --help             Show help for command
+
+Global Options:
+  -V, --version          Show the current version
+  --debug                Print the current log file path when the CLI exits
+  --lang <lang>          Specify the display language
+"
+,
+  },
+  "result": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Search packages and connector actions with one free-form query.
+
+Arguments:
+  text                   Search text
+
+Options:
+  --format <format>      Specify output format (use json for structured output)
+  --json                 Alias for --format=json
+  --keywords <keywords>  Specify comma-separated keywords to refine the
+                         connector action search
+  -h, --help             Show help for command
+
+Global Options:
+  -V, --version          Show the current version
+  --debug                Print the current log file path when the CLI exits
+  --lang <lang>          Specify the display language
+"
+,
+  },
+}
+`;

--- a/src/application/commands/catalog.ts
+++ b/src/application/commands/catalog.ts
@@ -12,6 +12,7 @@ import { logCommand } from "./log/index.ts";
 import { loginCommand } from "./login.ts";
 import { logoutCommand } from "./logout.ts";
 import { packageCommand } from "./package/index.ts";
+import { mixedSearchCommand } from "./search.ts";
 import { skillsCommand } from "./skills/index.ts";
 
 const globalOptions = [
@@ -47,6 +48,7 @@ export function createCliCatalog(): CliCatalog {
             configCommand,
             skillsCommand,
             logCommand,
+            mixedSearchCommand,
             packageCommand,
         ],
     };

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -20,25 +20,26 @@ exports[`config CLI persists the configured locale and allows explicit override 
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  connector           Manage connector actions
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  help [command]           Show help for a command
 "
 ,
   },
@@ -49,25 +50,26 @@ Commands:
 "oo 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成
 
 选项：
-  -V, --version       显示当前版本
-  --debug             在 CLI 退出时打印当前日志文件路径
-  --lang <lang>       指定显示语言
-  -h, --help          显示命令帮助
+  -V, --version            显示当前版本
+  --debug                  在 CLI 退出时打印当前日志文件路径
+  --lang <lang>            指定显示语言
+  -h, --help               显示命令帮助
 
 命令：
-  auth                管理 CLI 认证
-  check-update        检查 CLI 更新
-  cloud-task          管理云任务
-  connector           管理 connector action
-  file                管理临时文件传输
-  login               通过浏览器登录（auth login 的别名）
-  logout              登出当前账号（auth logout 的别名）
-  completion <shell>  生成 shell 补全脚本
-  config              管理持久化配置
-  skills              管理 Codex skill
-  log                 管理持久化 debug 日志
-  packages            包相关工具
-  help [command]      显示命令帮助
+  auth                     管理 CLI 认证
+  check-update             检查 CLI 更新
+  cloud-task               管理云任务
+  connector                管理 connector action
+  file                     管理临时文件传输
+  login                    通过浏览器登录（auth login 的别名）
+  logout                   登出当前账号（auth logout 的别名）
+  completion <shell>       生成 shell 补全脚本
+  config                   管理持久化配置
+  skills                   管理 Codex skill
+  log                      管理持久化 debug 日志
+  search [options] <text>  搜索 package 与 connector action
+  packages                 包相关工具
+  help [command]           显示命令帮助
 "
 ,
   },

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -19,7 +19,7 @@ import {
 import {
     connectorSearchActionColor,
     connectorSearchServiceColor,
-} from "./search.ts";
+} from "./search-provider.ts";
 
 describe("connectorCommand CLI", () => {
     test("supports connector search with text output and writes schema caches", async () => {

--- a/src/application/commands/connector/search-provider.ts
+++ b/src/application/commands/connector/search-provider.ts
@@ -1,0 +1,132 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+import type { TerminalColors } from "../../terminal-colors.ts";
+
+import { createWriterColors } from "../../terminal-colors.ts";
+
+import { persistConnectorActionSchemaCache } from "./schema-cache.ts";
+import {
+    listAuthenticatedConnectorServices,
+    searchConnectorActions,
+} from "./shared.ts";
+
+export const connectorSearchActionColor = "#59F78D";
+export const connectorSearchServiceColor = "#CAA8FA";
+
+export interface ConnectorSearchResult {
+    authenticated: boolean;
+    description: string;
+    name: string;
+    schemaPath: string;
+    service: string;
+}
+
+type ConnectorSearchTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
+
+export async function loadConnectorSearchResults(
+    options: {
+        apiKey: string;
+        endpoint: string;
+        keywords: readonly string[];
+        text: string;
+    },
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "settingsStore">,
+): Promise<ConnectorSearchResult[]> {
+    const actions = await searchConnectorActions(options, context);
+
+    if (actions.length === 0) {
+        return [];
+    }
+
+    const authenticatedServices = await listAuthenticatedConnectorServices(
+        {
+            apiKey: options.apiKey,
+            endpoint: options.endpoint,
+            services: readUniqueConnectorServices(actions),
+        },
+        context,
+    );
+
+    return await Promise.all(actions.map(async action => ({
+        authenticated: authenticatedServices.has(action.service),
+        description: action.description,
+        name: action.name,
+        schemaPath: await persistConnectorActionSchemaCache(action, context),
+        service: action.service,
+    })));
+}
+
+export function formatConnectorSearchResultsAsText(
+    results: readonly ConnectorSearchResult[],
+    context: ConnectorSearchTextContext,
+): string {
+    const colors = createWriterColors(context.stdout);
+
+    return results
+        .map(result => formatConnectorSearchResultAsText(result, context, {
+            colors,
+        }))
+        .join("\n\n");
+}
+
+export function formatConnectorSearchResultAsText(
+    result: ConnectorSearchResult,
+    context: ConnectorSearchTextContext,
+    options: {
+        colors?: TerminalColors;
+        extraLinesAfterDescription?: readonly string[];
+    } = {},
+): string {
+    const colors = options.colors ?? createWriterColors(context.stdout);
+    const lines = [
+        `${colors.hex(connectorSearchServiceColor)(result.service)}.${colors.hex(connectorSearchActionColor)(result.name)}`,
+    ];
+
+    if (result.description !== "") {
+        lines.push(result.description);
+    }
+
+    if (options.extraLinesAfterDescription !== undefined) {
+        lines.push(...options.extraLinesAfterDescription);
+    }
+
+    lines.push(
+        `${context.translator.t("connector.search.text.authenticated")}: ${formatConnectorAuthenticationLabel(result.authenticated, context, colors)}`,
+        `${context.translator.t("connector.search.text.schemaPath")}: ${colors.gray(result.schemaPath)}`,
+    );
+
+    return lines.join("\n");
+}
+
+function readUniqueConnectorServices(
+    actions: readonly Pick<ConnectorSearchResult, "service">[],
+): string[] {
+    const services: string[] = [];
+    const seen = new Set<string>();
+
+    for (const action of actions) {
+        if (seen.has(action.service)) {
+            continue;
+        }
+
+        seen.add(action.service);
+        services.push(action.service);
+    }
+
+    return services;
+}
+
+function formatConnectorAuthenticationLabel(
+    authenticated: boolean,
+    context: Pick<CliExecutionContext, "translator">,
+    colors: TerminalColors,
+): string {
+    if (authenticated) {
+        return colors.green(
+            context.translator.t("connector.search.text.authenticated.yes"),
+        );
+    }
+
+    return colors.yellow(
+        context.translator.t("connector.search.text.authenticated.no"),
+    );
+}

--- a/src/application/commands/connector/search.ts
+++ b/src/application/commands/connector/search.ts
@@ -1,31 +1,15 @@
-import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
-import type { TerminalColors } from "../../terminal-colors.ts";
 import { z } from "zod";
-import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
-import { persistConnectorActionSchemaCache } from "./schema-cache.ts";
+import { parseCommaSeparatedKeywords } from "../shared/keywords.ts";
 import {
-    connectorFormatValues,
-    listAuthenticatedConnectorServices,
-    parseConnectorSearchKeywords,
-    searchConnectorActions,
-} from "./shared.ts";
-
-export const connectorSearchActionColor = "#59F78D";
-export const connectorSearchServiceColor = "#CAA8FA";
-
-type ConnectorSearchTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
-
-interface ConnectorSearchResult {
-    authenticated: boolean;
-    description: string;
-    name: string;
-    schemaPath: string;
-    service: string;
-}
+    formatConnectorSearchResultsAsText,
+    loadConnectorSearchResults,
+} from "./search-provider.ts";
+import { connectorFormatValues } from "./shared.ts";
 
 interface ConnectorSearchInput {
     format?: (typeof connectorFormatValues)[number];
@@ -62,8 +46,8 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         const account = await requireCurrentAccount(context);
-        const keywords = parseConnectorSearchKeywords(input.keywords);
-        const actions = await searchConnectorActions(
+        const keywords = parseCommaSeparatedKeywords(input.keywords);
+        const results = await loadConnectorSearchResults(
             {
                 apiKey: account.apiKey,
                 endpoint: account.endpoint,
@@ -73,7 +57,7 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
             context,
         );
 
-        if (actions.length === 0) {
+        if (results.length === 0) {
             if (input.format === "json") {
                 writeJsonOutput(context.stdout, []);
                 return;
@@ -85,22 +69,6 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
             return;
         }
 
-        const authenticatedServices = await listAuthenticatedConnectorServices(
-            {
-                apiKey: account.apiKey,
-                endpoint: account.endpoint,
-                services: uniqueServices(actions),
-            },
-            context,
-        );
-        const results = await Promise.all(actions.map(async action => ({
-            authenticated: authenticatedServices.has(action.service),
-            description: action.description,
-            name: action.name,
-            schemaPath: await persistConnectorActionSchemaCache(action, context),
-            service: action.service,
-        })));
-
         if (input.format === "json") {
             writeJsonOutput(context.stdout, results);
             return;
@@ -111,66 +79,3 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
         );
     },
 };
-
-function uniqueServices(
-    actions: readonly Pick<ConnectorSearchResult, "service">[],
-): string[] {
-    const services: string[] = [];
-    const seen = new Set<string>();
-
-    for (const action of actions) {
-        if (seen.has(action.service)) {
-            continue;
-        }
-
-        seen.add(action.service);
-        services.push(action.service);
-    }
-
-    return services;
-}
-
-function formatConnectorSearchResultsAsText(
-    results: readonly ConnectorSearchResult[],
-    context: ConnectorSearchTextContext,
-): string {
-    const colors = createWriterColors(context.stdout);
-
-    return results
-        .map(result => formatConnectorSearchResult(result, context, colors))
-        .join("\n\n");
-}
-
-function formatConnectorSearchResult(
-    result: ConnectorSearchResult,
-    context: ConnectorSearchTextContext,
-    colors: TerminalColors,
-): string {
-    const lines = [
-        `${colors.hex(connectorSearchServiceColor)(result.service)}.${colors.hex(connectorSearchActionColor)(result.name)}`,
-        `${context.translator.t("connector.search.text.authenticated")}: ${formatConnectorAuthenticationLabel(result.authenticated, context, colors)}`,
-        `${context.translator.t("connector.search.text.schemaPath")}: ${colors.gray(result.schemaPath)}`,
-    ];
-
-    if (result.description !== "") {
-        lines.splice(1, 0, result.description);
-    }
-
-    return lines.join("\n");
-}
-
-function formatConnectorAuthenticationLabel(
-    authenticated: boolean,
-    context: Pick<CliExecutionContext, "translator">,
-    colors: TerminalColors,
-): string {
-    if (authenticated) {
-        return colors.green(
-            context.translator.t("connector.search.text.authenticated.yes"),
-        );
-    }
-
-    return colors.yellow(
-        context.translator.t("connector.search.text.authenticated.no"),
-    );
-}

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -7,24 +7,9 @@ import { toRequest } from "../../../../__tests__/helpers.ts";
 import {
     getConnectorActionMetadata,
     listAuthenticatedConnectorServices,
-    parseConnectorSearchKeywords,
     runConnectorAction,
     searchConnectorActions,
 } from "./shared.ts";
-
-describe("parseConnectorSearchKeywords", () => {
-    test("trims empty values and removes duplicates", () => {
-        expect(parseConnectorSearchKeywords(" gmail, email ,,gmail, inbox ")).toEqual([
-            "gmail",
-            "email",
-            "inbox",
-        ]);
-    });
-
-    test("returns an empty list when the option is omitted", () => {
-        expect(parseConnectorSearchKeywords(undefined)).toEqual([]);
-    });
-});
 
 describe("connector shared requests", () => {
     test("searchConnectorActions sends the expected request and parses actions", async () => {

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -65,30 +65,6 @@ export const connectorFormatValues = ["json"] as const;
 export type ConnectorActionDefinition = z.output<typeof connectorActionDefinitionSchema>;
 export type ConnectorActionRunResponse = z.output<typeof connectorActionRunResponseSchema>;
 
-export function parseConnectorSearchKeywords(
-    value: string | undefined,
-): string[] {
-    if (value === undefined) {
-        return [];
-    }
-
-    const keywords: string[] = [];
-    const seen = new Set<string>();
-
-    for (const segment of value.split(",")) {
-        const keyword = segment.trim();
-
-        if (keyword === "" || seen.has(keyword)) {
-            continue;
-        }
-
-        seen.add(keyword);
-        keywords.push(keyword);
-    }
-
-    return keywords;
-}
-
 export async function searchConnectorActions(
     options: {
         apiKey: string;

--- a/src/application/commands/package/search-provider.ts
+++ b/src/application/commands/package/search-provider.ts
@@ -1,0 +1,362 @@
+import type { CliExecutionContext, SupportedLocale } from "../../contracts/cli.ts";
+import type { AuthAccount } from "../../schemas/auth.ts";
+import type { TerminalColors } from "../../terminal-colors.ts";
+
+import { z } from "zod";
+
+import { resolveRequestLanguage } from "../../../i18n/locale.ts";
+import { CliUserError } from "../../contracts/cli.ts";
+import {
+    withAccountIdentity,
+    withPath,
+} from "../../logging/log-fields.ts";
+import { createWriterColors } from "../../terminal-colors.ts";
+import { requestText } from "../shared/request.ts";
+
+const MAX_SEARCH_TEXT_LENGTH = 200;
+const SEARCH_CACHE_ID = "search.intent-response";
+const SEARCH_CACHE_MAX_ENTRIES = 100;
+const SEARCH_CACHE_TTL_MS = 30_000;
+const searchDisplayNameColor = "#59F78D";
+const searchBlockTitleColor = "#CAA8FA";
+
+const packageSearchBlockSchema = z.object({
+    description: z.string().optional().default(""),
+    name: z.string().optional().default(""),
+    title: z.string().optional().default(""),
+}).passthrough();
+
+const packageSearchPackageSchema = z.object({
+    blocks: z.array(packageSearchBlockSchema).optional().default([]),
+    description: z.string().optional().default(""),
+    displayName: z.string().optional().default(""),
+    name: z.string().optional().default(""),
+    version: z.string().optional().default(""),
+}).passthrough();
+
+const packageSearchJsonResponseSchema = z.object({
+    packages: z.array(z.unknown()).optional().default([]),
+}).passthrough();
+
+const packageSearchResponseSchema = z.object({
+    packages: z.array(packageSearchPackageSchema).optional().default([]),
+}).passthrough();
+
+export interface ParsedPackageSearchResponse {
+    packages: PackageSearchResponse["packages"];
+    rawPackages: PackageSearchJsonResponse["packages"];
+}
+
+export type PackageSearchBlock = z.output<typeof packageSearchBlockSchema>;
+export type PackageSearchPackage = z.output<typeof packageSearchPackageSchema>;
+
+type PackageSearchJsonResponse = z.output<typeof packageSearchJsonResponseSchema>;
+type PackageSearchResponse = z.output<typeof packageSearchResponseSchema>;
+type PackageSearchTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
+
+export async function loadPackageSearchResponse(
+    options: {
+        account: Pick<AuthAccount, "apiKey" | "endpoint" | "id">;
+        locale: SupportedLocale;
+        text: string;
+    },
+    context: Pick<CliExecutionContext, "cacheStore" | "fetcher" | "logger">,
+): Promise<ParsedPackageSearchResponse> {
+    const requestUrl = createPackageSearchRequestUrl(
+        options.account.endpoint,
+        options.locale,
+        options.text,
+    );
+
+    return await loadPackageSearchResponseFromUrl(
+        requestUrl,
+        options.account,
+        context,
+    );
+}
+
+export function formatPackageSearchResultsAsText(
+    packages: readonly PackageSearchPackage[],
+    context: PackageSearchTextContext,
+): string {
+    const colors = createWriterColors(context.stdout);
+
+    return packages
+        .map(pkg => formatPackageSearchPackageAsText(pkg, context, { colors }))
+        .join("\n\n");
+}
+
+export function formatPackageSearchPackageAsText(
+    pkg: PackageSearchPackage,
+    context: PackageSearchTextContext,
+    options: {
+        colors?: TerminalColors;
+        extraLinesAfterDescription?: readonly string[];
+    } = {},
+): string {
+    const colors = options.colors ?? createWriterColors(context.stdout);
+    const lines = [readPackageSearchLabel(pkg, context, colors)];
+
+    if (pkg.description !== "") {
+        lines.push(pkg.description);
+    }
+
+    if (options.extraLinesAfterDescription !== undefined) {
+        lines.push(...options.extraLinesAfterDescription);
+    }
+
+    if (pkg.blocks.length > 0) {
+        lines.push(context.translator.t("labels.blocks"));
+
+        for (const block of pkg.blocks) {
+            lines.push(...formatPackageSearchBlock(block, context, colors));
+        }
+    }
+
+    return lines.join("\n");
+}
+
+export function readPackageSearchIds(
+    packages: readonly PackageSearchPackage[],
+): string[] {
+    return packages
+        .map(pkg => readPackageSearchId(pkg))
+        .filter(packageId => packageId !== "");
+}
+
+export function readPackageSearchId(
+    pkg: Pick<PackageSearchPackage, "name" | "version">,
+): string {
+    if (pkg.name === "") {
+        return "";
+    }
+
+    if (pkg.version === "") {
+        return pkg.name;
+    }
+
+    return `${pkg.name}@${pkg.version}`;
+}
+
+function createPackageSearchRequestUrl(
+    endpoint: string,
+    locale: SupportedLocale,
+    text: string,
+): URL {
+    const requestUrl = new URL(
+        `https://search.${endpoint}/v1/packages/-/intent-search`,
+    );
+
+    requestUrl.searchParams.set("q", truncatePackageSearchText(text));
+    requestUrl.searchParams.set("lang", resolveRequestLanguage(locale));
+
+    return requestUrl;
+}
+
+function truncatePackageSearchText(text: string): string {
+    const characters = Array.from(text);
+
+    if (characters.length <= MAX_SEARCH_TEXT_LENGTH) {
+        return text;
+    }
+
+    return characters.slice(0, MAX_SEARCH_TEXT_LENGTH).join("");
+}
+
+async function requestPackageSearch(
+    requestUrl: URL,
+    apiKey: string,
+    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+): Promise<string> {
+    return await requestText({
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.search.requestFailed",
+            1,
+            {
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.search.requestError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            start: {
+                queryLength: requestUrl.searchParams.get("q")?.length ?? 0,
+                requestLanguage: requestUrl.searchParams.get("lang") ?? "",
+            },
+        },
+        init: {
+            headers: {
+                Authorization: apiKey,
+            },
+        },
+        requestLabel: "Search",
+        requestUrl,
+    });
+}
+
+async function loadPackageSearchResponseFromUrl(
+    requestUrl: URL,
+    account: Pick<AuthAccount, "apiKey" | "endpoint" | "id">,
+    context: Pick<CliExecutionContext, "cacheStore" | "fetcher" | "logger">,
+): Promise<ParsedPackageSearchResponse> {
+    const searchCache = context.cacheStore.getCache<string>({
+        id: SEARCH_CACHE_ID,
+        defaultTtlMs: SEARCH_CACHE_TTL_MS,
+        maxEntries: SEARCH_CACHE_MAX_ENTRIES,
+    });
+    const cacheKey = JSON.stringify({
+        accountId: account.id,
+        endpoint: account.endpoint,
+        requestUrl: requestUrl.toString(),
+    });
+    const logFields = {
+        ...withAccountIdentity(account.id, account.endpoint),
+        ...withPath(requestUrl.pathname),
+    };
+    const cached = tryReadPackageSearchCache(
+        searchCache,
+        cacheKey,
+        logFields,
+        context,
+    );
+
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const rawResponse = await requestPackageSearch(
+        requestUrl,
+        account.apiKey,
+        context,
+    );
+    const response = parsePackageSearchResponse(rawResponse);
+
+    searchCache.set(cacheKey, rawResponse);
+    context.logger.debug(
+        {
+            ...logFields,
+            packageCount: response.packages.length,
+        },
+        "Search response cached.",
+    );
+
+    return response;
+}
+
+function tryReadPackageSearchCache(
+    cache: { delete: (key: string) => void; get: (key: string) => string | null },
+    cacheKey: string,
+    logFields: Record<string, unknown>,
+    context: Pick<CliExecutionContext, "logger">,
+): ParsedPackageSearchResponse | undefined {
+    const cachedResponse = cache.get(cacheKey);
+
+    if (cachedResponse === null) {
+        context.logger.debug(logFields, "Search response cache miss.");
+        return undefined;
+    }
+
+    context.logger.debug(logFields, "Search response cache hit.");
+
+    try {
+        return parsePackageSearchResponse(cachedResponse);
+    }
+    catch (error) {
+        if (
+            !(error instanceof CliUserError)
+            || error.key !== "errors.search.invalidResponse"
+        ) {
+            throw error;
+        }
+
+        cache.delete(cacheKey);
+        context.logger.warn(
+            logFields,
+            "Search response cache entry was invalidated after a parse failure.",
+        );
+
+        return undefined;
+    }
+}
+
+function parsePackageSearchResponse(
+    rawResponse: string,
+): ParsedPackageSearchResponse {
+    try {
+        const parsed = JSON.parse(rawResponse) as unknown;
+
+        return {
+            packages: packageSearchResponseSchema.parse(parsed).packages,
+            rawPackages: packageSearchJsonResponseSchema.parse(parsed).packages,
+        };
+    }
+    catch {
+        throw new CliUserError("errors.search.invalidResponse", 1);
+    }
+}
+
+function formatPackageSearchBlock(
+    block: PackageSearchBlock,
+    context: PackageSearchTextContext,
+    colors: TerminalColors,
+): string[] {
+    const label = readPackageSearchBlockLabel(block, context, colors);
+
+    if (block.description === "") {
+        return [label];
+    }
+
+    return [label, `  ${block.description}`];
+}
+
+function readPackageSearchLabel(
+    pkg: PackageSearchPackage,
+    context: PackageSearchTextContext,
+    colors: TerminalColors,
+): string {
+    const packageId = readPackageSearchId(pkg);
+
+    if (pkg.displayName !== "") {
+        const displayName = colors.hex(searchDisplayNameColor)(pkg.displayName);
+
+        if (packageId !== "" && pkg.displayName !== packageId) {
+            return `${displayName} (${packageId})`;
+        }
+
+        return displayName;
+    }
+
+    if (packageId !== "") {
+        return packageId;
+    }
+
+    return context.translator.t("search.text.unnamedPackage");
+}
+
+function readPackageSearchBlockLabel(
+    block: PackageSearchBlock,
+    context: PackageSearchTextContext,
+    colors: TerminalColors,
+): string {
+    if (block.title !== "") {
+        const title = colors.hex(searchBlockTitleColor)(block.title);
+
+        if (block.name !== "" && block.title !== block.name) {
+            return `- ${title} (${block.name})`;
+        }
+
+        return `- ${title}`;
+    }
+
+    if (block.name !== "") {
+        return `- ${block.name}`;
+    }
+
+    return `- ${context.translator.t("search.text.unnamedBlock")}`;
+}

--- a/src/application/commands/package/search.ts
+++ b/src/application/commands/package/search.ts
@@ -1,58 +1,16 @@
-import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
-import type { AuthAccount } from "../../schemas/auth.ts";
-import type { TerminalColors } from "../../terminal-colors.ts";
 import { z } from "zod";
-import { resolveRequestLanguage } from "../../../i18n/locale.ts";
-import { CliUserError } from "../../contracts/cli.ts";
-import {
-    withAccountIdentity,
-    withPath,
-} from "../../logging/log-fields.ts";
-import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
-import { requestText } from "../shared/request.ts";
+import {
+    formatPackageSearchResultsAsText,
+    loadPackageSearchResponse,
+    readPackageSearchIds,
+} from "./search-provider.ts";
 
-const MAX_SEARCH_TEXT_LENGTH = 200;
-const SEARCH_CACHE_ID = "search.intent-response";
-const SEARCH_CACHE_MAX_ENTRIES = 100;
-const SEARCH_CACHE_TTL_MS = 30_000;
 const searchFormatValues = ["json"] as const;
-const searchDisplayNameColor = "#59F78D";
-const searchBlockTitleColor = "#CAA8FA";
-
-const searchBlockSchema = z.object({
-    description: z.string().optional().default(""),
-    name: z.string().optional().default(""),
-    title: z.string().optional().default(""),
-}).passthrough();
-
-const searchPackageSchema = z.object({
-    blocks: z.array(searchBlockSchema).optional().default([]),
-    description: z.string().optional().default(""),
-    displayName: z.string().optional().default(""),
-    name: z.string().optional().default(""),
-    version: z.string().optional().default(""),
-}).passthrough();
-
-const searchJsonResponseSchema = z.object({
-    packages: z.array(z.unknown()).optional().default([]),
-}).passthrough();
-
-const searchResponseSchema = z.object({
-    packages: z.array(searchPackageSchema).optional().default([]),
-}).passthrough();
-
-interface ParsedSearchResponse {
-    json: SearchJsonResponse;
-    text: SearchResponse;
-}
-
-type SearchJsonResponse = z.output<typeof searchJsonResponseSchema>;
-type SearchResponse = z.output<typeof searchResponseSchema>;
-type SearchTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
 
 interface SearchInput {
     text: string;
@@ -88,25 +46,17 @@ export const packageSearchCommand: CliCommandDefinition<SearchInput> = {
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         const account = await requireCurrentAccount(context);
-        const query = truncateSearchText(input.text);
-        const requestUrl = new URL(
-            `https://search.${account.endpoint}/v1/packages/-/intent-search`,
-        );
-
-        requestUrl.searchParams.set("q", query);
-        requestUrl.searchParams.set(
-            "lang",
-            resolveRequestLanguage(context.translator.locale),
-        );
-
-        const response = await loadSearchResponse(
-            requestUrl,
-            account,
+        const response = await loadPackageSearchResponse(
+            {
+                account,
+                locale: context.translator.locale,
+                text: input.text,
+            },
             context,
         );
 
         if (input.onlyPackageId === true) {
-            const packageIds = readSearchPackageIds(response.text);
+            const packageIds = readPackageSearchIds(response.packages);
 
             if (input.format === "json") {
                 writeJsonOutput(context.stdout, packageIds);
@@ -122,11 +72,14 @@ export const packageSearchCommand: CliCommandDefinition<SearchInput> = {
         }
 
         if (input.format === "json") {
-            writeJsonOutput(context.stdout, response.json.packages);
+            writeJsonOutput(context.stdout, response.rawPackages);
             return;
         }
 
-        const output = formatSearchResponseAsText(response.text, context);
+        const output = formatPackageSearchResultsAsText(
+            response.packages,
+            context,
+        );
 
         context.stdout.write(
             output === ""
@@ -135,252 +88,3 @@ export const packageSearchCommand: CliCommandDefinition<SearchInput> = {
         );
     },
 };
-
-function truncateSearchText(text: string): string {
-    const characters = Array.from(text);
-
-    if (characters.length <= MAX_SEARCH_TEXT_LENGTH) {
-        return text;
-    }
-
-    return characters.slice(0, MAX_SEARCH_TEXT_LENGTH).join("");
-}
-
-async function requestSearch(
-    requestUrl: URL,
-    apiKey: string,
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
-): Promise<string> {
-    return await requestText({
-        context,
-        createRequestFailedError: status => new CliUserError(
-            "errors.search.requestFailed",
-            1,
-            {
-                status,
-            },
-        ),
-        createUnexpectedError: error => new CliUserError(
-            "errors.search.requestError",
-            1,
-            {
-                message: error instanceof Error ? error.message : String(error),
-            },
-        ),
-        fields: {
-            start: {
-                queryLength: requestUrl.searchParams.get("q")?.length ?? 0,
-                requestLanguage: requestUrl.searchParams.get("lang") ?? "",
-            },
-        },
-        init: {
-            headers: {
-                Authorization: apiKey,
-            },
-        },
-        requestLabel: "Search",
-        requestUrl,
-    });
-}
-
-async function loadSearchResponse(
-    requestUrl: URL,
-    account: Pick<AuthAccount, "apiKey" | "endpoint" | "id">,
-    context: Pick<CliExecutionContext, "cacheStore" | "fetcher" | "logger">,
-): Promise<ParsedSearchResponse> {
-    const searchCache = context.cacheStore.getCache<string>({
-        id: SEARCH_CACHE_ID,
-        defaultTtlMs: SEARCH_CACHE_TTL_MS,
-        maxEntries: SEARCH_CACHE_MAX_ENTRIES,
-    });
-    const cacheKey = JSON.stringify({
-        accountId: account.id,
-        endpoint: account.endpoint,
-        requestUrl: requestUrl.toString(),
-    });
-    const logFields = {
-        ...withAccountIdentity(account.id, account.endpoint),
-        ...withPath(requestUrl.pathname),
-    };
-
-    const cached = tryReadSearchCache(searchCache, cacheKey, logFields, context);
-
-    if (cached !== undefined) {
-        return cached;
-    }
-
-    const rawResponse = await requestSearch(requestUrl, account.apiKey, context);
-    const response = parseSearchResponse(rawResponse);
-
-    searchCache.set(cacheKey, rawResponse);
-    context.logger.debug(
-        {
-            ...logFields,
-            packageCount: response.text.packages.length,
-        },
-        "Search response cached.",
-    );
-
-    return response;
-}
-
-function tryReadSearchCache(
-    cache: { delete: (key: string) => void; get: (key: string) => string | null },
-    cacheKey: string,
-    logFields: Record<string, unknown>,
-    context: Pick<CliExecutionContext, "logger">,
-): ParsedSearchResponse | undefined {
-    const cachedResponse = cache.get(cacheKey);
-
-    if (cachedResponse === null) {
-        context.logger.debug(logFields, "Search response cache miss.");
-        return undefined;
-    }
-
-    context.logger.debug(logFields, "Search response cache hit.");
-
-    try {
-        return parseSearchResponse(cachedResponse);
-    }
-    catch (error) {
-        if (
-            !(error instanceof CliUserError)
-            || error.key !== "errors.search.invalidResponse"
-        ) {
-            throw error;
-        }
-
-        cache.delete(cacheKey);
-        context.logger.warn(
-            logFields,
-            "Search response cache entry was invalidated after a parse failure.",
-        );
-
-        return undefined;
-    }
-}
-
-function parseSearchResponse(rawResponse: string): ParsedSearchResponse {
-    try {
-        const parsed = JSON.parse(rawResponse) as unknown;
-
-        return {
-            json: searchJsonResponseSchema.parse(parsed),
-            text: searchResponseSchema.parse(parsed),
-        };
-    }
-    catch {
-        throw new CliUserError("errors.search.invalidResponse", 1);
-    }
-}
-
-function formatSearchResponseAsText(
-    response: SearchResponse,
-    context: SearchTextContext,
-): string {
-    const colors = createWriterColors(context.stdout);
-
-    return response.packages
-        .map(pkg => formatSearchPackage(pkg, context, colors))
-        .join("\n\n");
-}
-
-function readSearchPackageIds(response: SearchResponse): string[] {
-    return response.packages
-        .map(pkg => readPackageId(pkg))
-        .filter(id => id !== "");
-}
-
-function formatSearchPackage(
-    pkg: SearchResponse["packages"][number],
-    context: SearchTextContext,
-    colors: TerminalColors,
-): string {
-    const lines = [readPackageLabel(pkg, context, colors)];
-
-    if (pkg.description !== "") {
-        lines.push(pkg.description);
-    }
-
-    if (pkg.blocks.length > 0) {
-        lines.push(context.translator.t("labels.blocks"));
-
-        for (const block of pkg.blocks) {
-            lines.push(...formatSearchBlock(block, context, colors));
-        }
-    }
-
-    return lines.join("\n");
-}
-
-function formatSearchBlock(
-    block: SearchResponse["packages"][number]["blocks"][number],
-    context: SearchTextContext,
-    colors: TerminalColors,
-): string[] {
-    const label = readBlockLabel(block, context, colors);
-
-    if (block.description === "") {
-        return [label];
-    }
-
-    return [label, `  ${block.description}`];
-}
-
-function readPackageLabel(
-    pkg: SearchResponse["packages"][number],
-    context: SearchTextContext,
-    colors: TerminalColors,
-): string {
-    const packageId = readPackageId(pkg);
-
-    if (pkg.displayName !== "") {
-        const displayName = colors.hex(searchDisplayNameColor)(pkg.displayName);
-
-        if (packageId !== "" && pkg.displayName !== packageId) {
-            return `${displayName} (${packageId})`;
-        }
-
-        return displayName;
-    }
-
-    if (packageId !== "") {
-        return packageId;
-    }
-
-    return context.translator.t("search.text.unnamedPackage");
-}
-
-function readPackageId(pkg: SearchResponse["packages"][number]): string {
-    if (pkg.name === "") {
-        return "";
-    }
-
-    if (pkg.version === "") {
-        return pkg.name;
-    }
-
-    return `${pkg.name}@${pkg.version}`;
-}
-
-function readBlockLabel(
-    block: SearchResponse["packages"][number]["blocks"][number],
-    context: SearchTextContext,
-    colors: TerminalColors,
-): string {
-    if (block.title !== "") {
-        const title = colors.hex(searchBlockTitleColor)(block.title);
-
-        if (block.name !== "" && block.title !== block.name) {
-            return `- ${title} (${block.name})`;
-        }
-
-        return `- ${title}`;
-    }
-
-    if (block.name !== "") {
-        return `- ${block.name}`;
-    }
-
-    return `- ${context.translator.t("search.text.unnamedBlock")}`;
-}

--- a/src/application/commands/search.cli.test.ts
+++ b/src/application/commands/search.cli.test.ts
@@ -1,0 +1,318 @@
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    createCliSandbox,
+    createCliSnapshot,
+    readLatestLogContent,
+    toRequest,
+    writeAuthFile,
+} from "../../../__tests__/helpers.ts";
+import { APP_NAME } from "../config/app-config.ts";
+import { createTerminalColors } from "../terminal-colors.ts";
+import { resolveConnectorActionSchemaPath } from "./connector/schema-cache.ts";
+import { mixedSearchKindColor } from "./search.ts";
+
+describe("mixedSearchCommand CLI", () => {
+    test("supports mixed search with text output and groups results by source", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["search", "send mail", "--keywords=gmail,email,gmail"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (
+                            request.url.startsWith("https://search.")
+                            && request.url.includes("/v1/packages/-/intent-search")
+                        ) {
+                            return new Response(JSON.stringify({
+                                packages: [
+                                    {
+                                        blocks: [
+                                            {
+                                                description: "Send templated emails.",
+                                                name: "send-email",
+                                                title: "Send Email",
+                                            },
+                                        ],
+                                        description: "Email automation package.",
+                                        displayName: "Mail Tools",
+                                        name: "@oomol/mail-tools",
+                                        version: "1.2.3",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.startsWith("https://search.")) {
+                            return new Response(JSON.stringify({
+                                data: [
+                                    {
+                                        description: "Send a Gmail message.",
+                                        inputSchema: {
+                                            type: "object",
+                                        },
+                                        name: "send_mail",
+                                        outputSchema: {
+                                            type: "object",
+                                        },
+                                        service: "gmail",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: ["gmail"],
+                        }));
+                    },
+                },
+            );
+            const logContent = await readLatestLogContent(sandbox);
+
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
+            expect(requests.map(request => request.url).sort()).toEqual([
+                "https://connector.oomol.com/v1/apps/authenticated?service=gmail",
+                "https://search.oomol.com/v1/connector-actions?q=send+mail&keywords=gmail%2Cemail",
+                "https://search.oomol.com/v1/packages/-/intent-search?q=send+mail&lang=en",
+            ]);
+            expect(logContent).toContain(`"path":"/v1/packages/-/intent-search"`);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports mixed search with json output", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["search", "send mail", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (
+                            request.url.startsWith("https://search.")
+                            && request.url.includes("/v1/packages/-/intent-search")
+                        ) {
+                            return new Response(JSON.stringify({
+                                packages: [
+                                    {
+                                        blocks: [
+                                            {
+                                                title: "Send Email",
+                                            },
+                                        ],
+                                        description: "Email automation package.",
+                                        displayName: "Mail Tools",
+                                        name: "@oomol/mail-tools",
+                                        version: "1.2.3",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.startsWith("https://search.")) {
+                            return new Response(JSON.stringify({
+                                data: [
+                                    {
+                                        description: "Send a Gmail message.",
+                                        inputSchema: {
+                                            type: "object",
+                                        },
+                                        name: "send_mail",
+                                        outputSchema: {
+                                            type: "object",
+                                        },
+                                        service: "gmail",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: [],
+                        }));
+                    },
+                },
+            );
+
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
+            expect(JSON.parse(result.stdout)).toEqual([
+                {
+                    blocks: [
+                        {
+                            description: "",
+                            name: "",
+                            title: "Send Email",
+                        },
+                    ],
+                    description: "Email automation package.",
+                    displayName: "Mail Tools",
+                    kind: "package",
+                    packageId: "@oomol/mail-tools@1.2.3",
+                },
+                {
+                    authenticated: false,
+                    description: "Send a Gmail message.",
+                    kind: "connector",
+                    name: "send_mail",
+                    schemaPath: resolveConnectorActionSchemaPath(
+                        join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml"),
+                        "gmail",
+                        "send_mail",
+                    ),
+                    service: "gmail",
+                },
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders kind lines after descriptions with field-specific colors", async () => {
+        const sandbox = await createCliSandbox();
+        const colors = createTerminalColors(true);
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["search", "send mail"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (
+                            request.url.startsWith("https://search.")
+                            && request.url.includes("/v1/packages/-/intent-search")
+                        ) {
+                            return new Response(JSON.stringify({
+                                packages: [
+                                    {
+                                        description: "Email automation package.",
+                                        displayName: "Mail Tools",
+                                        name: "@oomol/mail-tools",
+                                        version: "1.2.3",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.startsWith("https://search.")) {
+                            return new Response(JSON.stringify({
+                                data: [
+                                    {
+                                        description: "Send a Gmail message.",
+                                        inputSchema: {
+                                            type: "object",
+                                        },
+                                        name: "send_mail",
+                                        outputSchema: {
+                                            type: "object",
+                                        },
+                                        service: "gmail",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: [],
+                        }));
+                    },
+                    stdout: {
+                        hasColors: true,
+                    },
+                },
+            );
+            const strippedSnapshot = createCliSnapshot(result, {
+                sandbox,
+                stripAnsi: true,
+            });
+
+            expect(strippedSnapshot).toMatchSnapshot();
+            expect(result.stdout).toContain(
+                `Kind: ${colors.hex(mixedSearchKindColor)("package")}`,
+            );
+            expect(result.stdout).toContain(
+                `Kind: ${colors.hex(mixedSearchKindColor)("connector")}`,
+            );
+            expect(strippedSnapshot.stdout).toContain(
+                "Mail Tools (@oomol/mail-tools@1.2.3)\nEmail automation package.\nKind: package",
+            );
+            expect(strippedSnapshot.stdout).toContain(
+                "gmail.send_mail\nSend a Gmail message.\nKind: connector",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders mixed search no-results output when both providers are empty", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["search", "send mail"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (
+                            request.url.startsWith("https://search.")
+                            && request.url.includes("/v1/packages/-/intent-search")
+                        ) {
+                            return new Response(JSON.stringify({
+                                packages: [],
+                            }));
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: [],
+                        }));
+                    },
+                },
+            );
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders mixed search help when text argument is omitted", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const expectedHelp = await sandbox.run(["search", "--help"]);
+            const result = await sandbox.run(["search"]);
+
+            expect({
+                expectedHelp: createCliSnapshot(expectedHelp),
+                result: createCliSnapshot(result),
+            }).toMatchSnapshot();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/search.ts
+++ b/src/application/commands/search.ts
@@ -1,0 +1,213 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../contracts/cli.ts";
+import type { TerminalColors } from "../terminal-colors.ts";
+import type { ConnectorSearchResult } from "./connector/search-provider.ts";
+import type {
+    PackageSearchBlock,
+    PackageSearchPackage,
+} from "./package/search-provider.ts";
+
+import { z } from "zod";
+
+import { createWriterColors } from "../terminal-colors.ts";
+import {
+    formatConnectorSearchResultAsText,
+    loadConnectorSearchResults,
+} from "./connector/search-provider.ts";
+import { jsonOutputOptions, writeJsonOutput } from "./json-output.ts";
+import {
+    formatPackageSearchPackageAsText,
+    loadPackageSearchResponse,
+    readPackageSearchId,
+} from "./package/search-provider.ts";
+import { requireCurrentAccount } from "./shared/auth-utils.ts";
+import { createFormatInputError } from "./shared/input-parsing.ts";
+import { parseCommaSeparatedKeywords } from "./shared/keywords.ts";
+
+const searchFormatValues = ["json"] as const;
+export const mixedSearchKindColor = "#7FDBFF";
+
+interface MixedSearchInput {
+    format?: (typeof searchFormatValues)[number];
+    keywords?: string;
+    text: string;
+}
+
+interface MixedPackageSearchItem {
+    blocks: {
+        description: string;
+        name: string;
+        title: string;
+    }[];
+    description: string;
+    displayName: string;
+    kind: "package";
+    packageId: string;
+}
+
+interface MixedConnectorSearchItem {
+    authenticated: boolean;
+    description: string;
+    kind: "connector";
+    name: string;
+    schemaPath: string;
+    service: string;
+}
+
+type MixedSearchItem = MixedPackageSearchItem | MixedConnectorSearchItem;
+type MixedSearchTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
+
+export const mixedSearchCommand: CliCommandDefinition<MixedSearchInput> = {
+    name: "search",
+    summaryKey: "commands.mixedSearch.summary",
+    descriptionKey: "commands.mixedSearch.description",
+    missingArgumentBehavior: "showHelp",
+    arguments: [
+        {
+            name: "text",
+            descriptionKey: "arguments.text",
+            required: true,
+        },
+    ],
+    options: [
+        ...jsonOutputOptions,
+        {
+            name: "keywords",
+            longFlag: "--keywords",
+            valueName: "keywords",
+            descriptionKey: "options.connectorKeywords",
+        },
+    ],
+    inputSchema: z.object({
+        format: z.enum(searchFormatValues).optional(),
+        keywords: z.string().optional(),
+        text: z.string(),
+    }),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+    handler: async (input, context) => {
+        const account = await requireCurrentAccount(context);
+        const keywords = parseCommaSeparatedKeywords(input.keywords);
+        const [packageResponse, connectorResults] = await Promise.all([
+            loadPackageSearchResponse(
+                {
+                    account,
+                    locale: context.translator.locale,
+                    text: input.text,
+                },
+                context,
+            ),
+            loadConnectorSearchResults(
+                {
+                    apiKey: account.apiKey,
+                    endpoint: account.endpoint,
+                    keywords,
+                    text: input.text,
+                },
+                context,
+            ),
+        ]);
+
+        if (input.format === "json") {
+            writeJsonOutput(
+                context.stdout,
+                createMixedSearchItems(
+                    packageResponse.packages,
+                    connectorResults,
+                ),
+            );
+            return;
+        }
+
+        const output = formatMixedSearchResultsAsText(
+            packageResponse.packages,
+            connectorResults,
+            context,
+        );
+
+        context.stdout.write(
+            output === ""
+                ? `${context.translator.t("mixedSearch.text.noResults")}\n`
+                : `${output}\n`,
+        );
+    },
+};
+
+function createMixedSearchItems(
+    packages: readonly PackageSearchPackage[],
+    connectorResults: readonly ConnectorSearchResult[],
+): MixedSearchItem[] {
+    return [
+        ...packages.map(createMixedPackageSearchItem),
+        ...connectorResults.map(createMixedConnectorSearchItem),
+    ];
+}
+
+function createMixedPackageSearchItem(
+    pkg: PackageSearchPackage,
+): MixedPackageSearchItem {
+    return {
+        blocks: pkg.blocks.map(createMixedPackageSearchBlock),
+        description: pkg.description,
+        displayName: pkg.displayName,
+        kind: "package",
+        packageId: readPackageSearchId(pkg),
+    };
+}
+
+function createMixedPackageSearchBlock(
+    block: PackageSearchBlock,
+): MixedPackageSearchItem["blocks"][number] {
+    return {
+        description: block.description,
+        name: block.name,
+        title: block.title,
+    };
+}
+
+function createMixedConnectorSearchItem(
+    result: ConnectorSearchResult,
+): MixedConnectorSearchItem {
+    return {
+        authenticated: result.authenticated,
+        description: result.description,
+        kind: "connector",
+        name: result.name,
+        schemaPath: result.schemaPath,
+        service: result.service,
+    };
+}
+
+function formatMixedSearchResultsAsText(
+    packages: readonly PackageSearchPackage[],
+    connectorResults: readonly ConnectorSearchResult[],
+    context: MixedSearchTextContext,
+): string {
+    const colors = createWriterColors(context.stdout);
+    const packageKindLine = readMixedSearchKindLine("package", context, colors);
+    const connectorKindLine = readMixedSearchKindLine("connector", context, colors);
+
+    return [
+        ...packages.map(pkg => formatPackageSearchPackageAsText(pkg, context, {
+            colors,
+            extraLinesAfterDescription: [packageKindLine],
+        })),
+        ...connectorResults.map(result => formatConnectorSearchResultAsText(result, context, {
+            colors,
+            extraLinesAfterDescription: [connectorKindLine],
+        })),
+    ].join("\n\n");
+}
+
+function readMixedSearchKindLine(
+    kind: MixedSearchItem["kind"],
+    context: MixedSearchTextContext,
+    colors: TerminalColors,
+): string {
+    const kindLabelKey = kind === "package"
+        ? "mixedSearch.text.kind.package"
+        : "mixedSearch.text.kind.connector";
+    const kindValue = colors.hex(mixedSearchKindColor)(
+        context.translator.t(kindLabelKey),
+    );
+
+    return `${context.translator.t("mixedSearch.text.kind")}: ${kindValue}`;
+}

--- a/src/application/commands/shared/json-schema-validation.ts
+++ b/src/application/commands/shared/json-schema-validation.ts
@@ -75,25 +75,13 @@ function createAjv(): Ajv {
 function stripSchemaDialectDeclaration(
     value: unknown,
 ): unknown {
-    if (Array.isArray(value)) {
-        return value.map(item => stripSchemaDialectDeclaration(item));
-    }
-
     if (!isPlainObject(value)) {
         return value;
     }
 
-    const entries: [string, unknown][] = [];
+    const { $schema: _schemaDialect, ...schemaWithoutDialect } = value;
 
-    for (const [key, entryValue] of Object.entries(value)) {
-        if (key === "$schema") {
-            continue;
-        }
-
-        entries.push([key, stripSchemaDialectDeclaration(entryValue)]);
-    }
-
-    return Object.fromEntries(entries);
+    return schemaWithoutDialect;
 }
 
 function isHexColorString(value: string): boolean {

--- a/src/application/commands/shared/json-schema-validation.ts
+++ b/src/application/commands/shared/json-schema-validation.ts
@@ -75,13 +75,25 @@ function createAjv(): Ajv {
 function stripSchemaDialectDeclaration(
     value: unknown,
 ): unknown {
+    if (Array.isArray(value)) {
+        return value.map(item => stripSchemaDialectDeclaration(item));
+    }
+
     if (!isPlainObject(value)) {
         return value;
     }
 
-    const { $schema: _schemaDialect, ...schemaWithoutDialect } = value;
+    const entries: [string, unknown][] = [];
 
-    return schemaWithoutDialect;
+    for (const [key, entryValue] of Object.entries(value)) {
+        if (key === "$schema") {
+            continue;
+        }
+
+        entries.push([key, stripSchemaDialectDeclaration(entryValue)]);
+    }
+
+    return Object.fromEntries(entries);
 }
 
 function isHexColorString(value: string): boolean {

--- a/src/application/commands/shared/keywords.test.ts
+++ b/src/application/commands/shared/keywords.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseCommaSeparatedKeywords } from "./keywords.ts";
+
+describe("parseCommaSeparatedKeywords", () => {
+    test("trims empty values and removes duplicates", () => {
+        expect(parseCommaSeparatedKeywords(" gmail, email ,,gmail, inbox ")).toEqual([
+            "gmail",
+            "email",
+            "inbox",
+        ]);
+    });
+
+    test("returns an empty list when the option is omitted", () => {
+        expect(parseCommaSeparatedKeywords(undefined)).toEqual([]);
+    });
+});

--- a/src/application/commands/shared/keywords.ts
+++ b/src/application/commands/shared/keywords.ts
@@ -1,0 +1,23 @@
+export function parseCommaSeparatedKeywords(
+    value: string | undefined,
+): string[] {
+    if (value === undefined) {
+        return [];
+    }
+
+    const keywords: string[] = [];
+    const seen = new Set<string>();
+
+    for (const segment of value.split(",")) {
+        const keyword = segment.trim();
+
+        if (keyword === "" || seen.has(keyword)) {
+            continue;
+        }
+
+        seen.add(keyword);
+        keywords.push(keyword);
+    }
+
+    return keywords;
+}

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -30,25 +30,26 @@ exports[`skills CLI silently installs the managed bundled skill on the first run
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  connector           Manage connector actions
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  help [command]           Show help for a command
 "
 ,
 }
@@ -62,25 +63,26 @@ exports[`skills CLI does not auto-install the managed bundled skill during local
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  connector           Manage connector actions
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  help [command]           Show help for a command
 "
 ,
 }
@@ -105,25 +107,26 @@ exports[`skills CLI synchronizes the managed bundled skill policy from persisted
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  connector           Manage connector actions
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  help [command]           Show help for a command
 "
 ,
 }
@@ -137,25 +140,26 @@ exports[`skills CLI silently installs bundled skills into Claude Code on the fir
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version       Show the current version
-  --debug             Print the current log file path when the CLI exits
-  --lang <lang>       Specify the display language
-  -h, --help          Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                Manage CLI authentication
-  check-update        Check for CLI updates
-  cloud-task          Manage cloud tasks
-  connector           Manage connector actions
-  file                Manage temporary file transfers
-  login               Log in with a browser flow (alias for auth login)
-  logout              Log out the current account (alias for auth logout)
-  completion <shell>  Generate shell completion scripts
-  config              Manage persisted configuration
-  skills              Manage Codex skills
-  log                 Manage persisted debug logs
-  packages            Package utilities
-  help [command]      Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with a browser flow (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  help [command]           Show help for a command
 "
 ,
 }

--- a/src/application/commands/skills/search.ts
+++ b/src/application/commands/skills/search.ts
@@ -7,6 +7,7 @@ import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
+import { parseCommaSeparatedKeywords } from "../shared/keywords.ts";
 import { requestText } from "../shared/request.ts";
 
 const searchFormatValues = ["json"] as const;
@@ -76,7 +77,7 @@ export const skillsSearchCommand: CliCommandDefinition<SkillsSearchInput> = {
         const requestUrl = createSkillsSearchRequestUrl(
             account.endpoint,
             input.text,
-            parseSkillSearchKeywords(input.keywords),
+            parseCommaSeparatedKeywords(input.keywords),
         );
         const response = parseSkillsSearchResponse(
             await requestSkillsSearch(requestUrl, account.apiKey, context),
@@ -115,28 +116,6 @@ function createSkillsSearchRequestUrl(
     requestUrl.searchParams.set("size", String(skillSearchResultLimit));
 
     return requestUrl;
-}
-
-function parseSkillSearchKeywords(value: string | undefined): string[] {
-    if (value === undefined) {
-        return [];
-    }
-
-    const keywords: string[] = [];
-    const seen = new Set<string>();
-
-    for (const segment of value.split(",")) {
-        const keyword = segment.trim();
-
-        if (keyword === "" || seen.has(keyword)) {
-            continue;
-        }
-
-        seen.add(keyword);
-        keywords.push(keyword);
-    }
-
-    return keywords;
 }
 
 async function requestSkillsSearch(

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -108,6 +108,10 @@ export const enMessages = {
         "Show transformed package metadata for an explicit package specifier.",
     "commands.package.info.summary": "Show package metadata",
     "commands.package.summary": "Package utilities",
+    "commands.mixedSearch.description":
+        "Search packages and connector actions with one free-form query.",
+    "commands.mixedSearch.summary":
+        "Search packages and connector actions",
     "commands.search.description":
         "Search packages with free-form text against the intent search API.",
     "commands.search.summary": "Search packages by intent",
@@ -535,6 +539,11 @@ export const enMessages = {
     "connector.search.text.noResults":
         "No matching connector actions were found.",
     "connector.search.text.schemaPath": "Schema path",
+    "mixedSearch.text.kind": "Kind",
+    "mixedSearch.text.kind.connector": "connector",
+    "mixedSearch.text.kind.package": "package",
+    "mixedSearch.text.noResults":
+        "No matching packages or connector actions were found.",
     "connector.run.text.dryRunPassed": "Validation passed.",
     "connector.run.text.executionId": "Execution ID",
     "connector.run.text.resultData": "Result data",
@@ -657,6 +666,10 @@ export const zhMessages = {
     "commands.package.info.description": "按显式包标识显示转换后的包元数据。",
     "commands.package.info.summary": "显示包元数据",
     "commands.package.summary": "包相关工具",
+    "commands.mixedSearch.description":
+        "使用一个自由文本查询同时搜索 package 与 connector action。",
+    "commands.mixedSearch.summary":
+        "搜索 package 与 connector action",
     "commands.search.description": "使用自由文本通过意图搜索 API 搜索包。",
     "commands.search.summary": "按意图搜索包",
     "commands.skills.description": "管理 Codex skill 及其配置。",
@@ -1066,6 +1079,10 @@ export const zhMessages = {
     "connector.search.text.authenticated.yes": "是",
     "connector.search.text.noResults": "未找到匹配的 connector action。",
     "connector.search.text.schemaPath": "Schema 路径",
+    "mixedSearch.text.kind": "类型",
+    "mixedSearch.text.kind.connector": "connector",
+    "mixedSearch.text.kind.package": "包",
+    "mixedSearch.text.noResults": "未找到匹配的包或 connector action。",
     "connector.run.text.dryRunPassed": "校验通过。",
     "connector.run.text.executionId": "执行 ID",
     "connector.run.text.resultData": "结果数据",


### PR DESCRIPTION
Introduce a top-level `search` command that queries packages and
connector actions with one free-form text and merges results into a
single output. Extract the existing package and connector search logic
into shared providers so both the dedicated subcommands and the new
unified command reuse the same discovery path, and add a small
keywords helper for parsing the `--keywords` option. Update English
and Chinese command docs to describe the new command and its stable
output shape.