### PR TITLE
feat(skills)!: migrate legacy canonical skill layout

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -288,15 +288,18 @@ published skills into the local Codex skills directory.
 - Notes: in the interactive picker, skills already installed from the same
   package start selected. Clearing such a selection removes that installed
   skill when the command completes.
-- Canonical directory: bundled Codex skills are materialized to
-  `<config-dir>/skills/<skill-id>`, where `<config-dir>` is the directory that
-  contains `settings.toml`.
-- Canonical directory: bundled Claude Code skills are materialized to
-  `<config-dir>/claude-skills/<skill-id>`.
-- Canonical directory: bundled OpenClaw skills are materialized to
-  `<config-dir>/openclaw-skills/<skill-id>`.
+- Canonical directory: bundled skills are materialized under
+  `<config-dir>/skills/bundled/<agent>/<skill-id>`, where `<config-dir>` is the
+  directory that contains `settings.toml` and `<agent>` is `codex`, `claude`,
+  or `openclaw`.
 - Canonical directory: published skills are materialized to
-  `<config-dir>/skills/<skill-id>`.
+  `<config-dir>/skills/registry/<skill-id>`.
+- Migration: on first run after upgrading, `oo skills install` removes legacy
+  canonical directories left over from earlier releases (`claude-skills/`,
+  `openclaw-skills/`, and any Codex-bundled or registry skill directory that
+  lived directly under `skills/`). Bundled skills are rebuilt automatically in
+  the new layout; previously-installed published skills must be reinstalled
+  with `oo skills install <packageName>`.
 - Target directory: bundled skills are published to each existing supported
   host directory, currently `${CODEX_HOME:-~/.codex}/skills/<skill-id>`,
   `~/.claude/skills/<skill-id>`, and
@@ -348,7 +351,7 @@ Update installed oo-managed Codex skills.
   `.oo-metadata.json`, then fetch package info without an explicit version to
   determine the latest available package version.
 - Update order: the command refreshes the canonical
-  `<config-dir>/skills/<skill-id>` copy before republishing to
+  `<config-dir>/skills/registry/<skill-id>` copy before republishing to
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`.
 - Interactive terminals: renders live progress while checking and updating
   skills.
@@ -364,11 +367,9 @@ oo-managed published skill from the local Codex skills directory.
 - Ownership rule: a bundled skill is removable from a supported host only when
   that host's installed directory has a `.oo-metadata.json` file that can be
   parsed and contains a non-empty `version`.
-- Canonical directory removed: bundled Codex skills remove
-  `<config-dir>/skills/<skill>`, bundled Claude Code skills remove
-  `<config-dir>/claude-skills/<skill>`, bundled OpenClaw skills remove
-  `<config-dir>/openclaw-skills/<skill>`, and published skills remove
-  `<config-dir>/skills/<skill>`.
+- Canonical directory removed: bundled skills remove
+  `<config-dir>/skills/bundled/<agent>/<skill>` for each installed agent, and
+  published skills remove `<config-dir>/skills/registry/<skill>`.
 - Target directory removed: bundled skills are removed from every existing
   supported host directory, currently `${CODEX_HOME:-~/.codex}/skills/<skill>`,
   `~/.claude/skills/<skill>`, and

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -261,13 +261,15 @@ Codex skills 目录。
   `-y`，命令会在 TTY 中打开交互选择页面。
 - 说明：在交互选择页面中，同一 package 下已安装的 skill 会默认保持勾选；
   如果用户取消这些勾选，命令完成时会移除对应已安装 skill。
-- canonical 目录：内置 Codex skill 会先释放到 `<config-dir>/skills/<skill-id>`，
-  其中 `<config-dir>` 是 `settings.toml` 所在目录。
-- canonical 目录：内置 Claude Code skill 会先释放到
-  `<config-dir>/claude-skills/<skill-id>`。
-- canonical 目录：内置 OpenClaw skill 会先释放到
-  `<config-dir>/openclaw-skills/<skill-id>`。
-- canonical 目录：已发布 skill 会先释放到 `<config-dir>/skills/<skill-id>`。
+- canonical 目录：内置 skill 会先释放到
+  `<config-dir>/skills/bundled/<agent>/<skill-id>`，其中 `<config-dir>` 是
+  `settings.toml` 所在目录，`<agent>` 为 `codex`、`claude` 或 `openclaw`。
+- canonical 目录：已发布 skill 会先释放到
+  `<config-dir>/skills/registry/<skill-id>`。
+- 迁移：升级后首次运行 `oo skills install` 时，命令会清理历史遗留的 canonical
+  目录（`claude-skills/`、`openclaw-skills/`，以及直接位于 `skills/` 下的旧
+  Codex 内置 / 已发布 skill 目录）。内置 skill 会自动以新布局重建；之前安装
+  的已发布 skill 需要通过 `oo skills install <packageName>` 重新安装。
 - 目标目录：内置 skill 会发布到所有已存在的受支持宿主目录，目前包括
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>` 和
   `~/.claude/skills/<skill-id>`，以及
@@ -311,7 +313,7 @@ Codex skills 目录。
 - 已发布 skill：registry skill 会从 `.oo-metadata.json` 读取所属包名，再通过
   不带显式版本的 package info 请求判断最新可用版本。
 - 更新顺序：命令会先刷新 canonical 目录
-  `<config-dir>/skills/<skill-id>`，再同步到
+  `<config-dir>/skills/registry/<skill-id>`，再同步到
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`。
 - 交互式终端：会显示实时进度。
 - 非交互式终端：每个处理过的 skill 输出一行状态信息。
@@ -325,11 +327,9 @@ Codex skills 目录。
 - 参数：省略 `[skill]` 时，命令会移除全部内置 skill。
 - 所有权规则：对内置 skill 来说，只有当某个受支持宿主中的安装目录包含可解
   析且带有非空 `version` 的 `.oo-metadata.json` 时，才允许从该宿主移除。
-- 会同时移除 canonical 目录：内置 Codex skill 会移除
-  `<config-dir>/skills/<skill>`，内置 Claude Code skill 会移除
-  `<config-dir>/claude-skills/<skill>`，内置 OpenClaw skill 会移除
-  `<config-dir>/openclaw-skills/<skill>`，已发布 skill 会移除
-  `<config-dir>/skills/<skill>`。
+- 会同时移除 canonical 目录：内置 skill 会移除
+  `<config-dir>/skills/bundled/<agent>/<skill>`（每个已安装宿主各一份），
+  已发布 skill 会移除 `<config-dir>/skills/registry/<skill>`。
 - 会同时移除目标目录：内置 skill 会从所有已存在的受支持宿主目录中移除，目
   前包括 `${CODEX_HOME:-~/.codex}/skills/<skill>` 和
   `~/.claude/skills/<skill>`，以及

--- a/src/application/commands/skills/bundled-skill-paths.ts
+++ b/src/application/commands/skills/bundled-skill-paths.ts
@@ -7,8 +7,8 @@ const codexDirectoryName = ".codex";
 const claudeDirectoryName = ".claude";
 const openClawDirectoryName = ".openclaw";
 export const codexSkillsDirectoryName = "skills";
-const claudeBundledSkillsDirectoryName = "claude-skills";
-const openClawBundledSkillsDirectoryName = "openclaw-skills";
+export const canonicalBundledSkillsDirectoryName = "bundled";
+export const canonicalRegistrySkillsDirectoryName = "registry";
 
 export const bundledSkillMetadataFileName = ".oo-metadata.json";
 
@@ -67,14 +67,12 @@ export function resolveBundledSkillCanonicalRootDirectoryPath(
     settingsFilePath: string,
     agentName: BundledSkillAgentName = "codex",
 ): string {
-    switch (agentName) {
-        case "claude":
-            return join(dirname(settingsFilePath), claudeBundledSkillsDirectoryName);
-        case "codex":
-            return join(dirname(settingsFilePath), codexSkillsDirectoryName);
-        case "openclaw":
-            return join(dirname(settingsFilePath), openClawBundledSkillsDirectoryName);
-    }
+    return join(
+        dirname(settingsFilePath),
+        codexSkillsDirectoryName,
+        canonicalBundledSkillsDirectoryName,
+        agentName,
+    );
 }
 
 export function resolveBundledSkillCanonicalDirectoryPath(

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -1436,4 +1436,62 @@ describe("skills commands", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("migrates legacy canonical skill layout on install", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const configDirectoryPath = join(storePaths.settingsFilePath, "..");
+        const legacyCodexBundledPath = join(configDirectoryPath, "skills", "oo");
+        const legacyRegistryPath = join(configDirectoryPath, "skills", "chatgpt");
+        const legacyClaudeRoot = join(configDirectoryPath, "claude-skills");
+        const legacyOpenClawRoot = join(configDirectoryPath, "openclaw-skills");
+        const newOoCanonicalPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(legacyCodexBundledPath, { recursive: true });
+            await Bun.write(
+                resolveBundledSkillMetadataFilePath(legacyCodexBundledPath),
+                renderSkillMetadataJson({ version: "0.0.1" }),
+            );
+            await mkdir(legacyRegistryPath, { recursive: true });
+            await Bun.write(
+                join(legacyRegistryPath, ".oo-metadata.json"),
+                renderSkillMetadataJson({ packageName: "foo", version: "0.0.2" }),
+            );
+            await mkdir(join(legacyClaudeRoot, "oo"), { recursive: true });
+            await mkdir(join(legacyOpenClawRoot, "oo"), { recursive: true });
+
+            const result = await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            await expect(stat(legacyClaudeRoot)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(legacyOpenClawRoot)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(legacyRegistryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            expect(await realpath(ooSkillDirectoryPath)).toBe(
+                await realpath(newOoCanonicalPath),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -3,6 +3,7 @@ import type { BundledSkillName } from "./embedded-assets.ts";
 
 import { z } from "zod";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
+import { migrateLegacyCanonicalSkillLayout } from "./legacy-canonical-migration.ts";
 import { installRegistrySkills } from "./registry-skill-install.ts";
 import { installBundledSkill, isBundledSkillName } from "./shared.ts";
 
@@ -52,6 +53,8 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         yes: z.boolean().optional(),
     }),
     handler: async (input, context) => {
+        await migrateLegacyCanonicalSkillLayout(context);
+
         if (input.packageName === undefined) {
             for (const skillName of availableBundledSkillNames) {
                 await installBundledSkill(skillName, context);

--- a/src/application/commands/skills/legacy-canonical-migration.test.ts
+++ b/src/application/commands/skills/legacy-canonical-migration.test.ts
@@ -1,0 +1,243 @@
+import type { Logger } from "pino";
+
+import { mkdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    createLogCapture,
+    createTemporaryDirectory,
+} from "../../../../__tests__/helpers.ts";
+import { migrateLegacyCanonicalSkillLayout } from "./legacy-canonical-migration.ts";
+
+describe("legacy canonical skill migration", () => {
+    test("is a no-op when no legacy canonical directories exist", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-canonical");
+        const configDirectoryPath = join(rootDirectory, "config");
+        const settingsFilePath = join(configDirectoryPath, "settings.toml");
+        const logCapture = createLogCapture();
+
+        try {
+            await mkdir(configDirectoryPath, { recursive: true });
+
+            await migrateLegacyCanonicalSkillLayout({
+                logger: logCapture.logger as unknown as Logger,
+                settingsStore: {
+                    getFilePath: () => settingsFilePath,
+                } as never,
+            });
+
+            logCapture.close();
+            expect(logCapture.read()).toBe("");
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("removes the legacy claude-skills canonical root", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-canonical");
+        const configDirectoryPath = join(rootDirectory, "config");
+        const settingsFilePath = join(configDirectoryPath, "settings.toml");
+        const legacyClaudePath = join(configDirectoryPath, "claude-skills");
+        const logCapture = createLogCapture();
+
+        try {
+            await mkdir(join(legacyClaudePath, "oo"), { recursive: true });
+            await Bun.write(
+                join(legacyClaudePath, "oo", "SKILL.md"),
+                "stale\n",
+            );
+
+            await migrateLegacyCanonicalSkillLayout({
+                logger: logCapture.logger as unknown as Logger,
+                settingsStore: {
+                    getFilePath: () => settingsFilePath,
+                } as never,
+            });
+
+            await expect(stat(legacyClaudePath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+
+            logCapture.close();
+            expect(logCapture.read()).toContain("claudeSkillsRoot");
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("removes the legacy openclaw-skills canonical root", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-canonical");
+        const configDirectoryPath = join(rootDirectory, "config");
+        const settingsFilePath = join(configDirectoryPath, "settings.toml");
+        const legacyOpenClawPath = join(configDirectoryPath, "openclaw-skills");
+        const logCapture = createLogCapture();
+
+        try {
+            await mkdir(join(legacyOpenClawPath, "oo"), { recursive: true });
+            await Bun.write(
+                join(legacyOpenClawPath, "oo", "SKILL.md"),
+                "stale\n",
+            );
+
+            await migrateLegacyCanonicalSkillLayout({
+                logger: logCapture.logger as unknown as Logger,
+                settingsStore: {
+                    getFilePath: () => settingsFilePath,
+                } as never,
+            });
+
+            await expect(stat(legacyOpenClawPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+
+            logCapture.close();
+            expect(logCapture.read()).toContain("openClawSkillsRoot");
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("removes legacy children directly under skills/ while preserving the new layout", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-canonical");
+        const configDirectoryPath = join(rootDirectory, "config");
+        const settingsFilePath = join(configDirectoryPath, "settings.toml");
+        const skillsDirectoryPath = join(configDirectoryPath, "skills");
+        const legacyCodexBundledPath = join(skillsDirectoryPath, "oo");
+        const legacyRegistryPath = join(skillsDirectoryPath, "chatgpt");
+        const newBundledPath = join(skillsDirectoryPath, "bundled", "codex", "oo");
+        const newRegistryPath = join(skillsDirectoryPath, "registry", "chatgpt");
+        const logCapture = createLogCapture();
+
+        try {
+            await mkdir(legacyCodexBundledPath, { recursive: true });
+            await Bun.write(
+                join(legacyCodexBundledPath, ".oo-metadata.json"),
+                JSON.stringify({ version: "0.0.1" }),
+            );
+            await mkdir(legacyRegistryPath, { recursive: true });
+            await Bun.write(
+                join(legacyRegistryPath, ".oo-metadata.json"),
+                JSON.stringify({ packageName: "foo", version: "0.0.2" }),
+            );
+            await mkdir(newBundledPath, { recursive: true });
+            await Bun.write(join(newBundledPath, "SKILL.md"), "new bundled\n");
+            await mkdir(newRegistryPath, { recursive: true });
+            await Bun.write(join(newRegistryPath, "SKILL.md"), "new registry\n");
+
+            await migrateLegacyCanonicalSkillLayout({
+                logger: logCapture.logger as unknown as Logger,
+                settingsStore: {
+                    getFilePath: () => settingsFilePath,
+                } as never,
+            });
+
+            await expect(stat(legacyCodexBundledPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(legacyRegistryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(newBundledPath)).resolves.toMatchObject({
+                isDirectory: expect.any(Function),
+            });
+            await expect(stat(newRegistryPath)).resolves.toMatchObject({
+                isDirectory: expect.any(Function),
+            });
+
+            logCapture.close();
+            const logOutput = logCapture.read();
+
+            expect(logOutput).toContain("legacySkillsChild");
+            expect(logOutput).toContain(serializeJsonPath(legacyCodexBundledPath));
+            expect(logOutput).toContain(serializeJsonPath(legacyRegistryPath));
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("logs a warning and continues when a legacy path cannot be inspected", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-canonical");
+        const configDirectoryPath = join(rootDirectory, "config");
+        const settingsFilePath = join(configDirectoryPath, "settings.toml");
+        const legacyClaudePath = join(configDirectoryPath, "claude-skills");
+        const legacyOpenClawPath = join(configDirectoryPath, "openclaw-skills");
+        const logCapture = createLogCapture();
+
+        try {
+            await mkdir(configDirectoryPath, { recursive: true });
+            // Write a regular file where a directory is expected; readdir will fail
+            // with ENOTDIR (or similar) and migration must swallow the error.
+            await Bun.write(legacyClaudePath, "not a directory\n");
+            await mkdir(legacyOpenClawPath, { recursive: true });
+
+            await migrateLegacyCanonicalSkillLayout({
+                logger: logCapture.logger as unknown as Logger,
+                settingsStore: {
+                    getFilePath: () => settingsFilePath,
+                } as never,
+            });
+
+            logCapture.close();
+            const logOutput = logCapture.read();
+
+            expect(logOutput).toContain(
+                "Failed to inspect legacy canonical skills directory.",
+            );
+            // The healthy openclaw-skills candidate must still have been removed.
+            await expect(stat(legacyOpenClawPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("is idempotent when run twice", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-canonical");
+        const configDirectoryPath = join(rootDirectory, "config");
+        const settingsFilePath = join(configDirectoryPath, "settings.toml");
+        const legacyClaudePath = join(configDirectoryPath, "claude-skills");
+        const firstLogCapture = createLogCapture();
+        const secondLogCapture = createLogCapture();
+
+        try {
+            await mkdir(legacyClaudePath, { recursive: true });
+
+            await migrateLegacyCanonicalSkillLayout({
+                logger: firstLogCapture.logger as unknown as Logger,
+                settingsStore: {
+                    getFilePath: () => settingsFilePath,
+                } as never,
+            });
+            await migrateLegacyCanonicalSkillLayout({
+                logger: secondLogCapture.logger as unknown as Logger,
+                settingsStore: {
+                    getFilePath: () => settingsFilePath,
+                } as never,
+            });
+
+            firstLogCapture.close();
+            secondLogCapture.close();
+            expect(firstLogCapture.read()).toContain("claudeSkillsRoot");
+            expect(secondLogCapture.read()).toBe("");
+            await expect(stat(legacyClaudePath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+});
+
+// pino serializes paths as JSON strings, so backslashes on win32 appear escaped.
+function serializeJsonPath(path: string): string {
+    return JSON.stringify(path).slice(1, -1);
+}

--- a/src/application/commands/skills/legacy-canonical-migration.ts
+++ b/src/application/commands/skills/legacy-canonical-migration.ts
@@ -1,0 +1,156 @@
+import type { Logger } from "pino";
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+
+import { readdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { isNodeNotFoundError, removePath } from "./bundled-skill-filesystem.ts";
+import {
+    canonicalBundledSkillsDirectoryName,
+    canonicalRegistrySkillsDirectoryName,
+    codexSkillsDirectoryName,
+} from "./bundled-skill-paths.ts";
+
+type LegacyCanonicalKind
+    = | "claudeSkillsRoot"
+        | "legacySkillsChild"
+        | "openClawSkillsRoot";
+
+interface LegacyCanonicalCandidate {
+    kind: LegacyCanonicalKind;
+    path: string;
+}
+
+const legacyClaudeBundledSkillsDirectoryName = "claude-skills";
+const legacyOpenClawBundledSkillsDirectoryName = "openclaw-skills";
+
+export async function migrateLegacyCanonicalSkillLayout(
+    context: Pick<CliExecutionContext, "logger" | "settingsStore">,
+): Promise<void> {
+    // Migration is best-effort: any failure is logged and swallowed so the
+    // surrounding `skills install` flow can still run.
+    const configDirectoryPath = dirname(context.settingsStore.getFilePath());
+    const candidates = await collectLegacyCanonicalCandidates(
+        configDirectoryPath,
+        context.logger,
+    );
+
+    for (const candidate of candidates) {
+        try {
+            await removePath(candidate.path);
+            context.logger.info(
+                {
+                    kind: candidate.kind,
+                    path: candidate.path,
+                },
+                "Removed legacy canonical skill directory.",
+            );
+        }
+        catch (error) {
+            context.logger.warn(
+                {
+                    err: error,
+                    kind: candidate.kind,
+                    path: candidate.path,
+                },
+                "Failed to remove legacy canonical skill directory.",
+            );
+        }
+    }
+}
+
+async function collectLegacyCanonicalCandidates(
+    configDirectoryPath: string,
+    logger: Pick<Logger, "warn">,
+): Promise<LegacyCanonicalCandidate[]> {
+    const [legacySkillsChildren, claudeRootPath, openClawRootPath] = await Promise.all([
+        readLegacySkillsChildren(configDirectoryPath, logger),
+        readDirectoryIfPresent(
+            join(configDirectoryPath, legacyClaudeBundledSkillsDirectoryName),
+            logger,
+        ),
+        readDirectoryIfPresent(
+            join(configDirectoryPath, legacyOpenClawBundledSkillsDirectoryName),
+            logger,
+        ),
+    ]);
+    const candidates: LegacyCanonicalCandidate[] = [];
+
+    if (claudeRootPath !== undefined) {
+        candidates.push({
+            kind: "claudeSkillsRoot",
+            path: claudeRootPath,
+        });
+    }
+
+    if (openClawRootPath !== undefined) {
+        candidates.push({
+            kind: "openClawSkillsRoot",
+            path: openClawRootPath,
+        });
+    }
+
+    for (const entryName of legacySkillsChildren) {
+        candidates.push({
+            kind: "legacySkillsChild",
+            path: join(configDirectoryPath, codexSkillsDirectoryName, entryName),
+        });
+    }
+
+    return candidates;
+}
+
+async function readLegacySkillsChildren(
+    configDirectoryPath: string,
+    logger: Pick<Logger, "warn">,
+): Promise<string[]> {
+    const skillsDirectoryPath = join(configDirectoryPath, codexSkillsDirectoryName);
+
+    try {
+        const entries = await readdir(skillsDirectoryPath, { withFileTypes: true });
+
+        return entries
+            .filter(entry => entry.isDirectory() || entry.isSymbolicLink())
+            .map(entry => entry.name)
+            .filter(name =>
+                name !== canonicalBundledSkillsDirectoryName
+                && name !== canonicalRegistrySkillsDirectoryName,
+            );
+    }
+    catch (error) {
+        if (!isNodeNotFoundError(error)) {
+            logger.warn(
+                {
+                    err: error,
+                    path: skillsDirectoryPath,
+                },
+                "Failed to inspect legacy canonical skills directory.",
+            );
+        }
+
+        return [];
+    }
+}
+
+async function readDirectoryIfPresent(
+    directoryPath: string,
+    logger: Pick<Logger, "warn">,
+): Promise<string | undefined> {
+    try {
+        await readdir(directoryPath);
+
+        return directoryPath;
+    }
+    catch (error) {
+        if (!isNodeNotFoundError(error)) {
+            logger.warn(
+                {
+                    err: error,
+                    path: directoryPath,
+                },
+                "Failed to inspect legacy canonical skills directory.",
+            );
+        }
+
+        return undefined;
+    }
+}

--- a/src/application/commands/skills/managed-skill-paths.test.ts
+++ b/src/application/commands/skills/managed-skill-paths.test.ts
@@ -32,7 +32,7 @@ describe("managed skill paths", () => {
                 "/tmp/config/settings.toml",
                 "chatgpt",
             ),
-        ).toBe(join("/tmp/config", "skills", "chatgpt"));
+        ).toBe(join("/tmp/config", "skills", "registry", "chatgpt"));
     });
 
     test("resolves the canonical skills root directory", () => {
@@ -40,7 +40,7 @@ describe("managed skill paths", () => {
             resolveManagedSkillCanonicalRootDirectoryPath(
                 "/tmp/config/settings.toml",
             ),
-        ).toBe(join("/tmp/config", "skills"));
+        ).toBe(join("/tmp/config", "skills", "registry"));
     });
 
     test("keeps contained managed skill paths and rejects escaping ones", () => {

--- a/src/application/commands/skills/managed-skill-paths.ts
+++ b/src/application/commands/skills/managed-skill-paths.ts
@@ -1,6 +1,7 @@
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
     bundledSkillMetadataFileName,
+    canonicalRegistrySkillsDirectoryName,
     codexSkillsDirectoryName,
 } from "./bundled-skill-paths.ts";
 
@@ -36,7 +37,11 @@ export function resolveManagedSkillDirectoryPath(
 export function resolveManagedSkillCanonicalRootDirectoryPath(
     settingsFilePath: string,
 ): string {
-    return join(dirname(settingsFilePath), codexSkillsDirectoryName);
+    return join(
+        dirname(settingsFilePath),
+        codexSkillsDirectoryName,
+        canonicalRegistrySkillsDirectoryName,
+    );
 }
 
 export function resolveManagedSkillCanonicalDirectoryPath(


### PR DESCRIPTION
Canonical skills now live under dedicated bundled and registry roots. Installing skills removes legacy directories first so stale copies cannot conflict with the new layout after users upgrade.

BREAKING CHANGE: existing registry skill installations under the legacy canonical layout are deleted during migration and must be reinstalled with `oo skills install <packageName>`.