### PR TITLE
fix(install): parse latest version in Windows cmd installer

### DIFF
--- a/contrib/install/install-cmd.test.ts
+++ b/contrib/install/install-cmd.test.ts
@@ -35,6 +35,11 @@ describe("install.cmd", () => {
         expect(scriptContent).toContain("win32-arm64");
     });
 
+    test("extracts the version field with cmd-compatible string substitutions", () => {
+        expect(scriptContent).toContain("set \"AFTER=!CONTENT:*\"version\":\"=!\"");
+        expect(scriptContent).toContain("set \"VERSION_VALUE=!VERSION_VALUE:\"=!\"");
+    });
+
     windowsCmdTest(
         "downloads the latest binary and removes the temporary executable when install is skipped",
         async () => {

--- a/contrib/install/install.cmd
+++ b/contrib/install/install.cmd
@@ -121,7 +121,7 @@ for /f "usebackq delims=" %%i in ("%~1") do (
 )
 
 set "CONTENT=!CONTENT: =!"
-set "AFTER=!CONTENT:*\"version\":\"=!"
+set "AFTER=!CONTENT:*"version":"=!"
 if "!AFTER!"=="!CONTENT!" (
     endlocal & exit /b 1
 )
@@ -129,7 +129,7 @@ if "!AFTER!"=="!CONTENT!" (
 for /f "tokens=1 delims=,}" %%v in ("!AFTER!") do (
     set "VERSION_VALUE=%%v"
 )
-set "VERSION_VALUE=!VERSION_VALUE:\"=!"
+set "VERSION_VALUE=!VERSION_VALUE:"=!"
 
 if not defined VERSION_VALUE (
     endlocal & exit /b 1


### PR DESCRIPTION
Batch variable substitution does not treat \" as an escaped quote, so the installer could download latest.json and still fail to read the version field on Windows. Add a regression test to keep the cmd-specific quoting syntax correct.