### PR TITLE
ci(publish): update GitHub Actions versions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -93,7 +93,7 @@ jobs:
           bun-version-file: .bun-version
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -110,7 +110,7 @@ jobs:
         run: bun run "${{ matrix.build_script }}"
 
       - name: Upload platform packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ matrix.artifact_name }}
           path: dist/release-packages/*
@@ -140,7 +140,7 @@ jobs:
           bun-version-file: .bun-version
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.3.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -149,7 +149,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Download platform packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: release-packages-*
           path: dist/release-packages


### PR DESCRIPTION
Refresh the publish workflow to the latest supported setup-node, upload-artifact, and download-artifact releases. This keeps the release pipeline aligned with upstream fixes and reduces future runner deprecation and compatibility risk.