### PR TITLE
ci(release): add bundled binary release asset

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -94,5 +94,5 @@ jobs:
 
       - name: Create GitHub Release
         run: |
-          mapfile -t release_assets < dist/npm-publish-order.txt
+          mapfile -t release_assets < dist/github-release-assets.txt
           bun run contrib/ci/release-workflow.ts create-github-release "${release_assets[@]}"

--- a/contrib/ci/npm-packages.ts
+++ b/contrib/ci/npm-packages.ts
@@ -3,6 +3,8 @@ import { dirname, join } from "node:path";
 import process from "node:process";
 
 import platformTargetsData from "../npm/platform-targets.json";
+import { createGitHubReleaseBundle } from "./release-bundle.ts";
+import { ensureReleaseVersion } from "./release-version.ts";
 
 interface PackageManifest {
     author?: string;
@@ -222,9 +224,23 @@ export async function buildNpmReleasePackages(options: {
     );
     tarballPaths.push(packPackage(wrapperDir, outDir));
 
+    const releaseBundlePath = await createGitHubReleaseBundle({
+        outDir,
+        releaseVersion,
+        stagingDir,
+        targets: selectedTargets.map(target => ({
+            executableFileName: target.executableFileName,
+            id: target.id,
+        })),
+    });
+
     writeFileSync(
         join(outDir, "npm-publish-order.txt"),
         `${tarballPaths.join("\n")}\n`,
+    );
+    writeFileSync(
+        join(outDir, "github-release-assets.txt"),
+        `${[...tarballPaths, releaseBundlePath].join("\n")}\n`,
     );
 
     return tarballPaths;
@@ -244,12 +260,6 @@ export function resolvePackageVersion(
     ensureReleaseVersion(resolvedVersion);
 
     return resolvedVersion;
-}
-
-function ensureReleaseVersion(releaseVersion: string): void {
-    if (releaseVersion.trim() === "") {
-        throw new Error("RELEASE_VERSION is required.");
-    }
 }
 
 export function selectPlatformTargets(targetIds: readonly string[] | undefined): readonly PlatformTarget[] {

--- a/contrib/ci/release-bundle.test.ts
+++ b/contrib/ci/release-bundle.test.ts
@@ -1,0 +1,117 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { createTemporaryDirectory } from "../../__tests__/helpers.ts";
+import {
+    buildReleaseBundleManifest,
+    createGitHubReleaseBundle,
+    releaseBundleFileName,
+    resolveReleaseBundleTargetDirectory,
+} from "./release-bundle.ts";
+
+describe("release bundle", () => {
+    test("builds a GitHub release archive with the expected directory layout", async () => {
+        const rootDirectoryPath = await createTemporaryDirectory("oo-release-bundle");
+        const extractDirectoryPath = await createTemporaryDirectory("oo-release-bundle-extract");
+        const outDirectoryPath = join(rootDirectoryPath, "dist");
+        const stagingDirectoryPath = join(rootDirectoryPath, ".packages");
+        const releaseVersion = "1.2.3";
+        const targets = [
+            { id: "darwin-arm64", executableFileName: "oo" },
+            { id: "darwin-x64", executableFileName: "oo" },
+            { id: "linux-arm64-gnu", executableFileName: "oo" },
+            { id: "linux-arm64-musl", executableFileName: "oo" },
+            { id: "linux-x64-gnu", executableFileName: "oo" },
+            { id: "linux-x64-musl", executableFileName: "oo" },
+            { id: "win32-arm64", executableFileName: "oo.exe" },
+            { id: "win32-x64", executableFileName: "oo.exe" },
+        ] as const;
+
+        try {
+            await Promise.all(
+                targets.map(target =>
+                    writeReleaseBundleBinaryFixture(
+                        stagingDirectoryPath,
+                        target.id,
+                        target.executableFileName,
+                    ),
+                ),
+            );
+
+            const archivePath = await createGitHubReleaseBundle({
+                outDir: outDirectoryPath,
+                releaseVersion,
+                stagingDir: stagingDirectoryPath,
+                targets,
+            });
+
+            expect(archivePath).toBe(
+                join(outDirectoryPath, releaseBundleFileName),
+            );
+
+            const archive = new Bun.Archive(await Bun.file(archivePath).bytes());
+            await archive.extract(extractDirectoryPath);
+
+            expect(
+                await readFile(join(extractDirectoryPath, "manifest.json"), "utf8"),
+            ).toBe(buildReleaseBundleManifest(releaseVersion));
+
+            for (const target of targets) {
+                expect(
+                    await readFile(
+                        join(
+                            extractDirectoryPath,
+                            releaseVersion,
+                            resolveReleaseBundleTargetDirectory(target.id),
+                            target.executableFileName,
+                        ),
+                        "utf8",
+                    ),
+                ).toBe(`${target.id}\n`);
+            }
+        }
+        finally {
+            await Promise.all([
+                rm(rootDirectoryPath, { force: true, recursive: true }),
+                rm(extractDirectoryPath, { force: true, recursive: true }),
+            ]);
+        }
+    });
+
+    test("maps release bundle directories to the requested platform names", () => {
+        expect(resolveReleaseBundleTargetDirectory("linux-arm64-gnu")).toBe("linux-arm64");
+        expect(resolveReleaseBundleTargetDirectory("linux-x64-gnu")).toBe("linux-x64");
+        expect(resolveReleaseBundleTargetDirectory("linux-arm64-musl")).toBe("linux-arm64-musl");
+        expect(resolveReleaseBundleTargetDirectory("win32-x64")).toBe("win32-x64");
+    });
+
+    test("rejects unsupported release bundle targets", () => {
+        expect(() => resolveReleaseBundleTargetDirectory("linux-ppc64")).toThrow(
+            "Unsupported release bundle target: linux-ppc64",
+        );
+    });
+
+    test("rejects an empty release version", () => {
+        expect(() => buildReleaseBundleManifest("")).toThrow("RELEASE_VERSION is required.");
+    });
+});
+
+async function writeReleaseBundleBinaryFixture(
+    stagingDirectoryPath: string,
+    targetId: string,
+    executableFileName: string,
+): Promise<void> {
+    const outputPath = join(
+        stagingDirectoryPath,
+        targetId,
+        "bin",
+        executableFileName,
+    );
+
+    await mkdir(join(stagingDirectoryPath, targetId, "bin"), {
+        recursive: true,
+    });
+    await writeFile(outputPath, `${targetId}\n`);
+}

--- a/contrib/ci/release-bundle.ts
+++ b/contrib/ci/release-bundle.ts
@@ -1,0 +1,86 @@
+import { mkdirSync } from "node:fs";
+import { join, posix } from "node:path";
+
+import { ensureReleaseVersion } from "./release-version.ts";
+
+interface ReleaseBundleTarget {
+    executableFileName: string;
+    id: string;
+}
+
+export const releaseBundleFileName = "oo-binaries.tgz";
+
+const releaseTargetDirectoryById = {
+    "darwin-arm64": "darwin-arm64",
+    "darwin-x64": "darwin-x64",
+    "linux-arm64-gnu": "linux-arm64",
+    "linux-arm64-musl": "linux-arm64-musl",
+    "linux-x64-gnu": "linux-x64",
+    "linux-x64-musl": "linux-x64-musl",
+    "win32-arm64": "win32-arm64",
+    "win32-x64": "win32-x64",
+} as const satisfies Record<string, string>;
+
+export function buildReleaseBundleManifest(releaseVersion: string): string {
+    ensureReleaseVersion(releaseVersion);
+
+    return `${JSON.stringify({ version: releaseVersion }, null, 2)}\n`;
+}
+
+export async function createGitHubReleaseBundle(options: {
+    outDir: string;
+    releaseVersion: string;
+    stagingDir: string;
+    targets: readonly ReleaseBundleTarget[];
+}): Promise<string> {
+    const archiveEntries = await buildReleaseBundleArchiveEntries(options);
+    const archivePath = join(options.outDir, releaseBundleFileName);
+    const archiveBytes = await new Bun.Archive(archiveEntries, {
+        compress: "gzip",
+    }).bytes();
+
+    mkdirSync(options.outDir, { recursive: true });
+    await Bun.write(archivePath, archiveBytes);
+
+    return archivePath;
+}
+
+export function resolveReleaseBundleTargetDirectory(targetId: string): string {
+    if (!(targetId in releaseTargetDirectoryById)) {
+        throw new Error(`Unsupported release bundle target: ${targetId}`);
+    }
+
+    return releaseTargetDirectoryById[targetId as keyof typeof releaseTargetDirectoryById];
+}
+
+async function buildReleaseBundleArchiveEntries(options: {
+    releaseVersion: string;
+    stagingDir: string;
+    targets: readonly ReleaseBundleTarget[];
+}): Promise<Record<string, string | Uint8Array>> {
+    const targetEntries = await Promise.all(
+        options.targets.map(async (target) => {
+            const sourcePath = join(
+                options.stagingDir,
+                target.id,
+                "bin",
+                target.executableFileName,
+            );
+            const archivePath = posix.join(
+                options.releaseVersion,
+                resolveReleaseBundleTargetDirectory(target.id),
+                target.executableFileName,
+            );
+
+            return [
+                archivePath,
+                await Bun.file(sourcePath).bytes(),
+            ] as const;
+        }),
+    );
+
+    return {
+        "manifest.json": buildReleaseBundleManifest(options.releaseVersion),
+        ...Object.fromEntries(targetEntries),
+    };
+}

--- a/contrib/ci/release-version.ts
+++ b/contrib/ci/release-version.ts
@@ -1,5 +1,11 @@
 export type VersionBump = "patch" | "minor" | "major";
 
+export function ensureReleaseVersion(releaseVersion: string): void {
+    if (releaseVersion.trim() === "") {
+        throw new Error("RELEASE_VERSION is required.");
+    }
+}
+
 export interface ReleaseVersionResult {
     version: string;
     tagName: string;

--- a/contrib/ci/release-workflow.test.ts
+++ b/contrib/ci/release-workflow.test.ts
@@ -43,7 +43,10 @@ describe("release-workflow", () => {
                 releaseTag: "v1.2.3",
                 previousTag: "v1.2.2",
                 target: "abc123",
-                assets: ["dist/oo-1.2.3.tgz"],
+                assets: [
+                    "dist/oo-1.2.3.tgz",
+                    "dist/oo-binaries.tgz",
+                ],
             }),
         ).toEqual([
             "gh",
@@ -51,6 +54,7 @@ describe("release-workflow", () => {
             "create",
             "v1.2.3",
             "dist/oo-1.2.3.tgz",
+            "dist/oo-binaries.tgz",
             "--target",
             "abc123",
             "--title",
@@ -68,7 +72,10 @@ describe("release-workflow", () => {
                 releaseTag: "v1.2.3",
                 previousTag: "",
                 target: "abc123",
-                assets: ["dist/oo-1.2.3.tgz"],
+                assets: [
+                    "dist/oo-1.2.3.tgz",
+                    "dist/oo-binaries.tgz",
+                ],
             }),
         ).toEqual([
             "gh",
@@ -76,6 +83,7 @@ describe("release-workflow", () => {
             "create",
             "v1.2.3",
             "dist/oo-1.2.3.tgz",
+            "dist/oo-binaries.tgz",
             "--target",
             "abc123",
             "--title",


### PR DESCRIPTION
Publish now needs a standalone binary archive in GitHub releases alongside the npm tarballs. This adds oo-binaries.tgz with the versioned platform layout and manifest, and wires the publish workflow to upload the generated asset.