### PR TITLE
feat(install): add hidden self-install command

### DIFF
--- a/src/adapters/commander/commander-cli-adapter.ts
+++ b/src/adapters/commander/commander-cli-adapter.ts
@@ -102,7 +102,9 @@ export class CommanderCliAdapter {
         definition: CliCommandDefinition,
         context: CliExecutionContext,
     ): void {
-        const command = parent.command(definition.name);
+        const command = parent.command(definition.name, {
+            hidden: definition.hidden === true,
+        });
         configureCommand(command, definition, context.translator);
 
         for (const child of definition.children ?? []) {

--- a/src/adapters/completion/static-completion-renderer.test.ts
+++ b/src/adapters/completion/static-completion-renderer.test.ts
@@ -14,6 +14,7 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain("completion");
         expect(output).toContain("config");
         expect(output).toContain("connector");
+        expect(output).not.toContain(`"|install")`);
         expect(output).toContain("login");
         expect(output).toContain("logout");
         expect(output).toContain("packages");
@@ -30,6 +31,7 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain("auth switch");
         expect(output).toContain("config set");
         expect(output).toContain("connector run");
+        expect(output).not.toContain(`"|install")`);
         expect(output).toContain("packages search");
         expect(output).toContain("search");
         expect(output).toContain(`compdef _${APP_NAME} ${APP_NAME}`);
@@ -45,6 +47,9 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain("completion");
         expect(output).toContain("config");
         expect(output).toContain("connector");
+        expect(output).not.toContain(
+            `complete -c ${APP_NAME} -n '__fish_use_subcommand' -a 'install'`,
+        );
         expect(output).toContain("login");
         expect(output).toContain("logout");
         expect(output).toContain("__fish_seen_subcommand_from packages");

--- a/src/adapters/completion/static-completion-renderer.ts
+++ b/src/adapters/completion/static-completion-renderer.ts
@@ -50,8 +50,9 @@ function buildCompletionNodes(
         commands: readonly CliCommandDefinition[],
         argumentChoices: readonly (readonly string[])[] = [],
     ): void => {
+        const visibleCommands = commands.filter(command => command.hidden !== true);
         const pathKey = path.join(" ");
-        const childCommands = commands.map(command => ({
+        const childCommands = visibleCommands.map(command => ({
             name: command.name,
             summary: translator.t(command.summaryKey),
         }));
@@ -79,7 +80,7 @@ function buildCompletionNodes(
             argumentChoices,
         });
 
-        for (const command of commands) {
+        for (const command of visibleCommands) {
             visit(
                 [...path, command.name],
                 command.children ?? [],

--- a/src/application/commands/__snapshots__/install.cli.test.ts.snap
+++ b/src/application/commands/__snapshots__/install.cli.test.ts.snap
@@ -1,0 +1,38 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`install CLI renders install help in English and Chinese 1`] = `
+{
+  "chineseHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"将当前运行中的 oo 二进制安装到用户级 bin 目录。
+
+选项：
+  -h, --help     显示命令帮助
+
+全局选项：
+  -V, --version  显示当前版本
+  --debug        在 CLI 退出时打印当前日志文件路径
+  --lang <lang>  指定显示语言
+"
+,
+  },
+  "englishHelp": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Install the current oo binary into the user-level bin directory.
+
+Options:
+  -h, --help     Show help for command
+
+Global Options:
+  -V, --version  Show the current version
+  --debug        Print the current log file path when the CLI exits
+  --lang <lang>  Specify the display language
+"
+,
+  },
+}
+`;

--- a/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
@@ -225,4 +225,3 @@ exports[`auth CLI renders the auth switch success block with gh-style emphasis w
 ,
 }
 `;
-

--- a/src/application/commands/catalog.ts
+++ b/src/application/commands/catalog.ts
@@ -8,6 +8,7 @@ import { completionCommand } from "./completion.ts";
 import { configCommand } from "./config/index.ts";
 import { connectorCommand } from "./connector/index.ts";
 import { fileCommand } from "./file/index.ts";
+import { installCommand } from "./install.ts";
 import { logCommand } from "./log/index.ts";
 import { loginCommand } from "./login.ts";
 import { logoutCommand } from "./logout.ts";
@@ -42,6 +43,7 @@ export function createCliCatalog(): CliCatalog {
             cloudTaskCommand,
             connectorCommand,
             fileCommand,
+            installCommand,
             loginCommand,
             logoutCommand,
             completionCommand,

--- a/src/application/commands/install.cli.test.ts
+++ b/src/application/commands/install.cli.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    createCliSandbox,
+    createCliSnapshot,
+} from "../../../__tests__/helpers.ts";
+
+describe("install CLI", () => {
+    test("renders install help in English and Chinese", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const englishHelp = await sandbox.run(["install", "--help"]);
+            const chineseHelp = await sandbox.run([
+                "--lang",
+                "zh",
+                "install",
+                "--help",
+            ]);
+
+            expect({
+                chineseHelp: createCliSnapshot(chineseHelp),
+                englishHelp: createCliSnapshot(englishHelp),
+            }).toMatchSnapshot();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/install.ts
+++ b/src/application/commands/install.ts
@@ -1,0 +1,15 @@
+import type { CliCommandDefinition } from "../contracts/cli.ts";
+
+import { z } from "zod";
+import { runSelfInstall } from "./self-install.ts";
+
+export const installCommand: CliCommandDefinition = {
+    hidden: true,
+    name: "install",
+    summaryKey: "commands.install.summary",
+    descriptionKey: "commands.install.description",
+    inputSchema: z.object({}),
+    handler: async (_, context) => {
+        await runSelfInstall(context);
+    },
+};

--- a/src/application/commands/self-install.test.ts
+++ b/src/application/commands/self-install.test.ts
@@ -1,0 +1,474 @@
+import type { CliExecutionContext } from "../contracts/cli.ts";
+
+import { chmod, lstat, mkdtemp, readlink, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, posix, win32 } from "node:path";
+import process from "node:process";
+import { describe, expect, test } from "bun:test";
+import pino from "pino";
+import {
+    createNoopFileDownloadSessionStore,
+    createNoopFileUploadStore,
+    createTextBuffer,
+} from "../../../__tests__/helpers.ts";
+import { createTranslator } from "../../i18n/translator.ts";
+import { CliUserError } from "../contracts/cli.ts";
+import {
+    checkPathSetup,
+    installBinary,
+    resolveInstallSource,
+    resolveInstallTarget,
+    runSelfInstall,
+    verifyInstall,
+} from "./self-install.ts";
+
+describe("self install helpers", () => {
+    test("resolves install targets for unix and windows platforms", () => {
+        expect(resolveInstallTarget({
+            env: {
+                HOME: "/Users/alice",
+                USERPROFILE: "C:\\Users\\Alice",
+            },
+            platform: "darwin",
+        })).toEqual({
+            binDir: posix.join("/Users/alice", ".local", "bin"),
+            binaryPath: posix.join("/Users/alice", ".local", "bin", "oo"),
+            displayBinDir: "~/.local/bin",
+            displayBinaryPath: "~/.local/bin/oo",
+            isWindows: false,
+            platform: "darwin",
+        });
+
+        expect(resolveInstallTarget({
+            env: {
+                HOME: "C:\\home-fallback",
+                USERPROFILE: "C:\\Users\\Alice",
+            },
+            platform: "win32",
+        })).toEqual({
+            binDir: win32.join("C:\\Users\\Alice", ".local", "bin"),
+            binaryPath: win32.join("C:\\Users\\Alice", ".local", "bin", "oo.exe"),
+            displayBinDir: win32.join("C:\\Users\\Alice", ".local", "bin"),
+            displayBinaryPath: win32.join(
+                "C:\\Users\\Alice",
+                ".local",
+                "bin",
+                "oo.exe",
+            ),
+            isWindows: true,
+            platform: "win32",
+        });
+    });
+
+    test("accepts PATH entries with duplicates and case differences", () => {
+        const translator = createTranslator("en");
+        const unixTarget = resolveInstallTarget({
+            env: {
+                HOME: "/Users/alice",
+            },
+            platform: "darwin",
+        });
+        const windowsTarget = resolveInstallTarget({
+            env: {
+                USERPROFILE: "C:\\Users\\Alice",
+            },
+            platform: "win32",
+        });
+
+        expect(checkPathSetup(unixTarget, {
+            cwd: "/repo",
+            env: {
+                PATH: [
+                    "",
+                    "/usr/bin",
+                    "/Users/alice/.local/bin",
+                    "/Users/alice/.local/bin",
+                ].join(":"),
+                SHELL: "/bin/zsh",
+            },
+            platform: "darwin",
+            translator,
+        })).toEqual([]);
+
+        expect(checkPathSetup(windowsTarget, {
+            cwd: "C:\\repo",
+            env: {
+                PATH: [
+                    "C:\\Windows\\System32",
+                    "c:\\users\\ALICE\\.local\\bin",
+                ].join(";"),
+            },
+            platform: "win32",
+            translator,
+        })).toEqual([]);
+    });
+
+    test("renders shell-specific PATH setup notes", () => {
+        const translator = createTranslator("en");
+        const target = resolveInstallTarget({
+            env: {
+                HOME: "/Users/alice",
+            },
+            platform: "darwin",
+        });
+
+        expect(checkPathSetup(target, {
+            cwd: "/repo",
+            env: {
+                PATH: "/usr/bin",
+                SHELL: "/bin/zsh",
+            },
+            platform: "darwin",
+            translator,
+        })[0]?.message).toContain("~/.zshrc");
+        expect(checkPathSetup(target, {
+            cwd: "/repo",
+            env: {
+                PATH: "/usr/bin",
+                SHELL: "/bin/bash",
+            },
+            platform: "darwin",
+            translator,
+        })[0]?.message).toContain("~/.bashrc");
+        expect(checkPathSetup(target, {
+            cwd: "/repo",
+            env: {
+                PATH: "/usr/bin",
+                SHELL: "/opt/homebrew/bin/fish",
+            },
+            platform: "darwin",
+            translator,
+        })[0]?.message).toContain("fish_add_path");
+        expect(checkPathSetup(target, {
+            cwd: "/repo",
+            env: {
+                PATH: "/usr/bin",
+            },
+            platform: "darwin",
+            translator,
+        })[0]?.message).toContain("shell config file");
+    });
+
+    test("rejects unstable source runtimes", async () => {
+        const sourceRoot = await mkdtemp(
+            join(process.cwd(), ".tmp-install-source-invalid-"),
+        );
+        const unstableBinaryPath = join(sourceRoot, "bun");
+
+        try {
+            await Bun.write(unstableBinaryPath, "binary\n");
+            await chmod(unstableBinaryPath, 0o755);
+
+            await expect(resolveInstallSource({
+                argv0: "bun",
+                execPath: unstableBinaryPath,
+                main: join(process.cwd(), "index.ts"),
+                pid: 123,
+                platform: "darwin",
+                tempDirectoryPath: "/tmp",
+            })).rejects.toMatchObject({
+                key: "errors.install.invalidSource",
+            });
+
+            await expect(resolveInstallSource({
+                argv0: unstableBinaryPath,
+                execPath: unstableBinaryPath,
+                main: "/$bunfs/root/oo",
+                pid: 123,
+                platform: "darwin",
+                tempDirectoryPath: process.cwd(),
+            })).rejects.toMatchObject({
+                key: "errors.install.invalidSource",
+            });
+        }
+        finally {
+            await rm(sourceRoot, { force: true, recursive: true });
+        }
+    });
+
+    test("restores the previous windows installation when copy fails", async () => {
+        const source = {
+            displayPath: "C:\\source\\oo.exe",
+            executablePath: "C:\\source\\oo.exe",
+        };
+        const target = {
+            binDir: "C:\\Users\\Alice\\.local\\bin",
+            binaryPath: "C:\\Users\\Alice\\.local\\bin\\oo.exe",
+            displayBinDir: "C:\\Users\\Alice\\.local\\bin",
+            displayBinaryPath: "C:\\Users\\Alice\\.local\\bin\\oo.exe",
+            isWindows: true,
+            platform: "win32" as const,
+        };
+        const renames: Array<{
+            sourcePath: string;
+            targetPath: string;
+        }> = [];
+
+        await expect(installBinary(
+            source,
+            target,
+            {
+                pid: 123,
+            },
+            {
+                copyFile: async () => {
+                    throw new Error("copy failed");
+                },
+                mkdir: async () => undefined,
+                now: () => 1000,
+                realpath: async (path) => {
+                    if (path === target.binaryPath) {
+                        return target.binaryPath;
+                    }
+
+                    return path;
+                },
+                rename: async (sourcePath, targetPath) => {
+                    renames.push({
+                        sourcePath,
+                        targetPath,
+                    });
+                },
+                rm: async () => undefined,
+            },
+        )).rejects.toMatchObject({
+            key: "errors.install.writeFailed",
+        });
+
+        expect(renames).toEqual([
+            {
+                sourcePath: target.binaryPath,
+                targetPath: `${target.binaryPath}.old.1000`,
+            },
+            {
+                sourcePath: `${target.binaryPath}.old.1000`,
+                targetPath: target.binaryPath,
+            },
+        ]);
+    });
+});
+
+describe("runSelfInstall", () => {
+    test("installs the current unix binary and warns when PATH is missing", async () => {
+        if (process.platform === "win32") {
+            return;
+        }
+
+        const sourceRoot = await mkdtemp(
+            join(process.cwd(), ".tmp-oo-install-source-"),
+        );
+        const homeRoot = await mkdtemp(join(tmpdir(), "oo-install-home-"));
+        const sourcePath = join(sourceRoot, "oo");
+        const stdout = createTextBuffer();
+
+        try {
+            await Bun.write(sourcePath, "binary\n");
+            await chmod(sourcePath, 0o755);
+
+            await runSelfInstall(
+                createInstallContext({
+                    cwd: process.cwd(),
+                    env: {
+                        HOME: homeRoot,
+                        PATH: "/usr/bin",
+                        USERPROFILE: homeRoot,
+                    },
+                    stdout,
+                }),
+                {
+                    runtime: {
+                        argv0: sourcePath,
+                        execPath: sourcePath,
+                        main: "/$bunfs/root/oo",
+                        pid: 42,
+                        platform: process.platform,
+                        tempDirectoryPath: tmpdir(),
+                    },
+                },
+            );
+
+            const target = resolveInstallTarget({
+                env: {
+                    HOME: homeRoot,
+                    USERPROFILE: homeRoot,
+                },
+                platform: process.platform,
+            });
+            const targetStats = await lstat(target.binaryPath);
+
+            expect(targetStats.isSymbolicLink()).toBeTrue();
+            expect(await readlink(target.binaryPath)).toBe(sourcePath);
+            expect(stdout.read()).toContain("Installing oo...");
+            expect(stdout.read()).toContain("oo successfully installed!");
+            expect(stdout.read()).toContain("Location: ~/.local/bin/oo");
+            expect(stdout.read()).toContain("Setup notes:");
+        }
+        finally {
+            await rm(sourceRoot, { force: true, recursive: true });
+            await rm(homeRoot, { force: true, recursive: true });
+        }
+    });
+
+    test("is idempotent when the binary is already installed", async () => {
+        if (process.platform === "win32") {
+            return;
+        }
+
+        const sourceRoot = await mkdtemp(
+            join(process.cwd(), ".tmp-oo-install-source-"),
+        );
+        const homeRoot = await mkdtemp(join(tmpdir(), "oo-install-home-"));
+        const sourcePath = join(sourceRoot, "oo");
+
+        try {
+            await Bun.write(sourcePath, "binary\n");
+            await chmod(sourcePath, 0o755);
+
+            const runtime = {
+                argv0: sourcePath,
+                execPath: sourcePath,
+                main: "/$bunfs/root/oo",
+                pid: 42,
+                platform: process.platform,
+                tempDirectoryPath: tmpdir(),
+            } as const;
+            const context = createInstallContext({
+                cwd: process.cwd(),
+                env: {
+                    HOME: homeRoot,
+                    PATH: [
+                        "/usr/bin",
+                        posix.join(homeRoot, ".local", "bin"),
+                    ].join(":"),
+                    USERPROFILE: homeRoot,
+                },
+            });
+
+            await runSelfInstall(context, { runtime });
+            const target = resolveInstallTarget({
+                env: {
+                    HOME: homeRoot,
+                    USERPROFILE: homeRoot,
+                },
+                platform: process.platform,
+            });
+            const firstLinkTarget = await readlink(target.binaryPath);
+
+            await runSelfInstall(context, { runtime });
+
+            expect(await readlink(target.binaryPath)).toBe(firstLinkTarget);
+            await verifyInstall(target);
+        }
+        finally {
+            await rm(sourceRoot, { force: true, recursive: true });
+            await rm(homeRoot, { force: true, recursive: true });
+        }
+    });
+
+    test("wraps invalid-source failures in a user-facing install error", async () => {
+        const context = createInstallContext({
+            cwd: process.cwd(),
+            env: {
+                HOME: "/Users/alice",
+                PATH: "/usr/bin",
+            },
+        });
+
+        await expect(runSelfInstall(context, {
+            runtime: {
+                argv0: "bun",
+                execPath: "/usr/local/bin/bun",
+                main: join(process.cwd(), "index.ts"),
+                pid: 42,
+                platform: "darwin",
+                tempDirectoryPath: "/tmp",
+            },
+            realpath: async path => path,
+            stat: async () => createStatsStub({
+                executable: true,
+                file: true,
+            }),
+        })).rejects.toEqual(new CliUserError("errors.install.failed", 1, {
+            reason:
+                "Cannot self-install from the current runtime: executable path is not a stable local binary.",
+        }));
+    });
+});
+
+function createInstallContext(options: {
+    cwd: string;
+    env: Record<string, string | undefined>;
+    stdout?: ReturnType<typeof createTextBuffer>;
+}): CliExecutionContext {
+    const stdout = options.stdout ?? createTextBuffer();
+    const stderr = createTextBuffer();
+
+    return {
+        authStore: {
+            clear() {},
+            getActiveAccountId: async () => undefined,
+            read: async () => ({
+                auth: [],
+                id: "",
+            }),
+            write: async () => undefined,
+        },
+        cacheStore: {
+            close() {},
+            clear: async () => undefined,
+            delete: async () => false,
+            deleteExpired: async () => 0,
+            get: async () => undefined,
+            getFilePath: () => "",
+            set: async () => undefined,
+        },
+        catalog: {
+            commands: [],
+            descriptionKey: "app.description",
+            globalOptions: [],
+            name: "oo",
+        },
+        completionRenderer: {
+            render: () => "",
+        },
+        currentLogFilePath: "",
+        cwd: options.cwd,
+        env: options.env,
+        fetcher: async () => {
+            throw new Error("fetcher should not run");
+        },
+        fileDownloadSessionStore: createNoopFileDownloadSessionStore(),
+        fileUploadStore: createNoopFileUploadStore(),
+        logger: pino({
+            enabled: false,
+        }),
+        packageName: "@oomol-lab/oo-cli",
+        settingsStore: {
+            getFilePath: () => "",
+            read: async () => ({}),
+            write: async () => undefined,
+        },
+        stderr: stderr.writer,
+        stdin: {
+            off() {},
+            on() {},
+        },
+        stdout: stdout.writer,
+        translator: createTranslator("en"),
+        version: "1.2.3",
+    } as unknown as CliExecutionContext;
+}
+
+function createStatsStub(options: {
+    directory?: boolean;
+    executable?: boolean;
+    file?: boolean;
+    symbolicLink?: boolean;
+}) {
+    return {
+        isDirectory: () => options.directory === true,
+        isFile: () => options.file === true,
+        isSymbolicLink: () => options.symbolicLink === true,
+        mode: options.executable === true ? 0o755 : 0o644,
+    };
+}

--- a/src/application/commands/self-install.ts
+++ b/src/application/commands/self-install.ts
@@ -1,0 +1,673 @@
+import type { CliExecutionContext, CliMessageParams } from "../contracts/cli.ts";
+import type { Translator } from "../contracts/translator.ts";
+
+import {
+    copyFile,
+    lstat,
+    mkdir,
+    realpath,
+    rename,
+    rm,
+    stat,
+    symlink,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { posix, win32 } from "node:path";
+import process from "node:process";
+import { APP_NAME } from "../config/app-config.ts";
+import { CliUserError } from "../contracts/cli.ts";
+import { writeLine } from "./shared/output.ts";
+
+export interface InstallSource {
+    displayPath: string;
+    executablePath: string;
+}
+
+export interface InstallTarget {
+    binDir: string;
+    binaryPath: string;
+    displayBinDir: string;
+    displayBinaryPath: string;
+    isWindows: boolean;
+    platform: NodeJS.Platform;
+}
+
+export interface InstallBinaryResult {
+    changed: boolean;
+    mode: "copy" | "symlink";
+}
+
+export interface SetupNote {
+    message: string;
+    type: "info" | "path";
+}
+
+export interface SelfInstallRuntime {
+    argv0: string | undefined;
+    execPath: string;
+    main: string;
+    pid: number;
+    platform: NodeJS.Platform;
+    tempDirectoryPath: string;
+}
+
+interface FileStatsLike {
+    isDirectory: () => boolean;
+    isFile: () => boolean;
+    isSymbolicLink: () => boolean;
+    mode: number;
+}
+
+interface SelfInstallFileDependencies {
+    copyFile?: (sourcePath: string, targetPath: string) => Promise<void>;
+    lstat?: (path: string) => Promise<FileStatsLike>;
+    mkdir?: (
+        path: string,
+        options: {
+            recursive: true;
+        },
+    ) => Promise<void>;
+    realpath?: (path: string) => Promise<string>;
+    rename?: (sourcePath: string, targetPath: string) => Promise<void>;
+    rm?: (
+        path: string,
+        options: {
+            force: true;
+            recursive: true;
+        },
+    ) => Promise<void>;
+    stat?: (path: string) => Promise<FileStatsLike>;
+    symlink?: (targetPath: string, linkPath: string) => Promise<void>;
+}
+
+export interface SelfInstallDependencies extends SelfInstallFileDependencies {
+    now?: () => number;
+    runtime?: SelfInstallRuntime;
+}
+
+class SelfInstallError extends Error {
+    constructor(
+        readonly key: string,
+        readonly params?: CliMessageParams,
+    ) {
+        super(key);
+        this.name = "SelfInstallError";
+    }
+}
+
+export async function runSelfInstall(
+    context: CliExecutionContext,
+    dependencies: SelfInstallDependencies = {},
+): Promise<void> {
+    writeLine(
+        context.stdout,
+        context.translator.t("install.progress.installing"),
+    );
+
+    try {
+        const runtime = dependencies.runtime ?? resolveDefaultInstallRuntime();
+        const source = await resolveInstallSource(runtime, dependencies);
+        const target = resolveInstallTarget({
+            env: context.env,
+            platform: runtime.platform,
+        });
+        const installResult = await installBinary(
+            source,
+            target,
+            runtime,
+            dependencies,
+        );
+
+        await verifyInstall(target, dependencies);
+
+        writeLine(context.stdout, context.translator.t("install.success.title"));
+        writeLine(
+            context.stdout,
+            context.translator.t("install.success.location", {
+                path: target.displayBinaryPath,
+            }),
+        );
+        writeLine(context.stdout, context.translator.t("install.success.next"));
+
+        const setupNotes = checkPathSetup(target, {
+            cwd: context.cwd,
+            env: context.env,
+            platform: runtime.platform,
+            translator: context.translator,
+        });
+
+        if (setupNotes.length > 0) {
+            writeLine(context.stdout, "");
+            writeLine(
+                context.stdout,
+                context.translator.t("install.setupNotes.title"),
+            );
+
+            for (const note of setupNotes) {
+                writeSetupNote(context.stdout, note);
+            }
+        }
+
+        context.logger.info(
+            {
+                changed: installResult.changed,
+                installMode: installResult.mode,
+                pathConfigured: setupNotes.length === 0,
+                sourcePath: source.executablePath,
+                targetPath: target.binaryPath,
+            },
+            "CLI binary installed.",
+        );
+    }
+    catch (error) {
+        if (error instanceof SelfInstallError) {
+            throw new CliUserError("errors.install.failed", 1, {
+                reason: context.translator.t(error.key, error.params),
+            });
+        }
+
+        throw new CliUserError("errors.install.failed", 1, {
+            reason: context.translator.t("errors.unexpected", {
+                message: toErrorMessage(error),
+            }),
+        });
+    }
+}
+
+export async function resolveInstallSource(
+    runtime: SelfInstallRuntime,
+    dependencies: SelfInstallFileDependencies = {},
+): Promise<InstallSource> {
+    const realpathFn = dependencies.realpath ?? realpath;
+    const statFn = dependencies.stat ?? stat;
+
+    try {
+        const executablePath = await realpathFn(runtime.execPath);
+
+        if (!isStableLocalBinaryRuntime(runtime, executablePath)) {
+            throw new SelfInstallError("errors.install.invalidSource");
+        }
+
+        const executableStats = await statFn(executablePath);
+
+        if (!isExecutableFile(executableStats, runtime.platform, executablePath)) {
+            throw new SelfInstallError("errors.install.invalidSource");
+        }
+
+        return {
+            displayPath: executablePath,
+            executablePath,
+        };
+    }
+    catch (error) {
+        if (error instanceof SelfInstallError) {
+            throw error;
+        }
+
+        throw new SelfInstallError("errors.install.invalidSource");
+    }
+}
+
+export function resolveInstallTarget(options: {
+    env: Record<string, string | undefined>;
+    platform: NodeJS.Platform;
+}): InstallTarget {
+    const executableFileName = resolveExecutableFileName(options.platform);
+    const pathModule = resolvePathModule(options.platform);
+    const homeDirectory = resolveTargetHomeDirectory(options.env, options.platform);
+    const binDir = pathModule.join(homeDirectory, ".local", "bin");
+    const binaryPath = pathModule.join(binDir, executableFileName);
+
+    return {
+        binDir,
+        binaryPath,
+        displayBinDir: options.platform === "win32"
+            ? binDir
+            : posix.join("~", ".local", "bin"),
+        displayBinaryPath: options.platform === "win32"
+            ? binaryPath
+            : posix.join("~", ".local", "bin", executableFileName),
+        isWindows: options.platform === "win32",
+        platform: options.platform,
+    };
+}
+
+export async function installBinary(
+    source: InstallSource,
+    target: InstallTarget,
+    runtime: Pick<SelfInstallRuntime, "pid">,
+    dependencies: SelfInstallDependencies = {},
+): Promise<InstallBinaryResult> {
+    await ensureInstallDirectory(target, dependencies);
+
+    if (target.isWindows) {
+        return await installWindowsBinary(
+            source,
+            target,
+            dependencies.now ?? Date.now,
+            dependencies,
+        );
+    }
+
+    return await installUnixBinary(
+        source,
+        target,
+        runtime,
+        dependencies.now ?? Date.now,
+        dependencies,
+    );
+}
+
+export async function verifyInstall(
+    target: InstallTarget,
+    dependencies: SelfInstallFileDependencies = {},
+): Promise<void> {
+    const lstatFn = dependencies.lstat ?? lstat;
+    const realpathFn = dependencies.realpath ?? realpath;
+    const statFn = dependencies.stat ?? stat;
+
+    try {
+        const binDirectoryStats = await statFn(target.binDir);
+
+        if (!binDirectoryStats.isDirectory()) {
+            throw new Error("install directory does not exist");
+        }
+
+        const targetStats = await statFn(target.binaryPath);
+
+        if (!isExecutableFile(targetStats, target.platform, target.binaryPath)) {
+            throw new Error("installed binary is not executable");
+        }
+
+        if (!target.isWindows) {
+            const linkStats = await lstatFn(target.binaryPath);
+
+            if (!linkStats.isSymbolicLink()) {
+                throw new Error("installed binary is not a symbolic link");
+            }
+
+            await realpathFn(target.binaryPath);
+        }
+    }
+    catch (error) {
+        throw new SelfInstallError("errors.install.verifyFailed", {
+            message: toErrorMessage(error),
+            path: target.displayBinaryPath,
+        });
+    }
+}
+
+export function checkPathSetup(
+    target: InstallTarget,
+    options: {
+        cwd: string;
+        env: Record<string, string | undefined>;
+        platform: NodeJS.Platform;
+        translator: Pick<Translator, "t">;
+    },
+): SetupNote[] {
+    const pathEntries = splitPathEntries(
+        options.env.PATH,
+        options.platform,
+    );
+    const normalizedTargetDirectory = normalizePathForComparison(
+        target.binDir,
+        options.platform,
+        options.cwd,
+    );
+    const pathContainsTargetDirectory = pathEntries.some(pathEntry =>
+        normalizePathForComparison(
+            pathEntry,
+            options.platform,
+            options.cwd,
+        ) === normalizedTargetDirectory,
+    );
+
+    if (pathContainsTargetDirectory) {
+        return [];
+    }
+
+    return [
+        {
+            message: options.translator.t(
+                resolvePathSetupMessageKey(options.platform, options.env.SHELL),
+                {
+                    path: target.displayBinDir,
+                },
+            ),
+            type: "path",
+        },
+    ];
+}
+
+function resolveDefaultInstallRuntime(): SelfInstallRuntime {
+    return {
+        argv0: process.argv0,
+        execPath: process.execPath,
+        main: Bun.main,
+        pid: process.pid,
+        platform: process.platform,
+        tempDirectoryPath: tmpdir(),
+    };
+}
+
+async function ensureInstallDirectory(
+    target: InstallTarget,
+    dependencies: SelfInstallFileDependencies,
+): Promise<void> {
+    const mkdirFn = dependencies.mkdir ?? mkdir;
+
+    try {
+        await mkdirFn(target.binDir, { recursive: true });
+    }
+    catch (error) {
+        throw new SelfInstallError("errors.install.mkdirFailed", {
+            message: toErrorMessage(error),
+            path: target.displayBinDir,
+        });
+    }
+}
+
+async function installUnixBinary(
+    source: InstallSource,
+    target: InstallTarget,
+    runtime: Pick<SelfInstallRuntime, "pid">,
+    now: () => number,
+    dependencies: SelfInstallFileDependencies,
+): Promise<InstallBinaryResult> {
+    const realpathFn = dependencies.realpath ?? realpath;
+    const renameFn = dependencies.rename ?? rename;
+    const rmFn = dependencies.rm ?? rm;
+    const symlinkFn = dependencies.symlink ?? symlink;
+    const currentTargetPath = await realpathFn(target.binaryPath).catch(
+        () => undefined,
+    );
+
+    if (currentTargetPath === source.executablePath) {
+        return {
+            changed: false,
+            mode: "symlink",
+        };
+    }
+
+    const temporaryBinaryPath
+        = `${target.binaryPath}.tmp.${runtime.pid}.${now()}`;
+
+    try {
+        await rmFn(temporaryBinaryPath, {
+            force: true,
+            recursive: true,
+        }).catch(() => undefined);
+        await symlinkFn(source.executablePath, temporaryBinaryPath);
+
+        try {
+            await renameFn(temporaryBinaryPath, target.binaryPath);
+        }
+        catch {
+            await rmFn(target.binaryPath, {
+                force: true,
+                recursive: true,
+            });
+            await renameFn(temporaryBinaryPath, target.binaryPath);
+        }
+
+        return {
+            changed: true,
+            mode: "symlink",
+        };
+    }
+    catch (error) {
+        throw new SelfInstallError("errors.install.writeFailed", {
+            message: toErrorMessage(error),
+            path: target.displayBinaryPath,
+        });
+    }
+    finally {
+        await rmFn(temporaryBinaryPath, {
+            force: true,
+            recursive: true,
+        }).catch(() => undefined);
+    }
+}
+
+async function installWindowsBinary(
+    source: InstallSource,
+    target: InstallTarget,
+    now: () => number,
+    dependencies: SelfInstallFileDependencies,
+): Promise<InstallBinaryResult> {
+    const copyFileFn = dependencies.copyFile ?? copyFile;
+    const realpathFn = dependencies.realpath ?? realpath;
+    const renameFn = dependencies.rename ?? rename;
+    const rmFn = dependencies.rm ?? rm;
+    const currentTargetPath = await realpathFn(target.binaryPath).catch(
+        () => undefined,
+    );
+
+    if (currentTargetPath === source.executablePath) {
+        return {
+            changed: false,
+            mode: "copy",
+        };
+    }
+
+    const backupPath = `${target.binaryPath}.old.${now()}`;
+    let movedExistingTarget = false;
+
+    try {
+        if (currentTargetPath !== undefined) {
+            await renameFn(target.binaryPath, backupPath);
+            movedExistingTarget = true;
+        }
+
+        await copyFileFn(source.executablePath, target.binaryPath);
+    }
+    catch (error) {
+        if (movedExistingTarget) {
+            try {
+                await renameFn(backupPath, target.binaryPath);
+            }
+            catch (rollbackError) {
+                throw new SelfInstallError("errors.install.rollbackFailed", {
+                    message:
+                        `${toErrorMessage(error)}; rollback error: ${toErrorMessage(rollbackError)}`,
+                    path: target.displayBinaryPath,
+                });
+            }
+        }
+
+        throw new SelfInstallError("errors.install.writeFailed", {
+            message: toErrorMessage(error),
+            path: target.displayBinaryPath,
+        });
+    }
+
+    if (movedExistingTarget) {
+        await rmFn(backupPath, {
+            force: true,
+            recursive: true,
+        }).catch(() => undefined);
+    }
+
+    return {
+        changed: true,
+        mode: "copy",
+    };
+}
+
+function writeSetupNote(
+    stream: CliExecutionContext["stdout"],
+    note: SetupNote,
+): void {
+    const [firstLine = "", ...remainingLines] = note.message.split("\n");
+
+    writeLine(stream, `• ${firstLine}`);
+
+    for (const line of remainingLines) {
+        if (line === "") {
+            writeLine(stream, "");
+            continue;
+        }
+
+        writeLine(stream, `  ${line}`);
+    }
+}
+
+function isStableLocalBinaryRuntime(
+    runtime: SelfInstallRuntime,
+    executablePath: string,
+): boolean {
+    if (isPathInside(
+        runtime.tempDirectoryPath,
+        executablePath,
+        runtime.platform,
+    )) {
+        return false;
+    }
+
+    if (isCompiledEmbeddedEntryPath(runtime.main)) {
+        return true;
+    }
+
+    const executableFileName = resolveExecutableFileName(runtime.platform)
+        .toLowerCase();
+    const pathModule = resolvePathModule(runtime.platform);
+    const executableName = pathModule.basename(runtime.execPath).toLowerCase();
+    const argv0Name = runtime.argv0 === undefined
+        ? ""
+        : pathModule.basename(runtime.argv0).toLowerCase();
+
+    return executableName === executableFileName
+        || argv0Name === executableFileName;
+}
+
+function isCompiledEmbeddedEntryPath(mainPath: string): boolean {
+    return mainPath.replaceAll("\\", "/").includes("/$bunfs/");
+}
+
+function resolveTargetHomeDirectory(
+    env: Record<string, string | undefined>,
+    platform: NodeJS.Platform,
+): string {
+    const homeDirectory = platform === "win32"
+        ? env.USERPROFILE ?? env.HOME
+        : env.HOME ?? env.USERPROFILE;
+
+    if (homeDirectory !== undefined && homeDirectory !== "") {
+        return homeDirectory;
+    }
+
+    return platform === "win32"
+        ? process.env.USERPROFILE ?? process.env.HOME ?? ""
+        : process.env.HOME ?? process.env.USERPROFILE ?? "";
+}
+
+function resolveExecutableFileName(platform: NodeJS.Platform): string {
+    return platform === "win32" ? `${APP_NAME}.exe` : APP_NAME;
+}
+
+function splitPathEntries(
+    pathValue: string | undefined,
+    platform: NodeJS.Platform,
+): string[] {
+    if (pathValue === undefined || pathValue === "") {
+        return [];
+    }
+
+    return pathValue
+        .split(platform === "win32" ? ";" : ":")
+        .filter(pathEntry => pathEntry !== "");
+}
+
+function normalizePathForComparison(
+    value: string,
+    platform: NodeJS.Platform,
+    cwd: string,
+): string {
+    const pathModule = resolvePathModule(platform);
+    const resolvedPath = pathModule.resolve(cwd, value);
+
+    return platform === "win32"
+        ? resolvedPath.toLowerCase()
+        : resolvedPath;
+}
+
+function resolvePathSetupMessageKey(
+    platform: NodeJS.Platform,
+    shellPath: string | undefined,
+): string {
+    if (platform === "win32") {
+        return "install.setupNotes.path.win32";
+    }
+
+    switch (resolveShellName(shellPath)) {
+        case "bash":
+            return "install.setupNotes.path.bash";
+        case "fish":
+            return "install.setupNotes.path.fish";
+        case "zsh":
+            return "install.setupNotes.path.zsh";
+        default:
+            return "install.setupNotes.path.unknown";
+    }
+}
+
+function resolveShellName(shellPath: string | undefined): string | undefined {
+    if (shellPath === undefined || shellPath === "") {
+        return undefined;
+    }
+
+    const normalizedShellPath = shellPath.replaceAll("\\", "/");
+    const shellName = normalizedShellPath
+        .slice(normalizedShellPath.lastIndexOf("/") + 1)
+        .toLowerCase();
+
+    return shellName.endsWith(".exe")
+        ? shellName.slice(0, -4)
+        : shellName;
+}
+
+function resolvePathModule(
+    platform: NodeJS.Platform,
+): typeof posix | typeof win32 {
+    return platform === "win32" ? win32 : posix;
+}
+
+function isPathInside(
+    parentPath: string,
+    childPath: string,
+    platform: NodeJS.Platform,
+): boolean {
+    const pathModule = resolvePathModule(platform);
+    const relativePath = pathModule.relative(
+        pathModule.resolve(parentPath),
+        pathModule.resolve(childPath),
+    );
+
+    if (relativePath === "" || relativePath === ".") {
+        return false;
+    }
+
+    return !relativePath.startsWith("..")
+        && !pathModule.isAbsolute(relativePath);
+}
+
+function isExecutableFile(
+    stats: FileStatsLike,
+    platform: NodeJS.Platform,
+    filePath: string,
+): boolean {
+    if (!stats.isFile()) {
+        return false;
+    }
+
+    if (platform === "win32") {
+        return filePath.toLowerCase().endsWith(".exe");
+    }
+
+    return (stats.mode & 0o111) !== 0;
+}
+
+function toErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -88,18 +88,7 @@ Commands:
 }
 `;
 
-exports[`skills CLI does not auto-install the managed bundled skill for skills subcommands 1`] = `
-{
-  "exitCode": 1,
-  "stderr": 
-"Skill oo is not installed at <HOME>/.codex/skills/oo.
-"
-,
-  "stdout": "",
-}
-`;
-
-exports[`skills CLI synchronizes the managed bundled skill policy from persisted settings 1`] = `
+exports[`skills CLI does not synchronize a managed bundled skill that uses the development metadata version 1`] = `
 {
   "exitCode": 0,
   "stderr": "",
@@ -129,6 +118,17 @@ Commands:
   help [command]           Show help for a command
 "
 ,
+}
+`;
+
+exports[`skills CLI does not auto-install the managed bundled skill for skills subcommands 1`] = `
+{
+  "exitCode": 1,
+  "stderr": 
+"Skill oo is not installed at <HOME>/.codex/skills/oo.
+"
+,
+  "stdout": "",
 }
 `;
 
@@ -185,38 +185,5 @@ Removed skill oo-find-skills from <HOME>/.codex/skills/oo-find-skills.
 "
 ,
   },
-}
-`;
-
-exports[`skills CLI does not synchronize a managed bundled skill that uses the development metadata version 1`] = `
-{
-  "exitCode": 0,
-  "stderr": "",
-  "stdout": 
-"oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
-
-Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
-
-Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  connector                Manage connector actions
-  file                     Manage temporary file transfers
-  login                    Log in with device login (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  search [options] <text>  Search packages and connector actions
-  packages                 Package utilities
-  help [command]           Show help for a command
-"
-,
 }
 `;

--- a/src/application/contracts/cli.ts
+++ b/src/application/contracts/cli.ts
@@ -65,6 +65,7 @@ export type CliCommandHandler<TInput> = {
 export interface CliCommandDefinition<TInput = unknown> {
     name: string;
     aliases?: readonly string[];
+    hidden?: boolean;
     summaryKey: string;
     descriptionKey?: string;
     arguments?: readonly CliArgumentDefinition[];

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -87,6 +87,9 @@ export const enMessages = {
         "Upload a file and store the signed download URL locally.",
     "commands.file.upload.summary": "Upload a file",
     "commands.help.summary": "Show help for a command",
+    "commands.install.description":
+        `Install the current ${APP_NAME} binary into the user-level bin directory.`,
+    "commands.install.summary": `Install the current ${APP_NAME} binary`,
     "commands.log.description": "Inspect persisted CLI debug logs.",
     "commands.log.summary": "Manage persisted debug logs",
     "commands.log.path.description": "Print the current persisted log directory path.",
@@ -136,6 +139,21 @@ export const enMessages = {
     "commands.skills.uninstall.summary": "Remove a managed skill",
     "config.set.success": "Set {key} to {value}.",
     "config.unset.success": "Removed {key}.",
+    "install.progress.installing": `Installing ${APP_NAME}...`,
+    "install.setupNotes.path.bash":
+        "Native installation exists but {path} is not in your PATH. Run:\n\necho 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc && source ~/.bashrc",
+    "install.setupNotes.path.fish":
+        "Native installation exists but {path} is not in your PATH. Run:\n\nfish_add_path $HOME/.local/bin",
+    "install.setupNotes.path.unknown":
+        "Native installation exists but {path} is not in your PATH. Add it to your shell config file, then restart your terminal.",
+    "install.setupNotes.path.win32":
+        "Native installation exists but {path} is not in your PATH. Add it by opening: System Properties -> Environment Variables -> Edit User PATH -> New -> Add the path above. Then restart your terminal.",
+    "install.setupNotes.path.zsh":
+        "Native installation exists but {path} is not in your PATH. Run:\n\necho 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.zshrc && source ~/.zshrc",
+    "install.setupNotes.title": "Setup notes:",
+    "install.success.location": "Location: {path}",
+    "install.success.next": `Next: Run ${APP_NAME} --help to get started`,
+    "install.success.title": `${APP_NAME} successfully installed!`,
     "errors.commander.excessArguments": "Too many arguments were provided.",
     "errors.commander.invalidArgument": "Invalid argument: {value}.",
     "errors.commander.missingArgument": "Missing required argument: {value}.",
@@ -166,6 +184,17 @@ export const enMessages = {
         "Failed to read the auth file at {path}.",
     "errors.authStore.writeFailed":
         "Failed to write the auth file at {path}.",
+    "errors.install.failed": "Installation failed\n{reason}",
+    "errors.install.invalidSource":
+        "Cannot self-install from the current runtime: executable path is not a stable local binary.",
+    "errors.install.mkdirFailed":
+        "Failed to create the install directory at {path}: {message}",
+    "errors.install.rollbackFailed":
+        "Failed to write the install entry at {path}, and the previous installation could not be restored: {message}",
+    "errors.install.verifyFailed":
+        "Installed binary verification failed at {path}: {message}",
+    "errors.install.writeFailed":
+        "Failed to write the install entry at {path}: {message}",
     "errors.shared.invalidFormat":
         "Invalid format: {value}. Use json.",
     "errors.shared.invalidPositiveIntegerOption":
@@ -641,6 +670,9 @@ export const zhMessages = {
     "commands.file.upload.description": "上传文件，并在本地保存带签名的下载地址。",
     "commands.file.upload.summary": "上传文件",
     "commands.help.summary": "显示命令帮助",
+    "commands.install.description":
+        `将当前运行中的 ${APP_NAME} 二进制安装到用户级 bin 目录。`,
+    "commands.install.summary": `安装当前 ${APP_NAME} 二进制`,
     "commands.log.description": "查看持久化的 CLI debug 日志。",
     "commands.log.summary": "管理持久化 debug 日志",
     "commands.log.path.description": "打印当前持久化日志目录路径。",
@@ -681,6 +713,21 @@ export const zhMessages = {
     "commands.skills.uninstall.summary": "移除一个受管理的 skill",
     "config.set.success": "已将 {key} 设置为 {value}。",
     "config.unset.success": "已移除 {key}。",
+    "install.progress.installing": `正在安装 ${APP_NAME}...`,
+    "install.setupNotes.path.bash":
+        "检测到原生安装已存在，但 {path} 不在你的 PATH 中。请运行：\n\necho 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.bashrc && source ~/.bashrc",
+    "install.setupNotes.path.fish":
+        "检测到原生安装已存在，但 {path} 不在你的 PATH 中。请运行：\n\nfish_add_path $HOME/.local/bin",
+    "install.setupNotes.path.unknown":
+        "检测到原生安装已存在，但 {path} 不在你的 PATH 中。请将它加入 shell 配置文件，然后重启终端。",
+    "install.setupNotes.path.win32":
+        "检测到原生安装已存在，但 {path} 不在你的 PATH 中。请打开 System Properties -> Environment Variables -> Edit User PATH -> New，添加上面的路径，然后重启终端。",
+    "install.setupNotes.path.zsh":
+        "检测到原生安装已存在，但 {path} 不在你的 PATH 中。请运行：\n\necho 'export PATH=\"$HOME/.local/bin:$PATH\"' >> ~/.zshrc && source ~/.zshrc",
+    "install.setupNotes.title": "配置提示：",
+    "install.success.location": "位置：{path}",
+    "install.success.next": `下一步：运行 ${APP_NAME} --help 开始使用`,
+    "install.success.title": `${APP_NAME} 安装成功！`,
     "errors.commander.excessArguments": "提供了过多的参数。",
     "errors.commander.invalidArgument": "参数无效：{value}。",
     "errors.commander.missingArgument": "缺少必填参数：{value}。",
@@ -701,6 +748,17 @@ export const zhMessages = {
     "errors.authStore.invalidSchema": "认证文件 {path} 的结构不受支持。",
     "errors.authStore.readFailed": "读取认证文件 {path} 失败。",
     "errors.authStore.writeFailed": "写入认证文件 {path} 失败。",
+    "errors.install.failed": "安装失败\n{reason}",
+    "errors.install.invalidSource":
+        "无法从当前运行时执行自安装：可执行路径不是稳定的本地二进制。",
+    "errors.install.mkdirFailed":
+        "无法创建安装目录 {path}：{message}",
+    "errors.install.rollbackFailed":
+        "无法写入安装入口 {path}，并且无法恢复之前的安装：{message}",
+    "errors.install.verifyFailed":
+        "已安装二进制在 {path} 的校验失败：{message}",
+    "errors.install.writeFailed":
+        "无法写入安装入口 {path}：{message}",
     "errors.shared.invalidFormat":
         "无效的 format：{value}。请使用 json。",
     "errors.shared.invalidPositiveIntegerOption":


### PR DESCRIPTION
Add a native self-install path so compiled oo binaries can place themselves in the user bin directory without extra tooling.

Implement cross-platform install logic with validation, PATH setup notes, and rollback-safe replacement behavior on Windows. Keep the command hidden from help, docs, and shell completion while covering the
workflow with tests and updated snapshots.