### PR TITLE
refactor(skills): remove unused ownership file path helper

### DIFF
--- a/src/application/commands/skills/bundled-skill-paths.ts
+++ b/src/application/commands/skills/bundled-skill-paths.ts
@@ -11,7 +11,6 @@ const claudeBundledSkillsDirectoryName = "claude-skills";
 const openClawBundledSkillsDirectoryName = "openclaw-skills";
 
 export const bundledSkillMetadataFileName = ".oo-metadata.json";
-const codexBundledSkillOwnershipFileRelativePath = "agents/openai.yaml";
 
 export function resolveCodexHomeDirectory(
     env: Record<string, string | undefined>,
@@ -87,19 +86,6 @@ export function resolveBundledSkillCanonicalDirectoryPath(
         resolveBundledSkillCanonicalRootDirectoryPath(settingsFilePath, agentName),
         skillName,
     );
-}
-
-export function resolveBundledSkillOwnershipFileRelativePath(
-    agentName: BundledSkillAgentName,
-): string | undefined {
-    switch (agentName) {
-        case "claude":
-            return undefined;
-        case "codex":
-            return codexBundledSkillOwnershipFileRelativePath;
-        case "openclaw":
-            return undefined;
-    }
 }
 
 export function resolveBundledSkillMetadataFilePath(


### PR DESCRIPTION
The resolveBundledSkillOwnershipFileRelativePath helper and its backing codexBundledSkillOwnershipFileRelativePath constant had no call sites. Ownership of a bundled skill installation is determined solely by .oo-metadata.json via isManagedBundledSkillInstallation, so the legacy Codex-only ownership file lookup no longer serves any purpose. Removing it cuts dead code and clarifies that metadata is the single source of truth for managed-install detection.