### PR TITLE
feat(login): replace browser callback with device flow

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -8,7 +8,6 @@ import type { FileUploadRecordStore } from "../src/application/contracts/file-up
 import type { SettingsStore } from "../src/application/contracts/settings-store.ts";
 import type { AuthFile } from "../src/application/schemas/auth.ts";
 import type { AppSettings } from "../src/application/schemas/settings.ts";
-import { Buffer } from "node:buffer";
 import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 
@@ -111,6 +110,7 @@ export interface AuthAccountFixture {
 export interface PrintedAuthLoginOptions {
     accountEndpoint?: string;
     argv?: readonly string[];
+    verificationUrl?: string;
     stdoutHasColors?: boolean;
 }
 
@@ -371,31 +371,48 @@ export async function runPrintedAuthLogin(
     apiKeyValue: string,
     options: PrintedAuthLoginOptions = {},
 ): Promise<CliRunResult> {
-    const stdout = createTextBuffer({
-        hasColors: options.stdoutHasColors,
-    });
-    const stderr = createTextBuffer();
-    const execution = executeCliInvocation({
-        argv: options.argv ?? ["auth", "login"],
-        cwd: sandbox.cwd,
-        env: sandbox.env,
-        stdout: stdout.writer,
-        stderr: stderr.writer,
-        systemLocale: "en-US",
-    });
-    const loginUrl = await waitForLoginUrl(stdout);
+    const accountEndpoint = options.accountEndpoint ?? defaultAuthEndpoint;
+    const verificationUrl = options.verificationUrl
+        ?? `https://${accountEndpoint}/login/device`;
 
-    await completeLoginCallback(
-        loginUrl,
-        apiKeyValue,
-        options.accountEndpoint ?? defaultAuthEndpoint,
-    );
+    return await sandbox.run(options.argv ?? ["auth", "login"], {
+        fetcher: async (input, init) => {
+            const request = toRequest(input, init);
+            const requestUrl = new URL(request.url);
 
-    return {
-        exitCode: await execution,
-        stdout: stdout.read(),
-        stderr: stderr.read(),
-    };
+            if (
+                request.method === "POST"
+                && requestUrl.host === `api.${accountEndpoint}`
+                && requestUrl.pathname === "/v1/auth/device_login/code"
+            ) {
+                return new Response(JSON.stringify({
+                    code: "M0KO41",
+                    expires_in: 1800,
+                    status: "waiting",
+                    verify_code_url: verificationUrl,
+                }));
+            }
+
+            if (
+                request.method === "GET"
+                && requestUrl.host === `api.${accountEndpoint}`
+                && requestUrl.pathname === "/v1/auth/device_login/result"
+            ) {
+                return new Response(JSON.stringify({
+                    api_key: apiKeyValue,
+                    endpoint: accountEndpoint,
+                    id: "user-1",
+                    name: "Alice",
+                    status: "verified",
+                }));
+            }
+
+            throw new Error(`Unexpected auth login request: ${request.method} ${requestUrl}`);
+        },
+        stdout: {
+            hasColors: options.stdoutHasColors,
+        },
+    });
 }
 
 export async function readLatestLogContent(sandbox: CliSandbox): Promise<string> {
@@ -475,7 +492,7 @@ export function expectCliSnapshot(
 }
 
 export function readAuthLoginUrlPrefix(endpoint: string): string {
-    return `https://api.${endpoint}/v1/auth/redirect?`;
+    return `https://${endpoint}/login/device`;
 }
 
 export interface ConnectorActionFixtureOverrides {
@@ -535,24 +552,6 @@ export async function expectCliUserError(
     throw new Error("Expected a CliUserError to be thrown.");
 }
 
-async function waitForLoginUrl(
-    stdout: ReturnType<typeof createTextBuffer>,
-): Promise<string> {
-    const deadline = Date.now() + 1000;
-
-    while (Date.now() < deadline) {
-        const loginUrl = findLoginUrl(stdout.read());
-
-        if (loginUrl !== undefined) {
-            return loginUrl;
-        }
-
-        await Bun.sleep(10);
-    }
-
-    throw new Error("Timed out waiting for the printed login URL.");
-}
-
 export function findLoginUrl(output: string): string | undefined {
     const plainOutput = createTerminalColors(true).strip(output);
 
@@ -565,7 +564,7 @@ export function findLoginUrl(output: string): string | undefined {
 
         const candidate = line.slice(urlStart).trim();
 
-        if (candidate.includes("/v1/auth/redirect?")) {
+        if (candidate !== "") {
             return candidate;
         }
     }
@@ -706,33 +705,6 @@ function createSandboxSnapshotReplacements(
             value: sandbox.env.XDG_STATE_HOME,
         },
     ];
-}
-
-async function completeLoginCallback(
-    loginUrlValue: string,
-    apiKeyValue: string,
-    endpoint: string,
-): Promise<void> {
-    const loginUrl = new URL(loginUrlValue);
-
-    expect(loginUrl.searchParams.get("cli_login")).toBe("true");
-
-    const redirectUrl = loginUrl.searchParams.get("redirect");
-
-    expect(redirectUrl).toBeTruthy();
-
-    const callbackUrl = new URL(redirectUrl!);
-    const requestUrl = new URL(callbackUrl.toString());
-    const encodedApiKey = Buffer.from(apiKeyValue, "utf8").toString("base64");
-
-    requestUrl.searchParams.set("apiKey", encodedApiKey);
-    requestUrl.searchParams.set("name", "Alice");
-    requestUrl.searchParams.set("endpoint", endpoint);
-    requestUrl.searchParams.set("id", "user-1");
-
-    const response = await fetch(requestUrl);
-
-    expect(response.status).toBe(200);
 }
 
 interface ResolvedSnapshotReplacement {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -19,8 +19,8 @@ Project overview: [README.md](../README.md)
   macOS: `~/Library/Logs/oo`
   Linux: `${XDG_STATE_HOME:-~/.local/state}/oo/logs`
   Windows: `%LOCALAPPDATA%\\oo\\Logs`
-- The debug logs include request lifecycles for remote APIs, browser-login
-  callback events, explicit update checks, persisted settings/auth store
+- The debug logs include request lifecycles for remote APIs, device-login
+  polling events, explicit update checks, persisted settings/auth store
   changes, and sqlite cache activity.
 - Error-oriented log entries also include a `category` field so user-facing
   failures, system failures, and recoverable cache issues can be filtered
@@ -33,10 +33,10 @@ Project overview: [README.md](../README.md)
 
 ### `oo auth login`
 
-Start a browser login flow and save the authenticated account.
+Start a device login flow and save the authenticated account.
 
-- Notes: the CLI prints a login URL and waits for the browser callback to
-  finish.
+- Notes: the CLI prints the verification URL and user code, then polls until
+  the device login is verified or times out.
 
 ### `oo auth logout`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -17,7 +17,7 @@
   macOS：`~/Library/Logs/oo`
   Linux：`${XDG_STATE_HOME:-~/.local/state}/oo/logs`
   Windows：`%LOCALAPPDATA%\\oo\\Logs`
-- Debug 日志会覆盖远端 API 请求生命周期、浏览器登录回调事件、显式更新检查，
+- Debug 日志会覆盖远端 API 请求生命周期、device login 轮询事件、显式更新检查，
   以及 settings/auth 持久化状态变化和 sqlite cache 活动。
 - 偏错误类的日志还会带上 `category` 字段，便于快速筛选用户错误、系统错误和可
   恢复的 cache 问题。
@@ -28,9 +28,9 @@
 
 ### `oo auth login`
 
-启动浏览器登录流程，并保存登录成功后的账号。
+启动 device login 流程，并保存登录成功后的账号。
 
-- 说明：CLI 会打印登录地址，并等待浏览器回调完成。
+- 说明：CLI 会打印验证地址和用户 code，然后轮询直到 device login 验证成功或超时。
 
 ### `oo auth logout`
 

--- a/src/application/auth/login-flow.test.ts
+++ b/src/application/auth/login-flow.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    createLogCapture,
+    toRequest,
+} from "../../../__tests__/helpers.ts";
+import { startAuthLoginSession } from "./login-flow.ts";
+
+describe("startAuthLoginSession", () => {
+    test("creates a device login session and returns the verified account", async () => {
+        const logCapture = createLogCapture();
+        const requests: Request[] = [];
+        let resultRequestCount = 0;
+
+        try {
+            const session = await startAuthLoginSession({
+                endpoint: "oomol.com",
+                fetcher: async (input, init) => {
+                    const request = toRequest(input, init);
+                    const requestUrl = new URL(request.url);
+
+                    requests.push(request);
+
+                    if (
+                        request.method === "POST"
+                        && requestUrl.pathname === "/v1/auth/device_login/code"
+                    ) {
+                        return new Response(JSON.stringify({
+                            code: "M0KO41",
+                            expires_in: 1800,
+                            status: "waiting",
+                            verify_code_url: "https://oomol.com/login/device",
+                        }));
+                    }
+
+                    if (
+                        request.method === "GET"
+                        && requestUrl.pathname === "/v1/auth/device_login/result"
+                    ) {
+                        resultRequestCount += 1;
+
+                        return new Response(JSON.stringify(resultRequestCount === 1
+                            ? {
+                                    status: "waiting",
+                                }
+                            : {
+                                    api_key: "secret-1",
+                                    endpoint: "oomol.com",
+                                    id: "user-1",
+                                    name: "Alice",
+                                    status: "verified",
+                                }));
+                    }
+
+                    throw new Error(`Unexpected request: ${request.method} ${requestUrl}`);
+                },
+                logger: logCapture.logger,
+                sleep: async () => {},
+            });
+
+            const account = await session.waitForAccount();
+            const codeRequest = requests[0];
+            const resultRequest = requests[1];
+            const codeRequestBody = JSON.parse(await codeRequest!.text()) as {
+                stat: string;
+            };
+
+            expect(session.code).toBe("M0KO41");
+            expect(session.expiresInSeconds).toBe(1800);
+            expect(session.verificationUrl).toBe("https://oomol.com/login/device");
+            expect(account).toEqual({
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                id: "user-1",
+                name: "Alice",
+            });
+            expect(codeRequest?.method).toBe("POST");
+            expect(codeRequestBody.stat.length).toBe(36);
+            expect(codeRequestBody.stat[14]).toBe("7");
+            expect(resultRequest?.method).toBe("GET");
+            expect(new URL(resultRequest!.url).searchParams.get("stat")).toBe(
+                codeRequestBody.stat,
+            );
+
+            const logs = logCapture.read();
+
+            expect(logs).toContain("\"msg\":\"Auth device login request started.\"");
+            expect(logs).toContain("\"msg\":\"Auth device login completed successfully.\"");
+            expect(logs).not.toContain("secret-1");
+            expect(logs).not.toContain("M0KO41");
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("throws a user error when the device login code response is invalid", async () => {
+        const logCapture = createLogCapture();
+
+        try {
+            await expect(startAuthLoginSession({
+                endpoint: "oomol.com",
+                fetcher: async () => new Response(JSON.stringify({
+                    expires_in: 1800,
+                    status: "waiting",
+                    verify_code_url: "https://oomol.com/login/device",
+                })),
+                logger: logCapture.logger,
+            })).rejects.toMatchObject({
+                key: "errors.auth.loginInvalidResponse",
+            });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("times out when the device login result never becomes verified", async () => {
+        const logCapture = createLogCapture();
+        let nowMs = 0;
+
+        try {
+            const session = await startAuthLoginSession({
+                endpoint: "oomol.com",
+                fetcher: async (input, init) => {
+                    const request = toRequest(input, init);
+                    const requestUrl = new URL(request.url);
+
+                    if (
+                        request.method === "POST"
+                        && requestUrl.pathname === "/v1/auth/device_login/code"
+                    ) {
+                        return new Response(JSON.stringify({
+                            code: "M0KO41",
+                            expires_in: 2,
+                            status: "waiting",
+                            verify_code_url: "https://oomol.com/login/device",
+                        }));
+                    }
+
+                    if (
+                        request.method === "GET"
+                        && requestUrl.pathname === "/v1/auth/device_login/result"
+                    ) {
+                        return new Response(JSON.stringify({
+                            status: "waiting",
+                        }));
+                    }
+
+                    throw new Error(`Unexpected request: ${request.method} ${requestUrl}`);
+                },
+                logger: logCapture.logger,
+                now: () => nowMs,
+                pollIntervalMs: 1_000,
+                sleep: async (ms) => {
+                    nowMs += ms;
+                },
+            });
+
+            await expect(session.waitForAccount()).rejects.toMatchObject({
+                key: "errors.auth.loginTimeout",
+            });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+});

--- a/src/application/auth/login-flow.ts
+++ b/src/application/auth/login-flow.ts
@@ -1,266 +1,284 @@
-import type { ServerResponse } from "node:http";
 import type { Logger } from "pino";
-import type { Translator } from "../contracts/translator.ts";
-import type { AuthAccount } from "../schemas/auth.ts";
-import { Buffer } from "node:buffer";
-import { createServer } from "node:http";
 
+import type { Fetcher } from "../contracts/cli.ts";
+import type { AuthAccount } from "../schemas/auth.ts";
+import { z } from "zod";
 import { CliUserError } from "../contracts/cli.ts";
 import {
     withAccountIdentity,
-    withPath,
+    withRequestTarget,
 } from "../logging/log-fields.ts";
 
-const loginCallbackPath = "/v1/login/callback";
-const loginTimeoutMs = 5 * 60 * 1000;
+const deviceLoginPollIntervalMs = 2_000;
+
+const deviceLoginCodeResponseSchema = z.object({
+    code: z.string().min(1),
+    expires_in: z.number().int().positive(),
+    status: z.literal("waiting"),
+    verify_code_url: z.string().url(),
+}).passthrough();
+
+const deviceLoginWaitingResponseSchema = z.object({
+    status: z.literal("waiting"),
+}).passthrough();
+
+const deviceLoginVerifiedResponseSchema = z.object({
+    api_key: z.string().min(1),
+    endpoint: z.string().min(1),
+    id: z.string().min(1),
+    name: z.string().min(1),
+    status: z.literal("verified"),
+}).passthrough();
+
+const deviceLoginResultResponseSchema = z.union([
+    deviceLoginWaitingResponseSchema,
+    deviceLoginVerifiedResponseSchema,
+]);
+
+type DeviceLoginCodeResponse = z.output<typeof deviceLoginCodeResponseSchema>;
+type DeviceLoginResultResponse = z.output<typeof deviceLoginResultResponseSchema>;
 
 export interface AuthLoginSession {
-    redirectUrl: string;
+    code: string;
+    expiresInSeconds: number;
+    verificationUrl: string;
     waitForAccount: () => Promise<AuthAccount>;
 }
 
-export async function startAuthLoginSession(
-    options: {
-        logger: Logger;
-        translator: Translator;
-    },
-): Promise<AuthLoginSession> {
-    return await new Promise((resolve, reject) => {
-        const server = createServer();
-        let resolveAccount: (account: AuthAccount) => void = () => {};
-        let rejectAccount: (error: unknown) => void = () => {};
-        const state = { settled: false };
-        const accountPromise = new Promise<AuthAccount>((innerResolve, innerReject) => {
-            resolveAccount = innerResolve;
-            rejectAccount = innerReject;
-        });
-        const timer = setTimeout(() => {
-            if (state.settled) {
-                return;
-            }
-
-            state.settled = true;
-            options.logger.warn(
-                {
-                    timeoutMs: loginTimeoutMs,
-                },
-                "Auth login callback timed out.",
-            );
-            rejectAccount(new CliUserError("errors.auth.loginTimeout", 1));
-            void closeServer(server).catch(() => undefined);
-        }, loginTimeoutMs);
-
-        server.on("request", (request, response) => {
-            void handleRequest({
-                rejectAccount,
-                requestUrl: request.url ?? "",
-                resolveAccount,
-                response,
-                server,
-                state,
-                logger: options.logger,
-                translator: options.translator,
-            });
-        });
-
-        server.once("error", (error) => {
-            clearTimeout(timer);
-            options.logger.error(
-                {
-                    err: error,
-                },
-                "Auth login callback server failed.",
-            );
-            reject(error);
-        });
-
-        server.listen(0, "127.0.0.1", () => {
-            const address = server.address();
-
-            if (!address || typeof address === "string") {
-                clearTimeout(timer);
-                reject(new Error("Failed to resolve the auth callback address."));
-                return;
-            }
-
-            options.logger.debug(
-                {
-                    port: address.port,
-                },
-                "Auth login callback server is listening.",
-            );
-
-            resolve({
-                redirectUrl: `http://127.0.0.1:${address.port}${loginCallbackPath}`,
-                async waitForAccount(): Promise<AuthAccount> {
-                    try {
-                        return await accountPromise;
-                    }
-                    finally {
-                        clearTimeout(timer);
-                    }
-                },
-            });
-        });
-    });
-}
-
-interface HandleRequestOptions {
-    rejectAccount: (error: unknown) => void;
-    requestUrl: string;
-    resolveAccount: (account: AuthAccount) => void;
-    response: ServerResponse;
-    server: ReturnType<typeof createServer>;
-    state: { settled: boolean };
+interface StartAuthLoginSessionOptions {
+    endpoint: string;
+    fetcher: Fetcher;
     logger: Logger;
-    translator: Translator;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+    pollIntervalMs?: number;
 }
 
-async function handleRequest(options: HandleRequestOptions): Promise<void> {
-    const url = new URL(options.requestUrl, "http://127.0.0.1");
-    const apiKey = url.searchParams.get("apiKey");
-    const endpoint = url.searchParams.get("endpoint");
-    const id = url.searchParams.get("id");
-    const name = url.searchParams.get("name");
+export async function startAuthLoginSession(
+    options: StartAuthLoginSessionOptions,
+): Promise<AuthLoginSession> {
+    const now = options.now ?? Date.now;
+    const sleep = options.sleep ?? Bun.sleep;
+    const pollIntervalMs = options.pollIntervalMs ?? deviceLoginPollIntervalMs;
+    const state = Bun.randomUUIDv7();
+    const codeResponse = await requestDeviceLoginCode(state, options);
+    const expiresAt = now() + (codeResponse.expires_in * 1000);
+
+    options.logger.info(
+        {
+            expiresInSeconds: codeResponse.expires_in,
+        },
+        "Auth device login code created.",
+    );
+
+    return {
+        code: codeResponse.code,
+        expiresInSeconds: codeResponse.expires_in,
+        verificationUrl: codeResponse.verify_code_url,
+        waitForAccount: async () => await waitForVerifiedAccount(
+            state,
+            expiresAt,
+            options,
+            { now, sleep, pollIntervalMs },
+        ),
+    };
+}
+
+async function waitForVerifiedAccount(
+    state: string,
+    expiresAt: number,
+    options: Pick<StartAuthLoginSessionOptions, "endpoint" | "fetcher" | "logger">,
+    resolved: {
+        now: () => number;
+        pollIntervalMs: number;
+        sleep: (ms: number) => Promise<void>;
+    },
+): Promise<AuthAccount> {
+    while (resolved.now() < expiresAt) {
+        const result = await requestDeviceLoginResult(state, options);
+
+        if (result.status === "verified") {
+            options.logger.info(
+                {
+                    ...withAccountIdentity(result.id, result.endpoint),
+                    name: result.name,
+                },
+                "Auth device login completed successfully.",
+            );
+
+            return {
+                apiKey: result.api_key,
+                endpoint: result.endpoint,
+                id: result.id,
+                name: result.name,
+            };
+        }
+
+        const remainingMs = expiresAt - resolved.now();
+
+        if (remainingMs <= 0) {
+            break;
+        }
+
+        await resolved.sleep(Math.min(resolved.pollIntervalMs, remainingMs));
+    }
+
+    options.logger.warn(
+        {
+            timeoutMs: expiresAt - resolved.now(),
+        },
+        "Auth device login timed out.",
+    );
+    throw new CliUserError("errors.auth.loginTimeout", 1);
+}
+
+async function requestDeviceLoginCode(
+    state: string,
+    options: StartAuthLoginSessionOptions,
+): Promise<DeviceLoginCodeResponse> {
+    const rawResponse = await requestDeviceLogin(
+        createDeviceLoginCodeUrl(options.endpoint),
+        options,
+        {
+            body: JSON.stringify({
+                stat: state,
+            }),
+            kind: "code",
+            method: "POST",
+        },
+    );
+
+    return parseDeviceLoginResponse(
+        rawResponse,
+        deviceLoginCodeResponseSchema,
+    );
+}
+
+async function requestDeviceLoginResult(
+    state: string,
+    options: StartAuthLoginSessionOptions,
+): Promise<DeviceLoginResultResponse> {
+    const requestUrl = createDeviceLoginResultUrl(options.endpoint, state);
+    const rawResponse = await requestDeviceLogin(
+        requestUrl,
+        options,
+        {
+            kind: "result",
+            method: "GET",
+        },
+    );
+
+    return parseDeviceLoginResponse(
+        rawResponse,
+        deviceLoginResultResponseSchema,
+    );
+}
+
+async function requestDeviceLogin(
+    requestUrl: URL,
+    options: Pick<StartAuthLoginSessionOptions, "fetcher" | "logger">,
+    requestOptions: {
+        body?: string;
+        kind: "code" | "result";
+        method: "GET" | "POST";
+    },
+): Promise<string> {
+    const requestStartedAt = Date.now();
 
     options.logger.debug(
         {
-            hasApiKey: apiKey !== null,
-            hasEndpoint: endpoint !== null,
-            hasId: id !== null,
-            hasName: name !== null,
-            ...withPath(url.pathname),
-            settled: options.state.settled,
+            bodyLength: requestOptions.body?.length ?? 0,
+            hasBody: requestOptions.body !== undefined,
+            kind: requestOptions.kind,
+            method: requestOptions.method,
+            ...withRequestTarget(requestUrl.host, requestUrl.pathname),
         },
-        "Auth login callback received.",
+        "Auth device login request started.",
     );
-
-    if (url.pathname !== loginCallbackPath) {
-        options.logger.warn(
-            {
-                ...withPath(url.pathname),
-            },
-            "Auth login callback used an unexpected path.",
-        );
-        writeHttpResponse(
-            options.response,
-            404,
-            options.translator.t("auth.login.callbackNotFound"),
-        );
-        return;
-    }
-
-    if (options.state.settled) {
-        options.logger.warn(
-            {
-                ...withPath(url.pathname),
-            },
-            "Auth login callback was received after the session had already settled.",
-        );
-        writeHttpResponse(
-            options.response,
-            409,
-            options.translator.t("auth.login.callbackAlreadyUsed"),
-        );
-        return;
-    }
-
-    if (
-        !apiKey
-        || !endpoint
-        || !id
-        || !name
-    ) {
-        options.logger.warn(
-            {
-                hasApiKey: apiKey !== null,
-                hasEndpoint: endpoint !== null,
-                hasId: id !== null,
-                hasName: name !== null,
-            },
-            "Auth login callback was missing required fields.",
-        );
-        writeHttpResponse(
-            options.response,
-            400,
-            options.translator.t("auth.login.callbackInvalid"),
-        );
-        return;
-    }
-
-    let decodedApiKey = "";
 
     try {
-        decodedApiKey = decodeApiKey(apiKey);
+        const response = await options.fetcher(requestUrl, {
+            body: requestOptions.body,
+            headers: requestOptions.body === undefined
+                ? undefined
+                : {
+                        "Content-Type": "application/json",
+                    },
+            method: requestOptions.method,
+        });
+        const durationMs = Date.now() - requestStartedAt;
+
+        if (!response.ok) {
+            options.logger.warn(
+                {
+                    durationMs,
+                    kind: requestOptions.kind,
+                    method: requestOptions.method,
+                    status: response.status,
+                    ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+                },
+                "Auth device login request returned a non-success status.",
+            );
+            throw new CliUserError("errors.auth.loginRequestFailed", 1, {
+                status: response.status,
+            });
+        }
+
+        options.logger.debug(
+            {
+                durationMs,
+                kind: requestOptions.kind,
+                method: requestOptions.method,
+                status: response.status,
+                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+            },
+            "Auth device login request completed.",
+        );
+
+        return await response.text();
     }
-    catch {
+    catch (error) {
+        if (error instanceof CliUserError) {
+            throw error;
+        }
+
         options.logger.warn(
             {
-                ...withAccountIdentity(id, endpoint),
-                name,
+                durationMs: Date.now() - requestStartedAt,
+                err: error,
+                kind: requestOptions.kind,
+                method: requestOptions.method,
+                ...withRequestTarget(requestUrl.host, requestUrl.pathname),
             },
-            "Auth login callback contained an invalid api key payload.",
+            "Auth device login request failed unexpectedly.",
         );
-        writeHttpResponse(
-            options.response,
-            400,
-            options.translator.t("auth.login.callbackInvalid"),
-        );
-        return;
-    }
-
-    options.state.settled = true;
-    writeHttpResponse(
-        options.response,
-        200,
-        options.translator.t("auth.login.callbackSuccess"),
-    );
-    options.logger.info(
-        {
-            ...withAccountIdentity(id, endpoint),
-            name,
-        },
-        "Auth login callback completed successfully.",
-    );
-    options.resolveAccount({
-        apiKey: decodedApiKey,
-        endpoint,
-        id,
-        name,
-    });
-    await closeServer(options.server);
-}
-
-function decodeApiKey(encodedApiKey: string): string {
-    const apiKey = Buffer.from(encodedApiKey, "base64").toString("utf8");
-
-    if (apiKey === "") {
-        throw new Error("The decoded auth api key is empty.");
-    }
-
-    return apiKey;
-}
-
-function writeHttpResponse(
-    response: ServerResponse,
-    statusCode: number,
-    body: string,
-): void {
-    response.writeHead(statusCode, {
-        "Content-Type": "text/plain; charset=utf-8",
-    });
-    response.end(body);
-}
-
-async function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-            if (error) {
-                reject(error);
-                return;
-            }
-
-            resolve();
+        throw new CliUserError("errors.auth.loginRequestError", 1, {
+            message: error instanceof Error ? error.message : String(error),
         });
-    });
+    }
+}
+
+function parseDeviceLoginResponse<TValue>(
+    rawResponse: string,
+    schema: z.ZodType<TValue>,
+): TValue {
+    try {
+        return schema.parse(JSON.parse(rawResponse) as unknown);
+    }
+    catch {
+        throw new CliUserError("errors.auth.loginInvalidResponse", 1);
+    }
+}
+
+function createDeviceLoginCodeUrl(endpoint: string): URL {
+    return new URL(`https://api.${endpoint}/v1/auth/device_login/code`);
+}
+
+function createDeviceLoginResultUrl(endpoint: string, state: string): URL {
+    const requestUrl = new URL(
+        `https://api.${endpoint}/v1/auth/device_login/result`,
+    );
+
+    requestUrl.searchParams.set("stat", state);
+    return requestUrl;
 }

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -45,7 +45,7 @@ Commands:
   cloud-task               Manage cloud tasks
   connector                Manage connector actions
   file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
+  login                    Log in with device login (alias for auth login)
   logout                   Log out the current account (alias for auth logout)
   completion <shell>       Generate shell completion scripts
   config                   Manage persisted configuration
@@ -78,7 +78,7 @@ Commands:
   cloud-task               Manage cloud tasks
   connector                Manage connector actions
   file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
+  login                    Log in with device login (alias for auth login)
   logout                   Log out the current account (alias for auth logout)
   completion <shell>       Generate shell completion scripts
   config                   Manage persisted configuration
@@ -114,7 +114,7 @@ Commands:
   cloud-task               Manage cloud tasks
   connector                Manage connector actions
   file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
+  login                    Log in with device login (alias for auth login)
   logout                   Log out the current account (alias for auth logout)
   completion <shell>       Generate shell completion scripts
   config                   Manage persisted configuration
@@ -148,7 +148,7 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
   cloud-task               管理云任务
   connector                管理 connector action
   file                     管理临时文件传输
-  login                    通过浏览器登录（auth login 的别名）
+  login                    通过 device login 登录（auth login 的别名）
   logout                   登出当前账号（auth logout 的别名）
   completion <shell>       生成 shell 补全脚本
   config                   管理持久化配置
@@ -178,7 +178,7 @@ Commands:
   cloud-task               Manage cloud tasks
   connector                Manage connector actions
   file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
+  login                    Log in with device login (alias for auth login)
   logout                   Log out the current account (alias for auth logout)
   completion <shell>       Generate shell completion scripts
   config                   Manage persisted configuration
@@ -212,7 +212,7 @@ Commands:
   cloud-task               Manage cloud tasks
   connector                Manage connector actions
   file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
+  login                    Log in with device login (alias for auth login)
   logout                   Log out the current account (alias for auth logout)
   completion <shell>       Generate shell completion scripts
   config                   Manage persisted configuration

--- a/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
@@ -1,12 +1,13 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`auth CLI writes auth login callback logs without persisting api keys 1`] = `
+exports[`auth CLI writes auth device login logs without persisting secrets 1`] = `
 {
   "exitCode": 0,
   "stderr": "",
   "stdout": 
 "Open this URL in your browser to continue: <LOGIN_URL>
-Waiting for the browser login to complete...
+Enter this code to continue: M0KO41
+Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
 "
@@ -33,7 +34,7 @@ exports[`auth CLI renders alias descriptions in login and logout help 1`] = `
     "exitCode": 0,
     "stderr": "",
     "stdout": 
-"Log in with an OOMOL account in the browser. Alias for auth login.
+"Log in with an OOMOL account using device login. Alias for auth login.
 
 Options:
   -h, --help     Show help for command
@@ -71,7 +72,8 @@ exports[`auth CLI supports auth login and updates the existing account without d
     "stderr": "",
     "stdout": 
 "Open this URL in your browser to continue: <LOGIN_URL>
-Waiting for the browser login to complete...
+Enter this code to continue: M0KO41
+Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
 "
@@ -82,7 +84,8 @@ Waiting for the browser login to complete...
     "stderr": "",
     "stdout": 
 "Open this URL in your browser to continue: <LOGIN_URL>
-Waiting for the browser login to complete...
+Enter this code to continue: M0KO41
+Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
 "
@@ -97,7 +100,8 @@ exports[`auth CLI supports auth login with a custom OOMOL_ENDPOINT 1`] = `
   "stderr": "",
   "stdout": 
 "Open this URL in your browser to continue: <LOGIN_URL>
-Waiting for the browser login to complete...
+Enter this code to continue: M0KO41
+Waiting for the device login to complete...
 ✓ Logged in to staging.oomol.test account Alice
   - Active account: true
 "
@@ -111,7 +115,8 @@ exports[`auth CLI supports login as an alias for auth login 1`] = `
   "stderr": "",
   "stdout": 
 "Open this URL in your browser to continue: <LOGIN_URL>
-Waiting for the browser login to complete...
+Enter this code to continue: M0KO41
+Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
 "
@@ -125,7 +130,8 @@ exports[`auth CLI renders the auth login url and success block with color stylin
   "stderr": "",
   "stdout": 
 "Open this URL in your browser to continue: <LOGIN_URL>
-Waiting for the browser login to complete...
+Enter this code to continue: M0KO41
+Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
 "
@@ -219,3 +225,4 @@ exports[`auth CLI renders the auth switch success block with gh-style emphasis w
 ,
 }
 `;
+

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -20,9 +19,8 @@ import { createTerminalColors } from "../../terminal-colors.ts";
 const loginUrlColor = "#c09ff5";
 
 describe("auth CLI", () => {
-    test("writes auth login callback logs without persisting api keys", async () => {
+    test("writes auth device login logs without persisting secrets", async () => {
         const sandbox = await createCliSandbox();
-        const encodedApiKey = Buffer.from("secret-1", "utf8").toString("base64");
 
         try {
             const result = await runPrintedAuthLogin(sandbox, "secret-1");
@@ -30,18 +28,19 @@ describe("auth CLI", () => {
 
             expect(createAuthLoginSnapshot(result)).toMatchSnapshot();
             expect(content).toContain(
-                `"msg":"Auth login callback server is listening."`,
-            );
-            expect(content).toContain(`"msg":"Auth login callback received."`);
-            expect(content).toContain(
-                `"msg":"Auth login callback completed successfully."`,
+                `"msg":"Auth device login request started."`,
             );
             expect(content).toContain(
-                `"msg":"Auth account persisted after browser login."`,
+                `"msg":"Auth device login request completed."`,
             );
-            expect(content).toContain(`"hasApiKey":true`);
+            expect(content).toContain(
+                `"msg":"Auth device login completed successfully."`,
+            );
+            expect(content).toContain(
+                `"msg":"Auth account persisted after device login."`,
+            );
             expect(content).not.toContain("secret-1");
-            expect(content).not.toContain(encodedApiKey);
+            expect(content).not.toContain("M0KO41");
         }
         finally {
             await sandbox.cleanup();
@@ -205,6 +204,7 @@ describe("auth CLI", () => {
             expect(login.stdout).toContain(
                 colors.hex(loginUrlColor)(plainLoginUrl!),
             );
+            expect(login.stdout).toContain(colors.bold("M0KO41"));
             expect(login.stdout).toContain(colors.green("✓"));
             expect(login.stdout).toContain(colors.bold("oomol.com"));
             expect(login.stdout).toContain(colors.bold("Alice"));

--- a/src/application/commands/auth/login.ts
+++ b/src/application/commands/auth/login.ts
@@ -24,28 +24,34 @@ export const authLoginCommand: CliCommandDefinition = {
     handler: async (_, context) => {
         const authEndpoint = readAuthEndpoint(context.env);
         const session = await startAuthLoginSession({
+            endpoint: authEndpoint,
+            fetcher: context.fetcher,
             logger: context.logger,
-            translator: context.translator,
         });
-        const loginUrl = createAuthLoginUrl(authEndpoint, session.redirectUrl);
         const colors = createWriterColors(context.stdout);
 
         context.logger.debug(
             {
                 authEndpoint,
-                redirectUrl: session.redirectUrl,
+                expiresInSeconds: session.expiresInSeconds,
             },
-            "Auth login URL prepared.",
+            "Auth device login session prepared.",
         );
         writeLine(
             context.stdout,
             context.translator.t("auth.login.openManually", {
-                url: colors.hex(loginUrlColor)(loginUrl.toString()),
+                url: colors.hex(loginUrlColor)(session.verificationUrl),
             }),
         );
         writeLine(
             context.stdout,
-            context.translator.t("auth.login.waitingForBrowser"),
+            context.translator.t("auth.login.code", {
+                code: colors.bold(session.code),
+            }),
+        );
+        writeLine(
+            context.stdout,
+            context.translator.t("auth.login.waiting"),
         );
 
         const account = await session.waitForAccount();
@@ -59,7 +65,7 @@ export const authLoginCommand: CliCommandDefinition = {
                 endpoint: account.endpoint,
                 name: account.name,
             },
-            "Auth account persisted after browser login.",
+            "Auth account persisted after device login.",
         );
 
         writeAuthBlock(context, {
@@ -77,19 +83,6 @@ export const authLoginCommand: CliCommandDefinition = {
         });
     },
 };
-
-function createAuthLoginUrl(
-    authEndpoint: string,
-    redirectUrl: string,
-): URL {
-    const loginUrl = new URL(
-        `https://api.${authEndpoint}/v1/auth/redirect`,
-    );
-
-    loginUrl.searchParams.set("redirect", redirectUrl);
-    loginUrl.searchParams.set("cli_login", "true");
-    return loginUrl;
-}
 
 function readAuthEndpoint(
     env: CliExecutionContext["env"],

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -31,7 +31,7 @@ Commands:
   cloud-task               Manage cloud tasks
   connector                Manage connector actions
   file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
+  login                    Log in with device login (alias for auth login)
   logout                   Log out the current account (alias for auth logout)
   completion <shell>       Generate shell completion scripts
   config                   Manage persisted configuration
@@ -61,7 +61,7 @@ Commands:
   cloud-task               管理云任务
   connector                管理 connector action
   file                     管理临时文件传输
-  login                    通过浏览器登录（auth login 的别名）
+  login                    通过 device login 登录（auth login 的别名）
   logout                   登出当前账号（auth logout 的别名）
   completion <shell>       生成 shell 补全脚本
   config                   管理持久化配置

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -41,7 +41,7 @@ Commands:
   cloud-task               Manage cloud tasks
   connector                Manage connector actions
   file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
+  login                    Log in with device login (alias for auth login)
   logout                   Log out the current account (alias for auth logout)
   completion <shell>       Generate shell completion scripts
   config                   Manage persisted configuration
@@ -74,7 +74,7 @@ Commands:
   cloud-task               Manage cloud tasks
   connector                Manage connector actions
   file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
+  login                    Log in with device login (alias for auth login)
   logout                   Log out the current account (alias for auth logout)
   completion <shell>       Generate shell completion scripts
   config                   Manage persisted configuration
@@ -118,7 +118,7 @@ Commands:
   cloud-task               Manage cloud tasks
   connector                Manage connector actions
   file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
+  login                    Log in with device login (alias for auth login)
   logout                   Log out the current account (alias for auth logout)
   completion <shell>       Generate shell completion scripts
   config                   Manage persisted configuration
@@ -151,7 +151,7 @@ Commands:
   cloud-task               Manage cloud tasks
   connector                Manage connector actions
   file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
+  login                    Log in with device login (alias for auth login)
   logout                   Log out the current account (alias for auth logout)
   completion <shell>       Generate shell completion scripts
   config                   Manage persisted configuration
@@ -207,7 +207,7 @@ Commands:
   cloud-task               Manage cloud tasks
   connector                Manage connector actions
   file                     Manage temporary file transfers
-  login                    Log in with a browser flow (alias for auth login)
+  login                    Log in with device login (alias for auth login)
   logout                   Log out the current account (alias for auth logout)
   completion <shell>       Generate shell completion scripts
   config                   Manage persisted configuration

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -2,15 +2,12 @@ import { APP_NAME } from "../application/config/app-config.ts";
 
 export const enMessages = {
     "app.description": `${APP_NAME} is OOMOL's CLI toolkit. Everything can be done in the CLI.`,
-    "auth.login.callbackAlreadyUsed": "This login callback has already been used.",
-    "auth.login.callbackInvalid": "The login callback payload is invalid.",
-    "auth.login.callbackNotFound": "The requested login callback endpoint was not found.",
-    "auth.login.callbackSuccess": "Login completed. You can close this tab now.",
+    "auth.login.code": "Enter this code to continue: {code}",
     "auth.login.openManually": "Open this URL in your browser to continue: {url}",
     "auth.account.activeAccountMissing":
         "The active account is missing from the auth store.",
     "auth.account.loggedIn": "Logged in to {endpoint} account {name}",
-    "auth.login.waitingForBrowser": "Waiting for the browser login to complete...",
+    "auth.login.waiting": "Waiting for the device login to complete...",
     "auth.logout.success": "Logged out the current account.",
     "auth.status.accountId": "Account ID",
     "auth.status.activeAccount": "Active account",
@@ -21,8 +18,8 @@ export const enMessages = {
     "auth.status.loggedOut": "Not logged in to any OOMOL account.",
     "auth.switch.success": "Switched active account for {endpoint} to {name}",
     "commands.auth.description": "Manage CLI authentication accounts.",
-    "commands.auth.login.description": "Log in with an OOMOL account in the browser.",
-    "commands.auth.login.summary": "Log in with a browser flow",
+    "commands.auth.login.description": "Log in with an OOMOL account using device login.",
+    "commands.auth.login.summary": "Log in with device login",
     "commands.auth.logout.description": "Remove the current account from persisted auth data.",
     "commands.auth.logout.summary": "Log out the current account",
     "commands.auth.status.description": "Show the current auth account and validate its API key.",
@@ -96,8 +93,8 @@ export const enMessages = {
         "Print one previous persisted debug log file by index.",
     "commands.log.print.summary": "Print a previous debug log",
     "commands.login.description":
-        "Log in with an OOMOL account in the browser. Alias for auth login.",
-    "commands.login.summary": "Log in with a browser flow (alias for auth login)",
+        "Log in with an OOMOL account using device login. Alias for auth login.",
+    "commands.login.summary": "Log in with device login (alias for auth login)",
     "commands.logout.description":
         "Remove the current account from persisted auth data. Alias for auth logout.",
     "commands.logout.summary":
@@ -147,8 +144,14 @@ export const enMessages = {
     "errors.commander.suggestion": "Did you mean {value}?",
     "errors.commander.unknownCommand": "Unknown command: {value}.",
     "errors.commander.unknownOption": "Unknown option: {value}.",
+    "errors.auth.loginInvalidResponse":
+        "The device login service returned an unsupported response body.",
+    "errors.auth.loginRequestError":
+        "The device login request failed: {message}",
+    "errors.auth.loginRequestFailed":
+        "The device login request returned HTTP {status}.",
     "errors.auth.loginTimeout":
-        "Timed out waiting for the browser login callback.",
+        "Timed out waiting for the device login to complete.",
     "errors.auth.noSavedAccounts":
         "There are no auth accounts to switch to.",
     "errors.auth.required":
@@ -558,14 +561,11 @@ export const enMessages = {
 
 export const zhMessages = {
     "app.description": `${APP_NAME} 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成`,
-    "auth.login.callbackAlreadyUsed": "这个登录回调已经被使用过。",
-    "auth.login.callbackInvalid": "登录回调携带的数据无效。",
-    "auth.login.callbackNotFound": "未找到请求的登录回调地址。",
-    "auth.login.callbackSuccess": "登录完成，现在可以关闭这个页面。",
+    "auth.login.code": "请输入这个 code 继续登录：{code}",
     "auth.login.openManually": "请在浏览器中打开这个 URL 继续登录：{url}",
     "auth.account.activeAccountMissing": "当前激活账号不存在于认证数据中。",
     "auth.account.loggedIn": "已登录 {endpoint} 账号 {name}",
-    "auth.login.waitingForBrowser": "正在等待浏览器完成登录...",
+    "auth.login.waiting": "正在等待 device login 完成...",
     "auth.logout.success": "已登出当前账号。",
     "auth.status.accountId": "账号 ID",
     "auth.status.activeAccount": "当前激活账号",
@@ -576,8 +576,8 @@ export const zhMessages = {
     "auth.status.loggedOut": "当前没有登录任何 OOMOL 账号。",
     "auth.switch.success": "已将 {endpoint} 的当前激活账号切换为 {name}",
     "commands.auth.description": "管理 CLI 的认证账号。",
-    "commands.auth.login.description": "在浏览器中登录 OOMOL 账号。",
-    "commands.auth.login.summary": "通过浏览器登录",
+    "commands.auth.login.description": "通过 device login 登录 OOMOL 账号。",
+    "commands.auth.login.summary": "通过 device login 登录",
     "commands.auth.logout.description": "从持久化认证数据中移除当前账号。",
     "commands.auth.logout.summary": "登出当前账号",
     "commands.auth.status.description": "显示当前认证账号并校验其 API key。",
@@ -641,8 +641,8 @@ export const zhMessages = {
     "commands.log.path.summary": "显示日志目录路径",
     "commands.log.print.description": "按序号打印某一份更早的持久化 debug 日志文件内容。",
     "commands.log.print.summary": "输出某一份更早的 debug 日志",
-    "commands.login.description": "在浏览器中登录 OOMOL 账号。是 auth login 的别名。",
-    "commands.login.summary": "通过浏览器登录（auth login 的别名）",
+    "commands.login.description": "通过 device login 登录 OOMOL 账号。是 auth login 的别名。",
+    "commands.login.summary": "通过 device login 登录（auth login 的别名）",
     "commands.logout.description": "从持久化认证数据中移除当前账号。是 auth logout 的别名。",
     "commands.logout.summary": "登出当前账号（auth logout 的别名）",
     "commands.package.description": "查看包注册表元数据及相关资源。",
@@ -684,7 +684,10 @@ export const zhMessages = {
     "errors.commander.suggestion": "你是想输入 {value} 吗？",
     "errors.commander.unknownCommand": "未知命令：{value}。",
     "errors.commander.unknownOption": "未知选项：{value}。",
-    "errors.auth.loginTimeout": "等待浏览器登录回调超时。",
+    "errors.auth.loginInvalidResponse": "device login 服务返回了不受支持的响应内容。",
+    "errors.auth.loginRequestError": "device login 请求失败：{message}",
+    "errors.auth.loginRequestFailed": "device login 请求返回了 HTTP {status}。",
+    "errors.auth.loginTimeout": "等待 device login 完成超时。",
     "errors.auth.noSavedAccounts": "没有可切换的认证账号。",
     "errors.auth.required":
         "使用此命令前请先登录。",


### PR DESCRIPTION
Move CLI authentication to the device login endpoints so login no
longer depends on a local callback server or browser redirect.

Keep the persisted auth.toml shape and command surface unchanged
while updating output, translations, docs, and tests for the new
verification URL, user code, and polling-based flow.