### PR TITLE
fix(install): hide install from help and completion

### DIFF
--- a/src/adapters/commander/commander-cli-adapter.ts
+++ b/src/adapters/commander/commander-cli-adapter.ts
@@ -102,7 +102,10 @@ export class CommanderCliAdapter {
         definition: CliCommandDefinition,
         context: CliExecutionContext,
     ): void {
-        const command = parent.command(definition.name);
+        const command = parent.command(
+            definition.name,
+            definition.hidden ? { hidden: true } : undefined,
+        );
         configureCommand(command, definition, context.translator);
 
         for (const child of definition.children ?? []) {

--- a/src/adapters/completion/static-completion-renderer.test.ts
+++ b/src/adapters/completion/static-completion-renderer.test.ts
@@ -49,7 +49,7 @@ describe("StaticCompletionRenderer", () => {
         expect(output).toContain("completion");
         expect(output).toContain("config");
         expect(output).toContain("connector");
-        expect(output).toContain(
+        expect(output).not.toContain(
             `complete -c ${APP_NAME} -n '__fish_use_subcommand' -a 'install'`,
         );
         expect(output).toContain("login");

--- a/src/adapters/completion/static-completion-renderer.ts
+++ b/src/adapters/completion/static-completion-renderer.ts
@@ -51,19 +51,25 @@ function buildCompletionNodes(
         argumentChoices: readonly (readonly string[])[] = [],
     ): void => {
         const pathKey = path.join(" ");
+        const hiddenNames = new Set(
+            commands.filter(command => command.hidden === true).map(command => command.name),
+        );
         const childCommands = commands.map(command => ({
             name: command.name,
             summary: translator.t(command.summaryKey),
         }));
-        const visibleSubcommands = childCommands.length > 0
+        const visibleChildCommands = childCommands.filter(
+            command => !hiddenNames.has(command.name),
+        );
+        const visibleSubcommands = visibleChildCommands.length > 0
             ? [
-                    ...childCommands,
+                    ...visibleChildCommands,
                     {
                         name: "help",
                         summary: translator.t("commands.help.summary"),
                     },
                 ]
-            : childCommands;
+            : [];
 
         nodes.push({
             path,

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -34,30 +34,27 @@ exports[`runCli bootstrap creates the sqlite cache file during cli startup 1`] =
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version                Show the current version
-  --debug                      Print the current log file path when the CLI
-                               exits
-  --lang <lang>                Specify the display language
-  -h, --help                   Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                         Manage CLI authentication
-  check-update                 Check for CLI updates
-  cloud-task                   Manage cloud tasks
-  connector                    Manage connector actions
-  file                         Manage temporary file transfers
-  install [options] [version]  Install the CLI
-  login                        Log in with device login (alias for auth login)
-  logout                       Log out the current account (alias for auth
-                               logout)
-  completion <shell>           Generate shell completion scripts
-  config                       Manage persisted configuration
-  skills                       Manage Codex skills
-  log                          Manage persisted debug logs
-  search [options] <text>      Search packages and connector actions
-  packages                     Package utilities
-  update|upgrade               Update the CLI
-  help [command]               Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with device login (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  update|upgrade           Update the CLI
+  help [command]           Show help for a command
 "
 ,
 }
@@ -71,30 +68,27 @@ exports[`runCli bootstrap writes debug logs to the log directory during cli star
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version                Show the current version
-  --debug                      Print the current log file path when the CLI
-                               exits
-  --lang <lang>                Specify the display language
-  -h, --help                   Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                         Manage CLI authentication
-  check-update                 Check for CLI updates
-  cloud-task                   Manage cloud tasks
-  connector                    Manage connector actions
-  file                         Manage temporary file transfers
-  install [options] [version]  Install the CLI
-  login                        Log in with device login (alias for auth login)
-  logout                       Log out the current account (alias for auth
-                               logout)
-  completion <shell>           Generate shell completion scripts
-  config                       Manage persisted configuration
-  skills                       Manage Codex skills
-  log                          Manage persisted debug logs
-  search [options] <text>      Search packages and connector actions
-  packages                     Package utilities
-  update|upgrade               Update the CLI
-  help [command]               Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with device login (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  update|upgrade           Update the CLI
+  help [command]           Show help for a command
 "
 ,
 }
@@ -111,30 +105,27 @@ exports[`runCli bootstrap prints the current log file path to stderr when --debu
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version                Show the current version
-  --debug                      Print the current log file path when the CLI
-                               exits
-  --lang <lang>                Specify the display language
-  -h, --help                   Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                         Manage CLI authentication
-  check-update                 Check for CLI updates
-  cloud-task                   Manage cloud tasks
-  connector                    Manage connector actions
-  file                         Manage temporary file transfers
-  install [options] [version]  Install the CLI
-  login                        Log in with device login (alias for auth login)
-  logout                       Log out the current account (alias for auth
-                               logout)
-  completion <shell>           Generate shell completion scripts
-  config                       Manage persisted configuration
-  skills                       Manage Codex skills
-  log                          Manage persisted debug logs
-  search [options] <text>      Search packages and connector actions
-  packages                     Package utilities
-  update|upgrade               Update the CLI
-  help [command]               Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with device login (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  update|upgrade           Update the CLI
+  help [command]           Show help for a command
 "
 ,
 }
@@ -149,28 +140,27 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
 "oo 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成
 
 选项：
-  -V, --version                显示当前版本
-  --debug                      在 CLI 退出时打印当前日志文件路径
-  --lang <lang>                指定显示语言
-  -h, --help                   显示命令帮助
+  -V, --version            显示当前版本
+  --debug                  在 CLI 退出时打印当前日志文件路径
+  --lang <lang>            指定显示语言
+  -h, --help               显示命令帮助
 
 命令：
-  auth                         管理 CLI 认证
-  check-update                 检查 CLI 更新
-  cloud-task                   管理云任务
-  connector                    管理 connector action
-  file                         管理临时文件传输
-  install [options] [version]  安装 CLI
-  login                        通过 device login 登录（auth login 的别名）
-  logout                       登出当前账号（auth logout 的别名）
-  completion <shell>           生成 shell 补全脚本
-  config                       管理持久化配置
-  skills                       管理 Codex skill
-  log                          管理持久化 debug 日志
-  search [options] <text>      搜索 package 与 connector action
-  packages                     包相关工具
-  update|upgrade               更新 CLI
-  help [command]               显示命令帮助
+  auth                     管理 CLI 认证
+  check-update             检查 CLI 更新
+  cloud-task               管理云任务
+  connector                管理 connector action
+  file                     管理临时文件传输
+  login                    通过 device login 登录（auth login 的别名）
+  logout                   登出当前账号（auth logout 的别名）
+  completion <shell>       生成 shell 补全脚本
+  config                   管理持久化配置
+  skills                   管理 Codex skill
+  log                      管理持久化 debug 日志
+  search [options] <text>  搜索 package 与 connector action
+  packages                 包相关工具
+  update|upgrade           更新 CLI
+  help [command]           显示命令帮助
 "
 ,
   },
@@ -181,30 +171,27 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version                Show the current version
-  --debug                      Print the current log file path when the CLI
-                               exits
-  --lang <lang>                Specify the display language
-  -h, --help                   Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                         Manage CLI authentication
-  check-update                 Check for CLI updates
-  cloud-task                   Manage cloud tasks
-  connector                    Manage connector actions
-  file                         Manage temporary file transfers
-  install [options] [version]  Install the CLI
-  login                        Log in with device login (alias for auth login)
-  logout                       Log out the current account (alias for auth
-                               logout)
-  completion <shell>           Generate shell completion scripts
-  config                       Manage persisted configuration
-  skills                       Manage Codex skills
-  log                          Manage persisted debug logs
-  search [options] <text>      Search packages and connector actions
-  packages                     Package utilities
-  update|upgrade               Update the CLI
-  help [command]               Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with device login (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  update|upgrade           Update the CLI
+  help [command]           Show help for a command
 "
 ,
   },
@@ -219,30 +206,27 @@ exports[`runCli bootstrap renders branded colors in help when stdout supports co
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version                Show the current version
-  --debug                      Print the current log file path when the CLI
-                               exits
-  --lang <lang>                Specify the display language
-  -h, --help                   Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                         Manage CLI authentication
-  check-update                 Check for CLI updates
-  cloud-task                   Manage cloud tasks
-  connector                    Manage connector actions
-  file                         Manage temporary file transfers
-  install [options] [version]  Install the CLI
-  login                        Log in with device login (alias for auth login)
-  logout                       Log out the current account (alias for auth
-                               logout)
-  completion <shell>           Generate shell completion scripts
-  config                       Manage persisted configuration
-  skills                       Manage Codex skills
-  log                          Manage persisted debug logs
-  search [options] <text>      Search packages and connector actions
-  packages                     Package utilities
-  update|upgrade               Update the CLI
-  help [command]               Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with device login (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  update|upgrade           Update the CLI
+  help [command]           Show help for a command
 "
 ,
 }

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -223,6 +223,22 @@ describe("runCli bootstrap", () => {
         }
     });
 
+    test("hides install from root help while keeping direct install help available", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const rootHelp = await sandbox.run(["--help"]);
+            const installHelp = await sandbox.run(["install", "--help"]);
+
+            expect(rootHelp.stdout).not.toContain("install [options] [version]");
+            expect(installHelp.stdout).toContain("Install one oo-managed CLI release");
+            expect(installHelp.stdout).toContain("--force");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("renders branded colors in help when stdout supports colors", async () => {
         const sandbox = await createCliSandbox();
         const colors = createTerminalColors(true);

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -20,30 +20,27 @@ exports[`config CLI persists the configured locale and allows explicit override 
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version                Show the current version
-  --debug                      Print the current log file path when the CLI
-                               exits
-  --lang <lang>                Specify the display language
-  -h, --help                   Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                         Manage CLI authentication
-  check-update                 Check for CLI updates
-  cloud-task                   Manage cloud tasks
-  connector                    Manage connector actions
-  file                         Manage temporary file transfers
-  install [options] [version]  Install the CLI
-  login                        Log in with device login (alias for auth login)
-  logout                       Log out the current account (alias for auth
-                               logout)
-  completion <shell>           Generate shell completion scripts
-  config                       Manage persisted configuration
-  skills                       Manage Codex skills
-  log                          Manage persisted debug logs
-  search [options] <text>      Search packages and connector actions
-  packages                     Package utilities
-  update|upgrade               Update the CLI
-  help [command]               Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with device login (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  update|upgrade           Update the CLI
+  help [command]           Show help for a command
 "
 ,
   },
@@ -54,28 +51,27 @@ Commands:
 "oo 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成
 
 选项：
-  -V, --version                显示当前版本
-  --debug                      在 CLI 退出时打印当前日志文件路径
-  --lang <lang>                指定显示语言
-  -h, --help                   显示命令帮助
+  -V, --version            显示当前版本
+  --debug                  在 CLI 退出时打印当前日志文件路径
+  --lang <lang>            指定显示语言
+  -h, --help               显示命令帮助
 
 命令：
-  auth                         管理 CLI 认证
-  check-update                 检查 CLI 更新
-  cloud-task                   管理云任务
-  connector                    管理 connector action
-  file                         管理临时文件传输
-  install [options] [version]  安装 CLI
-  login                        通过 device login 登录（auth login 的别名）
-  logout                       登出当前账号（auth logout 的别名）
-  completion <shell>           生成 shell 补全脚本
-  config                       管理持久化配置
-  skills                       管理 Codex skill
-  log                          管理持久化 debug 日志
-  search [options] <text>      搜索 package 与 connector action
-  packages                     包相关工具
-  update|upgrade               更新 CLI
-  help [command]               显示命令帮助
+  auth                     管理 CLI 认证
+  check-update             检查 CLI 更新
+  cloud-task               管理云任务
+  connector                管理 connector action
+  file                     管理临时文件传输
+  login                    通过 device login 登录（auth login 的别名）
+  logout                   登出当前账号（auth logout 的别名）
+  completion <shell>       生成 shell 补全脚本
+  config                   管理持久化配置
+  skills                   管理 Codex skill
+  log                      管理持久化 debug 日志
+  search [options] <text>  搜索 package 与 connector action
+  packages                 包相关工具
+  update|upgrade           更新 CLI
+  help [command]           显示命令帮助
 "
 ,
   },

--- a/src/application/commands/install.ts
+++ b/src/application/commands/install.ts
@@ -22,6 +22,7 @@ export const installCommand: CliCommandDefinition<
     z.infer<typeof installCommandInputSchema>
 > = {
     name: "install",
+    hidden: true,
     summaryKey: "commands.install.summary",
     descriptionKey: "commands.install.description",
     arguments: [

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -30,30 +30,27 @@ exports[`skills CLI silently installs the managed bundled skill on the first run
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version                Show the current version
-  --debug                      Print the current log file path when the CLI
-                               exits
-  --lang <lang>                Specify the display language
-  -h, --help                   Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                         Manage CLI authentication
-  check-update                 Check for CLI updates
-  cloud-task                   Manage cloud tasks
-  connector                    Manage connector actions
-  file                         Manage temporary file transfers
-  install [options] [version]  Install the CLI
-  login                        Log in with device login (alias for auth login)
-  logout                       Log out the current account (alias for auth
-                               logout)
-  completion <shell>           Generate shell completion scripts
-  config                       Manage persisted configuration
-  skills                       Manage Codex skills
-  log                          Manage persisted debug logs
-  search [options] <text>      Search packages and connector actions
-  packages                     Package utilities
-  update|upgrade               Update the CLI
-  help [command]               Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with device login (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  update|upgrade           Update the CLI
+  help [command]           Show help for a command
 "
 ,
 }
@@ -67,30 +64,27 @@ exports[`skills CLI does not auto-install the managed bundled skill during local
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version                Show the current version
-  --debug                      Print the current log file path when the CLI
-                               exits
-  --lang <lang>                Specify the display language
-  -h, --help                   Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                         Manage CLI authentication
-  check-update                 Check for CLI updates
-  cloud-task                   Manage cloud tasks
-  connector                    Manage connector actions
-  file                         Manage temporary file transfers
-  install [options] [version]  Install the CLI
-  login                        Log in with device login (alias for auth login)
-  logout                       Log out the current account (alias for auth
-                               logout)
-  completion <shell>           Generate shell completion scripts
-  config                       Manage persisted configuration
-  skills                       Manage Codex skills
-  log                          Manage persisted debug logs
-  search [options] <text>      Search packages and connector actions
-  packages                     Package utilities
-  update|upgrade               Update the CLI
-  help [command]               Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with device login (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  update|upgrade           Update the CLI
+  help [command]           Show help for a command
 "
 ,
 }
@@ -104,30 +98,27 @@ exports[`skills CLI does not synchronize a managed bundled skill that uses the d
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version                Show the current version
-  --debug                      Print the current log file path when the CLI
-                               exits
-  --lang <lang>                Specify the display language
-  -h, --help                   Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                         Manage CLI authentication
-  check-update                 Check for CLI updates
-  cloud-task                   Manage cloud tasks
-  connector                    Manage connector actions
-  file                         Manage temporary file transfers
-  install [options] [version]  Install the CLI
-  login                        Log in with device login (alias for auth login)
-  logout                       Log out the current account (alias for auth
-                               logout)
-  completion <shell>           Generate shell completion scripts
-  config                       Manage persisted configuration
-  skills                       Manage Codex skills
-  log                          Manage persisted debug logs
-  search [options] <text>      Search packages and connector actions
-  packages                     Package utilities
-  update|upgrade               Update the CLI
-  help [command]               Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with device login (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  update|upgrade           Update the CLI
+  help [command]           Show help for a command
 "
 ,
 }
@@ -152,30 +143,27 @@ exports[`skills CLI silently installs bundled skills into Claude Code on the fir
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version                Show the current version
-  --debug                      Print the current log file path when the CLI
-                               exits
-  --lang <lang>                Specify the display language
-  -h, --help                   Show help for command
+  -V, --version            Show the current version
+  --debug                  Print the current log file path when the CLI exits
+  --lang <lang>            Specify the display language
+  -h, --help               Show help for command
 
 Commands:
-  auth                         Manage CLI authentication
-  check-update                 Check for CLI updates
-  cloud-task                   Manage cloud tasks
-  connector                    Manage connector actions
-  file                         Manage temporary file transfers
-  install [options] [version]  Install the CLI
-  login                        Log in with device login (alias for auth login)
-  logout                       Log out the current account (alias for auth
-                               logout)
-  completion <shell>           Generate shell completion scripts
-  config                       Manage persisted configuration
-  skills                       Manage Codex skills
-  log                          Manage persisted debug logs
-  search [options] <text>      Search packages and connector actions
-  packages                     Package utilities
-  update|upgrade               Update the CLI
-  help [command]               Show help for a command
+  auth                     Manage CLI authentication
+  check-update             Check for CLI updates
+  cloud-task               Manage cloud tasks
+  connector                Manage connector actions
+  file                     Manage temporary file transfers
+  login                    Log in with device login (alias for auth login)
+  logout                   Log out the current account (alias for auth logout)
+  completion <shell>       Generate shell completion scripts
+  config                   Manage persisted configuration
+  skills                   Manage Codex skills
+  log                      Manage persisted debug logs
+  search [options] <text>  Search packages and connector actions
+  packages                 Package utilities
+  update|upgrade           Update the CLI
+  help [command]           Show help for a command
 "
 ,
 }

--- a/src/application/contracts/cli.ts
+++ b/src/application/contracts/cli.ts
@@ -66,6 +66,7 @@ export type CliCommandHandler<TInput> = {
 export interface CliCommandDefinition<TInput = unknown> {
     name: string;
     aliases?: readonly string[];
+    hidden?: boolean;
     summaryKey: string;
     descriptionKey?: string;
     arguments?: readonly CliArgumentDefinition[];


### PR DESCRIPTION
The managed install entrypoint should stay callable without being advertised in root help or top-level shell completion.

Add a hidden command flag to the CLI catalog and teach the Commander and completion adapters to filter hidden commands while keeping direct install invocation supported.