### PR TITLE
fix(skills): fold duplicate list entries by host

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -236,14 +236,16 @@ List oo-managed skills from supported local skill directories.
   `${CODEX_HOME:-~/.codex}/skills`, `~/.claude/skills`, and
   `${OPENCLAW_HOME:-~/.openclaw}/skills`. It keeps only child directories whose
   `.oo-metadata.json` can be parsed and contains a non-empty `version`.
-- Output: text output prints a summary line and one block per skill.
-- Ordering: blocks are grouped by host in `Codex`, `Claude Code`, `OpenClaw`
-  order. Within each host, `oo` is always listed first when present; the
-  remaining skills are ordered by skill name.
+- Output: text output prints a summary line and one block per unique visible
+  skill identity. Identical `name`/source/version installs across multiple
+  hosts are folded into one block.
+- Ordering: `oo` is always listed first when present; the remaining skills are
+  ordered by skill name. Host names within a block follow `Codex`,
+  `Claude Code`, `OpenClaw` order.
 - Output: each skill block shows the skill name, host, source package or
   bundled marker, and recorded version.
-- Notes: when the same skill name is installed in multiple supported hosts,
-  each host installation is listed separately.
+- Notes: when a folded skill is installed in multiple supported hosts, the
+  `Host` field lists all matching hosts.
 
 ### `oo skills search <text>`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -214,13 +214,14 @@
   `${CODEX_HOME:-~/.codex}/skills`、`~/.claude/skills`，以及
   `${OPENCLAW_HOME:-~/.openclaw}/skills`。只保留包含可解析
   `.oo-metadata.json` 且其中包含非空 `version` 的子目录。
-- 输出：文本输出会先打印摘要行，再为每个 skill 打印一个块。
-- 排序：输出会先按宿主分组，顺序为 `Codex`、`Claude Code`、`OpenClaw`。
-  在每个宿主内，如果存在 `oo`，它总是排在最前面；其余 skill 按名称排序。
+- 输出：文本输出会先打印摘要行，再为每个唯一的可见 skill 身份打印一个块。
+  如果多个宿主中的安装具有相同 `name`、来源和版本，则会折叠到同一个块中。
+- 排序：如果存在 `oo`，它总是排在最前面；其余 skill 按名称排序。每个块内
+  的宿主名称按 `Codex`、`Claude Code`、`OpenClaw` 顺序显示。
 - 输出：每个 skill 块会显示 skill 名称、宿主、来源 package 或内置标记，以
   及记录的版本号。
-- 说明：如果同名 skill 同时安装在多个受支持宿主中，每个宿主的安装都会分别
-  列出。
+- 说明：如果折叠后的 skill 安装在多个受支持宿主中，`宿主` 字段会列出所有
+  匹配的宿主。
 
 ### `oo skills search <text>`
 

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -5,7 +5,11 @@ import { describe, expect, test } from "bun:test";
 
 import { createCliSandbox } from "../../../../__tests__/helpers.ts";
 import { createTerminalColors } from "../../terminal-colors.ts";
-import { resolveCodexHomeDirectory, resolveOpenClawHomeDirectory } from "./bundled-skill-paths.ts";
+import {
+    resolveClaudeHomeDirectory,
+    resolveCodexHomeDirectory,
+    resolveOpenClawHomeDirectory,
+} from "./bundled-skill-paths.ts";
 import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 const managedSkillNameColor = "#59F78D";
@@ -86,6 +90,44 @@ describe("skills list CLI", () => {
                     "",
                     "oo",
                     "  Host: OpenClaw",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                ].join("\n"),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("groups identical skills installed across multiple hosts", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(claudeHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
+            });
+
+            const result = await sandbox.run(["skills", "list"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    "✓ Found 2 oo-managed skills.",
+                    "",
+                    "oo",
+                    "  Host: Codex, Claude Code",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-find-skills",
+                    "  Host: Codex, Claude Code",
                     "  Source: bundled",
                     "  Version: 9.9.9",
                     "",

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -6,6 +6,7 @@ import type { ManagedSkillMetadata } from "./managed-skill-metadata.ts";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
+import { compareSemver } from "../../semver.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
 import {
@@ -43,6 +44,13 @@ interface ManagedSkillHostListItem extends ManagedSkillListItem {
     hostName: BundledSkillAgentName;
 }
 
+interface ManagedSkillOutputListItem {
+    hostNames: BundledSkillAgentName[];
+    metadata?: ManagedSkillMetadata;
+    name: string;
+    paths: string[];
+}
+
 type ManagedSkillListTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
 
 export const skillsListCommand: CliCommandDefinition<Record<string, never>> = {
@@ -51,13 +59,15 @@ export const skillsListCommand: CliCommandDefinition<Record<string, never>> = {
     descriptionKey: "commands.skills.list.description",
     inputSchema: z.object({}),
     handler: async (_, context) => {
-        const skills = await listManagedSkillInstallationsByHost(context.env);
+        const skills = groupManagedSkillInstallationsByIdentity(
+            await listManagedSkillInstallationsByHost(context.env),
+        );
 
         context.logger.info(
             {
                 count: skills.length,
-                paths: skills.map(skill => skill.path),
-                skillNames: skills.map(skill => `${skill.hostName}:${skill.name}`),
+                paths: skills.flatMap(skill => skill.paths),
+                skillNames: skills.map(skill => skill.name),
             },
             "Managed skills listed.",
         );
@@ -87,25 +97,49 @@ async function listManagedSkillInstallationsByHost(
                 : undefined;
         }),
     );
+    const existingHostDirectories = hostDirectories.filter(
+        hostDirectory => hostDirectory !== undefined,
+    );
     const skillsByHost = await Promise.all(
-        hostDirectories.flatMap((hostDirectory) => {
-            if (hostDirectory === undefined) {
-                return [];
-            }
-
-            return [
-                listManagedSkillInstallations(hostDirectory.skillsDirectoryPath)
-                    .then(skills => skills.map(skill => ({
-                        ...skill,
-                        hostName: hostDirectory.hostName,
-                    }) satisfies ManagedSkillHostListItem)),
-            ];
-        }),
+        existingHostDirectories.map(hostDirectory =>
+            listManagedSkillInstallations(hostDirectory.skillsDirectoryPath)
+                .then(skills => skills.map(skill => ({
+                    ...skill,
+                    hostName: hostDirectory.hostName,
+                }) satisfies ManagedSkillHostListItem)),
+        ),
     );
 
     return skillsByHost
         .flat()
         .sort(compareManagedSkillHostListItems);
+}
+
+function groupManagedSkillInstallationsByIdentity(
+    installations: readonly ManagedSkillHostListItem[],
+): ManagedSkillOutputListItem[] {
+    const groups: ManagedSkillOutputListItem[] = [];
+
+    for (const installation of installations) {
+        const group = groups.find(candidate =>
+            hasSameManagedSkillIdentity(candidate, installation),
+        );
+
+        if (group === undefined) {
+            groups.push({
+                hostNames: [installation.hostName],
+                metadata: installation.metadata,
+                name: installation.name,
+                paths: [installation.path],
+            });
+            continue;
+        }
+
+        group.hostNames.push(installation.hostName);
+        group.paths.push(installation.path);
+    }
+
+    return groups.sort(compareManagedSkillOutputListItems);
 }
 
 export async function listManagedSkillInstallations(
@@ -142,12 +176,12 @@ export async function listManagedSkillInstallations(
 
     return skills
         .filter(skill => skill !== undefined)
-        .sort(compareManagedSkillListItems);
+        .sort((left, right) => compareManagedSkillNames(left.name, right.name));
 }
 
 export function formatManagedSkillListAsText(
     inventory: {
-        skills: readonly ManagedSkillHostListItem[];
+        skills: readonly ManagedSkillOutputListItem[];
     },
     context: ManagedSkillListTextContext,
 ): string {
@@ -191,7 +225,7 @@ async function readSkillsDirectoryEntries(
 }
 
 function formatManagedSkillListItem(
-    skill: ManagedSkillHostListItem,
+    skill: ManagedSkillOutputListItem,
     context: ManagedSkillListTextContext,
     colors: TerminalColors,
 ): string {
@@ -200,7 +234,7 @@ function formatManagedSkillListItem(
         formatManagedSkillDetailLine(
             context.translator.t("skills.list.host"),
             colors.hex(managedSkillSourceColor)(
-                readManagedSkillHostLabel(skill.hostName, context),
+                readManagedSkillHostLabels(skill.hostNames, context),
             ),
             colors,
         ),
@@ -230,7 +264,7 @@ function formatManagedSkillDetailLine(
 }
 
 function readManagedSkillSource(
-    skill: ManagedSkillListItem,
+    skill: Pick<ManagedSkillListItem, "metadata" | "name">,
     context: Pick<CliExecutionContext, "translator">,
 ): string {
     if (skill.metadata?.packageName !== undefined) {
@@ -242,6 +276,29 @@ function readManagedSkillSource(
     }
 
     return context.translator.t("versionInfo.unknown");
+}
+
+function readManagedSkillSourceIdentity(
+    skill: Pick<ManagedSkillListItem, "metadata" | "name">,
+): string {
+    if (skill.metadata?.packageName !== undefined) {
+        return `package:${skill.metadata.packageName}`;
+    }
+
+    if (isBundledSkillName(skill.name)) {
+        return "bundled";
+    }
+
+    return "unknown";
+}
+
+function readManagedSkillHostLabels(
+    hostNames: readonly BundledSkillAgentName[],
+    context: Pick<CliExecutionContext, "translator">,
+): string {
+    return hostNames.map(hostName =>
+        readManagedSkillHostLabel(hostName, context),
+    ).join(", ");
 }
 
 function readManagedSkillHostLabel(
@@ -260,19 +317,48 @@ function readManagedSkillHostLabel(
     }
 }
 
-function compareManagedSkillListItems(
-    left: ManagedSkillListItem,
-    right: ManagedSkillListItem,
-): number {
-    if (left.name === "oo" && right.name !== "oo") {
+function hasSameManagedSkillIdentity(
+    left: Pick<ManagedSkillListItem, "metadata" | "name">,
+    right: Pick<ManagedSkillListItem, "metadata" | "name">,
+): boolean {
+    return left.name === right.name
+        && readManagedSkillSourceIdentity(left) === readManagedSkillSourceIdentity(right)
+        && (left.metadata?.version ?? "") === (right.metadata?.version ?? "");
+}
+
+function compareManagedSkillNames(left: string, right: string): number {
+    if (left === "oo" && right !== "oo") {
         return -1;
     }
 
-    if (left.name !== "oo" && right.name === "oo") {
+    if (left !== "oo" && right === "oo") {
         return 1;
     }
 
-    return left.name.localeCompare(right.name);
+    return left.localeCompare(right);
+}
+
+function compareManagedSkillOutputListItems(
+    left: ManagedSkillOutputListItem,
+    right: ManagedSkillOutputListItem,
+): number {
+    const nameDifference = compareManagedSkillNames(left.name, right.name);
+
+    if (nameDifference !== 0) {
+        return nameDifference;
+    }
+
+    const sourceDifference = readManagedSkillSourceIdentity(left)
+        .localeCompare(readManagedSkillSourceIdentity(right));
+
+    if (sourceDifference !== 0) {
+        return sourceDifference;
+    }
+
+    return compareSemver(
+        left.metadata?.version ?? "",
+        right.metadata?.version ?? "",
+    );
 }
 
 function compareManagedSkillHostListItems(
@@ -286,5 +372,5 @@ function compareManagedSkillHostListItems(
         return hostOrderDifference;
     }
 
-    return compareManagedSkillListItems(left, right);
+    return compareManagedSkillNames(left.name, right.name);
 }


### PR DESCRIPTION
Why: Bundled skills installed for multiple hosts appeared as duplicate entries, making the inventory count noisy and harder to scan. What: Fold list output by visible skill identity while retaining all matching host labels in the rendered block.
How: Group scanned host installations by name, source, and version, then sort folded entries deterministically and cover the multi-host case.