### PR TITLE
fix(sandbox): add network-restricted sandbox hints

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -23,6 +23,10 @@ import { resolveStorePaths } from "../src/adapters/store/store-path.ts";
 import {
     executeCli as executeCliInvocation,
 } from "../src/application/bootstrap/run-cli.ts";
+import {
+    connectionRefusedErrorCode,
+    failedToOpenSocketErrorCode,
+} from "../src/application/commands/shared/request.ts";
 import { APP_NAME } from "../src/application/config/app-config.ts";
 import { CliUserError } from "../src/application/contracts/cli.ts";
 import { defaultSettings, renderSettingsFile } from "../src/application/schemas/settings.ts";
@@ -771,6 +775,26 @@ export function createCacheStore<Value>(
         },
         close() {},
     };
+}
+
+export function createFailedToOpenSocketError(
+    message: string,
+): Error & { code: typeof failedToOpenSocketErrorCode } {
+    const error = new Error(message) as Error & { code: typeof failedToOpenSocketErrorCode };
+
+    error.code = failedToOpenSocketErrorCode;
+
+    return error;
+}
+
+export function createConnectionRefusedError(
+    message: string,
+): Error & { code: typeof connectionRefusedErrorCode } {
+    const error = new Error(message) as Error & { code: typeof connectionRefusedErrorCode };
+
+    error.code = connectionRefusedErrorCode;
+
+    return error;
 }
 
 export function createCache<Value>(handlers: {

--- a/contrib/skills/codex/oo/SKILL.md
+++ b/contrib/skills/codex/oo/SKILL.md
@@ -20,6 +20,14 @@ build a local workaround.
 
 Read only the reference file needed for the current step.
 
+## Runtime note
+
+- The substantive `oo` commands used by this skill rely on outbound network
+  access.
+- If one of those commands fails because the environment cannot establish
+  outbound network connections in a sandboxed environment, request elevated
+  permissions and retry the same `oo` command before changing strategy.
+
 ## When to use this skill
 
 - When the user wants a hosted capability `oo` likely already exposes: OCR,

--- a/src/application/auth/login-flow.test.ts
+++ b/src/application/auth/login-flow.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+    createFailedToOpenSocketError,
     createLogCapture,
     toRequest,
 } from "../../../__tests__/helpers.ts";
+import { createTranslator } from "../../i18n/translator.ts";
 import { startAuthLoginSession } from "./login-flow.ts";
 
 describe("startAuthLoginSession", () => {
@@ -56,6 +58,7 @@ describe("startAuthLoginSession", () => {
                 },
                 logger: logCapture.logger,
                 sleep: async () => {},
+                translator: createTranslator("en"),
             });
 
             const account = await session.waitForAccount();
@@ -106,6 +109,7 @@ describe("startAuthLoginSession", () => {
                     verify_code_url: "https://oomol.com/login/device",
                 })),
                 logger: logCapture.logger,
+                translator: createTranslator("en"),
             })).rejects.toMatchObject({
                 key: "errors.auth.loginInvalidResponse",
             });
@@ -155,10 +159,35 @@ describe("startAuthLoginSession", () => {
                 sleep: async (ms) => {
                     nowMs += ms;
                 },
+                translator: createTranslator("en"),
             });
 
             await expect(session.waitForAccount()).rejects.toMatchObject({
                 key: "errors.auth.loginTimeout",
+            });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("appends the sandbox hint when the device login fetcher cannot open a socket", async () => {
+        const logCapture = createLogCapture();
+
+        try {
+            await expect(startAuthLoginSession({
+                endpoint: "oomol.com",
+                fetcher: async () => {
+                    throw createFailedToOpenSocketError("network down");
+                },
+                logger: logCapture.logger,
+                translator: createTranslator("zh"),
+            })).rejects.toMatchObject({
+                key: "errors.auth.loginRequestError",
+                params: {
+                    message:
+                        "network down\n当前环境可能在网络受限的沙箱中，请尝试提权。",
+                },
             });
         }
         finally {

--- a/src/application/auth/login-flow.ts
+++ b/src/application/auth/login-flow.ts
@@ -1,8 +1,9 @@
 import type { Logger } from "pino";
 
-import type { Fetcher } from "../contracts/cli.ts";
+import type { CliExecutionContext, Fetcher } from "../contracts/cli.ts";
 import type { AuthAccount } from "../schemas/auth.ts";
 import { z } from "zod";
+import { getUnexpectedRequestErrorMessage } from "../commands/shared/request.ts";
 import { CliUserError } from "../contracts/cli.ts";
 import {
     withAccountIdentity,
@@ -49,6 +50,7 @@ interface StartAuthLoginSessionOptions {
     endpoint: string;
     fetcher: Fetcher;
     logger: Logger;
+    translator: Pick<CliExecutionContext["translator"], "t">;
     now?: () => number;
     sleep?: (ms: number) => Promise<void>;
     pollIntervalMs?: number;
@@ -87,7 +89,10 @@ export async function startAuthLoginSession(
 async function waitForVerifiedAccount(
     state: string,
     expiresAt: number,
-    options: Pick<StartAuthLoginSessionOptions, "endpoint" | "fetcher" | "logger">,
+    options: Pick<
+        StartAuthLoginSessionOptions,
+        "endpoint" | "fetcher" | "logger" | "translator"
+    >,
     resolved: {
         now: () => number;
         pollIntervalMs: number;
@@ -176,7 +181,10 @@ async function requestDeviceLoginResult(
 
 async function requestDeviceLogin(
     requestUrl: URL,
-    options: Pick<StartAuthLoginSessionOptions, "fetcher" | "logger">,
+    options: Pick<
+        StartAuthLoginSessionOptions,
+        "fetcher" | "logger" | "translator"
+    >,
     requestOptions: {
         body?: string;
         kind: "code" | "result";
@@ -252,8 +260,9 @@ async function requestDeviceLogin(
             },
             "Auth device login request failed unexpectedly.",
         );
+
         throw new CliUserError("errors.auth.loginRequestError", 1, {
-            message: error instanceof Error ? error.message : String(error),
+            message: getUnexpectedRequestErrorMessage(error, options.translator),
         });
     }
 }

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, test } from "bun:test";
 import {
     createCliSandbox,
     createCliSnapshot,
+    createConnectionRefusedError,
+    createFailedToOpenSocketError,
     defaultAuthEndpoint,
     findLoginUrl,
     readAuthLoginUrlPrefix,
@@ -355,6 +357,92 @@ describe("auth CLI", () => {
             expect(invalidRequests[0]?.url).toBe("https://api.oomol.com/v1/users/profile");
             expect(invalidRequests[0]?.headers.get("Authorization")).toBe("secret-1");
             expect(await readFile(authFilePath, "utf8")).toContain("api_key = \"secret-1\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports a sandbox hint when auth status cannot open a socket", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const authFilePath = join(
+                sandbox.env.XDG_CONFIG_HOME!,
+                APP_NAME,
+                "auth.toml",
+            );
+
+            await Bun.write(
+                authFilePath,
+                [
+                    "id = \"user-1\"",
+                    "",
+                    "[[auth]]",
+                    "id = \"user-1\"",
+                    "name = \"Alice\"",
+                    "api_key = \"secret-1\"",
+                    "endpoint = \"oomol.com\"",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(
+                ["auth", "status"],
+                {
+                    fetcher: async () => {
+                        throw createFailedToOpenSocketError("network down");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                "Request failed (network-restricted sandbox, try requesting elevated permissions)",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports a sandbox hint when auth status connection is refused", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const authFilePath = join(
+                sandbox.env.XDG_CONFIG_HOME!,
+                APP_NAME,
+                "auth.toml",
+            );
+
+            await Bun.write(
+                authFilePath,
+                [
+                    "id = \"user-1\"",
+                    "",
+                    "[[auth]]",
+                    "id = \"user-1\"",
+                    "name = \"Alice\"",
+                    "api_key = \"secret-1\"",
+                    "endpoint = \"oomol.com\"",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(
+                ["auth", "status"],
+                {
+                    fetcher: async () => {
+                        throw createConnectionRefusedError("connection refused");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                "Request failed (network-restricted sandbox, try requesting elevated permissions)",
+            );
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/auth/login.ts
+++ b/src/application/commands/auth/login.ts
@@ -27,6 +27,7 @@ export const authLoginCommand: CliCommandDefinition = {
             endpoint: authEndpoint,
             fetcher: context.fetcher,
             logger: context.logger,
+            translator: context.translator,
         });
         const colors = createWriterColors(context.stdout);
 

--- a/src/application/commands/auth/status.ts
+++ b/src/application/commands/auth/status.ts
@@ -1,6 +1,7 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 
 import type { AuthAccount } from "../../schemas/auth.ts";
+import { isNetworkRestrictedSandboxError } from "../shared/request.ts";
 import {
     emptyAuthCommandInputSchema,
     formatAuthStrong,
@@ -11,8 +12,14 @@ import {
 const apiKeyStatusConfig = {
     invalid: { tone: "danger", translationKey: "auth.status.apiKeyInvalid" },
     request_failed: { tone: "warning", translationKey: "auth.status.apiKeyRequestFailed" },
+    request_failed_sandbox: {
+        tone: "warning",
+        translationKey: "auth.status.apiKeyRequestFailedSandbox",
+    },
     valid: { tone: "success", translationKey: "auth.status.apiKeyValid" },
 } as const;
+
+type ApiKeyStatus = keyof typeof apiKeyStatusConfig;
 
 export const authStatusCommand: CliCommandDefinition = {
     name: "status",
@@ -71,7 +78,7 @@ export const authStatusCommand: CliCommandDefinition = {
 async function readApiKeyStatus(
     account: AuthAccount,
     context: Pick<CliExecutionContext, "fetcher" | "logger">,
-): Promise<"invalid" | "request_failed" | "valid"> {
+): Promise<ApiKeyStatus> {
     const requestStartedAt = Date.now();
     const requestUrl = `https://api.${account.endpoint}/v1/users/profile`;
 
@@ -114,6 +121,9 @@ async function readApiKeyStatus(
             },
             "Auth status request failed unexpectedly.",
         );
+        if (isNetworkRestrictedSandboxError(error)) {
+            return "request_failed_sandbox";
+        }
         return "request_failed";
     }
 }

--- a/src/application/commands/cloud-task/shared.ts
+++ b/src/application/commands/cloud-task/shared.ts
@@ -170,7 +170,7 @@ export function createCloudTaskTaskUrl(
 export async function requestCloudTask(
     requestUrl: URL,
     apiKey: string,
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
     options: {
         body?: string;
         method?: string;

--- a/src/application/commands/connector/schema-cache.test.ts
+++ b/src/application/commands/connector/schema-cache.test.ts
@@ -10,6 +10,7 @@ import {
     createConnectorActionFixture,
     createTemporaryDirectory,
 } from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
 import {
     ensureConnectorActionSchemaReference,
     persistConnectorActionSchemaCache,
@@ -195,5 +196,6 @@ function createCacheContext(
                 updater(emptySettings),
             write: async (value: AppSettings) => value,
         },
+        translator: createTranslator("en"),
     };
 }

--- a/src/application/commands/connector/schema-cache.ts
+++ b/src/application/commands/connector/schema-cache.ts
@@ -20,7 +20,7 @@ export async function ensureConnectorActionSchemaReference(
         endpoint: string;
         serviceName: string;
     },
-    context: Pick<CliExecutionContext, "fetcher" | "logger" | "settingsStore">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "settingsStore" | "translator">,
 ): Promise<ConnectorActionSchemaReference> {
     const schemaPath = resolveConnectorActionSchemaPath(
         context.settingsStore.getFilePath(),

--- a/src/application/commands/connector/search-provider.ts
+++ b/src/application/commands/connector/search-provider.ts
@@ -29,7 +29,7 @@ export async function loadConnectorSearchResults(
         keywords: readonly string[];
         text: string;
     },
-    context: Pick<CliExecutionContext, "fetcher" | "logger" | "settingsStore">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "settingsStore" | "translator">,
 ): Promise<ConnectorSearchResult[]> {
     const actions = await searchConnectorActions(options, context);
 

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -3,7 +3,12 @@ import type { Fetcher } from "../../contracts/cli.ts";
 import { describe, expect, test } from "bun:test";
 import pino from "pino";
 
-import { expectCliUserError, toRequest } from "../../../../__tests__/helpers.ts";
+import {
+    createFailedToOpenSocketError,
+    expectCliUserError,
+    toRequest,
+} from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
 import {
     getConnectorActionMetadata,
     listAuthenticatedConnectorServices,
@@ -199,6 +204,29 @@ describe("connector shared requests", () => {
             status: 400,
         });
     });
+
+    test("runConnectorAction appends the sandbox hint when the fetcher cannot open a socket", async () => {
+        const error = await expectCliUserError(runConnectorAction(
+            {
+                actionName: "send_mail",
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                inputData: {},
+                serviceName: "gmail",
+            },
+            createRequestContext({
+                fetcher: async () => {
+                    throw createFailedToOpenSocketError("network down");
+                },
+            }),
+        ));
+
+        expect(error.key).toBe("errors.connectorRun.requestError");
+        expect(error.params).toEqual({
+            message:
+                "network down\nCurrent environment may be running in a network-restricted sandbox. Try requesting elevated permissions.",
+        });
+    });
 });
 
 function createRequestContext(options: {
@@ -209,5 +237,6 @@ function createRequestContext(options: {
         logger: pino({
             enabled: false,
         }),
+        translator: createTranslator("en"),
     };
 }

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -3,7 +3,7 @@ import type { CliExecutionContext } from "../../contracts/cli.ts";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { withRequestTarget } from "../../logging/log-fields.ts";
-import { requestText } from "../shared/request.ts";
+import { getUnexpectedRequestErrorMessage, requestText } from "../shared/request.ts";
 
 export const connectorActionDefinitionSchema = z.object({
     description: z.string().optional().default(""),
@@ -73,7 +73,7 @@ export async function searchConnectorActions(
         keywords: readonly string[];
         text: string;
     },
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<ConnectorActionDefinition[]> {
     const requestUrl = new URL(
         `https://search.${options.endpoint}/v1/connector-actions`,
@@ -132,7 +132,7 @@ export async function listAuthenticatedConnectorServices(
         endpoint: string;
         services: readonly string[];
     },
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<Set<string>> {
     if (options.services.length === 0) {
         return new Set<string>();
@@ -195,7 +195,7 @@ export async function getConnectorActionMetadata(
         endpoint: string;
         serviceName: string;
     },
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<ConnectorActionDefinition> {
     const requestUrl = createConnectorActionRequestUrl(
         options.endpoint,
@@ -251,7 +251,7 @@ export async function runConnectorAction(
         inputData: unknown;
         serviceName: string;
     },
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<ConnectorActionRunResponse> {
     const requestUrl = createConnectorActionRequestUrl(
         options.endpoint,
@@ -345,7 +345,7 @@ export async function runConnectorAction(
         );
 
         throw new CliUserError("errors.connectorRun.requestError", 1, {
-            message: error instanceof Error ? error.message : String(error),
+            message: getUnexpectedRequestErrorMessage(error, context.translator),
         });
     }
 

--- a/src/application/commands/file/download/plan.ts
+++ b/src/application/commands/file/download/plan.ts
@@ -19,7 +19,7 @@ import {
 
 type DownloadPlanContext = Pick<
     CliExecutionContext,
-    "fetcher" | "fileDownloadSessionStore" | "logger"
+    "fetcher" | "fileDownloadSessionStore" | "logger" | "translator"
 >;
 
 export async function resolveDownloadPlan(

--- a/src/application/commands/file/download/request.test.ts
+++ b/src/application/commands/file/download/request.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
     createLogCapture,
 } from "../../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../../i18n/translator.ts";
 import {
     createDownloadSessionRecordFixture,
     expectCliUserError,
@@ -29,6 +30,7 @@ describe("requestFreshDownload", () => {
                     return response;
                 },
                 logger: logCapture.logger,
+                translator: createTranslator("en"),
             });
 
             expect(result).toBe(response);
@@ -50,6 +52,7 @@ describe("requestFreshDownload", () => {
                         status: 404,
                     }),
                     logger: logCapture.logger,
+                    translator: createTranslator("en"),
                 },
             ));
 
@@ -74,6 +77,7 @@ describe("requestFreshDownload", () => {
                         throw new Error("Connection dropped.");
                     },
                     logger: logCapture.logger,
+                    translator: createTranslator("en"),
                 },
             ));
 
@@ -111,6 +115,7 @@ describe("requestResumeDownload", () => {
                         });
                     },
                     logger: logCapture.logger,
+                    translator: createTranslator("en"),
                 },
                 7,
                 session,
@@ -145,6 +150,7 @@ describe("requestResumeDownload", () => {
                         });
                     },
                     logger: logCapture.logger,
+                    translator: createTranslator("en"),
                 },
                 10,
                 session,

--- a/src/application/commands/file/download/request.ts
+++ b/src/application/commands/file/download/request.ts
@@ -4,7 +4,7 @@ import type { FileDownloadSessionRecord } from "../../../contracts/file-download
 import { CliUserError } from "../../../contracts/cli.ts";
 import { performLoggedRequest } from "../../shared/request.ts";
 
-type DownloadRequestContext = Pick<CliExecutionContext, "fetcher" | "logger">;
+type DownloadRequestContext = Pick<CliExecutionContext, "fetcher" | "logger" | "translator">;
 
 export async function requestFreshDownload(
     requestUrl: URL,

--- a/src/application/commands/file/shared.test.ts
+++ b/src/application/commands/file/shared.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { createLogCapture } from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
 import { uploadFileParts } from "./shared.ts";
 
 describe("uploadFileParts", () => {
@@ -29,6 +30,7 @@ describe("uploadFileParts", () => {
                         throw new Error("network down");
                     },
                     logger: logCapture.logger,
+                    translator: createTranslator("en"),
                 },
             )).rejects.toMatchObject({
                 key: "errors.fileUpload.requestError",

--- a/src/application/commands/file/shared.ts
+++ b/src/application/commands/file/shared.ts
@@ -109,7 +109,7 @@ export async function initFileUpload(
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
     fileName: string,
     fileSize: number,
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<InitFileUploadResponse> {
     const [baseName, extension] = splitFileNameAndExtension(fileName);
     const requestUrl = createFileUploadRequestUrl(account.endpoint, "init");
@@ -147,7 +147,7 @@ export async function initFileUpload(
 export async function uploadFileParts(
     file: SliceableBlob,
     session: InitFileUploadResponse,
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<void> {
     for (let partNumber = 1; partNumber <= session.totalParts; partNumber += 1) {
         const presignedUrl = session.presignedUrls[String(partNumber)];
@@ -171,7 +171,7 @@ export async function uploadFileParts(
 export async function resolveUploadedFileUrl(
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
     uploadId: string,
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<FinalFileUploadResponse> {
     const requestUrl = createFileUploadRequestUrl(
         account.endpoint,
@@ -222,7 +222,7 @@ function createFileUploadRequestUrl(
 async function requestFileUpload(
     requestUrl: URL,
     apiKey: string,
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
     options: {
         body?: string;
         method?: string;
@@ -281,7 +281,7 @@ async function uploadFilePart(
     presignedUrl: string,
     partData: Blob,
     partNumber: number,
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<void> {
     const requestUrl = new URL(presignedUrl);
 

--- a/src/application/commands/package/search-provider.ts
+++ b/src/application/commands/package/search-provider.ts
@@ -62,7 +62,7 @@ export async function loadPackageSearchResponse(
         locale: SupportedLocale;
         text: string;
     },
-    context: Pick<CliExecutionContext, "cacheStore" | "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "cacheStore" | "fetcher" | "logger" | "translator">,
 ): Promise<ParsedPackageSearchResponse> {
     const requestUrl = createPackageSearchRequestUrl(
         options.account.endpoint,
@@ -170,7 +170,7 @@ function truncatePackageSearchText(text: string): string {
 async function requestPackageSearch(
     requestUrl: URL,
     apiKey: string,
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<string> {
     return await requestText({
         context,
@@ -207,7 +207,7 @@ async function requestPackageSearch(
 async function loadPackageSearchResponseFromUrl(
     requestUrl: URL,
     account: Pick<AuthAccount, "apiKey" | "endpoint" | "id">,
-    context: Pick<CliExecutionContext, "cacheStore" | "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "cacheStore" | "fetcher" | "logger" | "translator">,
 ): Promise<ParsedPackageSearchResponse> {
     const searchCache = context.cacheStore.getCache<string>({
         id: SEARCH_CACHE_ID,

--- a/src/application/commands/package/shared.test.ts
+++ b/src/application/commands/package/shared.test.ts
@@ -10,6 +10,7 @@ import {
     createCache,
     createCacheStore,
 } from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
 import { loadPackageInfo, parsePackageSpecifier } from "./shared.ts";
 
 const packageInfoAccount = {
@@ -379,6 +380,7 @@ function createPackageInfoContext(
         logger: pino({
             enabled: false,
         }),
+        translator: createTranslator("en"),
     };
 }
 

--- a/src/application/commands/package/shared.ts
+++ b/src/application/commands/package/shared.ts
@@ -174,7 +174,7 @@ export async function loadPackageInfo(
     packageSpecifier: ParsedPackageSpecifier,
     account: Pick<AuthAccount, "apiKey" | "endpoint" | "id">,
     requestLanguage: RequestLanguage,
-    context: Pick<CliExecutionContext, "cacheStore" | "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "cacheStore" | "fetcher" | "logger" | "translator">,
 ): Promise<PackageInfoResponse> {
     const packageInfoCache = context.cacheStore.getCache<string>({
         id: PACKAGE_INFO_CACHE_ID,
@@ -353,7 +353,7 @@ function createPackageInfoRequestUrl(
 async function requestPackageInfo(
     requestUrl: URL,
     apiKey: string,
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<string> {
     const pathSegments = requestUrl.pathname.split("/");
     const packageName = decodeURIComponent(pathSegments.at(-2) ?? "");

--- a/src/application/commands/shared/request.test.ts
+++ b/src/application/commands/shared/request.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { createLogCapture } from "../../../../__tests__/helpers.ts";
+import {
+    createConnectionRefusedError,
+    createFailedToOpenSocketError,
+    createLogCapture,
+} from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { executeCliRequest } from "./request.ts";
 
@@ -16,6 +21,7 @@ describe("executeCliRequest", () => {
                         status: 200,
                     }),
                     logger: logCapture.logger,
+                    translator: createTranslator("en"),
                 },
                 createRequestError: error => new CliUserError(
                     "errors.shared.requestError",
@@ -62,6 +68,7 @@ describe("executeCliRequest", () => {
                         status: 416,
                     }),
                     logger: logCapture.logger,
+                    translator: createTranslator("en"),
                 },
                 createRequestError: error => new CliUserError(
                     "errors.shared.requestError",
@@ -98,6 +105,7 @@ describe("executeCliRequest", () => {
                         status: 404,
                     }),
                     logger: logCapture.logger,
+                    translator: createTranslator("en"),
                 },
                 createRequestError: error => new CliUserError(
                     "errors.shared.requestError",
@@ -137,6 +145,7 @@ describe("executeCliRequest", () => {
                         throw new Error("network down");
                     },
                     logger: logCapture.logger,
+                    translator: createTranslator("en"),
                 },
                 createRequestError: error => new CliUserError(
                     "errors.shared.requestError",
@@ -164,6 +173,88 @@ describe("executeCliRequest", () => {
             expect(logCapture.read()).toContain(
                 "\"msg\":\"Shared request failed unexpectedly.\"",
             );
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("adds a sandbox network hint when the fetcher cannot open a socket", async () => {
+        const logCapture = createLogCapture();
+
+        try {
+            await expect(executeCliRequest({
+                context: {
+                    fetcher: async () => {
+                        throw createFailedToOpenSocketError("network down");
+                    },
+                    logger: logCapture.logger,
+                    translator: createTranslator("zh"),
+                },
+                createRequestError: error => new CliUserError(
+                    "errors.shared.requestError",
+                    1,
+                    {
+                        message: error instanceof Error ? error.message : String(error),
+                    },
+                ),
+                createRequestFailedError: status => new CliUserError(
+                    "errors.shared.requestFailed",
+                    1,
+                    {
+                        status,
+                    },
+                ),
+                label: "Shared",
+                requestUrl: new URL("https://example.com/items/1"),
+            })).rejects.toMatchObject({
+                key: "errors.shared.requestError",
+                params: {
+                    message:
+                        "network down\n当前环境可能在网络受限的沙箱中，请尝试提权。",
+                },
+            });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("adds a sandbox network hint when the fetcher connection is refused", async () => {
+        const logCapture = createLogCapture();
+
+        try {
+            await expect(executeCliRequest({
+                context: {
+                    fetcher: async () => {
+                        throw createConnectionRefusedError("connection refused");
+                    },
+                    logger: logCapture.logger,
+                    translator: createTranslator("zh"),
+                },
+                createRequestError: error => new CliUserError(
+                    "errors.shared.requestError",
+                    1,
+                    {
+                        message: error instanceof Error ? error.message : String(error),
+                    },
+                ),
+                createRequestFailedError: status => new CliUserError(
+                    "errors.shared.requestFailed",
+                    1,
+                    {
+                        status,
+                    },
+                ),
+                label: "Shared",
+                requestUrl: new URL("https://example.com/items/1"),
+            })).rejects.toMatchObject({
+                key: "errors.shared.requestError",
+                params: {
+                    message:
+                        "connection refused\n当前环境可能在网络受限的沙箱中，请尝试提权。",
+                },
+            });
         }
         finally {
             logCapture.close();

--- a/src/application/commands/shared/request.ts
+++ b/src/application/commands/shared/request.ts
@@ -3,9 +3,20 @@ import type { CliExecutionContext } from "../../contracts/cli.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { withRequestTarget } from "../../logging/log-fields.ts";
 
-type RequestContext = Pick<CliExecutionContext, "fetcher" | "logger">;
+type RequestContext = Pick<CliExecutionContext, "fetcher" | "logger" | "translator">;
 type LogFields = Record<string, unknown>;
 type LogFieldsResolver<TValue> = LogFields | ((input: TValue) => LogFields);
+
+export const failedToOpenSocketErrorCode = "FailedToOpenSocket";
+export const connectionRefusedErrorCode = "ConnectionRefused";
+
+const networkRestrictedSandboxErrorCodes = [
+    failedToOpenSocketErrorCode,
+    connectionRefusedErrorCode,
+] as const;
+
+type NetworkRestrictedSandboxErrorCode
+    = typeof networkRestrictedSandboxErrorCodes[number];
 
 interface ExecuteCliRequestOptions {
     allowedStatusCodes?: readonly number[];
@@ -103,7 +114,12 @@ export async function executeCliRequest(
             },
             `${options.label} request failed unexpectedly.`,
         );
-        throw options.createRequestError(error);
+        throw options.createRequestError(
+            enhanceUnexpectedRequestError(
+                error,
+                options.context.translator,
+            ),
+        );
     }
 }
 
@@ -134,6 +150,45 @@ function resolveLogFields<TValue>(
     }
 
     return value ?? {};
+}
+
+export function getUnexpectedRequestErrorMessage(
+    error: unknown,
+    translator: Pick<CliExecutionContext["translator"], "t">,
+): string {
+    const baseMessage = error instanceof Error ? error.message : String(error);
+
+    if (!isNetworkRestrictedSandboxError(error)) {
+        return baseMessage;
+    }
+
+    return `${baseMessage}\n${translator.t("errors.shared.networkRestrictedSandboxHint")}`;
+}
+
+function enhanceUnexpectedRequestError(
+    error: unknown,
+    translator: Pick<CliExecutionContext["translator"], "t">,
+): unknown {
+    if (!isNetworkRestrictedSandboxError(error)) {
+        return error;
+    }
+
+    const enhanced = new Error(getUnexpectedRequestErrorMessage(error, translator)) as
+        Error & { code: NetworkRestrictedSandboxErrorCode };
+
+    enhanced.code = error.code;
+    enhanced.stack = error.stack;
+
+    return enhanced;
+}
+
+export function isNetworkRestrictedSandboxError(
+    error: unknown,
+): error is Error & { code: NetworkRestrictedSandboxErrorCode } {
+    return error instanceof Error
+        && "code" in error
+        && typeof error.code === "string"
+        && (networkRestrictedSandboxErrorCodes as readonly string[]).includes(error.code);
 }
 
 export async function performLoggedRequest(

--- a/src/application/commands/skills/registry-skill-source.test.ts
+++ b/src/application/commands/skills/registry-skill-source.test.ts
@@ -6,6 +6,7 @@ import pino from "pino";
 import {
     toRequest,
 } from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
 import {
     createRegistryPackageInfoRequestUrl,
     createRegistryPackageTarballRequestUrl,
@@ -122,11 +123,12 @@ describe("registry skill source", () => {
 
 function createRegistrySkillSourceContext(options: {
     fetcher: Fetcher;
-}): Pick<CliExecutionContext, "fetcher" | "logger"> {
+}): Pick<CliExecutionContext, "fetcher" | "logger" | "translator"> {
     return {
         fetcher: options.fetcher,
         logger: pino({
             enabled: false,
         }),
+        translator: createTranslator("en"),
     };
 }

--- a/src/application/commands/skills/registry-skill-source.ts
+++ b/src/application/commands/skills/registry-skill-source.ts
@@ -56,7 +56,7 @@ export function createRegistryPackageTarballRequestUrl(
 export async function loadRegistryPackageSkillInfo(
     packageName: string,
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<RegistryPackageSkillInfo> {
     const requestUrl = createRegistryPackageInfoRequestUrl(
         account.endpoint,
@@ -97,7 +97,7 @@ export async function downloadRegistryPackageTarball(
     packageName: string,
     packageVersion: string,
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<Uint8Array<ArrayBuffer>> {
     const requestUrl = createRegistryPackageTarballRequestUrl(
         account.endpoint,

--- a/src/application/commands/skills/search.cli.test.ts
+++ b/src/application/commands/skills/search.cli.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
     createCliSandbox,
     createCliSnapshot,
+    createFailedToOpenSocketError,
     toRequest,
     writeAuthFile,
 } from "../../../../__tests__/helpers.ts";
@@ -241,6 +242,32 @@ describe("skills search CLI", () => {
                 result: createCliSnapshot(result),
             }).toMatchSnapshot();
             expect(result).toEqual(expectedHelp);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("adds a sandbox hint when the skills search request cannot open a socket", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "search", "text generation"],
+                {
+                    fetcher: async () => {
+                        throw createFailedToOpenSocketError("network down");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "The skills search request failed: network down\nCurrent environment may be running in a network-restricted sandbox. Try requesting elevated permissions.\n",
+            );
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/search.ts
+++ b/src/application/commands/skills/search.ts
@@ -121,7 +121,7 @@ function createSkillsSearchRequestUrl(
 async function requestSkillsSearch(
     requestUrl: URL,
     apiKey: string,
-    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<string> {
     const keywordCount = requestUrl.searchParams.getAll("keywords").length;
 

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -13,6 +13,8 @@ export const enMessages = {
     "auth.status.activeAccount": "Active account",
     "auth.status.apiKeyInvalid": "Invalid",
     "auth.status.apiKeyRequestFailed": "Request failed",
+    "auth.status.apiKeyRequestFailedSandbox":
+        "Request failed (network-restricted sandbox, try requesting elevated permissions)",
     "auth.status.apiKeyStatus": "API key status",
     "auth.status.apiKeyValid": "Valid",
     "auth.status.loggedOut": "Not logged in to any OOMOL account.",
@@ -168,6 +170,8 @@ export const enMessages = {
         "Invalid format: {value}. Use json.",
     "errors.shared.invalidPositiveIntegerOption":
         "Invalid value for {option}: {value}. Use an integer greater than or equal to 1.",
+    "errors.shared.networkRestrictedSandboxHint":
+        "Current environment may be running in a network-restricted sandbox. Try requesting elevated permissions.",
     "errors.cloudTask.invalidResponse":
         "The cloud task service returned an unsupported response body.",
     "errors.cloudTask.requestError":
@@ -571,6 +575,8 @@ export const zhMessages = {
     "auth.status.activeAccount": "当前激活账号",
     "auth.status.apiKeyInvalid": "无效",
     "auth.status.apiKeyRequestFailed": "请求失败",
+    "auth.status.apiKeyRequestFailedSandbox":
+        "请求失败（网络受限沙箱，请尝试提权）",
     "auth.status.apiKeyStatus": "API key 状态",
     "auth.status.apiKeyValid": "有效",
     "auth.status.loggedOut": "当前没有登录任何 OOMOL 账号。",
@@ -699,6 +705,8 @@ export const zhMessages = {
         "无效的 format：{value}。请使用 json。",
     "errors.shared.invalidPositiveIntegerOption":
         "{option} 的值无效：{value}。请使用大于等于 1 的整数。",
+    "errors.shared.networkRestrictedSandboxHint":
+        "当前环境可能在网络受限的沙箱中，请尝试提权。",
     "errors.cloudTask.invalidResponse":
         "云任务服务返回了不受支持的响应内容。",
     "errors.cloudTask.requestError":


### PR DESCRIPTION
Sandboxed network failures were surfacing as generic request errors, which made it unclear that the user should retry with elevated permissions.

Detect socket-open and connection-refused sandbox errors in the shared request path, append localized guidance, and update affected auth, connector, file, package, and skills flows with coverage.