### PR TITLE
refactor(skills): remove unused embedded asset helpers

### DIFF
--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -3,9 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
     availableBundledSkillAgentNames,
     availableBundledSkillNames,
-    getBundledSkillAgentNames,
     getBundledSkillFiles,
-    getBundledSkillSourceDirectory,
 } from "./embedded-assets.ts";
 
 describe("embedded skill assets", () => {
@@ -70,19 +68,8 @@ describe("embedded skill assets", () => {
         expect([...availableBundledSkillAgentNames]).toEqual(["codex", "claude", "openclaw"]);
 
         for (const skillName of availableBundledSkillNames) {
-            expect(getBundledSkillAgentNames(skillName)).toEqual(
-                [...availableBundledSkillAgentNames],
-            );
-
             for (const agentName of availableBundledSkillAgentNames) {
-                const sourceDirectory = getBundledSkillSourceDirectory(
-                    skillName,
-                    agentName,
-                );
-
-                expect(sourceDirectory).toBe(
-                    `contrib/skills/${agentName}/${skillName}`,
-                );
+                const sourceDirectory = `contrib/skills/${agentName}/${skillName}`;
                 const skillFiles = getBundledSkillFiles(skillName, agentName);
 
                 expect(skillFiles.every(file => file.agentName === agentName)).toBeTrue();

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -155,21 +155,6 @@ const bundledSkillRegistry = {
     Record<BundledSkillAgentName, BundledSkillDefinition>
 >;
 
-export function getBundledSkillAgentNames(
-    skillName: BundledSkillName,
-): readonly BundledSkillAgentName[] {
-    return Object.keys(
-        bundledSkillRegistry[skillName],
-    ) as BundledSkillAgentName[];
-}
-
-export function getBundledSkillSourceDirectory(
-    skillName: BundledSkillName,
-    agentName: BundledSkillAgentName = "codex",
-): string {
-    return `contrib/skills/${agentName}/${skillName}`;
-}
-
 export function getBundledSkillFiles(
     skillName: BundledSkillName,
     agentName: BundledSkillAgentName = "codex",


### PR DESCRIPTION
The embedded asset source directory and agent-name helpers no longer
add value now that callers use the bundled registry data directly.
Removing them keeps the skills asset API smaller and leaves tests
focused on the remaining public behavior.