### PR TITLE
fix(package): exclude connector scope from intent search

### DIFF
--- a/src/application/commands/package/search-provider.ts
+++ b/src/application/commands/package/search-provider.ts
@@ -17,6 +17,7 @@ const MAX_SEARCH_TEXT_LENGTH = 200;
 const SEARCH_CACHE_ID = "search.intent-response";
 const SEARCH_CACHE_MAX_ENTRIES = 100;
 const SEARCH_CACHE_TTL_MS = 30_000;
+const PACKAGE_SEARCH_EXCLUDED_SCOPE = "connector";
 const searchDisplayNameColor = "#59F78D";
 const searchBlockTitleColor = "#CAA8FA";
 
@@ -149,6 +150,7 @@ function createPackageSearchRequestUrl(
 
     requestUrl.searchParams.set("q", truncatePackageSearchText(text));
     requestUrl.searchParams.set("lang", resolveRequestLanguage(locale));
+    requestUrl.searchParams.set("excludeScopes", PACKAGE_SEARCH_EXCLUDED_SCOPE);
 
     return requestUrl;
 }

--- a/src/application/commands/package/search.cli.test.ts
+++ b/src/application/commands/package/search.cli.test.ts
@@ -172,7 +172,7 @@ describe("packageSearchCommand CLI", () => {
             expectCliSnapshot(result);
             expect(requests).toHaveLength(1);
             expect(requests[0]?.url).toBe(
-                "https://search.oomol.com/v1/packages/-/intent-search?q=image+processing&lang=en",
+                "https://search.oomol.com/v1/packages/-/intent-search?q=image+processing&lang=en&excludeScopes=connector",
             );
             expect(requests[0]?.headers.get("Authorization")).toBe("secret-1");
         }
@@ -224,6 +224,9 @@ describe("packageSearchCommand CLI", () => {
             expect(
                 new URL(requests[0]!.url).searchParams.get("lang"),
             ).toBe("zh-CN");
+            expect(
+                new URL(requests[0]!.url).searchParams.get("excludeScopes"),
+            ).toBe("connector");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/search.cli.test.ts
+++ b/src/application/commands/search.cli.test.ts
@@ -83,7 +83,7 @@ describe("mixedSearchCommand CLI", () => {
             expect(requests.map(request => request.url).sort()).toEqual([
                 "https://connector.oomol.com/v1/apps/authenticated?service=gmail",
                 "https://search.oomol.com/v1/connector-actions?q=send+mail&keywords=gmail%2Cemail",
-                "https://search.oomol.com/v1/packages/-/intent-search?q=send+mail&lang=en",
+                "https://search.oomol.com/v1/packages/-/intent-search?q=send+mail&lang=en&excludeScopes=connector",
             ]);
             expect(logContent).toContain(`"path":"/v1/packages/-/intent-search"`);
         }


### PR DESCRIPTION
Package intent search should filter connector-scoped packages so oo search and oo packages search stay focused on real packages. Add the fixed excludeScopes=connector parameter in the shared request builder and update CLI tests to lock the new contract.