### PR TITLE
fix(cli): defer stdin initialization to avoid terminal state race

### DIFF
--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -22,7 +22,7 @@ import { resolveCodexHomeDirectory } from "../commands/skills/bundled-skill-path
 import { APP_NAME } from "../config/app-config.ts";
 import { CliUserError } from "../contracts/cli.ts";
 import { createTerminalColors } from "../terminal-colors.ts";
-import { executeCli } from "./run-cli.ts";
+import { createLazyInput, executeCli } from "./run-cli.ts";
 
 describe("runCli bootstrap", () => {
     test("keeps the cli command name aligned with package metadata", () => {
@@ -614,3 +614,57 @@ function createFailingSettingsStore(error: Error): SettingsStore {
         },
     };
 }
+
+describe("createLazyInput", () => {
+    test("does not call the factory until a property is accessed", () => {
+        let called = false;
+        const inner = createInteractiveInput();
+
+        createLazyInput(() => {
+            called = true;
+            return inner;
+        });
+
+        expect(called).toBe(false);
+    });
+
+    test("calls the factory on first property access and caches the result", () => {
+        let callCount = 0;
+        const inner = createInteractiveInput();
+        const lazy = createLazyInput(() => {
+            callCount += 1;
+            return inner;
+        });
+
+        void lazy.isTTY;
+        void lazy.isTTY;
+
+        expect(callCount).toBe(1);
+    });
+
+    test("delegates isTTY to the underlying input", () => {
+        const inner = createInteractiveInput();
+        const lazy = createLazyInput(() => inner);
+
+        expect(lazy.isTTY).toBe(true);
+    });
+
+    test("delegates on and off to the underlying input", () => {
+        const inner = createInteractiveInput();
+        const lazy = createLazyInput(() => inner);
+        const received: Array<string | Uint8Array> = [];
+        const listener = (chunk: string | Uint8Array): void => {
+            received.push(chunk);
+        };
+
+        lazy.on("data", listener);
+        inner.feed("hello");
+
+        expect(received.length).toBe(1);
+
+        lazy.off("data", listener);
+        inner.feed("world");
+
+        expect(received.length).toBe(1);
+    });
+});

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -91,7 +91,7 @@ export async function runCli(argv: string[]): Promise<number> {
         cwd: process.cwd(),
         env: process.env,
         fetcher: fetch,
-        stdin: process.stdin,
+        stdin: createLazyStdin(),
         stdout: process.stdout,
         stderr: process.stderr,
         systemLocale: getSystemLocale(),
@@ -503,6 +503,48 @@ function closeCleanupResources(
     }
 
     return nextExitCode;
+}
+
+function createLazyStdin(): InteractiveInput {
+    // Defer access to process.stdin until a command actually needs interactive
+    // input.  Eagerly evaluating process.stdin causes the runtime to initialise
+    // a TTY handle and save the terminal state.  On exit it restores that state,
+    // which can race with a downstream process (e.g. `fx`) that has already
+    // switched the terminal to raw mode, breaking its keyboard input.
+    return createLazyInput(() => process.stdin);
+}
+
+// Exported for testing. Creates a lazy proxy around an InteractiveInput source
+// that defers the factory call until one of the proxy's properties or methods
+// is first accessed.
+export function createLazyInput(factory: () => InteractiveInput): InteractiveInput {
+    let resolved: InteractiveInput | undefined;
+
+    function source(): InteractiveInput {
+        resolved ??= factory();
+        return resolved;
+    }
+
+    return {
+        get isTTY() {
+            return source().isTTY;
+        },
+        setRawMode(value: boolean) {
+            source().setRawMode?.(value);
+        },
+        resume() {
+            source().resume?.();
+        },
+        pause() {
+            source().pause?.();
+        },
+        on(event: "data", listener: (chunk: string | Uint8Array) => void) {
+            source().on(event, listener);
+        },
+        off(event: "data", listener: (chunk: string | Uint8Array) => void) {
+            source().off(event, listener);
+        },
+    };
 }
 
 function createDetachedStdin(): InteractiveInput {


### PR DESCRIPTION
Eagerly accessing process.stdin causes the runtime to initialise a TTY handle and save terminal state on startup. On exit it restores that state, which can race with a downstream process (e.g. fx) that has already switched the terminal to raw mode, breaking its keyboard input. Wrap stdin in a lazy proxy so the TTY handle is only created when a command actually needs interactive input.