### PR TITLE
ci(install): deploy install worker after publish

### DIFF
--- a/.github/workflows/deploy-install-worker.yaml
+++ b/.github/workflows/deploy-install-worker.yaml
@@ -1,0 +1,62 @@
+name: Deploy Install Worker
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Git tag whose install scripts should be published.
+        required: false
+        type: string
+    secrets:
+      CLOUDFLARE_ACCOUNT_ID:
+        required: true
+      CLOUDFLARE_API_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Git tag whose install scripts should be published.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-install-worker-${{ inputs.tag != '' && format('tag-{0}', inputs.tag) || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.tag != '' && format('refs/tags/{0}', inputs.tag) || github.sha }}
+
+      - name: Prepare install worker assets
+        run: |
+          set -euo pipefail
+
+          asset_directory="dist/install-worker-assets"
+
+          rm -rf "${asset_directory}"
+          mkdir -p "${asset_directory}"
+
+          cp contrib/install/install.cmd "${asset_directory}/install.cmd"
+          cp contrib/install/install.ps1 "${asset_directory}/install.ps1"
+          cp contrib/install/install.sh "${asset_directory}/install.sh"
+
+      - name: Deploy install worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+          packageManager: npm
+          workingDirectory: contrib/cloudflare/oo-cli
+          wranglerVersion: "4"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -108,3 +108,13 @@ jobs:
     with:
       version: ${{ needs.compute-version.outputs.version }}
     secrets: inherit
+
+  deploy-install-worker:
+    needs:
+      - compute-version
+      - publish
+      - upload-release-binaries-to-oss
+    uses: ./.github/workflows/deploy-install-worker.yaml
+    with:
+      tag: ${{ needs.compute-version.outputs.tag_name }}
+    secrets: inherit

--- a/contrib/cloudflare/oo-cli/deploy-install-worker.test.ts
+++ b/contrib/cloudflare/oo-cli/deploy-install-worker.test.ts
@@ -1,0 +1,45 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const workerDirectoryPath = import.meta.dir;
+const workflowPath = join(workerDirectoryPath, "..", "..", "..", ".github", "workflows", "deploy-install-worker.yaml");
+const wranglerConfigPath = join(workerDirectoryPath, "wrangler.jsonc");
+
+describe("install worker deployment", () => {
+    test("deploys the install scripts through the expected worker endpoints", async () => {
+        const wranglerConfig = await readFile(wranglerConfigPath, "utf8");
+
+        expect(wranglerConfig).toContain("\"name\": \"oo-cli\"");
+        expect(wranglerConfig).toContain("\"workers_dev\": true");
+        expect(wranglerConfig).toContain("\"directory\": \"../../../dist/install-worker-assets\"");
+        expect(wranglerConfig).toContain("\"pattern\": \"cli.oomol.com\"");
+        expect(wranglerConfig).toContain("\"custom_domain\": true");
+    });
+
+    test("defines a reusable workflow with manual deployment support", async () => {
+        const workflow = await readFile(workflowPath, "utf8");
+
+        expect(workflow).toContain("workflow_call:");
+        expect(workflow).toContain("workflow_dispatch:");
+        expect(workflow).toContain("tag:");
+        expect(workflow).toContain("Git tag whose install scripts should be published.");
+        expect(workflow).not.toContain("deployment_url:");
+        expect(workflow).not.toContain("custom_domain_url:");
+        expect(workflow).not.toContain("worker_name:");
+        expect(workflow).not.toContain("Set deployment metadata");
+        expect(workflow).toContain("deploy-install-worker-");
+        expect(workflow).toContain("format('tag-{0}', inputs.tag)");
+        expect(workflow).toContain("ref: ${{ inputs.tag != ''");
+        expect(workflow).toContain("format('refs/tags/{0}', inputs.tag)");
+        expect(workflow).toContain("|| github.sha }}");
+        expect(workflow).toContain("Prepare install worker assets");
+        expect(workflow).toContain("asset_directory=\"dist/install-worker-assets\"");
+        expect(workflow).toContain("cp contrib/install/install.cmd");
+        expect(workflow).toContain("cp contrib/install/install.ps1");
+        expect(workflow).toContain("cp contrib/install/install.sh");
+        expect(workflow).toContain("uses: cloudflare/wrangler-action@v3");
+        expect(workflow).toContain("workingDirectory: contrib/cloudflare/oo-cli");
+        expect(workflow).toContain("command: deploy");
+    });
+});

--- a/contrib/cloudflare/oo-cli/wrangler.jsonc
+++ b/contrib/cloudflare/oo-cli/wrangler.jsonc
@@ -1,0 +1,14 @@
+{
+  "name": "oo-cli",
+  "compatibility_date": "2026-04-21",
+  "workers_dev": true,
+  "assets": {
+    "directory": "../../../dist/install-worker-assets"
+  },
+  "routes": [
+    {
+      "pattern": "cli.oomol.com",
+      "custom_domain": true
+    }
+  ]
+}


### PR DESCRIPTION
Publish the Cloudflare-hosted install scripts from the same release tag
that produced the npm packages and GitHub release artifacts. This adds
a reusable deploy workflow, checks out the requested tag before copying
the three installer scripts, and runs it as the final publish step.