### PR TITLE
fix(self-update): remove legacy oo installs across PATH

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,10 +117,9 @@ Install one managed `oo` release into the local self-managed runtime.
 - Notes: when the executable directory is not on `PATH`, install also prints a
   setup note that tells the user which directory to add.
 - Notes: after a successful install, the CLI best-effort removes legacy global
-  `@oomol-lab/oo-cli` package-manager installs that appear on `PATH` before the
-  managed executable; when `PATH` yields no `oo` candidates, the CLI falls back
-  to the current command path. Cleanup failures do not change the command
-  result.
+  `@oomol-lab/oo-cli` package-manager installs that appear anywhere on `PATH`;
+  when `PATH` yields no `oo` candidates, the CLI falls back to the current
+  command path. Cleanup failures do not change the command result.
 - Notes: after a successful install workflow, the CLI silently runs
   `oo skills add` with the managed executable so bundled skills refresh to the
   installed CLI version.
@@ -144,10 +143,9 @@ Update the managed `oo` install to the latest published release.
   still refreshes bundled skills for the active managed version before printing
   the up-to-date message.
 - Notes: after a successful update, the CLI best-effort removes legacy global
-  `@oomol-lab/oo-cli` package-manager installs that appear on `PATH` before the
-  managed executable; when `PATH` yields no `oo` candidates, the CLI falls back
-  to the current command path. Cleanup failures do not change the command
-  result.
+  `@oomol-lab/oo-cli` package-manager installs that appear anywhere on `PATH`;
+  when `PATH` yields no `oo` candidates, the CLI falls back to the current
+  command path. Cleanup failures do not change the command result.
 - Notes: after a successful update workflow, the CLI silently runs
   `oo skills add` with the managed executable so bundled skills refresh to the
   installed CLI version.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -105,9 +105,9 @@
 - 说明：install 在报告成功前会校验已安装的 `oo` 命令可正常使用。
 - 说明：如果可执行目录没有出现在 `PATH` 中，install 还会额外打印 setup note，
   告知用户应当把哪个目录加入 `PATH`。
-- 说明：install 成功后，CLI 会尽力移除在 `PATH` 中排在托管可执行文件之前的
-  旧全局 package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到
-  `oo` 候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
+- 说明：install 成功后，CLI 会尽力移除在 `PATH` 中任意位置出现的旧全局
+  package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到 `oo`
+  候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
 - 说明：install 成功后，CLI 会使用托管的可执行文件静默执行一次
   `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /
@@ -126,9 +126,9 @@
   `--force`。
 - 说明：当最新发布版本与当前版本一致时，update 仍会先为当前激活的托管版本
   刷新 bundled skills，再输出“已是最新版本”的消息。
-- 说明：update 成功后，CLI 会尽力移除在 `PATH` 中排在托管可执行文件之前的
-  旧全局 package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到
-  `oo` 候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
+- 说明：update 成功后，CLI 会尽力移除在 `PATH` 中任意位置出现的旧全局
+  package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到 `oo`
+  候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
 - 说明：update 成功后，CLI 会使用托管的可执行文件静默执行一次
   `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /

--- a/src/application/self-update/legacy-installation.test.ts
+++ b/src/application/self-update/legacy-installation.test.ts
@@ -86,7 +86,7 @@ describe("attemptLegacyPackageManagerUninstall", () => {
         }
     });
 
-    test("uninstalls package managers found on PATH before the managed executable", async () => {
+    test("uninstalls package managers found anywhere on PATH", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-legacy-path");
         const env = createLegacyCleanupEnv(rootDirectory);
         const paths = resolveSelfUpdatePaths({
@@ -100,13 +100,13 @@ describe("attemptLegacyPackageManagerUninstall", () => {
 
         trackDirectory(rootDirectory);
         env.PATH = joinPathEntries(
-            [bunDirectory, pnpmDirectory, paths.executableDirectory],
+            [bunDirectory, paths.executableDirectory, pnpmDirectory],
             process.platform,
         );
         await Promise.all([
             writeExecutable(join(bunDirectory, basename(paths.executablePath))),
-            writeExecutable(join(pnpmDirectory, basename(paths.executablePath))),
             writeExecutable(paths.executablePath),
+            writeExecutable(join(pnpmDirectory, basename(paths.executablePath))),
         ]);
 
         try {

--- a/src/application/self-update/legacy-installation.ts
+++ b/src/application/self-update/legacy-installation.ts
@@ -111,7 +111,7 @@ async function resolveLegacyPackageManagersFromPath(
         });
 
         if (installation.method === "native" || installation.method === "unknown") {
-            break;
+            continue;
         }
 
         if (seenPackageManagers.has(installation.method)) {


### PR DESCRIPTION
The managed installer should clean up legacy package-manager installs even when they appear after the native executable on PATH.

Continue scanning PATH after native and unknown oo entries so every recognized legacy install is removed. Update the regression test and command docs to match the broader cleanup behavior.