### PR TITLE
docs(readme): update installation commands

### DIFF
--- a/README-ZH_CN.md
+++ b/README-ZH_CN.md
@@ -11,8 +11,28 @@
 
 ## 安装
 
+按你的平台选择对应命令：
+
+macOS / Linux（二选一）：
+
 ```bash
-bun install -g @oomol-lab/oo-cli
+wget -qO - https://cli.oomol.com/install.sh | bash
+```
+
+```bash
+curl -fsSL https://cli.oomol.com/install.sh | bash
+```
+
+Windows PowerShell：
+
+```powershell
+irm https://cli.oomol.com/install.ps1 | iex
+```
+
+Windows CMD：
+
+```bat
+curl -fsSL https://cli.oomol.com/install.cmd -o install.cmd && install.cmd && del install.cmd
 ```
 
 ## 快速开始

--- a/README.md
+++ b/README.md
@@ -13,8 +13,28 @@ inspection, cloud task execution, and shell completion generation.
 
 ## Installation
 
+Choose the command for your platform:
+
+macOS / Linux (pick one):
+
 ```bash
-bun install -g @oomol-lab/oo-cli
+wget -qO - https://cli.oomol.com/install.sh | bash
+```
+
+```bash
+curl -fsSL https://cli.oomol.com/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://cli.oomol.com/install.ps1 | iex
+```
+
+Windows CMD:
+
+```bat
+curl -fsSL https://cli.oomol.com/install.cmd -o install.cmd && install.cmd && del install.cmd
 ```
 
 ## Quick Start


### PR DESCRIPTION
Replace the package-manager install snippet with the managed
platform-specific installer commands in both README files.

This keeps the docs aligned with the intended user entrypoint on
macOS, Linux, and Windows without exposing package-manager installs.