### PR TITLE
fix(install): remove shadowing package-manager oo installs

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -823,6 +823,13 @@ export function createConnectionRefusedError(
     return error;
 }
 
+export function joinPathEntries(
+    pathEntries: readonly string[],
+    platform: NodeJS.Platform,
+): string {
+    return pathEntries.join(platform === "win32" ? ";" : ":");
+}
+
 export function requireAbortSignal(init?: RequestInit): AbortSignal {
     const signal = init?.signal;
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -116,9 +116,11 @@ Install one managed `oo` release into the local self-managed runtime.
   reporting success.
 - Notes: when the executable directory is not on `PATH`, install also prints a
   setup note that tells the user which directory to add.
-- Notes: after a successful install, the CLI best-effort removes a legacy
-  global `@oomol-lab/oo-cli` package-manager install when the current command
-  is running from one; cleanup failures do not change the command result.
+- Notes: after a successful install, the CLI best-effort removes legacy global
+  `@oomol-lab/oo-cli` package-manager installs that appear on `PATH` before the
+  managed executable; when `PATH` yields no `oo` candidates, the CLI falls back
+  to the current command path. Cleanup failures do not change the command
+  result.
 - Notes: after a successful install workflow, the CLI silently runs
   `oo skills add` with the managed executable so bundled skills refresh to the
   installed CLI version.
@@ -141,9 +143,11 @@ Update the managed `oo` install to the latest published release.
   workflow and prints the up-to-date message immediately.
 - Notes: `oo update` ensures the managed install is current and usable, and
   does not expose a separate `--force` flag.
-- Notes: after a successful update, the CLI best-effort removes a legacy global
-  `@oomol-lab/oo-cli` package-manager install when the current command is
-  running from one; cleanup failures do not change the command result.
+- Notes: after a successful update, the CLI best-effort removes legacy global
+  `@oomol-lab/oo-cli` package-manager installs that appear on `PATH` before the
+  managed executable; when `PATH` yields no `oo` candidates, the CLI falls back
+  to the current command path. Cleanup failures do not change the command
+  result.
 - Notes: after a successful update workflow, the CLI silently runs
   `oo skills add` with the managed executable so bundled skills refresh to the
   installed CLI version.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -105,8 +105,9 @@
 - 说明：install 在报告成功前会校验已安装的 `oo` 命令可正常使用。
 - 说明：如果可执行目录没有出现在 `PATH` 中，install 还会额外打印 setup note，
   告知用户应当把哪个目录加入 `PATH`。
-- 说明：install 成功后，如果当前命令运行自一个旧的全局 package-manager
-  `@oomol-lab/oo-cli` 安装，CLI 会尽力将其移除；清理失败不会改变命令结果。
+- 说明：install 成功后，CLI 会尽力移除在 `PATH` 中排在托管可执行文件之前的
+  旧全局 package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到
+  `oo` 候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
 - 说明：install 成功后，CLI 会使用托管的可执行文件静默执行一次
   `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /
@@ -125,8 +126,9 @@
   update 会直接跳过托管重装流程，并立即输出“已是最新版本”的消息。
 - 说明：`oo update` 会确保托管安装保持为当前可用状态，不额外暴露
   `--force`。
-- 说明：update 成功后，如果当前命令运行自一个旧的全局 package-manager
-  `@oomol-lab/oo-cli` 安装，CLI 会尽力将其移除；清理失败不会改变命令结果。
+- 说明：update 成功后，CLI 会尽力移除在 `PATH` 中排在托管可执行文件之前的
+  旧全局 package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到
+  `oo` 候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
 - 说明：update 成功后，CLI 会使用托管的可执行文件静默执行一次
   `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /

--- a/src/application/self-update/core.test.ts
+++ b/src/application/self-update/core.test.ts
@@ -9,6 +9,7 @@ import {
     createLogCapture,
     createTemporaryDirectory,
     expectCliUserError,
+    joinPathEntries,
     requireAbortSignal,
     useTemporaryDirectoryCleanup,
 } from "../../../__tests__/helpers.ts";
@@ -297,6 +298,90 @@ describe("performSelfUpdateOperation", () => {
                 {
                     commandArguments: ["remove", "-g", "@oomol-lab/oo-cli"],
                     commandPath: "/mock/bin/pnpm",
+                },
+            ]);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("uses PATH fallback to uninstall legacy package-manager installs after activation", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-self-update-legacy-path");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const targetVersionPath = resolveSelfUpdateVersionFilePath(
+            paths,
+            "1.2.3",
+        );
+        const bunDirectory = join(rootDirectory, ".bun", "bin");
+        const bunExecutablePath = join(bunDirectory, basename(paths.executablePath));
+        const logCapture = createLogCapture();
+        const invokedCommands: Array<{
+            commandArguments: readonly string[];
+            commandPath: string;
+        }> = [];
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries(
+            [bunDirectory, paths.executableDirectory],
+            process.platform,
+        );
+        await Promise.all([
+            mkdir(paths.versionsDirectory, { recursive: true }),
+            writeManagedVersion(targetVersionPath),
+        ]);
+        await mkdir(bunDirectory, { recursive: true });
+        await writeFile(bunExecutablePath, "binary");
+
+        if (process.platform !== "win32") {
+            await chmod(bunExecutablePath, 0o755);
+        }
+
+        try {
+            const result = await performSelfUpdateOperation({
+                currentVersion: "1.0.0",
+                forceReinstall: false,
+                runtime: {
+                    arch: process.arch,
+                    env,
+                    execPath: join(rootDirectory, "downloads", basename(paths.executablePath)),
+                    fetcher: async () => {
+                        throw new Error("binary download should not be called");
+                    },
+                    logger: logCapture.logger,
+                    platform: process.platform,
+                    processId: process.pid,
+                    resolveCommandPath: commandName => `/mock/bin/${commandName}`,
+                    runCommand: async (options) => {
+                        invokedCommands.push({
+                            commandArguments: options.commandArguments,
+                            commandPath: options.commandPath,
+                        });
+
+                        return {
+                            exitCode: 0,
+                            signalCode: null,
+                            stderr: "",
+                            stdout: "",
+                        };
+                    },
+                },
+                targetVersion: "1.2.3",
+            });
+
+            expect(result.status).toBe("installed");
+            expect(invokedCommands).toEqual([
+                {
+                    commandArguments: ["skills", "add"],
+                    commandPath: paths.executablePath,
+                },
+                {
+                    commandArguments: ["remove", "-g", "@oomol-lab/oo-cli"],
+                    commandPath: "/mock/bin/bun",
                 },
             ]);
         }

--- a/src/application/self-update/legacy-installation.test.ts
+++ b/src/application/self-update/legacy-installation.test.ts
@@ -1,6 +1,18 @@
+import type { SelfUpdateCommandRunOptions } from "../contracts/self-update.ts";
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import process from "node:process";
 import { describe, expect, test } from "bun:test";
-import { createLogCapture } from "../../../__tests__/helpers.ts";
+import {
+    createLogCapture,
+    createTemporaryDirectory,
+    joinPathEntries,
+    useTemporaryDirectoryCleanup,
+} from "../../../__tests__/helpers.ts";
 import { attemptLegacyPackageManagerUninstall } from "./legacy-installation.ts";
+import { resolveSelfUpdatePaths } from "./paths.ts";
+
+const { track: trackDirectory } = useTemporaryDirectoryCleanup();
 
 describe("attemptLegacyPackageManagerUninstall", () => {
     test("runs the matching package manager uninstall command", async () => {
@@ -73,4 +85,258 @@ describe("attemptLegacyPackageManagerUninstall", () => {
             logCapture.close();
         }
     });
+
+    test("uninstalls package managers found on PATH before the managed executable", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-path");
+        const env = createLegacyCleanupEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const bunDirectory = join(rootDirectory, ".bun", "bin");
+        const pnpmDirectory = join(rootDirectory, "Library", "pnpm", "bin");
+        const commands = createRecordedCommands();
+        const logCapture = createLogCapture();
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries(
+            [bunDirectory, pnpmDirectory, paths.executableDirectory],
+            process.platform,
+        );
+        await Promise.all([
+            writeExecutable(join(bunDirectory, basename(paths.executablePath))),
+            writeExecutable(join(pnpmDirectory, basename(paths.executablePath))),
+            writeExecutable(paths.executablePath),
+        ]);
+
+        try {
+            await attemptLegacyPackageManagerUninstall({
+                env,
+                execPath: join(rootDirectory, "downloads", basename(paths.executablePath)),
+                logger: logCapture.logger,
+                platform: process.platform,
+                resolveCommandPath: commandName => `/mock/bin/${commandName}`,
+                runCommand: commands.runCommand,
+            });
+
+            expect(commands.read()).toEqual([
+                {
+                    commandArguments: ["remove", "-g", "@oomol-lab/oo-cli"],
+                    commandPath: "/mock/bin/bun",
+                    timeoutMs: 10_000,
+                },
+                {
+                    commandArguments: ["remove", "-g", "@oomol-lab/oo-cli"],
+                    commandPath: "/mock/bin/pnpm",
+                    timeoutMs: 10_000,
+                },
+            ]);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("does not fall back to execPath when PATH is blocked by an unknown oo executable", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-blocked");
+        const env = createLegacyCleanupEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const customDirectory = join(rootDirectory, "custom", "bin");
+        const commands = createRecordedCommands();
+        const logCapture = createLogCapture();
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries(
+            [customDirectory, paths.executableDirectory],
+            process.platform,
+        );
+        await Promise.all([
+            writeExecutable(join(customDirectory, basename(paths.executablePath))),
+            writeExecutable(paths.executablePath),
+        ]);
+
+        try {
+            await attemptLegacyPackageManagerUninstall({
+                env,
+                execPath: join(
+                    rootDirectory,
+                    ".bun",
+                    "install",
+                    "global",
+                    "node_modules",
+                    "@oomol-lab",
+                    "oo-cli",
+                    "bin",
+                    basename(paths.executablePath),
+                ),
+                logger: logCapture.logger,
+                platform: process.platform,
+                resolveCommandPath: commandName => `/mock/bin/${commandName}`,
+                runCommand: commands.runCommand,
+            });
+
+            expect(commands.read()).toEqual([]);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("falls back to execPath when PATH has no oo candidates", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-fallback");
+        const env = createLegacyCleanupEnv(rootDirectory);
+        const commands = createRecordedCommands();
+        const logCapture = createLogCapture();
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries([join(rootDirectory, "empty", "bin")], process.platform);
+
+        try {
+            await attemptLegacyPackageManagerUninstall({
+                env,
+                execPath: join(
+                    rootDirectory,
+                    ".bun",
+                    "install",
+                    "global",
+                    "node_modules",
+                    "@oomol-lab",
+                    "oo-cli",
+                    "bin",
+                    readExecutableName(process.platform),
+                ),
+                logger: logCapture.logger,
+                platform: process.platform,
+                resolveCommandPath: commandName => `/mock/bin/${commandName}`,
+                runCommand: commands.runCommand,
+            });
+
+            expect(commands.read()).toEqual([
+                {
+                    commandArguments: ["remove", "-g", "@oomol-lab/oo-cli"],
+                    commandPath: "/mock/bin/bun",
+                    timeoutMs: 10_000,
+                },
+            ]);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("ignores oo.cmd PATH candidates on Windows and falls back to execPath", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-win32");
+        const env = createLegacyCleanupEnv(rootDirectory);
+        const commands = createRecordedCommands();
+        const logCapture = createLogCapture();
+        const probedPaths: string[] = [];
+
+        trackDirectory(rootDirectory);
+        env.PATH = "legacy-bin;managed-bin";
+
+        try {
+            await attemptLegacyPackageManagerUninstall({
+                env,
+                execPath: "C:\\Users\\demo\\.bun\\install\\global\\node_modules\\@oomol-lab\\oo-cli\\bin\\oo.exe",
+                logger: logCapture.logger,
+                pathExists: async (path) => {
+                    probedPaths.push(path);
+                    return path === "legacy-bin\\oo.cmd";
+                },
+                platform: "win32",
+                resolveCommandPath: commandName => `/mock/bin/${commandName}`,
+                runCommand: commands.runCommand,
+            });
+
+            expect(probedPaths).toEqual([
+                "legacy-bin\\oo.exe",
+                "managed-bin\\oo.exe",
+            ]);
+            expect(commands.read()).toEqual([
+                {
+                    commandArguments: ["remove", "-g", "@oomol-lab/oo-cli"],
+                    commandPath: "/mock/bin/bun",
+                    timeoutMs: 10_000,
+                },
+            ]);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
 });
+
+function createLegacyCleanupEnv(rootDirectory: string): Record<string, string | undefined> {
+    return {
+        APPDATA: join(rootDirectory, "appdata"),
+        HOME: rootDirectory,
+        PATH: undefined,
+        TEMP: join(rootDirectory, "temp"),
+        TMP: join(rootDirectory, "temp"),
+        TMPDIR: join(rootDirectory, "tmpdir"),
+        USERPROFILE: rootDirectory,
+        XDG_CACHE_HOME: join(rootDirectory, "cache"),
+        XDG_DATA_HOME: join(rootDirectory, "data"),
+        XDG_RUNTIME_DIR: join(rootDirectory, "runtime"),
+    };
+}
+
+function readExecutableName(
+    platform: NodeJS.Platform,
+): string {
+    return platform === "win32"
+        ? "oo.exe"
+        : "oo";
+}
+
+async function writeExecutable(path: string): Promise<void> {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, "binary");
+
+    if (process.platform !== "win32") {
+        await chmod(path, 0o755);
+    }
+}
+
+function createRecordedCommands(): {
+    read: () => Array<{
+        commandArguments: readonly string[];
+        commandPath: string;
+        timeoutMs: number;
+    }>;
+    runCommand: (options: SelfUpdateCommandRunOptions) => Promise<{
+        exitCode: number;
+        signalCode: null;
+        stderr: string;
+        stdout: string;
+    }>;
+} {
+    const commands: Array<{
+        commandArguments: readonly string[];
+        commandPath: string;
+        timeoutMs: number;
+    }> = [];
+
+    return {
+        read() {
+            return [...commands];
+        },
+        runCommand: async (options) => {
+            commands.push({
+                commandArguments: options.commandArguments,
+                commandPath: options.commandPath,
+                timeoutMs: options.timeoutMs,
+            });
+
+            return {
+                exitCode: 0,
+                signalCode: null,
+                stderr: "",
+                stdout: "",
+            };
+        },
+    };
+}

--- a/src/application/self-update/legacy-installation.ts
+++ b/src/application/self-update/legacy-installation.ts
@@ -1,6 +1,10 @@
 import type { SelfUpdateCommandRuntime } from "./command-runner.ts";
+import type { InstallationDetection, PackageManagerInstallationMethod } from "./installation.ts";
+import { realpath } from "node:fs/promises";
+import { pathExists } from "../shared/fs-utils.ts";
 import { runSelfUpdateCommandWithLogging } from "./command-runner.ts";
 import { detectInstallationMethodFromExecPath } from "./installation.ts";
+import { readPathModule, resolveSelfUpdatePaths } from "./paths.ts";
 
 const legacyCliPackageName = "@oomol-lab/oo-cli";
 const legacyPackageManagerUninstallTimeoutMs = 10_000;
@@ -22,25 +26,176 @@ const legacyPackageManagerConfigurations = {
 
 export interface LegacyPackageManagerCleanupRuntime extends SelfUpdateCommandRuntime {
     execPath: string;
+    pathExists?: (path: string) => Promise<boolean>;
     platform: NodeJS.Platform;
 }
 
 export async function attemptLegacyPackageManagerUninstall(
     runtime: LegacyPackageManagerCleanupRuntime,
 ): Promise<void> {
+    const packageManagers = await resolveLegacyPackageManagersToUninstall(runtime);
+
+    if (packageManagers.length === 0) {
+        return;
+    }
+
+    for (const packageManager of packageManagers) {
+        await runLegacyPackageManagerUninstall(packageManager, runtime);
+    }
+}
+
+async function resolveLegacyPackageManagersToUninstall(
+    runtime: LegacyPackageManagerCleanupRuntime,
+): Promise<PackageManagerInstallationMethod[]> {
+    const pathResolution = await resolveLegacyPackageManagersFromPath(runtime);
+
+    if (pathResolution.encounteredCandidate) {
+        return pathResolution.packageManagers;
+    }
+
     const installation = detectInstallationMethodFromExecPath({
         env: runtime.env,
         execPath: runtime.execPath,
         platform: runtime.platform,
     });
-    const packageManager = installation.method === "native" || installation.method === "unknown"
-        ? undefined
-        : installation.method;
 
-    if (packageManager === undefined) {
-        return;
+    return installation.method === "native" || installation.method === "unknown"
+        ? []
+        : [installation.method];
+}
+
+async function resolveLegacyPackageManagersFromPath(
+    runtime: LegacyPackageManagerCleanupRuntime,
+): Promise<{
+    encounteredCandidate: boolean;
+    packageManagers: PackageManagerInstallationMethod[];
+}> {
+    const pathValue = runtime.env.PATH?.trim();
+
+    if (pathValue === undefined || pathValue === "") {
+        return {
+            encounteredCandidate: false,
+            packageManagers: [],
+        };
     }
 
+    const paths = resolveSelfUpdatePaths({
+        env: runtime.env,
+        platform: runtime.platform,
+    });
+    const pathModule = readPathModule(runtime.platform);
+    const executableName = pathModule.basename(paths.executablePath);
+    const packageManagers: PackageManagerInstallationMethod[] = [];
+    const seenPackageManagers = new Set<PackageManagerInstallationMethod>();
+    let encounteredCandidate = false;
+
+    for (const directoryPath of splitPathEntries(pathValue, runtime.platform)) {
+        const candidatePath = await resolveFirstPathCandidatePath({
+            directoryPath,
+            executableNames: [executableName],
+            pathExists: candidatePath =>
+                runtime.pathExists?.(candidatePath)
+                ?? pathExists(candidatePath),
+            pathModule,
+        });
+
+        if (candidatePath === undefined) {
+            continue;
+        }
+
+        encounteredCandidate = true;
+        const installation = await detectInstallationMethodFromPathCandidate({
+            candidatePath,
+            env: runtime.env,
+            platform: runtime.platform,
+        });
+
+        if (installation.method === "native" || installation.method === "unknown") {
+            break;
+        }
+
+        if (seenPackageManagers.has(installation.method)) {
+            continue;
+        }
+
+        seenPackageManagers.add(installation.method);
+        packageManagers.push(installation.method);
+    }
+
+    return {
+        encounteredCandidate,
+        packageManagers,
+    };
+}
+
+function splitPathEntries(
+    pathValue: string,
+    platform: NodeJS.Platform,
+): string[] {
+    const pathEntries = pathValue
+        .split(readPathDelimiter(platform))
+        .map(pathEntry => pathEntry.trim())
+        .filter(Boolean);
+
+    return pathEntries;
+}
+
+function readPathDelimiter(
+    platform: NodeJS.Platform,
+): string {
+    return platform === "win32"
+        ? ";"
+        : ":";
+}
+
+async function resolveFirstPathCandidatePath(options: {
+    directoryPath: string;
+    executableNames: readonly string[];
+    pathExists: (path: string) => Promise<boolean>;
+    pathModule: ReturnType<typeof readPathModule>;
+}): Promise<string | undefined> {
+    for (const executableName of options.executableNames) {
+        const candidatePath = options.pathModule.join(options.directoryPath, executableName);
+
+        if (await options.pathExists(candidatePath)) {
+            return candidatePath;
+        }
+    }
+
+    return undefined;
+}
+
+async function detectInstallationMethodFromPathCandidate(options: {
+    candidatePath: string;
+    env: Record<string, string | undefined>;
+    platform: NodeJS.Platform;
+}): Promise<InstallationDetection> {
+    const resolvedCandidatePath = await realpath(options.candidatePath)
+        .catch(() => options.candidatePath);
+    const resolvedInstallation = detectInstallationMethodFromExecPath({
+        env: options.env,
+        execPath: resolvedCandidatePath,
+        platform: options.platform,
+    });
+
+    if (
+        resolvedInstallation.method !== "unknown"
+        || resolvedCandidatePath === options.candidatePath
+    ) {
+        return resolvedInstallation;
+    }
+
+    return detectInstallationMethodFromExecPath({
+        env: options.env,
+        execPath: options.candidatePath,
+        platform: options.platform,
+    });
+}
+
+async function runLegacyPackageManagerUninstall(
+    packageManager: PackageManagerInstallationMethod,
+    runtime: LegacyPackageManagerCleanupRuntime,
+): Promise<void> {
     const configuration = legacyPackageManagerConfigurations[packageManager];
     const commandPath = runtime.resolveCommandPath?.(packageManager)
         ?? Bun.which(packageManager);


### PR DESCRIPTION
Self-managed installs could remain shadowed by older package-manager binaries when install or update was launched from a downloaded helper. Resolve legacy cleanup from PATH order, restrict Windows probes to `oo.exe`, and document the new behavior with regression coverage.