### PR TITLE
feat(install): refresh bundled skills after self-update

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -119,6 +119,9 @@ Install one managed `oo` release into the local self-managed runtime.
 - Notes: after a successful install, the CLI best-effort removes a legacy
   global `@oomol-lab/oo-cli` package-manager install when the current command
   is running from one; cleanup failures do not change the command result.
+- Notes: after a successful install workflow, the CLI silently runs
+  `oo skills add` with the managed executable so bundled skills refresh to the
+  installed CLI version.
 - Notes: when the current version is `0.0.0-development`, the CLI prints the
   managed install/update unsupported message and exits successfully.
 
@@ -141,6 +144,9 @@ Update the managed `oo` install to the latest published release.
 - Notes: after a successful update, the CLI best-effort removes a legacy global
   `@oomol-lab/oo-cli` package-manager install when the current command is
   running from one; cleanup failures do not change the command result.
+- Notes: after a successful update workflow, the CLI silently runs
+  `oo skills add` with the managed executable so bundled skills refresh to the
+  installed CLI version.
 - Notes: when the current version is `0.0.0-development`, the CLI prints the
   managed install/update unsupported message and exits successfully.
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -107,6 +107,8 @@
   告知用户应当把哪个目录加入 `PATH`。
 - 说明：install 成功后，如果当前命令运行自一个旧的全局 package-manager
   `@oomol-lab/oo-cli` 安装，CLI 会尽力将其移除；清理失败不会改变命令结果。
+- 说明：install 成功后，CLI 会使用托管的可执行文件静默执行一次
+  `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /
   update 的提示，并以成功状态退出。
 
@@ -125,6 +127,8 @@
   `--force`。
 - 说明：update 成功后，如果当前命令运行自一个旧的全局 package-manager
   `@oomol-lab/oo-cli` 安装，CLI 会尽力将其移除；清理失败不会改变命令结果。
+- 说明：update 成功后，CLI 会使用托管的可执行文件静默执行一次
+  `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /
   update 的提示，并以成功状态退出。
 

--- a/src/application/commands/self-update.cli.test.ts
+++ b/src/application/commands/self-update.cli.test.ts
@@ -41,6 +41,7 @@ describe("self-update commands", () => {
             platform: process.platform,
         });
         let latestRequestCount = 0;
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime();
 
         try {
             const result = await sandbox.run(["install"], {
@@ -60,6 +61,7 @@ describe("self-update commands", () => {
 
                     throw new Error(`Unexpected request: ${url}`);
                 },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
                 version: "1.0.0",
             });
 
@@ -78,6 +80,7 @@ describe("self-update commands", () => {
             platform: process.platform,
         });
         let latestRequestCount = 0;
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime();
 
         try {
             const result = await sandbox.run(["install", "2.0.0"], {
@@ -95,11 +98,67 @@ describe("self-update commands", () => {
 
                     throw new Error(`Unexpected request: ${url}`);
                 },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
                 version: "1.0.0",
             });
 
             expect(createSelfUpdateInstallSnapshot(result, sandbox)).toMatchSnapshot();
             expect(latestRequestCount).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("install silently refreshes bundled skills with the managed executable", async () => {
+        const sandbox = await createCliSandbox();
+        const releasePlatform = await detectSelfUpdateReleasePlatform({
+            arch: process.arch,
+            platform: process.platform,
+        });
+        const paths = resolveSelfUpdatePaths({
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime({
+            exitCode: 1,
+            signalCode: null,
+            stderr: "bundled skill stderr",
+            stdout: "bundled skill stdout",
+        });
+
+        try {
+            const result = await sandbox.run(["install", "2.0.0"], {
+                execPath: paths.executablePath,
+                fetcher: async (input, init) => {
+                    const url = toRequest(input, init).url;
+
+                    if (url.endsWith("/latest.json")) {
+                        throw new Error("latest.json should not be requested");
+                    }
+
+                    if (url.endsWith(`/${releasePlatform}/${process.platform === "win32" ? "oo.exe" : "oo"}`)) {
+                        return new Response("binary");
+                    }
+
+                    throw new Error(`Unexpected request: ${url}`);
+                },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
+                version: "1.0.0",
+            });
+
+            expect(createSelfUpdateInstallSnapshot(result, sandbox)).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: `Installed oo 2.0.0.\nExecutable: <EXECUTABLE_PATH>\nAdd <HOME>/.local/bin to PATH to run oo in new shells.\n`,
+            });
+            expect(selfUpdateRuntime.commands).toEqual([
+                {
+                    commandArguments: ["skills", "add"],
+                    commandPath: paths.executablePath,
+                    timeoutMs: 10_000,
+                },
+            ]);
         }
         finally {
             await sandbox.cleanup();
@@ -112,6 +171,7 @@ describe("self-update commands", () => {
             arch: process.arch,
             platform: process.platform,
         });
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime();
 
         try {
             const result = await sandbox.run(["install"], {
@@ -134,6 +194,7 @@ describe("self-update commands", () => {
                     hasColors: true,
                     isTTY: true,
                 },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
                 version: "1.0.0",
             });
             const snapshot = createCliSnapshot(result, {
@@ -184,6 +245,63 @@ describe("self-update commands", () => {
             });
 
             expect(createCliSnapshot(result)).toMatchSnapshot();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("update silently refreshes bundled skills with the managed executable", async () => {
+        const sandbox = await createCliSandbox();
+        const releasePlatform = await detectSelfUpdateReleasePlatform({
+            arch: process.arch,
+            platform: process.platform,
+        });
+        const paths = resolveSelfUpdatePaths({
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime({
+            exitCode: 0,
+            signalCode: null,
+            stderr: "bundled skill stderr",
+            stdout: "bundled skill stdout",
+        });
+
+        try {
+            const result = await sandbox.run(["update"], {
+                execPath: paths.executablePath,
+                fetcher: async (input, init) => {
+                    const url = toRequest(input, init).url;
+
+                    if (url.endsWith("/latest.json")) {
+                        return new Response(JSON.stringify({
+                            version: "2.0.0",
+                        }));
+                    }
+
+                    if (url.endsWith(`/${releasePlatform}/${process.platform === "win32" ? "oo.exe" : "oo"}`)) {
+                        return new Response("binary");
+                    }
+
+                    throw new Error(`Unexpected request: ${url}`);
+                },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
+                version: "1.0.0",
+            });
+
+            expect(createCliSnapshot(result)).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: "Updated oo from 1.0.0 to 2.0.0.\n",
+            });
+            expect(selfUpdateRuntime.commands).toEqual([
+                {
+                    commandArguments: ["skills", "add"],
+                    commandPath: paths.executablePath,
+                    timeoutMs: 10_000,
+                },
+            ]);
         }
         finally {
             await sandbox.cleanup();
@@ -247,6 +365,7 @@ describe("self-update commands", () => {
             platform: process.platform,
         });
         let binaryRequestCount = 0;
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime();
 
         try {
             const result = await sandbox.run(["update"], {
@@ -271,6 +390,7 @@ describe("self-update commands", () => {
 
                     throw new Error(`Unexpected request: ${url}`);
                 },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
                 version: "1.2.3",
             });
 
@@ -288,7 +408,7 @@ describe("self-update commands", () => {
 
     test("upgrade uses the same update path and repairs a same-version package-manager install", async () => {
         const sandbox = await createCliSandbox();
-        const legacyCleanup = createLegacyPackageManagerCleanupRuntime();
+        const legacyCleanup = createCapturedSelfUpdateRuntime();
         const releasePlatform = await detectSelfUpdateReleasePlatform({
             arch: process.arch,
             platform: process.platform,
@@ -333,6 +453,11 @@ describe("self-update commands", () => {
             expect(binaryRequestCount).toBe(1);
             expect(legacyCleanup.commands).toEqual([
                 {
+                    commandArguments: ["skills", "add"],
+                    commandPath: paths.executablePath,
+                    timeoutMs: 10_000,
+                },
+                {
                     commandArguments: ["uninstall", "-g", "@oomol-lab/oo-cli"],
                     commandPath: "/mock/bin/npm",
                     timeoutMs: 10_000,
@@ -351,6 +476,7 @@ describe("self-update commands", () => {
             arch: process.arch,
             platform: process.platform,
         });
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime();
 
         try {
             const result = await sandbox.run(["update"], {
@@ -373,6 +499,7 @@ describe("self-update commands", () => {
                     hasColors: true,
                     isTTY: true,
                 },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
                 version: "1.0.0",
             });
             const snapshot = createCliSnapshot(result, {
@@ -415,17 +542,29 @@ function createSelfUpdateInstallSnapshot(
     });
 }
 
-interface CapturedLegacyPackageManagerCommand {
+interface CapturedSelfUpdateCommand {
     commandArguments: readonly string[];
     commandPath: string;
     timeoutMs: number;
 }
 
-function createLegacyPackageManagerCleanupRuntime(): {
-    commands: CapturedLegacyPackageManagerCommand[];
+function createCapturedSelfUpdateRuntime(commandResult?: {
+    exitCode?: number;
+    signalCode?: NodeJS.Signals | null;
+    stderr?: string;
+    stdout?: string;
+}): {
+    commands: CapturedSelfUpdateCommand[];
     runtime: NonNullable<CliRunOptions["selfUpdateRuntime"]>;
 } {
-    const commands: CapturedLegacyPackageManagerCommand[] = [];
+    const commands: CapturedSelfUpdateCommand[] = [];
+    const result = {
+        exitCode: 0,
+        signalCode: null,
+        stderr: "",
+        stdout: "",
+        ...commandResult,
+    };
 
     return {
         commands,
@@ -438,12 +577,7 @@ function createLegacyPackageManagerCleanupRuntime(): {
                     timeoutMs: options.timeoutMs,
                 });
 
-                return {
-                    exitCode: 0,
-                    signalCode: null,
-                    stderr: "",
-                    stdout: "",
-                };
+                return result;
             },
         },
     };

--- a/src/application/contracts/self-update.ts
+++ b/src/application/contracts/self-update.ts
@@ -1,11 +1,11 @@
-export interface LegacyPackageManagerCommandRunOptions {
+export interface SelfUpdateCommandRunOptions {
     commandArguments: readonly string[];
     commandPath: string;
     env: Record<string, string | undefined>;
     timeoutMs: number;
 }
 
-export interface LegacyPackageManagerCommandRunResult {
+export interface SelfUpdateCommandRunResult {
     exitCode: number;
     signalCode: NodeJS.Signals | null;
     stderr: string;
@@ -15,6 +15,6 @@ export interface LegacyPackageManagerCommandRunResult {
 export interface SelfUpdateRuntimeOverrides {
     resolveCommandPath?: (commandName: string) => string | null;
     runCommand?: (
-        options: LegacyPackageManagerCommandRunOptions,
-    ) => Promise<LegacyPackageManagerCommandRunResult>;
+        options: SelfUpdateCommandRunOptions,
+    ) => Promise<SelfUpdateCommandRunResult>;
 }

--- a/src/application/self-update/bundled-skills.ts
+++ b/src/application/self-update/bundled-skills.ts
@@ -1,0 +1,25 @@
+import type { SelfUpdateCommandRuntime } from "./command-runner.ts";
+import { runSelfUpdateCommandWithLogging } from "./command-runner.ts";
+
+const selfUpdateBundledSkillRefreshCommandArguments = [
+    "skills",
+    "add",
+] as const;
+const selfUpdateBundledSkillRefreshTimeoutMs = 10_000;
+
+export async function attemptBundledSkillRefreshAfterSelfUpdate(options: {
+    executablePath: string;
+    runtime: SelfUpdateCommandRuntime;
+}): Promise<void> {
+    await runSelfUpdateCommandWithLogging({
+        commandArguments: selfUpdateBundledSkillRefreshCommandArguments,
+        commandPath: options.executablePath,
+        failureMessage: "Bundled skill refresh after self-update failed.",
+        logContext: {
+            timeoutMs: selfUpdateBundledSkillRefreshTimeoutMs,
+        },
+        runtime: options.runtime,
+        successMessage: "Bundled skill refresh after self-update completed.",
+        timeoutMs: selfUpdateBundledSkillRefreshTimeoutMs,
+    });
+}

--- a/src/application/self-update/command-runner.ts
+++ b/src/application/self-update/command-runner.ts
@@ -1,0 +1,107 @@
+import type { Logger } from "pino";
+import type {
+    SelfUpdateCommandRunOptions,
+    SelfUpdateCommandRunResult,
+    SelfUpdateRuntimeOverrides,
+} from "../contracts/self-update.ts";
+
+export interface SelfUpdateCommandRuntime extends SelfUpdateRuntimeOverrides {
+    env: Record<string, string | undefined>;
+    logger: Logger;
+}
+
+export async function runSelfUpdateCommand(
+    options: SelfUpdateCommandRunOptions,
+): Promise<SelfUpdateCommandRunResult> {
+    const subprocess = Bun.spawn({
+        cmd: [options.commandPath, ...options.commandArguments],
+        env: options.env,
+        stderr: "pipe",
+        stdin: "ignore",
+        stdout: "pipe",
+        timeout: options.timeoutMs,
+        windowsHide: true,
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+        subprocess.exited,
+        readSubprocessOutput(subprocess.stdout),
+        readSubprocessOutput(subprocess.stderr),
+    ]);
+
+    return {
+        exitCode,
+        signalCode: subprocess.signalCode,
+        stderr,
+        stdout,
+    };
+}
+
+export async function runSelfUpdateCommandWithLogging(options: {
+    commandArguments: readonly string[];
+    commandPath: string;
+    failureMessage: string;
+    logContext?: Record<string, unknown>;
+    runtime: SelfUpdateCommandRuntime;
+    successMessage: string;
+    timeoutMs: number;
+}): Promise<void> {
+    const baseLogFields = {
+        ...options.logContext,
+        commandArguments: options.commandArguments,
+        commandPath: options.commandPath,
+    };
+
+    try {
+        const result = await (options.runtime.runCommand ?? runSelfUpdateCommand)({
+            commandArguments: options.commandArguments,
+            commandPath: options.commandPath,
+            env: options.runtime.env,
+            timeoutMs: options.timeoutMs,
+        });
+
+        if (result.exitCode !== 0 || result.signalCode !== null) {
+            options.runtime.logger.warn(
+                {
+                    ...baseLogFields,
+                    exitCode: result.exitCode,
+                    signalCode: result.signalCode,
+                    stderr: normalizeLoggedCommandOutput(result.stderr),
+                    stdout: normalizeLoggedCommandOutput(result.stdout),
+                },
+                options.failureMessage,
+            );
+            return;
+        }
+
+        options.runtime.logger.info(baseLogFields, options.successMessage);
+    }
+    catch (error) {
+        options.runtime.logger.warn(
+            {
+                ...baseLogFields,
+                err: error,
+            },
+            options.failureMessage,
+        );
+    }
+}
+
+export function normalizeLoggedCommandOutput(
+    output: string,
+): string | undefined {
+    const trimmedOutput = output.trim();
+
+    return trimmedOutput === ""
+        ? undefined
+        : trimmedOutput;
+}
+
+async function readSubprocessOutput(
+    output: ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined | null,
+): Promise<string> {
+    if (output === null || output === undefined || typeof output === "number") {
+        return "";
+    }
+
+    return await new Response(output).text();
+}

--- a/src/application/self-update/core.test.ts
+++ b/src/application/self-update/core.test.ts
@@ -1,3 +1,4 @@
+import type { SelfUpdateCommandRunOptions } from "../contracts/self-update.ts";
 import type { SelfUpdateProgressEvent } from "./progress.ts";
 import { rmSync, symlinkSync } from "node:fs";
 import { chmod, mkdir, readlink, realpath, writeFile } from "node:fs/promises";
@@ -70,6 +71,7 @@ describe("performSelfUpdateOperation", () => {
                     logger: logCapture.logger,
                     platform: process.platform,
                     processId: process.pid,
+                    runCommand: createSuccessfulSelfUpdateCommandRunner(),
                 },
                 targetVersion: "1.2.3",
             });
@@ -140,6 +142,7 @@ describe("performSelfUpdateOperation", () => {
                     logger: logCapture.logger,
                     platform: process.platform,
                     processId: process.pid,
+                    runCommand: createSuccessfulSelfUpdateCommandRunner(),
                 },
                 targetVersion: "2.0.0",
             });
@@ -216,6 +219,7 @@ describe("performSelfUpdateOperation", () => {
                     logger: logCapture.logger,
                     platform: process.platform,
                     processId: process.pid,
+                    runCommand: createSuccessfulSelfUpdateCommandRunner(),
                 },
                 targetVersion: "3.0.0",
             });
@@ -287,6 +291,10 @@ describe("performSelfUpdateOperation", () => {
             expect(result.status).toBe("installed");
             expect(invokedCommands).toEqual([
                 {
+                    commandArguments: ["skills", "add"],
+                    commandPath: paths.executablePath,
+                },
+                {
                     commandArguments: ["remove", "-g", "@oomol-lab/oo-cli"],
                     commandPath: "/mock/bin/pnpm",
                 },
@@ -357,6 +365,7 @@ describe("performSelfUpdateOperation", () => {
                     logger: logCapture.logger,
                     platform: process.platform,
                     processId: process.pid,
+                    runCommand: createSuccessfulSelfUpdateCommandRunner(),
                 },
                 targetVersion: "2.0.0",
             });
@@ -547,6 +556,7 @@ describe("performSelfUpdateOperation", () => {
                     logger: logCapture.logger,
                     platform: process.platform,
                     processId: process.pid,
+                    runCommand: createSuccessfulSelfUpdateCommandRunner(),
                 },
                 targetVersion: "2.0.0",
             });
@@ -680,6 +690,7 @@ describe("performSelfUpdateOperation", () => {
                     logger: logCapture.logger,
                     platform: process.platform,
                     processId: process.pid,
+                    runCommand: createSuccessfulSelfUpdateCommandRunner(),
                 },
                 targetVersion: "2.0.0",
             });
@@ -750,4 +761,27 @@ function trackAbortSignal(
     }, { once: true });
 
     return signal;
+}
+
+function createSuccessfulSelfUpdateCommandRunner(
+    invokedCommands?: Array<{
+        commandArguments: readonly string[];
+        commandPath: string;
+        timeoutMs: number;
+    }>,
+) {
+    return async (options: SelfUpdateCommandRunOptions) => {
+        invokedCommands?.push({
+            commandArguments: options.commandArguments,
+            commandPath: options.commandPath,
+            timeoutMs: options.timeoutMs,
+        });
+
+        return {
+            exitCode: 0,
+            signalCode: null,
+            stderr: "",
+            stdout: "",
+        };
+    };
 }

--- a/src/application/self-update/core.ts
+++ b/src/application/self-update/core.ts
@@ -15,6 +15,7 @@ import {
     fetchLatestCliReleaseVersion,
     parseLatestCliSemverReleaseVersion,
 } from "../update/release-metadata.ts";
+import { attemptBundledSkillRefreshAfterSelfUpdate } from "./bundled-skills.ts";
 import { attemptLegacyPackageManagerUninstall } from "./legacy-installation.ts";
 import {
     acquireProcessLifetimeVersionLock,
@@ -172,6 +173,10 @@ export async function performSelfUpdateOperation(options: {
             paths,
             platform: options.runtime.platform,
             targetVersion: options.targetVersion,
+        });
+        await attemptBundledSkillRefreshAfterSelfUpdate({
+            executablePath: paths.executablePath,
+            runtime: options.runtime,
         });
         await attemptLegacyPackageManagerUninstall(options.runtime);
 

--- a/src/application/self-update/legacy-installation.ts
+++ b/src/application/self-update/legacy-installation.ts
@@ -1,9 +1,5 @@
-import type { Logger } from "pino";
-import type {
-    LegacyPackageManagerCommandRunOptions,
-    LegacyPackageManagerCommandRunResult,
-    SelfUpdateRuntimeOverrides,
-} from "../contracts/self-update.ts";
+import type { SelfUpdateCommandRuntime } from "./command-runner.ts";
+import { runSelfUpdateCommandWithLogging } from "./command-runner.ts";
 import { detectInstallationMethodFromExecPath } from "./installation.ts";
 
 const legacyCliPackageName = "@oomol-lab/oo-cli";
@@ -24,10 +20,8 @@ const legacyPackageManagerConfigurations = {
     },
 } as const;
 
-export interface LegacyPackageManagerCleanupRuntime extends SelfUpdateRuntimeOverrides {
-    env: Record<string, string | undefined>;
+export interface LegacyPackageManagerCleanupRuntime extends SelfUpdateCommandRuntime {
     execPath: string;
-    logger: Logger;
     platform: NodeJS.Platform;
 }
 
@@ -61,92 +55,15 @@ export async function attemptLegacyPackageManagerUninstall(
         return;
     }
 
-    try {
-        const result = await (runtime.runCommand ?? runLegacyPackageManagerCommand)({
-            commandArguments: configuration.commandArguments,
-            commandPath,
-            env: runtime.env,
-            timeoutMs: legacyPackageManagerUninstallTimeoutMs,
-        });
-
-        if (result.exitCode !== 0 || result.signalCode !== null) {
-            runtime.logger.warn(
-                {
-                    commandArguments: configuration.commandArguments,
-                    commandPath,
-                    exitCode: result.exitCode,
-                    packageManager,
-                    signalCode: result.signalCode,
-                    stderr: normalizeLoggedProcessOutput(result.stderr),
-                    stdout: normalizeLoggedProcessOutput(result.stdout),
-                },
-                "Legacy package-manager oo-cli uninstall failed.",
-            );
-            return;
-        }
-
-        runtime.logger.info(
-            {
-                commandArguments: configuration.commandArguments,
-                commandPath,
-                packageManager,
-            },
-            "Legacy package-manager oo-cli uninstall completed.",
-        );
-    }
-    catch (error) {
-        runtime.logger.warn(
-            {
-                commandArguments: configuration.commandArguments,
-                commandPath,
-                err: error,
-                packageManager,
-            },
-            "Legacy package-manager oo-cli uninstall failed.",
-        );
-    }
-}
-
-async function runLegacyPackageManagerCommand(
-    options: LegacyPackageManagerCommandRunOptions,
-): Promise<LegacyPackageManagerCommandRunResult> {
-    const subprocess = Bun.spawn({
-        cmd: [options.commandPath, ...options.commandArguments],
-        env: options.env,
-        stderr: "pipe",
-        stdin: "ignore",
-        stdout: "pipe",
-        timeout: options.timeoutMs,
-        windowsHide: true,
+    await runSelfUpdateCommandWithLogging({
+        commandArguments: configuration.commandArguments,
+        commandPath,
+        failureMessage: "Legacy package-manager oo-cli uninstall failed.",
+        logContext: {
+            packageManager,
+        },
+        runtime,
+        successMessage: "Legacy package-manager oo-cli uninstall completed.",
+        timeoutMs: legacyPackageManagerUninstallTimeoutMs,
     });
-    const [exitCode, stdout, stderr] = await Promise.all([
-        subprocess.exited,
-        readSubprocessOutput(subprocess.stdout),
-        readSubprocessOutput(subprocess.stderr),
-    ]);
-
-    return {
-        exitCode,
-        signalCode: subprocess.signalCode,
-        stderr,
-        stdout,
-    };
-}
-
-function normalizeLoggedProcessOutput(output: string): string | undefined {
-    const trimmedOutput = output.trim();
-
-    return trimmedOutput === ""
-        ? undefined
-        : trimmedOutput;
-}
-
-async function readSubprocessOutput(
-    output: ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined | null,
-): Promise<string> {
-    if (output === null || output === undefined || typeof output === "number") {
-        return "";
-    }
-
-    return await new Response(output).text();
 }


### PR DESCRIPTION
After a successful managed install or update, silently invoke the freshly installed `oo skills add` so bundled skills are realigned with the new CLI version. Without this step, users who upgrade retain stale bundled skills from the prior install.

Extract shared `runSelfUpdateCommandWithLogging` and `SelfUpdateCommandRuntime` from the legacy package-manager cleanup path so both post-install flows share the same subprocess and logging shape.