### PR TITLE
fix(bootstrap): detach fd 0/2 on pipe to protect downstream pager

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,15 @@
 #!/usr/bin/env bun
 
 import process from "node:process";
+import { detachNonInteractiveTtyFdsFromProcess } from "./src/application/bootstrap/detach-stdin.ts";
 
-import { runCli } from "./src/application/bootstrap/run-cli.ts";
+// Point fd 0 and fd 2 at /dev/null for non-interactive piping scenarios so
+// Bun's exit-time `tcsetattr(0)` and `tcsetattr(2)` land on /dev/null
+// (ENOTTY) instead of mutating the shared `/dev/pts/*` device a downstream
+// pager (fx, fzf, less) is actively using.
+await detachNonInteractiveTtyFdsFromProcess();
+
+const { runCli } = await import("./src/application/bootstrap/run-cli.ts");
 
 const exitCode = await runCli(process.argv.slice(2));
 

--- a/oo
+++ b/oo
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-exec bun run --silent dev -- "$@"
+exec bun run --silent ./index.ts -- "$@"

--- a/oo.bat
+++ b/oo.bat
@@ -1,2 +1,2 @@
 @echo off
-bun run --silent dev -- %*
+bun run --silent .\index.ts -- %*

--- a/src/application/bootstrap/detach-stdin.test.ts
+++ b/src/application/bootstrap/detach-stdin.test.ts
@@ -2,89 +2,37 @@ import { describe, expect, test } from "bun:test";
 import { detachFdToDevNull, shouldDetachTtyFds } from "./detach-stdin.ts";
 
 describe("shouldDetachTtyFds", () => {
-    test("skips on win32", () => {
+    test("skips on win32 (the mitigation targets POSIX /dev/pts behavior)", () => {
         expect(
             shouldDetachTtyFds({
-                argv: ["search", "foo", "--json"],
                 platform: "win32",
-                stderrIsTTY: true,
                 stdoutIsTTY: false,
             }),
         ).toBe(false);
     });
 
-    test("skips when stdout is a TTY (running interactively, no pipe to protect)", () => {
+    test("skips when stdout is a TTY (no downstream pager to protect)", () => {
         expect(
             shouldDetachTtyFds({
-                argv: ["search", "foo"],
                 platform: "linux",
-                stderrIsTTY: true,
                 stdoutIsTTY: true,
             }),
         ).toBe(false);
     });
 
-    test("skips when both stdout and stderr are TTY", () => {
+    test("detaches on linux when stdout is piped", () => {
         expect(
             shouldDetachTtyFds({
-                argv: ["search", "foo"],
                 platform: "linux",
-                stderrIsTTY: true,
-                stdoutIsTTY: true,
-            }),
-        ).toBe(false);
-    });
-
-    test("skips for skills subcommand (consumes stdin)", () => {
-        expect(
-            shouldDetachTtyFds({
-                argv: ["skills", "install", "my-package"],
-                platform: "linux",
-                stderrIsTTY: true,
-                stdoutIsTTY: false,
-            }),
-        ).toBe(false);
-    });
-
-    test("detaches for a plain piped --json invocation", () => {
-        expect(
-            shouldDetachTtyFds({
-                argv: ["connector", "search", "send mail", "--json"],
-                platform: "linux",
-                stderrIsTTY: true,
                 stdoutIsTTY: false,
             }),
         ).toBe(true);
     });
 
-    test("detaches when both stdout and stderr are pipes (full redirect)", () => {
+    test("detaches on darwin when stdout is piped", () => {
         expect(
             shouldDetachTtyFds({
-                argv: ["search", "foo"],
-                platform: "linux",
-                stderrIsTTY: false,
-                stdoutIsTTY: false,
-            }),
-        ).toBe(true);
-    });
-
-    test("detaches when argv is empty (help/version paths still safe)", () => {
-        expect(
-            shouldDetachTtyFds({
-                argv: [],
-                platform: "linux",
-                stderrIsTTY: true,
-                stdoutIsTTY: false,
-            }),
-        ).toBe(true);
-    });
-
-    test("detaches on darwin for non-interactive subcommands", () => {
-        expect(
-            shouldDetachTtyFds({
-                argv: ["search", "foo", "--json"],
                 platform: "darwin",
-                stderrIsTTY: true,
                 stdoutIsTTY: false,
             }),
         ).toBe(true);

--- a/src/application/bootstrap/detach-stdin.test.ts
+++ b/src/application/bootstrap/detach-stdin.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import { detachFdToDevNull, shouldDetachTtyFds } from "./detach-stdin.ts";
+
+describe("shouldDetachTtyFds", () => {
+    test("skips on win32", () => {
+        expect(
+            shouldDetachTtyFds({
+                argv: ["search", "foo", "--json"],
+                platform: "win32",
+                stderrIsTTY: true,
+                stdoutIsTTY: false,
+            }),
+        ).toBe(false);
+    });
+
+    test("skips when stdout is a TTY (running interactively, no pipe to protect)", () => {
+        expect(
+            shouldDetachTtyFds({
+                argv: ["search", "foo"],
+                platform: "linux",
+                stderrIsTTY: true,
+                stdoutIsTTY: true,
+            }),
+        ).toBe(false);
+    });
+
+    test("skips when both stdout and stderr are TTY", () => {
+        expect(
+            shouldDetachTtyFds({
+                argv: ["search", "foo"],
+                platform: "linux",
+                stderrIsTTY: true,
+                stdoutIsTTY: true,
+            }),
+        ).toBe(false);
+    });
+
+    test("skips for skills subcommand (consumes stdin)", () => {
+        expect(
+            shouldDetachTtyFds({
+                argv: ["skills", "install", "my-package"],
+                platform: "linux",
+                stderrIsTTY: true,
+                stdoutIsTTY: false,
+            }),
+        ).toBe(false);
+    });
+
+    test("detaches for a plain piped --json invocation", () => {
+        expect(
+            shouldDetachTtyFds({
+                argv: ["connector", "search", "send mail", "--json"],
+                platform: "linux",
+                stderrIsTTY: true,
+                stdoutIsTTY: false,
+            }),
+        ).toBe(true);
+    });
+
+    test("detaches when both stdout and stderr are pipes (full redirect)", () => {
+        expect(
+            shouldDetachTtyFds({
+                argv: ["search", "foo"],
+                platform: "linux",
+                stderrIsTTY: false,
+                stdoutIsTTY: false,
+            }),
+        ).toBe(true);
+    });
+
+    test("detaches when argv is empty (help/version paths still safe)", () => {
+        expect(
+            shouldDetachTtyFds({
+                argv: [],
+                platform: "linux",
+                stderrIsTTY: true,
+                stdoutIsTTY: false,
+            }),
+        ).toBe(true);
+    });
+
+    test("detaches on darwin for non-interactive subcommands", () => {
+        expect(
+            shouldDetachTtyFds({
+                argv: ["search", "foo", "--json"],
+                platform: "darwin",
+                stderrIsTTY: true,
+                stdoutIsTTY: false,
+            }),
+        ).toBe(true);
+    });
+});
+
+describe("detachFdToDevNull", () => {
+    test("opens /dev/null, dup2s it onto the target fd, and releases the source fd", () => {
+        const closed: number[] = [];
+        const dup2Calls: Array<[number, number]> = [];
+
+        detachFdToDevNull(
+            {
+                openDevNullFd: () => 7,
+                dup2: (src, dst) => {
+                    dup2Calls.push([src, dst]);
+                    return dst;
+                },
+                closeFd: (fd) => {
+                    closed.push(fd);
+                },
+            },
+            0,
+        );
+
+        expect(dup2Calls).toEqual([[7, 0]]);
+        expect(closed).toEqual([7]);
+    });
+
+    test("can target fd 2 just as easily as fd 0", () => {
+        const dup2Calls: Array<[number, number]> = [];
+
+        detachFdToDevNull(
+            {
+                openDevNullFd: () => 9,
+                dup2: (src, dst) => {
+                    dup2Calls.push([src, dst]);
+                    return dst;
+                },
+                closeFd: () => {},
+            },
+            2,
+        );
+
+        expect(dup2Calls).toEqual([[9, 2]]);
+    });
+
+    test("skips the close when /dev/null happened to land on the target fd directly", () => {
+        const closed: number[] = [];
+
+        detachFdToDevNull(
+            {
+                openDevNullFd: () => 0,
+                dup2: () => 0,
+                closeFd: (fd) => {
+                    closed.push(fd);
+                },
+            },
+            0,
+        );
+
+        expect(closed).toEqual([]);
+    });
+
+    test("swallows errors from openDevNullFd and never touches close", () => {
+        const closed: number[] = [];
+        const action = (): void => {
+            detachFdToDevNull(
+                {
+                    openDevNullFd: () => {
+                        throw new Error("simulated EMFILE");
+                    },
+                    dup2: () => 0,
+                    closeFd: (fd) => {
+                        closed.push(fd);
+                    },
+                },
+                0,
+            );
+        };
+
+        expect(action).not.toThrow();
+        expect(closed).toEqual([]);
+    });
+
+    test("still releases the source fd when dup2 throws", () => {
+        const closed: number[] = [];
+        const action = (): void => {
+            detachFdToDevNull(
+                {
+                    openDevNullFd: () => 7,
+                    dup2: () => {
+                        throw new Error("simulated EBADF");
+                    },
+                    closeFd: (fd) => {
+                        closed.push(fd);
+                    },
+                },
+                0,
+            );
+        };
+
+        expect(action).not.toThrow();
+        expect(closed).toEqual([7]);
+    });
+});

--- a/src/application/bootstrap/detach-stdin.ts
+++ b/src/application/bootstrap/detach-stdin.ts
@@ -1,0 +1,154 @@
+import { closeSync, openSync } from "node:fs";
+import process from "node:process";
+
+// Subcommands that genuinely consume fd 0 for interactive input. Everything
+// else is treated as non-interactive and has its fd 0 / fd 2 pointed at
+// /dev/null so Bun's exit-time `tcsetattr` cannot disturb the shared
+// terminal when the caller has piped us into another process. Keep this set
+// tight: adding an entry here gives up the downstream-pager fix for that
+// subcommand.
+const interactiveCommandNames: ReadonlySet<string> = new Set([
+    "skills",
+]);
+
+export interface DetachTtyProbe {
+    readonly argv: readonly string[];
+    readonly platform: NodeJS.Platform;
+    readonly stderrIsTTY: boolean;
+    readonly stdoutIsTTY: boolean;
+}
+
+// The Bun runtime `tcgetattr` both fd 0 and fd 2 at startup whenever either
+// is a TTY, then `tcsetattr` them back at exit. When our stdout is a pipe
+// (e.g. `oo X --json | fx`) that exit-time tcsetattr can fire after the
+// downstream process has switched the real terminal to raw mode, wiping out
+// its keyboard handling. Since termios is per-device, writing back "cooked"
+// via *any* fd on the /dev/pts/* device clobbers the raw mode. We can't stop
+// the syscall, but we can point fd 0 and fd 2 at /dev/null so Bun's restore
+// hits a non-terminal descriptor and fails with ENOTTY.
+export function shouldDetachTtyFds(probe: DetachTtyProbe): boolean {
+    if (probe.platform === "win32") {
+        return false;
+    }
+
+    // Nothing to protect: either stream being a real TTY means the user is
+    // running oo interactively at the terminal, not piping its output.
+    if (probe.stdoutIsTTY && probe.stderrIsTTY) {
+        return false;
+    }
+
+    // If stdout is a TTY but stderr is not, the pipe is on stderr (unusual)
+    // and we leave the mitigation off to avoid surprises.
+    if (probe.stdoutIsTTY) {
+        return false;
+    }
+
+    const firstArg = probe.argv[0];
+
+    if (firstArg !== undefined && interactiveCommandNames.has(firstArg)) {
+        return false;
+    }
+
+    return true;
+}
+
+export interface DetachFdIo {
+    openDevNullFd: () => number;
+    dup2: (srcFd: number, dstFd: number) => number;
+    closeFd: (fd: number) => void;
+}
+
+// Atomically reassign `targetFd` to /dev/null. We must NOT use `closeSync` +
+// `openSync` to take the lowest-free-fd: Bun guards fds 0/1/2 at the JS
+// layer, so `closeSync(0)` and `closeSync(2)` are silently no-ops and the
+// follow-up open lands on fd 3+. Using `dup2` goes straight to libc and
+// atomically reassigns the target fd regardless of Bun's guards.
+export function detachFdToDevNull(io: DetachFdIo, targetFd: number): void {
+    let srcFd: number | undefined;
+    try {
+        srcFd = io.openDevNullFd();
+        io.dup2(srcFd, targetFd);
+    }
+    catch {
+        // Intentionally swallowed: the mitigation is best-effort.
+    }
+    finally {
+        if (srcFd !== undefined && srcFd !== targetFd) {
+            try {
+                io.closeFd(srcFd);
+            }
+            catch {
+                // Intentionally swallowed.
+            }
+        }
+    }
+}
+
+// Resolves a libc `dup2` implementation appropriate for the current
+// platform. Returns `undefined` when none can be found, which causes the
+// mitigation to no-op rather than crash.
+type Dup2 = (srcFd: number, dstFd: number) => number;
+
+async function loadLibcDup2(platform: NodeJS.Platform): Promise<Dup2 | undefined> {
+    if (platform === "win32") {
+        return undefined;
+    }
+
+    const candidateLibraryNames = platform === "darwin"
+        ? ["libSystem.B.dylib", "libc.dylib"]
+        : ["libc.so.6", "libc.so"];
+
+    const { dlopen, FFIType } = await import("bun:ffi");
+
+    for (const name of candidateLibraryNames) {
+        try {
+            const lib = dlopen(name, {
+                dup2: { args: [FFIType.i32, FFIType.i32], returns: FFIType.i32 },
+            });
+            return (src, dst) => Number(lib.symbols.dup2(src, dst));
+        }
+        catch {
+            // Try the next candidate.
+        }
+    }
+
+    return undefined;
+}
+
+export async function detachNonInteractiveTtyFdsFromProcess(): Promise<void> {
+    const probe: DetachTtyProbe = {
+        argv: process.argv.slice(2),
+        platform: process.platform,
+        stderrIsTTY: process.stderr.isTTY === true,
+        stdoutIsTTY: process.stdout.isTTY === true,
+    };
+
+    if (!shouldDetachTtyFds(probe)) {
+        return;
+    }
+
+    const dup2 = await loadLibcDup2(probe.platform);
+
+    if (dup2 === undefined) {
+        return;
+    }
+
+    const io: DetachFdIo = {
+        openDevNullFd: () => openSync("/dev/null", "r"),
+        dup2,
+        closeFd: closeSync,
+    };
+
+    // fd 0: detach immediately. Nothing reads stdin for non-interactive
+    // commands, so pointing it at /dev/null up front has no downside.
+    detachFdToDevNull(io, 0);
+
+    // fd 2: detach at the last possible moment so CLI errors keep reaching
+    // the real terminal during normal execution. Node/Bun run `exit` event
+    // listeners right before runtime cleanup, so our dup2 happens just
+    // before Bun's exit-time `tcsetattr(2, ...)`, causing it to land on
+    // /dev/null (ENOTTY) instead of the shared /dev/pts device.
+    process.on("exit", () => {
+        detachFdToDevNull(io, 2);
+    });
+}

--- a/src/application/bootstrap/detach-stdin.ts
+++ b/src/application/bootstrap/detach-stdin.ts
@@ -1,20 +1,8 @@
 import { closeSync, openSync } from "node:fs";
 import process from "node:process";
 
-// Subcommands that genuinely consume fd 0 for interactive input. Everything
-// else is treated as non-interactive and has its fd 0 / fd 2 pointed at
-// /dev/null so Bun's exit-time `tcsetattr` cannot disturb the shared
-// terminal when the caller has piped us into another process. Keep this set
-// tight: adding an entry here gives up the downstream-pager fix for that
-// subcommand.
-const interactiveCommandNames: ReadonlySet<string> = new Set([
-    "skills",
-]);
-
 export interface DetachTtyProbe {
-    readonly argv: readonly string[];
     readonly platform: NodeJS.Platform;
-    readonly stderrIsTTY: boolean;
     readonly stdoutIsTTY: boolean;
 }
 
@@ -26,26 +14,18 @@ export interface DetachTtyProbe {
 // via *any* fd on the /dev/pts/* device clobbers the raw mode. We can't stop
 // the syscall, but we can point fd 0 and fd 2 at /dev/null so Bun's restore
 // hits a non-terminal descriptor and fails with ENOTTY.
+//
+// stdoutIsTTY being true is sufficient to opt out: interactive subcommands
+// (e.g. `skills install`) already require both stdin and stdout to be TTYs
+// and hard-error otherwise, so a stdout-is-TTY run is always the "running
+// interactively at the terminal" case where there is nothing downstream to
+// protect.
 export function shouldDetachTtyFds(probe: DetachTtyProbe): boolean {
     if (probe.platform === "win32") {
         return false;
     }
 
-    // Nothing to protect: either stream being a real TTY means the user is
-    // running oo interactively at the terminal, not piping its output.
-    if (probe.stdoutIsTTY && probe.stderrIsTTY) {
-        return false;
-    }
-
-    // If stdout is a TTY but stderr is not, the pipe is on stderr (unusual)
-    // and we leave the mitigation off to avoid surprises.
     if (probe.stdoutIsTTY) {
-        return false;
-    }
-
-    const firstArg = probe.argv[0];
-
-    if (firstArg !== undefined && interactiveCommandNames.has(firstArg)) {
         return false;
     }
 
@@ -117,9 +97,7 @@ async function loadLibcDup2(platform: NodeJS.Platform): Promise<Dup2 | undefined
 
 export async function detachNonInteractiveTtyFdsFromProcess(): Promise<void> {
     const probe: DetachTtyProbe = {
-        argv: process.argv.slice(2),
         platform: process.platform,
-        stderrIsTTY: process.stderr.isTTY === true,
         stdoutIsTTY: process.stdout.isTTY === true,
     };
 
@@ -134,7 +112,12 @@ export async function detachNonInteractiveTtyFdsFromProcess(): Promise<void> {
     }
 
     const io: DetachFdIo = {
-        openDevNullFd: () => openSync("/dev/null", "r"),
+        // Open /dev/null read-write ("r+") so the same descriptor is safe to
+        // dup onto either fd 0 (read) or fd 2 (write). Opening read-only and
+        // then reusing it for fd 2 would cause any stray `write(2, ...)`
+        // between our exit handler and process termination to fail with
+        // EBADF instead of being silently discarded.
+        openDevNullFd: () => openSync("/dev/null", "r+"),
         dup2,
         closeFd: closeSync,
     };
@@ -144,11 +127,15 @@ export async function detachNonInteractiveTtyFdsFromProcess(): Promise<void> {
     detachFdToDevNull(io, 0);
 
     // fd 2: detach at the last possible moment so CLI errors keep reaching
-    // the real terminal during normal execution. Node/Bun run `exit` event
-    // listeners right before runtime cleanup, so our dup2 happens just
-    // before Bun's exit-time `tcsetattr(2, ...)`, causing it to land on
-    // /dev/null (ENOTTY) instead of the shared /dev/pts device.
-    process.on("exit", () => {
-        detachFdToDevNull(io, 2);
-    });
+    // the real terminal during normal execution. Only relevant when stderr
+    // is a TTY — otherwise Bun never saved termios for fd 2 and won't
+    // restore it at exit. Node/Bun run `exit` event listeners right before
+    // runtime cleanup, so our dup2 happens just before Bun's exit-time
+    // `tcsetattr(2, ...)`, causing it to land on /dev/null (ENOTTY) instead
+    // of the shared /dev/pts device.
+    if (process.stderr.isTTY === true) {
+        process.on("exit", () => {
+            detachFdToDevNull(io, 2);
+        });
+    }
 }


### PR DESCRIPTION
When piping oo output into an interactive pager (fx, fzf, less), Bun's exit-time `tcsetattr` on fd 0 and fd 2 would reset the shared `/dev/pts/*` device to cooked mode, wiping out the pager's raw-mode keyboard handling.

Point fd 0 and fd 2 at /dev/null before Bun's restore runs so the tcsetattr lands on a non-terminal descriptor and fails with ENOTTY instead of clobbering the caller's terminal. fd 0 is detached upfront; fd 2 is deferred to the `exit` event so CLI errors keep reaching the real terminal during normal execution.

Use libc `dup2` via `bun:ffi` because Bun's JS layer guards fds 0/1/2 against `closeSync`, so the usual close+open trick would land on fd 3 instead of reassigning the target fd.

Upstream bug: https://github.com/oven-sh/bun/issues/29592