### PR TITLE
feat(self-update): auto-configure PATH for install and update

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -108,18 +108,26 @@ Install one managed `oo` release into the local self-managed runtime.
   published release.
 - Options: `--force` forces a reinstall even when the requested version is
   already installed.
+- Options: `--no-modify-path` skips automatic PATH configuration; install will
+  still print a setup note when the executable directory is not on `PATH`.
+- Environment: setting `OO_NO_MODIFY_PATH` to a truthy value (`1`, `true`,
+  `yes`, `on`, case-insensitive) is equivalent to `--no-modify-path`. The flag
+  and the env var combine with OR semantics: either one being set skips PATH
+  configuration.
 - Output: on success, the CLI prints the installed version and the final
   executable path.
 - Output: when `stderr` is an interactive TTY, the CLI also renders colored
   progress stages to `stderr` while the install is running.
 - Notes: install verifies that the installed `oo` command is usable before
   reporting success.
-- Notes: when the executable directory is not on `PATH`, install also prints a
-  setup note that tells the user which directory to add.
 - Notes: after a successful install, the CLI best-effort removes legacy global
   `@oomol-lab/oo-cli` package-manager installs that appear anywhere on `PATH`;
   when `PATH` yields no `oo` candidates, the CLI falls back to the current
   command path. Cleanup failures do not change the command result.
+- Notes: when the executable directory is not on `PATH`, install attempts to
+  persist it for future shells. When automatic PATH configuration succeeds,
+  install tells the user to restart their shell; when it fails, install prints
+  a setup note that tells the user which directory to add.
 - Notes: after a successful install workflow, the CLI silently runs
   `oo skills add` with the managed executable so bundled skills refresh to the
   installed CLI version.
@@ -131,6 +139,12 @@ Install one managed `oo` release into the local self-managed runtime.
 Update the managed `oo` install to the latest published release.
 
 - Arguments: none.
+- Options: `--no-modify-path` skips automatic PATH configuration; update will
+  still print a setup note when the executable directory is not on `PATH`.
+- Environment: setting `OO_NO_MODIFY_PATH` to a truthy value (`1`, `true`,
+  `yes`, `on`, case-insensitive) is equivalent to `--no-modify-path`. The flag
+  and the env var combine with OR semantics: either one being set skips PATH
+  configuration.
 - Output: when the current version is already the latest published release, the
   CLI prints the up-to-date message.
 - Output: when a newer published release is available, the CLI prints the
@@ -146,6 +160,10 @@ Update the managed `oo` install to the latest published release.
   `@oomol-lab/oo-cli` package-manager installs that appear anywhere on `PATH`;
   when `PATH` yields no `oo` candidates, the CLI falls back to the current
   command path. Cleanup failures do not change the command result.
+- Notes: when the executable directory is not on `PATH`, update attempts to
+  persist it for future shells. When automatic PATH configuration succeeds,
+  update tells the user to restart their shell; when it fails, update prints a
+  setup note that tells the user which directory to add.
 - Notes: after a successful update workflow, the CLI silently runs
   `oo skills add` with the managed executable so bundled skills refresh to the
   installed CLI version.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -128,6 +128,10 @@ Install one managed `oo` release into the local self-managed runtime.
   persist it for future shells. When automatic PATH configuration succeeds,
   install tells the user to restart their shell; when it fails, install prints
   a setup note that tells the user which directory to add.
+- Notes: when some shell profiles were updated and others could not be,
+  install lists both — the profiles that were updated and the profiles that
+  could not be updated — followed by the restart-shell note. The user can
+  then decide whether to update the failed profiles manually.
 - Notes: after a successful install workflow, the CLI silently runs
   `oo skills add` with the managed executable so bundled skills refresh to the
   installed CLI version.
@@ -164,6 +168,10 @@ Update the managed `oo` install to the latest published release.
   persist it for future shells. When automatic PATH configuration succeeds,
   update tells the user to restart their shell; when it fails, update prints a
   setup note that tells the user which directory to add.
+- Notes: when some shell profiles were updated and others could not be,
+  update lists both — the profiles that were updated and the profiles that
+  could not be updated — followed by the restart-shell note. The user can
+  then decide whether to update the failed profiles manually.
 - Notes: after a successful update workflow, the CLI silently runs
   `oo skills add` with the managed executable so bundled skills refresh to the
   installed CLI version.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -99,15 +99,21 @@
 
 - 参数：`[version]` 为可选参数。省略时，`oo` 会安装最新发布版本。
 - 选项：`--force` 会在请求的版本已经安装时仍然强制重装。
+- 选项：`--no-modify-path` 跳过自动 PATH 配置；当可执行目录不在 `PATH` 上时，
+  install 仍会打印 setup note。
+- 环境变量：将 `OO_NO_MODIFY_PATH` 设为真值（`1`、`true`、`yes`、`on`，大小写不敏感）
+  等价于 `--no-modify-path`。标志和环境变量按"任一为跳过即跳过"的或关系组合，
+  任一设置都会跳过 PATH 配置。
 - 输出：成功时，CLI 会打印已安装版本和最终的可执行入口路径。
 - 输出：当 `stderr` 是交互式 TTY 时，CLI 还会在安装过程中向 `stderr`
   渲染带颜色的进度阶段。
 - 说明：install 在报告成功前会校验已安装的 `oo` 命令可正常使用。
-- 说明：如果可执行目录没有出现在 `PATH` 中，install 还会额外打印 setup note，
-  告知用户应当把哪个目录加入 `PATH`。
 - 说明：install 成功后，CLI 会尽力移除在 `PATH` 中任意位置出现的旧全局
   package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到 `oo`
   候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
+- 说明：如果可执行目录没有出现在 `PATH` 中，install 会尝试为后续 shell
+  持久化 PATH 配置；如果自动配置成功，install 会提示用户重启 shell；如果自动配置失败，
+  install 会打印 setup note，告知用户应当把哪个目录加入 `PATH`。
 - 说明：install 成功后，CLI 会使用托管的可执行文件静默执行一次
   `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /
@@ -118,6 +124,11 @@
 把托管的 `oo` 安装更新到最新发布版本。
 
 - 参数：无。
+- 选项：`--no-modify-path` 跳过自动 PATH 配置；当可执行目录不在 `PATH` 上时，
+  update 仍会打印 setup note。
+- 环境变量：将 `OO_NO_MODIFY_PATH` 设为真值（`1`、`true`、`yes`、`on`，大小写不敏感）
+  等价于 `--no-modify-path`。标志和环境变量按"任一为跳过即跳过"的或关系组合，
+  任一设置都会跳过 PATH 配置。
 - 输出：当当前版本已经是最新发布版本时，CLI 会打印“已是最新版本”的消息。
 - 输出：当有更新的发布版本可用时，CLI 会打印版本变更结果。
 - 输出：当 `stderr` 是交互式 TTY 时，CLI 还会在更新过程中向 `stderr`
@@ -129,6 +140,9 @@
 - 说明：update 成功后，CLI 会尽力移除在 `PATH` 中任意位置出现的旧全局
   package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到 `oo`
   候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
+- 说明：如果可执行目录没有出现在 `PATH` 中，update 会尝试为后续 shell
+  持久化 PATH 配置；如果自动配置成功，update 会提示用户重启 shell；如果自动配置失败，
+  update 会打印 setup note，告知用户应当把哪个目录加入 `PATH`。
 - 说明：update 成功后，CLI 会使用托管的可执行文件静默执行一次
   `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -114,6 +114,9 @@
 - 说明：如果可执行目录没有出现在 `PATH` 中，install 会尝试为后续 shell
   持久化 PATH 配置；如果自动配置成功，install 会提示用户重启 shell；如果自动配置失败，
   install 会打印 setup note，告知用户应当把哪个目录加入 `PATH`。
+- 说明：当部分 shell profile 配置成功、另一部分失败时，install 会分别列出两组
+  ——已配置的 profile 和未能配置的 profile，并附带重启 shell 的提示；用户可据此
+  决定是否手动补全未配置的 profile。
 - 说明：install 成功后，CLI 会使用托管的可执行文件静默执行一次
   `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /
@@ -143,6 +146,9 @@
 - 说明：如果可执行目录没有出现在 `PATH` 中，update 会尝试为后续 shell
   持久化 PATH 配置；如果自动配置成功，update 会提示用户重启 shell；如果自动配置失败，
   update 会打印 setup note，告知用户应当把哪个目录加入 `PATH`。
+- 说明：当部分 shell profile 配置成功、另一部分失败时，update 会分别列出两组
+  ——已配置的 profile 和未能配置的 profile，并附带重启 shell 的提示；用户可据此
+  决定是否手动补全未配置的 profile。
 - 说明：update 成功后，CLI 会使用托管的可执行文件静默执行一次
   `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -34,27 +34,27 @@ exports[`runCli bootstrap creates the sqlite cache file during cli startup 1`] =
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version             Show the current version
+  --debug                   Print the current log file path when the CLI exits
+  --lang <lang>             Specify the display language
+  -h, --help                Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  connector                Manage connector actions
-  file                     Manage temporary file transfers
-  login                    Log in with device login (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  search [options] <text>  Search packages and connector actions
-  packages                 Package utilities
-  update|upgrade           Update the CLI
-  help [command]           Show help for a command
+  auth                      Manage CLI authentication
+  check-update              Check for CLI updates
+  cloud-task                Manage cloud tasks
+  connector                 Manage connector actions
+  file                      Manage temporary file transfers
+  login                     Log in with device login (alias for auth login)
+  logout                    Log out the current account (alias for auth logout)
+  completion <shell>        Generate shell completion scripts
+  config                    Manage persisted configuration
+  skills                    Manage Codex skills
+  log                       Manage persisted debug logs
+  search [options] <text>   Search packages and connector actions
+  packages                  Package utilities
+  update|upgrade [options]  Update the CLI
+  help [command]            Show help for a command
 "
 ,
 }
@@ -68,27 +68,27 @@ exports[`runCli bootstrap writes debug logs to the log directory during cli star
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version             Show the current version
+  --debug                   Print the current log file path when the CLI exits
+  --lang <lang>             Specify the display language
+  -h, --help                Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  connector                Manage connector actions
-  file                     Manage temporary file transfers
-  login                    Log in with device login (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  search [options] <text>  Search packages and connector actions
-  packages                 Package utilities
-  update|upgrade           Update the CLI
-  help [command]           Show help for a command
+  auth                      Manage CLI authentication
+  check-update              Check for CLI updates
+  cloud-task                Manage cloud tasks
+  connector                 Manage connector actions
+  file                      Manage temporary file transfers
+  login                     Log in with device login (alias for auth login)
+  logout                    Log out the current account (alias for auth logout)
+  completion <shell>        Generate shell completion scripts
+  config                    Manage persisted configuration
+  skills                    Manage Codex skills
+  log                       Manage persisted debug logs
+  search [options] <text>   Search packages and connector actions
+  packages                  Package utilities
+  update|upgrade [options]  Update the CLI
+  help [command]            Show help for a command
 "
 ,
 }
@@ -105,27 +105,27 @@ exports[`runCli bootstrap prints the current log file path to stderr when --debu
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version             Show the current version
+  --debug                   Print the current log file path when the CLI exits
+  --lang <lang>             Specify the display language
+  -h, --help                Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  connector                Manage connector actions
-  file                     Manage temporary file transfers
-  login                    Log in with device login (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  search [options] <text>  Search packages and connector actions
-  packages                 Package utilities
-  update|upgrade           Update the CLI
-  help [command]           Show help for a command
+  auth                      Manage CLI authentication
+  check-update              Check for CLI updates
+  cloud-task                Manage cloud tasks
+  connector                 Manage connector actions
+  file                      Manage temporary file transfers
+  login                     Log in with device login (alias for auth login)
+  logout                    Log out the current account (alias for auth logout)
+  completion <shell>        Generate shell completion scripts
+  config                    Manage persisted configuration
+  skills                    Manage Codex skills
+  log                       Manage persisted debug logs
+  search [options] <text>   Search packages and connector actions
+  packages                  Package utilities
+  update|upgrade [options]  Update the CLI
+  help [command]            Show help for a command
 "
 ,
 }
@@ -140,27 +140,27 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
 "oo 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成
 
 选项：
-  -V, --version            显示当前版本
-  --debug                  在 CLI 退出时打印当前日志文件路径
-  --lang <lang>            指定显示语言
-  -h, --help               显示命令帮助
+  -V, --version             显示当前版本
+  --debug                   在 CLI 退出时打印当前日志文件路径
+  --lang <lang>             指定显示语言
+  -h, --help                显示命令帮助
 
 命令：
-  auth                     管理 CLI 认证
-  check-update             检查 CLI 更新
-  cloud-task               管理云任务
-  connector                管理 connector action
-  file                     管理临时文件传输
-  login                    通过 device login 登录（auth login 的别名）
-  logout                   登出当前账号（auth logout 的别名）
-  completion <shell>       生成 shell 补全脚本
-  config                   管理持久化配置
-  skills                   管理 Codex skill
-  log                      管理持久化 debug 日志
-  search [options] <text>  搜索 package 与 connector action
-  packages                 包相关工具
-  update|upgrade           更新 CLI
-  help [command]           显示命令帮助
+  auth                      管理 CLI 认证
+  check-update              检查 CLI 更新
+  cloud-task                管理云任务
+  connector                 管理 connector action
+  file                      管理临时文件传输
+  login                     通过 device login 登录（auth login 的别名）
+  logout                    登出当前账号（auth logout 的别名）
+  completion <shell>        生成 shell 补全脚本
+  config                    管理持久化配置
+  skills                    管理 Codex skill
+  log                       管理持久化 debug 日志
+  search [options] <text>   搜索 package 与 connector action
+  packages                  包相关工具
+  update|upgrade [options]  更新 CLI
+  help [command]            显示命令帮助
 "
 ,
   },
@@ -171,27 +171,27 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version             Show the current version
+  --debug                   Print the current log file path when the CLI exits
+  --lang <lang>             Specify the display language
+  -h, --help                Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  connector                Manage connector actions
-  file                     Manage temporary file transfers
-  login                    Log in with device login (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  search [options] <text>  Search packages and connector actions
-  packages                 Package utilities
-  update|upgrade           Update the CLI
-  help [command]           Show help for a command
+  auth                      Manage CLI authentication
+  check-update              Check for CLI updates
+  cloud-task                Manage cloud tasks
+  connector                 Manage connector actions
+  file                      Manage temporary file transfers
+  login                     Log in with device login (alias for auth login)
+  logout                    Log out the current account (alias for auth logout)
+  completion <shell>        Generate shell completion scripts
+  config                    Manage persisted configuration
+  skills                    Manage Codex skills
+  log                       Manage persisted debug logs
+  search [options] <text>   Search packages and connector actions
+  packages                  Package utilities
+  update|upgrade [options]  Update the CLI
+  help [command]            Show help for a command
 "
 ,
   },
@@ -206,27 +206,27 @@ exports[`runCli bootstrap renders branded colors in help when stdout supports co
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version             Show the current version
+  --debug                   Print the current log file path when the CLI exits
+  --lang <lang>             Specify the display language
+  -h, --help                Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  connector                Manage connector actions
-  file                     Manage temporary file transfers
-  login                    Log in with device login (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  search [options] <text>  Search packages and connector actions
-  packages                 Package utilities
-  update|upgrade           Update the CLI
-  help [command]           Show help for a command
+  auth                      Manage CLI authentication
+  check-update              Check for CLI updates
+  cloud-task                Manage cloud tasks
+  connector                 Manage connector actions
+  file                      Manage temporary file transfers
+  login                     Log in with device login (alias for auth login)
+  logout                    Log out the current account (alias for auth logout)
+  completion <shell>        Generate shell completion scripts
+  config                    Manage persisted configuration
+  skills                    Manage Codex skills
+  log                       Manage persisted debug logs
+  search [options] <text>   Search packages and connector actions
+  packages                  Package utilities
+  update|upgrade [options]  Update the CLI
+  help [command]            Show help for a command
 "
 ,
 }

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -93,6 +93,12 @@ export async function runCli(argv: string[]): Promise<number> {
         cwd: process.cwd(),
         env: process.env,
         fetcher: fetch,
+        // The real CLI entry is the only caller allowed to touch the Windows
+        // user registry. Tests and programmatic embedders go through
+        // executeCli directly and inherit the safer default (off).
+        selfUpdateRuntime: {
+            allowWindowsRegistryWrite: true,
+        },
         stdin: createLazyStdin(),
         stdout: process.stdout,
         stderr: process.stderr,

--- a/src/application/commands/__snapshots__/self-update.cli.test.ts.snap
+++ b/src/application/commands/__snapshots__/self-update.cli.test.ts.snap
@@ -18,7 +18,7 @@ exports[`self-update commands install resolves latest.json when no explicit vers
   "stdout": 
 "Installed oo 1.2.3.
 Executable: <EXECUTABLE_PATH>
-Add <HOME>/.local/bin to PATH to run oo in new shells.
+Added <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.
 "
 ,
 }
@@ -31,7 +31,7 @@ exports[`self-update commands install with an explicit version skips latest.json
   "stdout": 
 "Installed oo 2.0.0.
 Executable: <EXECUTABLE_PATH>
-Add <HOME>/.local/bin to PATH to run oo in new shells.
+Added <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.
 "
 ,
 }
@@ -54,6 +54,7 @@ exports[`self-update commands upgrade uses the same update path and repairs a sa
   "stderr": "",
   "stdout": 
 "Already up to date at 1.2.3.
+Added <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.
 "
 ,
 }

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -20,27 +20,27 @@ exports[`config CLI persists the configured locale and allows explicit override 
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version             Show the current version
+  --debug                   Print the current log file path when the CLI exits
+  --lang <lang>             Specify the display language
+  -h, --help                Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  connector                Manage connector actions
-  file                     Manage temporary file transfers
-  login                    Log in with device login (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  search [options] <text>  Search packages and connector actions
-  packages                 Package utilities
-  update|upgrade           Update the CLI
-  help [command]           Show help for a command
+  auth                      Manage CLI authentication
+  check-update              Check for CLI updates
+  cloud-task                Manage cloud tasks
+  connector                 Manage connector actions
+  file                      Manage temporary file transfers
+  login                     Log in with device login (alias for auth login)
+  logout                    Log out the current account (alias for auth logout)
+  completion <shell>        Generate shell completion scripts
+  config                    Manage persisted configuration
+  skills                    Manage Codex skills
+  log                       Manage persisted debug logs
+  search [options] <text>   Search packages and connector actions
+  packages                  Package utilities
+  update|upgrade [options]  Update the CLI
+  help [command]            Show help for a command
 "
 ,
   },
@@ -51,27 +51,27 @@ Commands:
 "oo 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成
 
 选项：
-  -V, --version            显示当前版本
-  --debug                  在 CLI 退出时打印当前日志文件路径
-  --lang <lang>            指定显示语言
-  -h, --help               显示命令帮助
+  -V, --version             显示当前版本
+  --debug                   在 CLI 退出时打印当前日志文件路径
+  --lang <lang>             指定显示语言
+  -h, --help                显示命令帮助
 
 命令：
-  auth                     管理 CLI 认证
-  check-update             检查 CLI 更新
-  cloud-task               管理云任务
-  connector                管理 connector action
-  file                     管理临时文件传输
-  login                    通过 device login 登录（auth login 的别名）
-  logout                   登出当前账号（auth logout 的别名）
-  completion <shell>       生成 shell 补全脚本
-  config                   管理持久化配置
-  skills                   管理 Codex skill
-  log                      管理持久化 debug 日志
-  search [options] <text>  搜索 package 与 connector action
-  packages                 包相关工具
-  update|upgrade           更新 CLI
-  help [command]           显示命令帮助
+  auth                      管理 CLI 认证
+  check-update              检查 CLI 更新
+  cloud-task                管理云任务
+  connector                 管理 connector action
+  file                      管理临时文件传输
+  login                     通过 device login 登录（auth login 的别名）
+  logout                    登出当前账号（auth logout 的别名）
+  completion <shell>        生成 shell 补全脚本
+  config                    管理持久化配置
+  skills                    管理 Codex skill
+  log                       管理持久化 debug 日志
+  search [options] <text>   搜索 package 与 connector action
+  packages                  包相关工具
+  update|upgrade [options]  更新 CLI
+  help [command]            显示命令帮助
 "
 ,
   },

--- a/src/application/commands/install.ts
+++ b/src/application/commands/install.ts
@@ -9,12 +9,15 @@ import {
     resolveLatestSelfUpdateVersion,
     selfUpdateDevelopmentVersion,
 } from "../self-update/core.ts";
+import { resolveSelfUpdateModifyPath } from "../self-update/modify-path-preference.ts";
 import { isSemver } from "../semver.ts";
+import { writeSelfUpdatePathNoteIfNeeded } from "./self-update-output.ts";
 import { SelfUpdateProgressReporter } from "./self-update-progress.ts";
 import { writeLine } from "./shared/output.ts";
 
 const installCommandInputSchema = z.object({
     force: z.boolean().default(false),
+    modifyPath: z.boolean().default(true),
     version: z.string().trim().min(1).optional(),
 });
 
@@ -37,6 +40,11 @@ export const installCommand: CliCommandDefinition<
             name: "force",
             longFlag: "--force",
             descriptionKey: "options.force",
+        },
+        {
+            name: "modifyPath",
+            longFlag: "--no-modify-path",
+            descriptionKey: "options.noModifyPath",
         },
     ],
     inputSchema: installCommandInputSchema,
@@ -86,6 +94,10 @@ export const installCommand: CliCommandDefinition<
             const result = await performSelfUpdateOperation({
                 currentVersion: context.version,
                 forceReinstall: input.force,
+                modifyPath: resolveSelfUpdateModifyPath({
+                    env: context.env,
+                    modifyPathFlag: input.modifyPath,
+                }),
                 reportStage: progressReporter?.createReportStage(),
                 runtime: {
                     arch: process.arch,
@@ -127,14 +139,12 @@ export const installCommand: CliCommandDefinition<
                 }),
             );
 
-            if (!result.pathConfigured) {
-                writeLine(
-                    context.stdout,
-                    context.translator.t("selfUpdate.install.pathNote", {
-                        path: result.executableDirectory,
-                    }),
-                );
-            }
+            writeSelfUpdatePathNoteIfNeeded({
+                executableDirectory: result.executableDirectory,
+                pathConfiguration: result.pathConfiguration,
+                stdout: context.stdout,
+                translator: context.translator,
+            });
         }
         catch (error) {
             progressReporter?.abort();

--- a/src/application/commands/self-update-output.test.ts
+++ b/src/application/commands/self-update-output.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { createTextBuffer } from "../../../__tests__/helpers.ts";
+import { createTranslator } from "../../i18n/translator.ts";
+import { writeSelfUpdatePathNoteIfNeeded } from "./self-update-output.ts";
+
+const translator = createTranslator("en");
+const executableDirectory = "/home/demo/.local/bin";
+
+describe("writeSelfUpdatePathNoteIfNeeded", () => {
+    test("stays silent when env PATH already contains the directory", () => {
+        const stdout = createTextBuffer();
+
+        writeSelfUpdatePathNoteIfNeeded({
+            executableDirectory,
+            pathConfiguration: { status: "already-configured" },
+            stdout: stdout.writer,
+            translator,
+        });
+
+        expect(stdout.read()).toBe("");
+    });
+
+    test("prints the restart-shell note when a profile already had the marker but the current shell is stale", () => {
+        const stdout = createTextBuffer();
+
+        writeSelfUpdatePathNoteIfNeeded({
+            executableDirectory,
+            pathConfiguration: {
+                status: "already-configured",
+                target: ["/home/demo/.zshrc"],
+            },
+            stdout: stdout.writer,
+            translator,
+        });
+
+        expect(stdout.read()).toBe(
+            "Added /home/demo/.local/bin to PATH. Restart your shell to reload PATH and use oo.\n",
+        );
+    });
+
+    test("prints the restart-shell note when PATH was freshly configured", () => {
+        const stdout = createTextBuffer();
+
+        writeSelfUpdatePathNoteIfNeeded({
+            executableDirectory,
+            pathConfiguration: {
+                status: "configured",
+                target: ["/home/demo/.zshrc"],
+            },
+            stdout: stdout.writer,
+            translator,
+        });
+
+        expect(stdout.read()).toContain("Restart your shell");
+    });
+
+    test("prints the manual setup note on failure", () => {
+        const stdout = createTextBuffer();
+
+        writeSelfUpdatePathNoteIfNeeded({
+            executableDirectory,
+            pathConfiguration: { status: "failed" },
+            stdout: stdout.writer,
+            translator,
+        });
+
+        expect(stdout.read()).toBe(
+            "Add /home/demo/.local/bin to PATH to run oo in new shells.\n",
+        );
+    });
+
+    test("prints the manual setup note when modification was skipped via flag/env", () => {
+        const stdout = createTextBuffer();
+
+        writeSelfUpdatePathNoteIfNeeded({
+            executableDirectory,
+            pathConfiguration: { status: "skipped" },
+            stdout: stdout.writer,
+            translator,
+        });
+
+        expect(stdout.read()).toContain("Add /home/demo/.local/bin to PATH");
+    });
+});

--- a/src/application/commands/self-update-output.test.ts
+++ b/src/application/commands/self-update-output.test.ts
@@ -54,6 +54,33 @@ describe("writeSelfUpdatePathNoteIfNeeded", () => {
         expect(stdout.read()).toContain("Restart your shell");
     });
 
+    test("prints a symmetric updated / failed listing on partial success", () => {
+        const stdout = createTextBuffer();
+
+        writeSelfUpdatePathNoteIfNeeded({
+            executableDirectory,
+            pathConfiguration: {
+                status: "partial-configured",
+                target: ["/home/demo/.zshrc", "/home/demo/.bashrc"],
+                failedTargets: ["/home/demo/.config/fish/conf.d/oo.fish"],
+            },
+            stdout: stdout.writer,
+            translator,
+        });
+
+        expect(stdout.read()).toBe(
+            [
+                "Updated PATH in:",
+                "  /home/demo/.zshrc",
+                "  /home/demo/.bashrc",
+                "Could not update:",
+                "  /home/demo/.config/fish/conf.d/oo.fish",
+                "Restart your shell to reload PATH and use oo.",
+                "",
+            ].join("\n"),
+        );
+    });
+
     test("prints the manual setup note on failure", () => {
         const stdout = createTextBuffer();
 

--- a/src/application/commands/self-update-output.ts
+++ b/src/application/commands/self-update-output.ts
@@ -35,6 +35,31 @@ export function writeSelfUpdatePathNoteIfNeeded(options: {
         return;
     }
 
+    if (options.pathConfiguration.status === "partial-configured") {
+        // Some profiles were updated, others failed. List both explicitly so
+        // the user can tell at a glance what worked and what didn't — no
+        // "success + failure" dissonance in a single sentence.
+        writeLine(
+            options.stdout,
+            options.translator.t("selfUpdate.pathPartiallyConfigured.updatedHeader"),
+        );
+        for (const target of options.pathConfiguration.target ?? []) {
+            writeLine(options.stdout, `  ${target}`);
+        }
+        writeLine(
+            options.stdout,
+            options.translator.t("selfUpdate.pathPartiallyConfigured.failedHeader"),
+        );
+        for (const target of options.pathConfiguration.failedTargets ?? []) {
+            writeLine(options.stdout, `  ${target}`);
+        }
+        writeLine(
+            options.stdout,
+            options.translator.t("selfUpdate.pathPartiallyConfigured.restart"),
+        );
+        return;
+    }
+
     // "failed" and "skipped" both fall back to the manual setup note.
     writeLine(
         options.stdout,

--- a/src/application/commands/self-update-output.ts
+++ b/src/application/commands/self-update-output.ts
@@ -1,0 +1,45 @@
+import type { Writer } from "../contracts/cli.ts";
+import type { SelfUpdatePathConfigurationResult } from "../contracts/self-update.ts";
+import type { Translator } from "../contracts/translator.ts";
+import { writeLine } from "./shared/output.ts";
+
+export function writeSelfUpdatePathNoteIfNeeded(options: {
+    executableDirectory: string;
+    pathConfiguration: SelfUpdatePathConfigurationResult;
+    stdout: Writer;
+    translator: Pick<Translator, "t">;
+}): void {
+    if (options.pathConfiguration.status === "already-configured") {
+        // `target` is populated only when a profile file already carries our
+        // marker — the current shell's env.PATH just hasn't been reloaded yet,
+        // so advise a restart. Without `target`, env.PATH itself already has
+        // the directory and there is nothing to tell the user.
+        if ((options.pathConfiguration.target?.length ?? 0) > 0) {
+            writeLine(
+                options.stdout,
+                options.translator.t("selfUpdate.pathConfiguredNote", {
+                    path: options.executableDirectory,
+                }),
+            );
+        }
+        return;
+    }
+
+    if (options.pathConfiguration.status === "configured") {
+        writeLine(
+            options.stdout,
+            options.translator.t("selfUpdate.pathConfiguredNote", {
+                path: options.executableDirectory,
+            }),
+        );
+        return;
+    }
+
+    // "failed" and "skipped" both fall back to the manual setup note.
+    writeLine(
+        options.stdout,
+        options.translator.t("selfUpdate.install.pathNote", {
+            path: options.executableDirectory,
+        }),
+    );
+}

--- a/src/application/commands/self-update.cli.test.ts
+++ b/src/application/commands/self-update.cli.test.ts
@@ -110,6 +110,126 @@ describe("self-update commands", () => {
         }
     });
 
+    test("install does not touch PATH when OO_NO_MODIFY_PATH is set", async () => {
+        const sandbox = await createCliSandbox();
+        const releasePlatform = await detectSelfUpdateReleasePlatform({
+            arch: process.arch,
+            platform: process.platform,
+        });
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime();
+
+        sandbox.env.OO_NO_MODIFY_PATH = "1";
+
+        try {
+            const result = await sandbox.run(["install", "2.0.0"], {
+                fetcher: async (input, init) => {
+                    const url = toRequest(input, init).url;
+
+                    if (url.endsWith("/latest.json")) {
+                        throw new Error("latest.json should not be requested");
+                    }
+
+                    if (url.endsWith(`/${releasePlatform}/${process.platform === "win32" ? "oo.exe" : "oo"}`)) {
+                        return new Response("binary");
+                    }
+
+                    throw new Error(`Unexpected request: ${url}`);
+                },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
+                version: "1.0.0",
+            });
+
+            expect(createSelfUpdateInstallSnapshot(result, sandbox)).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: `Installed oo 2.0.0.\nExecutable: <EXECUTABLE_PATH>\nAdd <HOME>/.local/bin to PATH to run oo in new shells.\n`,
+            });
+            expect(selfUpdateRuntime.configurePathCallCount()).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("install does not touch PATH when --no-modify-path is passed", async () => {
+        const sandbox = await createCliSandbox();
+        const releasePlatform = await detectSelfUpdateReleasePlatform({
+            arch: process.arch,
+            platform: process.platform,
+        });
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime();
+
+        try {
+            const result = await sandbox.run(["install", "2.0.0", "--no-modify-path"], {
+                fetcher: async (input, init) => {
+                    const url = toRequest(input, init).url;
+
+                    if (url.endsWith("/latest.json")) {
+                        throw new Error("latest.json should not be requested");
+                    }
+
+                    if (url.endsWith(`/${releasePlatform}/${process.platform === "win32" ? "oo.exe" : "oo"}`)) {
+                        return new Response("binary");
+                    }
+
+                    throw new Error(`Unexpected request: ${url}`);
+                },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
+                version: "1.0.0",
+            });
+
+            expect(createSelfUpdateInstallSnapshot(result, sandbox)).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: `Installed oo 2.0.0.\nExecutable: <EXECUTABLE_PATH>\nAdd <HOME>/.local/bin to PATH to run oo in new shells.\n`,
+            });
+            expect(selfUpdateRuntime.configurePathCallCount()).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("install prints a setup note when automatic PATH configuration fails", async () => {
+        const sandbox = await createCliSandbox();
+        const releasePlatform = await detectSelfUpdateReleasePlatform({
+            arch: process.arch,
+            platform: process.platform,
+        });
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime(undefined, {
+            pathConfigured: false,
+        });
+
+        try {
+            const result = await sandbox.run(["install", "2.0.0"], {
+                fetcher: async (input, init) => {
+                    const url = toRequest(input, init).url;
+
+                    if (url.endsWith("/latest.json")) {
+                        throw new Error("latest.json should not be requested");
+                    }
+
+                    if (url.endsWith(`/${releasePlatform}/${process.platform === "win32" ? "oo.exe" : "oo"}`)) {
+                        return new Response("binary");
+                    }
+
+                    throw new Error(`Unexpected request: ${url}`);
+                },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
+                version: "1.0.0",
+            });
+
+            expect(createSelfUpdateInstallSnapshot(result, sandbox)).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: `Installed oo 2.0.0.\nExecutable: <EXECUTABLE_PATH>\nAdd <HOME>/.local/bin to PATH to run oo in new shells.\n`,
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("install silently refreshes bundled skills with the target version executable", async () => {
         const sandbox = await createCliSandbox();
         const releasePlatform = await detectSelfUpdateReleasePlatform({
@@ -154,7 +274,7 @@ describe("self-update commands", () => {
             expect(createSelfUpdateInstallSnapshot(result, sandbox)).toEqual({
                 exitCode: 0,
                 stderr: "",
-                stdout: `Installed oo 2.0.0.\nExecutable: <EXECUTABLE_PATH>\nAdd <HOME>/.local/bin to PATH to run oo in new shells.\n`,
+                stdout: `Installed oo 2.0.0.\nExecutable: <EXECUTABLE_PATH>\nAdded <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.\n`,
             });
             expect(selfUpdateRuntime.commands).toEqual([
                 {
@@ -298,10 +418,10 @@ describe("self-update commands", () => {
                 version: "1.0.0",
             });
 
-            expect(createCliSnapshot(result)).toEqual({
+            expect(createCliSnapshot(result, { sandbox })).toEqual({
                 exitCode: 0,
                 stderr: "",
-                stdout: "Updated oo from 1.0.0 to 2.0.0.\n",
+                stdout: "Updated oo from 1.0.0 to 2.0.0.\nAdded <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.\n",
             });
             expect(selfUpdateRuntime.commands).toEqual([
                 {
@@ -310,6 +430,132 @@ describe("self-update commands", () => {
                     timeoutMs: 10_000,
                 },
             ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("update does not touch PATH when OO_NO_MODIFY_PATH is set", async () => {
+        const sandbox = await createCliSandbox();
+        const releasePlatform = await detectSelfUpdateReleasePlatform({
+            arch: process.arch,
+            platform: process.platform,
+        });
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime();
+
+        sandbox.env.OO_NO_MODIFY_PATH = "yes";
+
+        try {
+            const result = await sandbox.run(["update"], {
+                fetcher: async (input, init) => {
+                    const url = toRequest(input, init).url;
+
+                    if (url.endsWith("/latest.json")) {
+                        return new Response(JSON.stringify({
+                            version: "2.0.0",
+                        }));
+                    }
+
+                    if (url.endsWith(`/${releasePlatform}/${process.platform === "win32" ? "oo.exe" : "oo"}`)) {
+                        return new Response("binary");
+                    }
+
+                    throw new Error(`Unexpected request: ${url}`);
+                },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
+                version: "1.0.0",
+            });
+
+            expect(createCliSnapshot(result, { sandbox })).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: "Updated oo from 1.0.0 to 2.0.0.\nAdd <HOME>/.local/bin to PATH to run oo in new shells.\n",
+            });
+            expect(selfUpdateRuntime.configurePathCallCount()).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("update does not touch PATH when --no-modify-path is passed", async () => {
+        const sandbox = await createCliSandbox();
+        const releasePlatform = await detectSelfUpdateReleasePlatform({
+            arch: process.arch,
+            platform: process.platform,
+        });
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime();
+
+        try {
+            const result = await sandbox.run(["update", "--no-modify-path"], {
+                fetcher: async (input, init) => {
+                    const url = toRequest(input, init).url;
+
+                    if (url.endsWith("/latest.json")) {
+                        return new Response(JSON.stringify({
+                            version: "2.0.0",
+                        }));
+                    }
+
+                    if (url.endsWith(`/${releasePlatform}/${process.platform === "win32" ? "oo.exe" : "oo"}`)) {
+                        return new Response("binary");
+                    }
+
+                    throw new Error(`Unexpected request: ${url}`);
+                },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
+                version: "1.0.0",
+            });
+
+            expect(createCliSnapshot(result, { sandbox })).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: "Updated oo from 1.0.0 to 2.0.0.\nAdd <HOME>/.local/bin to PATH to run oo in new shells.\n",
+            });
+            expect(selfUpdateRuntime.configurePathCallCount()).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("update prints a setup note when automatic PATH configuration fails", async () => {
+        const sandbox = await createCliSandbox();
+        const releasePlatform = await detectSelfUpdateReleasePlatform({
+            arch: process.arch,
+            platform: process.platform,
+        });
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime(undefined, {
+            pathConfigured: false,
+        });
+
+        try {
+            const result = await sandbox.run(["update"], {
+                fetcher: async (input, init) => {
+                    const url = toRequest(input, init).url;
+
+                    if (url.endsWith("/latest.json")) {
+                        return new Response(JSON.stringify({
+                            version: "2.0.0",
+                        }));
+                    }
+
+                    if (url.endsWith(`/${releasePlatform}/${process.platform === "win32" ? "oo.exe" : "oo"}`)) {
+                        return new Response("binary");
+                    }
+
+                    throw new Error(`Unexpected request: ${url}`);
+                },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
+                version: "1.0.0",
+            });
+
+            expect(createCliSnapshot(result, { sandbox })).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: "Updated oo from 1.0.0 to 2.0.0.\nAdd <HOME>/.local/bin to PATH to run oo in new shells.\n",
+            });
         }
         finally {
             await sandbox.cleanup();
@@ -361,10 +607,10 @@ describe("self-update commands", () => {
                 version: "1.2.3",
             });
 
-            expect(createCliSnapshot(result)).toEqual({
+            expect(createCliSnapshot(result, { sandbox })).toEqual({
                 exitCode: 0,
                 stderr: "",
-                stdout: "Already up to date at 1.2.3.\n",
+                stdout: "Already up to date at 1.2.3.\nAdded <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.\n",
             });
             expect(latestRequestCount).toBe(1);
             expect(binaryRequestCount).toBe(0);
@@ -417,10 +663,10 @@ describe("self-update commands", () => {
                 version: "1.2.3",
             });
 
-            expect(createCliSnapshot(result)).toEqual({
+            expect(createCliSnapshot(result, { sandbox })).toEqual({
                 exitCode: 0,
                 stderr: "",
-                stdout: "Already up to date at 1.2.3.\n",
+                stdout: "Already up to date at 1.2.3.\nAdded <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.\n",
             });
             expect(binaryRequestCount).toBe(1);
         }
@@ -472,7 +718,7 @@ describe("self-update commands", () => {
                 version: "1.2.3",
             });
 
-            expect(createCliSnapshot(result)).toMatchSnapshot();
+            expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             expect(binaryRequestCount).toBe(1);
             expect(legacyCleanup.commands).toEqual([
                 {
@@ -576,8 +822,12 @@ function createCapturedSelfUpdateRuntime(commandResult?: {
     signalCode?: NodeJS.Signals | null;
     stderr?: string;
     stdout?: string;
-}): {
+}, options: {
+    pathConfigurationTarget?: readonly string[];
+    pathConfigured?: boolean;
+} = {}): {
     commands: CapturedSelfUpdateCommand[];
+    configurePathCallCount: () => number;
     runtime: NonNullable<CliRunOptions["selfUpdateRuntime"]>;
 } {
     const commands: CapturedSelfUpdateCommand[] = [];
@@ -588,10 +838,21 @@ function createCapturedSelfUpdateRuntime(commandResult?: {
         stdout: "",
         ...commandResult,
     };
+    let configurePathCalls = 0;
 
     return {
         commands,
+        configurePathCallCount: () => configurePathCalls,
         runtime: {
+            configurePath: async () => {
+                configurePathCalls += 1;
+                return options.pathConfigured === false
+                    ? { status: "failed" }
+                    : {
+                            status: "configured",
+                            target: options.pathConfigurationTarget ?? ["shell profile"],
+                        };
+            },
             resolveCommandPath: commandName => `/mock/bin/${commandName}`,
             runCommand: async (options) => {
                 commands.push({

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -30,31 +30,32 @@ exports[`skills CLI does not auto-install bundled skills during cli startup 1`] 
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version             Show the current version
+  --debug                   Print the current log file path when the CLI exits
+  --lang <lang>             Specify the display language
+  -h, --help                Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  connector                Manage connector actions
-  file                     Manage temporary file transfers
-  login                    Log in with device login (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  search [options] <text>  Search packages and connector actions
-  packages                 Package utilities
-  update|upgrade           Update the CLI
-  help [command]           Show help for a command
+  auth                      Manage CLI authentication
+  check-update              Check for CLI updates
+  cloud-task                Manage cloud tasks
+  connector                 Manage connector actions
+  file                      Manage temporary file transfers
+  login                     Log in with device login (alias for auth login)
+  logout                    Log out the current account (alias for auth logout)
+  completion <shell>        Generate shell completion scripts
+  config                    Manage persisted configuration
+  skills                    Manage Codex skills
+  log                       Manage persisted debug logs
+  search [options] <text>   Search packages and connector actions
+  packages                  Package utilities
+  update|upgrade [options]  Update the CLI
+  help [command]            Show help for a command
 "
 ,
 }
 `;
+
 exports[`skills CLI does not auto-refresh installed bundled skills during cli startup 1`] = `
 {
   "exitCode": 0,
@@ -63,27 +64,27 @@ exports[`skills CLI does not auto-refresh installed bundled skills during cli st
 "oo is OOMOL's CLI toolkit. Everything can be done in the CLI.
 
 Options:
-  -V, --version            Show the current version
-  --debug                  Print the current log file path when the CLI exits
-  --lang <lang>            Specify the display language
-  -h, --help               Show help for command
+  -V, --version             Show the current version
+  --debug                   Print the current log file path when the CLI exits
+  --lang <lang>             Specify the display language
+  -h, --help                Show help for command
 
 Commands:
-  auth                     Manage CLI authentication
-  check-update             Check for CLI updates
-  cloud-task               Manage cloud tasks
-  connector                Manage connector actions
-  file                     Manage temporary file transfers
-  login                    Log in with device login (alias for auth login)
-  logout                   Log out the current account (alias for auth logout)
-  completion <shell>       Generate shell completion scripts
-  config                   Manage persisted configuration
-  skills                   Manage Codex skills
-  log                      Manage persisted debug logs
-  search [options] <text>  Search packages and connector actions
-  packages                 Package utilities
-  update|upgrade           Update the CLI
-  help [command]           Show help for a command
+  auth                      Manage CLI authentication
+  check-update              Check for CLI updates
+  cloud-task                Manage cloud tasks
+  connector                 Manage connector actions
+  file                      Manage temporary file transfers
+  login                     Log in with device login (alias for auth login)
+  logout                    Log out the current account (alias for auth logout)
+  completion <shell>        Generate shell completion scripts
+  config                    Manage persisted configuration
+  skills                    Manage Codex skills
+  log                       Manage persisted debug logs
+  search [options] <text>   Search packages and connector actions
+  packages                  Package utilities
+  update|upgrade [options]  Update the CLI
+  help [command]            Show help for a command
 "
 ,
 }

--- a/src/application/commands/update.ts
+++ b/src/application/commands/update.ts
@@ -7,22 +7,43 @@ import {
     resolveBundledSkillRefreshCommandPath,
 } from "../self-update/bundled-skills.ts";
 import {
+    ensureSelfUpdateExecutableDirectoryOnPath,
     performSelfUpdateOperation,
     renderSelfUpdateLockBusyMessage,
     resolveLatestSelfUpdateVersion,
     selfUpdateDevelopmentVersion,
 } from "../self-update/core.ts";
 import { detectInstallationMethodFromExecPath } from "../self-update/installation.ts";
+import { resolveSelfUpdateModifyPath } from "../self-update/modify-path-preference.ts";
+import { writeSelfUpdatePathNoteIfNeeded } from "./self-update-output.ts";
 import { SelfUpdateProgressReporter } from "./self-update-progress.ts";
 import { writeLine } from "./shared/output.ts";
 
-export const updateCommand: CliCommandDefinition = {
+const updateCommandInputSchema = z.object({
+    modifyPath: z.boolean().default(true),
+});
+
+export const updateCommand: CliCommandDefinition<
+    z.infer<typeof updateCommandInputSchema>
+> = {
     name: "update",
     aliases: ["upgrade"],
     summaryKey: "commands.update.summary",
     descriptionKey: "commands.update.description",
-    inputSchema: z.object({}),
-    handler: async (_, context) => {
+    options: [
+        {
+            name: "modifyPath",
+            longFlag: "--no-modify-path",
+            descriptionKey: "options.noModifyPath",
+        },
+    ],
+    inputSchema: updateCommandInputSchema,
+    handler: async (input, context) => {
+        const effectiveModifyPath = resolveSelfUpdateModifyPath({
+            env: context.env,
+            modifyPathFlag: input.modifyPath,
+        });
+
         if (context.version === selfUpdateDevelopmentVersion) {
             writeLine(
                 context.stdout,
@@ -73,6 +94,16 @@ export const updateCommand: CliCommandDefinition = {
                         ...context.selfUpdateRuntime,
                     },
                 });
+                const { executableDirectory, pathConfiguration }
+                    = await ensureSelfUpdateExecutableDirectoryOnPath({
+                        modifyPath: effectiveModifyPath,
+                        runtime: {
+                            env: context.env,
+                            logger: context.logger,
+                            platform: process.platform,
+                            ...context.selfUpdateRuntime,
+                        },
+                    });
                 progressReporter?.finish();
                 writeLine(
                     context.stdout,
@@ -80,12 +111,19 @@ export const updateCommand: CliCommandDefinition = {
                         version: context.version,
                     }),
                 );
+                writeSelfUpdatePathNoteIfNeeded({
+                    executableDirectory,
+                    pathConfiguration,
+                    stdout: context.stdout,
+                    translator: context.translator,
+                });
                 return;
             }
 
             const result = await performSelfUpdateOperation({
                 currentVersion: context.version,
                 forceReinstall: true,
+                modifyPath: effectiveModifyPath,
                 reportStage: progressReporter?.createReportStage(),
                 runtime: {
                     arch: process.arch,
@@ -121,6 +159,12 @@ export const updateCommand: CliCommandDefinition = {
                         version: context.version,
                     }),
                 );
+                writeSelfUpdatePathNoteIfNeeded({
+                    executableDirectory: result.executableDirectory,
+                    pathConfiguration: result.pathConfiguration,
+                    stdout: context.stdout,
+                    translator: context.translator,
+                });
                 return;
             }
 
@@ -131,6 +175,12 @@ export const updateCommand: CliCommandDefinition = {
                     version: latestVersion,
                 }),
             );
+            writeSelfUpdatePathNoteIfNeeded({
+                executableDirectory: result.executableDirectory,
+                pathConfiguration: result.pathConfiguration,
+                stdout: context.stdout,
+                translator: context.translator,
+            });
         }
         catch (error) {
             progressReporter?.abort();

--- a/src/application/contracts/self-update.ts
+++ b/src/application/contracts/self-update.ts
@@ -20,11 +20,24 @@ export interface SelfUpdatePathConfigurationOptions {
 }
 
 export interface SelfUpdatePathConfigurationResult {
-    status: "already-configured" | "configured" | "failed" | "skipped";
+    status:
+        | "already-configured"
+        | "configured"
+        | "failed"
+        | "partial-configured"
+        | "skipped";
     target?: readonly string[];
+    failedTargets?: readonly string[];
 }
 
 export interface SelfUpdateRuntimeOverrides {
+    /**
+     * Gates the Windows HKCU\Environment registry write. Must be true for the
+     * real user environment to be touched; defaults to false so test sandboxes
+     * never mutate the host registry by accident. Production wiring flips it
+     * to true at the CLI entry point.
+     */
+    allowWindowsRegistryWrite?: boolean;
     configurePath?: (
         options: SelfUpdatePathConfigurationOptions,
     ) => Promise<SelfUpdatePathConfigurationResult>;

--- a/src/application/contracts/self-update.ts
+++ b/src/application/contracts/self-update.ts
@@ -12,7 +12,22 @@ export interface SelfUpdateCommandRunResult {
     stdout: string;
 }
 
+export interface SelfUpdatePathConfigurationOptions {
+    env: Record<string, string | undefined>;
+    executableDirectory: string;
+    modifyPath?: boolean;
+    platform: NodeJS.Platform;
+}
+
+export interface SelfUpdatePathConfigurationResult {
+    status: "already-configured" | "configured" | "failed" | "skipped";
+    target?: readonly string[];
+}
+
 export interface SelfUpdateRuntimeOverrides {
+    configurePath?: (
+        options: SelfUpdatePathConfigurationOptions,
+    ) => Promise<SelfUpdatePathConfigurationResult>;
     resolveCommandPath?: (commandName: string) => string | null;
     runCommand?: (
         options: SelfUpdateCommandRunOptions,

--- a/src/application/self-update/core.ts
+++ b/src/application/self-update/core.ts
@@ -1,9 +1,10 @@
 import type { Logger } from "pino";
 import type { CliExecutionContext, Fetcher } from "../contracts/cli.ts";
+import type { SelfUpdatePathConfigurationResult } from "../contracts/self-update.ts";
 import type { LegacyPackageManagerCleanupRuntime } from "./legacy-installation.ts";
 import type { SelfUpdateProgressEvent } from "./progress.ts";
 import { chmod, copyFile, lstat, mkdir, open, readdir, readlink, realpath, rename, rm, stat, symlink } from "node:fs/promises";
-import { basename, delimiter, dirname, isAbsolute, join, normalize, relative, resolve as resolvePath, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, normalize, relative, sep } from "node:path";
 import process from "node:process";
 import { APP_NAME } from "../config/app-config.ts";
 import { CliUserError } from "../contracts/cli.ts";
@@ -23,6 +24,7 @@ import {
     cleanupStaleVersionLocks,
     listActiveVersionLocks,
 } from "./lock.ts";
+import { ensureExecutableDirectoryOnPath } from "./path-configuration.ts";
 import {
     resolveSelfUpdateLockFilePath,
     resolveSelfUpdatePaths,
@@ -54,7 +56,7 @@ export const selfUpdateReleaseRequestTimeoutMs = 10_000;
 export interface SelfUpdateOperationResult {
     executableDirectory: string;
     executablePath: string;
-    pathConfigured: boolean;
+    pathConfiguration: SelfUpdatePathConfigurationResult;
     releasePlatform: string;
     status: "installed";
     targetVersion: string;
@@ -94,6 +96,7 @@ export async function resolveLatestSelfUpdateVersion(options: {
 export async function performSelfUpdateOperation(options: {
     currentVersion: string;
     forceReinstall: boolean;
+    modifyPath?: boolean;
     reportStage?: (event: SelfUpdateProgressEvent) => void;
     runtime: SelfUpdateRuntime;
     targetVersion: string;
@@ -155,8 +158,7 @@ export async function performSelfUpdateOperation(options: {
             timestamp: (options.runtime.now ?? Date.now)(),
         });
 
-        const pathConfigured = await verifyInstalledEntrypoint({
-            env: options.runtime.env,
+        await verifyInstalledEntrypoint({
             paths,
             platform: options.runtime.platform,
             reportStage: options.reportStage,
@@ -182,11 +184,15 @@ export async function performSelfUpdateOperation(options: {
             runtime: options.runtime,
         });
         await attemptLegacyPackageManagerUninstall(options.runtime);
+        const { pathConfiguration } = await ensureSelfUpdateExecutableDirectoryOnPath({
+            modifyPath: options.modifyPath,
+            runtime: options.runtime,
+        });
 
         return {
             executableDirectory: paths.executableDirectory,
             executablePath: paths.executablePath,
-            pathConfigured,
+            pathConfiguration,
             releasePlatform,
             status: "installed",
             targetVersion: options.targetVersion,
@@ -195,6 +201,31 @@ export async function performSelfUpdateOperation(options: {
     finally {
         await lockResult.handle.close();
     }
+}
+
+export async function ensureSelfUpdateExecutableDirectoryOnPath(options: {
+    modifyPath?: boolean;
+    runtime: Pick<SelfUpdateRuntime, "configurePath" | "env" | "logger" | "platform" | "resolveCommandPath" | "runCommand">;
+}): Promise<{
+    executableDirectory: string;
+    pathConfiguration: SelfUpdatePathConfigurationResult;
+}> {
+    const paths = resolveSelfUpdatePaths({
+        env: options.runtime.env,
+        platform: options.runtime.platform,
+    });
+    const pathConfiguration = await ensureExecutableDirectoryOnPath({
+        env: options.runtime.env,
+        executableDirectory: paths.executableDirectory,
+        modifyPath: options.modifyPath,
+        platform: options.runtime.platform,
+        runtime: options.runtime,
+    });
+
+    return {
+        executableDirectory: paths.executableDirectory,
+        pathConfiguration,
+    };
 }
 
 export async function initializeCurrentVersionProcessLock(options: {
@@ -731,12 +762,11 @@ async function restoreWindowsExecutableBackup(options: {
 }
 
 async function verifyInstalledEntrypoint(options: {
-    env: Record<string, string | undefined>;
     paths: ReturnType<typeof resolveSelfUpdatePaths>;
     platform: NodeJS.Platform;
     reportStage?: (event: SelfUpdateProgressEvent) => void;
     targetVersion: string;
-}): Promise<boolean> {
+}): Promise<void> {
     const targetVersionPath = resolveSelfUpdateVersionFilePath(
         options.paths,
         options.targetVersion,
@@ -809,12 +839,6 @@ async function verifyInstalledEntrypoint(options: {
             });
         }
     }
-
-    return isExecutableDirectoryOnPath(
-        options.paths.executableDirectory,
-        options.env,
-        options.platform,
-    );
 }
 
 async function cleanupSelfUpdateArtifacts(options: {
@@ -951,45 +975,6 @@ async function cleanupWindowsExecutableBackups(
         },
         "CLI self-update executable-backup cleanup completed.",
     );
-}
-
-function isExecutableDirectoryOnPath(
-    executableDirectory: string,
-    env: Record<string, string | undefined>,
-    platform: NodeJS.Platform,
-): boolean {
-    const pathValue = platform === "win32"
-        ? env.Path ?? env.PATH
-        : env.PATH;
-
-    if (!pathValue) {
-        return false;
-    }
-
-    const normalizedExecutableDirectory = normalizePathForComparison(
-        executableDirectory,
-        platform,
-    );
-
-    return pathValue
-        .split(delimiter)
-        .some(segment =>
-            normalizePathForComparison(segment, platform)
-            === normalizedExecutableDirectory,
-        );
-}
-
-function normalizePathForComparison(
-    value: string,
-    platform: NodeJS.Platform,
-): string {
-    const resolvedValue = normalize(
-        isAbsolute(value) ? value : resolvePath(value),
-    );
-
-    return platform === "win32"
-        ? resolvedValue.toLowerCase()
-        : resolvedValue;
 }
 
 async function readDirectoryEntries(path: string): Promise<string[]> {

--- a/src/application/self-update/modify-path-preference.test.ts
+++ b/src/application/self-update/modify-path-preference.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import {
+    resolveSelfUpdateModifyPath,
+    selfUpdateNoModifyPathEnvName,
+} from "./modify-path-preference.ts";
+
+describe("resolveSelfUpdateModifyPath", () => {
+    test("modifies PATH by default when neither flag nor env disables it", () => {
+        expect(resolveSelfUpdateModifyPath({
+            env: {},
+            modifyPathFlag: true,
+        })).toBeTrue();
+    });
+
+    test("skips PATH modification when --no-modify-path is passed", () => {
+        expect(resolveSelfUpdateModifyPath({
+            env: {},
+            modifyPathFlag: false,
+        })).toBeFalse();
+    });
+
+    test("skips PATH modification when OO_NO_MODIFY_PATH is truthy", () => {
+        for (const value of ["1", "true", "YES"]) {
+            expect(resolveSelfUpdateModifyPath({
+                env: { [selfUpdateNoModifyPathEnvName]: value },
+                modifyPathFlag: true,
+            })).toBeFalse();
+        }
+    });
+
+    test("keeps modifying PATH when OO_NO_MODIFY_PATH is falsy or unrecognized", () => {
+        for (const value of ["0", "false", "no", "", "maybe"]) {
+            expect(resolveSelfUpdateModifyPath({
+                env: { [selfUpdateNoModifyPathEnvName]: value },
+                modifyPathFlag: true,
+            })).toBeTrue();
+        }
+    });
+
+    test("flag and env combine with OR semantics for skipping", () => {
+        expect(resolveSelfUpdateModifyPath({
+            env: { [selfUpdateNoModifyPathEnvName]: "1" },
+            modifyPathFlag: false,
+        })).toBeFalse();
+    });
+});

--- a/src/application/self-update/modify-path-preference.ts
+++ b/src/application/self-update/modify-path-preference.ts
@@ -1,0 +1,14 @@
+import { readEnvBoolean } from "../shared/env-boolean.ts";
+
+export const selfUpdateNoModifyPathEnvName = "OO_NO_MODIFY_PATH";
+
+export function resolveSelfUpdateModifyPath(options: {
+    env: Record<string, string | undefined>;
+    modifyPathFlag: boolean;
+}): boolean {
+    if (!options.modifyPathFlag) {
+        return false;
+    }
+
+    return readEnvBoolean(options.env[selfUpdateNoModifyPathEnvName]) !== true;
+}

--- a/src/application/self-update/path-configuration.test.ts
+++ b/src/application/self-update/path-configuration.test.ts
@@ -1,5 +1,5 @@
 import type { SelfUpdateCommandRunOptions } from "../contracts/self-update.ts";
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { posix, win32 } from "node:path";
 import process from "node:process";
 import { describe, expect, test } from "bun:test";
@@ -505,6 +505,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
                 executableDirectory,
                 platform: "win32",
                 runtime: {
+                    allowWindowsRegistryWrite: true,
                     env: process.env,
                     logger: logCapture.logger,
                     platform: "win32",
@@ -546,6 +547,89 @@ describe("ensureExecutableDirectoryOnPath", () => {
             expect(commandText).not.toContain(
                 "[Environment]::SetEnvironmentVariable('Path'",
             );
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("returns partial-configured when some profiles succeed and others fail", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-partial");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const zshrcPath = posix.join(homeDirectory, ".zshrc");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/bin/zsh",
+        };
+
+        trackDirectory(rootDirectory);
+        // Put a directory where .zshenv would be written so writeFile errors
+        // with EISDIR while .zshrc still succeeds.
+        await mkdir(zshenvPath, { recursive: true });
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "zsh" ? "/mock/bin/zsh" : null,
+                },
+            });
+
+            expect(result).toEqual({
+                status: "partial-configured",
+                target: [zshrcPath],
+                failedTargets: [zshenvPath],
+            });
+            await expect(Bun.file(zshrcPath).exists()).resolves.toBeTrue();
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("returns failed with failedTargets when every write fails", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-all-failed");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const zshrcPath = posix.join(homeDirectory, ".zshrc");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/bin/zsh",
+        };
+
+        trackDirectory(rootDirectory);
+        await mkdir(zshrcPath, { recursive: true });
+        await mkdir(zshenvPath, { recursive: true });
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "zsh" ? "/mock/bin/zsh" : null,
+                },
+            });
+
+            expect(result.status).toBe("failed");
+            expect(result.failedTargets).toEqual([zshrcPath, zshenvPath]);
         }
         finally {
             logCapture.close();
@@ -623,8 +707,8 @@ describe("ensureExecutableDirectoryOnPath", () => {
         }
     });
 
-    test("does not run Windows user PATH commands for sandboxed environments", async () => {
-        const rootDirectory = await createTemporaryDirectory("oo-path-win-sandbox");
+    test("skips Windows registry write when allowWindowsRegistryWrite is not set", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-win-no-flag");
         const executableDirectory = win32.join(rootDirectory, ".local", "bin");
         const logCapture = createLogCapture();
         const env = {
@@ -652,6 +736,54 @@ describe("ensureExecutableDirectoryOnPath", () => {
             expect(result).toEqual({
                 status: "failed",
             });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("runs the Windows registry write even when env is a cloned (non-identity) object", async () => {
+        // Regression for the old `options.env !== process.env` guard: a caller
+        // that innocently clones env (e.g. `{ ...process.env, DEBUG: "1" }`)
+        // must still be able to write the registry when explicitly allowed.
+        const rootDirectory = await createTemporaryDirectory("oo-path-win-cloned-env");
+        const executableDirectory = win32.join(rootDirectory, ".local", "bin");
+        const logCapture = createLogCapture();
+        const clonedEnv = { ...process.env };
+        const commands: SelfUpdateCommandRunOptions[] = [];
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env: clonedEnv,
+                executableDirectory,
+                platform: "win32",
+                runtime: {
+                    allowWindowsRegistryWrite: true,
+                    env: clonedEnv,
+                    logger: logCapture.logger,
+                    platform: "win32",
+                    resolveCommandPath: commandName =>
+                        commandName === "powershell.exe"
+                            ? "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+                            : null,
+                    runCommand: async (runOptions) => {
+                        commands.push(runOptions);
+                        return {
+                            exitCode: 0,
+                            signalCode: null,
+                            stderr: "",
+                            stdout: "",
+                        };
+                    },
+                },
+            });
+
+            expect(clonedEnv).not.toBe(process.env);
+            expect(result.status).toBe("configured");
+            expect(commands).toHaveLength(1);
+            expect(commands[0]!.env.OO_SELF_UPDATE_PATH_ENTRY).toBe(executableDirectory);
         }
         finally {
             logCapture.close();

--- a/src/application/self-update/path-configuration.test.ts
+++ b/src/application/self-update/path-configuration.test.ts
@@ -1,0 +1,707 @@
+import type { SelfUpdateCommandRunOptions } from "../contracts/self-update.ts";
+import { readFile } from "node:fs/promises";
+import { posix, win32 } from "node:path";
+import process from "node:process";
+import { describe, expect, test } from "bun:test";
+import {
+    createLogCapture,
+    createTemporaryDirectory,
+    useTemporaryDirectoryCleanup,
+} from "../../../__tests__/helpers.ts";
+import {
+    ensureExecutableDirectoryOnPath,
+    isExecutableDirectoryOnPath,
+} from "./path-configuration.ts";
+
+const { track: trackDirectory } = useTemporaryDirectoryCleanup();
+
+describe("ensureExecutableDirectoryOnPath", () => {
+    test("writes zsh profile PATH setup when the executable directory is missing from PATH", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-zsh");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const zshrcPath = posix.join(homeDirectory, ".zshrc");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/bin/zsh",
+        };
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "zsh" ? "/mock/bin/zsh" : null,
+                },
+            });
+
+            expect(result).toEqual({
+                status: "configured",
+                target: [zshrcPath, zshenvPath],
+            });
+            const expectedSnippet = [
+                "# Added by oo CLI",
+                "case \":$PATH:\" in",
+                "    *\":$HOME/.local/bin:\"*) ;;",
+                "    *) export PATH=\"$HOME/.local/bin:$PATH\" ;;",
+                "esac",
+                "",
+            ].join("\n");
+
+            expect(await readFile(zshrcPath, "utf8")).toBe(expectedSnippet);
+            expect(await readFile(zshenvPath, "utf8")).toBe(expectedSnippet);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("writes the macOS zsh login profile and .zshenv", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-darwin-zsh");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/bin/zsh",
+        };
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "darwin",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "darwin",
+                    resolveCommandPath: commandName =>
+                        commandName === "zsh" ? "/mock/bin/zsh" : null,
+                },
+            });
+
+            expect(result.target).toEqual([zprofilePath, zshenvPath]);
+            expect(await readFile(zprofilePath, "utf8")).toContain(
+                "# Added by oo CLI\n",
+            );
+            expect(await readFile(zshenvPath, "utf8")).toContain(
+                "# Added by oo CLI\n",
+            );
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("writes every installed Unix shell profile", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-multi-shell");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const configHomeDirectory = posix.join(homeDirectory, "xdg");
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const zshProfilePath = posix.join(homeDirectory, ".zshrc");
+        const bashProfilePath = posix.join(homeDirectory, ".bashrc");
+        const fishProfilePath = posix.join(configHomeDirectory, "fish", "conf.d", "oo.fish");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/bin/zsh",
+            XDG_CONFIG_HOME: configHomeDirectory,
+        };
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        ["bash", "fish"].includes(commandName)
+                            ? `/mock/bin/${commandName}`
+                            : null,
+                },
+            });
+
+            const zshenvPath = posix.join(homeDirectory, ".zshenv");
+            const profilePath = posix.join(homeDirectory, ".profile");
+
+            expect(result).toEqual({
+                status: "configured",
+                target: [
+                    zshProfilePath,
+                    zshenvPath,
+                    bashProfilePath,
+                    profilePath,
+                    fishProfilePath,
+                ],
+            });
+            await expect(Bun.file(zshProfilePath).exists()).resolves.toBeTrue();
+            await expect(Bun.file(zshenvPath).exists()).resolves.toBeTrue();
+            await expect(Bun.file(bashProfilePath).exists()).resolves.toBeTrue();
+            await expect(Bun.file(profilePath).exists()).resolves.toBeTrue();
+            await expect(Bun.file(fishProfilePath).exists()).resolves.toBeTrue();
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("writes fish config once when the executable directory is missing from PATH", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-fish");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const configHomeDirectory = posix.join(homeDirectory, "xdg");
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const profilePath = posix.join(configHomeDirectory, "fish", "conf.d", "oo.fish");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/usr/bin/fish",
+            XDG_CONFIG_HOME: configHomeDirectory,
+        };
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const firstResult = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "fish" ? "/mock/bin/fish" : null,
+                },
+            });
+            const secondResult = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "fish" ? "/mock/bin/fish" : null,
+                },
+            });
+            const profileContent = await readFile(profilePath, "utf8");
+
+            expect(firstResult.status).toBe("configured");
+            expect(secondResult).toEqual({
+                status: "already-configured",
+                target: [profilePath],
+            });
+            expect(countOccurrences(
+                profileContent,
+                `    fish_add_path "$HOME/.local/bin"`,
+            )).toBe(1);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("uses an existing bash profile before creating the platform-preferred fallback", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-bash");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const bashProfilePath = posix.join(homeDirectory, ".bash_profile");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/bin/bash",
+        };
+
+        trackDirectory(rootDirectory);
+        await Bun.write(bashProfilePath, "# existing bash profile\n");
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "bash" ? "/mock/bin/bash" : null,
+                },
+            });
+
+            expect(result.target).toEqual([bashProfilePath]);
+            expect(await readFile(bashProfilePath, "utf8")).toContain(
+                "# existing bash profile\n# Added by oo CLI\n",
+            );
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("bash writes every existing rc file so SSH login and interactive shells both get PATH", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-bash-multi");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const bashrcPath = posix.join(homeDirectory, ".bashrc");
+        const profilePath = posix.join(homeDirectory, ".profile");
+        const bashProfilePath = posix.join(homeDirectory, ".bash_profile");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/bin/bash",
+        };
+
+        trackDirectory(rootDirectory);
+        await Bun.write(bashrcPath, "# existing bashrc\n");
+        await Bun.write(profilePath, "# existing profile\n");
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "bash" ? "/mock/bin/bash" : null,
+                },
+            });
+
+            expect(result.status).toBe("configured");
+            expect(result.target).toEqual([bashrcPath, profilePath]);
+            expect(await readFile(bashrcPath, "utf8")).toContain(
+                "# existing bashrc\n# Added by oo CLI\n",
+            );
+            expect(await readFile(profilePath, "utf8")).toContain(
+                "# existing profile\n# Added by oo CLI\n",
+            );
+            await expect(Bun.file(bashProfilePath).exists()).resolves.toBeFalse();
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("fresh Linux bash fallback creates both .bashrc and .profile so login shells also load PATH", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-bash-none");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const bashrcPath = posix.join(homeDirectory, ".bashrc");
+        const bashProfilePath = posix.join(homeDirectory, ".bash_profile");
+        const profilePath = posix.join(homeDirectory, ".profile");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/bin/bash",
+        };
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "bash" ? "/mock/bin/bash" : null,
+                },
+            });
+
+            // .bashrc covers interactive non-login; .profile covers SSH/login
+            // bash when .bash_profile and .bash_login are absent.
+            expect(result.target).toEqual([bashrcPath, profilePath]);
+            await expect(Bun.file(bashrcPath).exists()).resolves.toBeTrue();
+            await expect(Bun.file(profilePath).exists()).resolves.toBeTrue();
+            await expect(Bun.file(bashProfilePath).exists()).resolves.toBeFalse();
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("fresh macOS bash fallback creates both .bash_profile and .bashrc so nested bash also loads PATH", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-darwin-bash");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const bashProfilePath = posix.join(homeDirectory, ".bash_profile");
+        const bashrcPath = posix.join(homeDirectory, ".bashrc");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/bin/bash",
+        };
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "darwin",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "darwin",
+                    resolveCommandPath: commandName =>
+                        commandName === "bash" ? "/mock/bin/bash" : null,
+                },
+            });
+
+            // .bash_profile covers login (Terminal.app default); .bashrc
+            // covers nested bash and `bash -c` invocations.
+            expect(result.target).toEqual([bashProfilePath, bashrcPath]);
+            expect(await readFile(bashProfilePath, "utf8")).toContain(
+                "# Added by oo CLI\n",
+            );
+            expect(await readFile(bashrcPath, "utf8")).toContain(
+                "# Added by oo CLI\n",
+            );
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("writes a nushell config when nu is the current shell", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-nu");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const configHomeDirectory = posix.join(homeDirectory, "xdg");
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const profilePath = posix.join(
+            configHomeDirectory,
+            "nushell",
+            "config.nu",
+        );
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/usr/bin/nu",
+            XDG_CONFIG_HOME: configHomeDirectory,
+        };
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "nu" ? "/mock/bin/nu" : null,
+                },
+            });
+
+            expect(result.target).toEqual([profilePath]);
+            const profileContent = await readFile(profilePath, "utf8");
+
+            expect(profileContent).toContain("# Added by oo CLI\n");
+            expect(profileContent).toContain(`use std/util "path add"`);
+            expect(profileContent).toContain(
+                `path add ($env.HOME | path join ".local/bin")`,
+            );
+            expect(profileContent).not.toContain("prepend");
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("writes a PowerShell profile for pwsh on Unix platforms", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-pwsh");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const configHomeDirectory = posix.join(homeDirectory, "xdg");
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const profilePath = posix.join(
+            configHomeDirectory,
+            "powershell",
+            "Microsoft.PowerShell_profile.ps1",
+        );
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/usr/bin/pwsh",
+            XDG_CONFIG_HOME: configHomeDirectory,
+        };
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "pwsh" ? "/mock/bin/pwsh" : null,
+                },
+            });
+
+            expect(result.target).toEqual([profilePath]);
+            const profileContent = await readFile(profilePath, "utf8");
+
+            expect(profileContent).toContain("Join-Path $HOME '.local/bin'");
+            expect(profileContent).not.toContain("$ooCliBin");
+            expect(profileContent).not.toContain("[string]::IsNullOrEmpty");
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("runs PowerShell to update the Windows user PATH", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-win");
+        const executableDirectory = win32.join(rootDirectory, ".local", "bin");
+        const logCapture = createLogCapture();
+        const commands: SelfUpdateCommandRunOptions[] = [];
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env: process.env,
+                executableDirectory,
+                platform: "win32",
+                runtime: {
+                    env: process.env,
+                    logger: logCapture.logger,
+                    platform: "win32",
+                    resolveCommandPath: commandName =>
+                        commandName === "powershell.exe"
+                            ? "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+                            : null,
+                    runCommand: async (options) => {
+                        commands.push(options);
+
+                        return {
+                            exitCode: 0,
+                            signalCode: null,
+                            stderr: "",
+                            stdout: "",
+                        };
+                    },
+                },
+            });
+
+            expect(result).toEqual({
+                status: "configured",
+                target: ["Windows user PATH"],
+            });
+            expect(commands).toHaveLength(1);
+            expect(commands[0]!.env.OO_SELF_UPDATE_PATH_ENTRY).toBe(executableDirectory);
+            expect(commands[0]!.commandArguments).toContain("-NoProfile");
+            const commandText = commands[0]!.commandArguments.join("\n");
+
+            expect(commandText).toContain(
+                "[Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)",
+            );
+            expect(commandText).toContain("$key.SetValue('Path', $next, $kind)");
+            expect(commandText).toContain(
+                "[Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames",
+            );
+            expect(commandText).toContain("SendMessageTimeout");
+            expect(commandText).toContain("'Environment'");
+            expect(commandText).not.toContain(
+                "[Environment]::SetEnvironmentVariable('Path'",
+            );
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("returns skipped without writing when modifyPath is false", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-skipped");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const profilePath = posix.join(homeDirectory, ".zshrc");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/bin/zsh",
+        };
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                modifyPath: false,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "zsh" ? "/mock/bin/zsh" : null,
+                },
+            });
+
+            expect(result).toEqual({
+                status: "skipped",
+            });
+            await expect(Bun.file(profilePath).exists()).resolves.toBeFalse();
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("returns already-configured even when modifyPath is false but the directory is present", async () => {
+        const homeDirectory = "/home/demo";
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: `/usr/bin:${executableDirectory}`,
+            SHELL: "/bin/zsh",
+        };
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                modifyPath: false,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                },
+            });
+
+            expect(result).toEqual({
+                status: "already-configured",
+            });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("does not run Windows user PATH commands for sandboxed environments", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-win-sandbox");
+        const executableDirectory = win32.join(rootDirectory, ".local", "bin");
+        const logCapture = createLogCapture();
+        const env = {
+            Path: "C:\\Windows\\System32",
+            USERPROFILE: rootDirectory,
+        };
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "win32",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "win32",
+                    runCommand: async () => {
+                        throw new Error("Windows user PATH command should not run");
+                    },
+                },
+            });
+
+            expect(result).toEqual({
+                status: "failed",
+            });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+});
+
+describe("isExecutableDirectoryOnPath", () => {
+    test("checks Windows Path case-insensitively", () => {
+        expect(isExecutableDirectoryOnPath(
+            "C:\\Users\\Demo\\.local\\bin",
+            {
+                Path: "C:\\WINDOWS\\System32;C:\\USERS\\DEMO\\.LOCAL\\BIN",
+            },
+            "win32",
+        )).toBeTrue();
+    });
+
+    test("ignores trailing separators on POSIX PATH entries", () => {
+        expect(isExecutableDirectoryOnPath(
+            "/home/demo/.local/bin",
+            {
+                PATH: "/usr/bin:/home/demo/.local/bin/",
+            },
+            "linux",
+        )).toBeTrue();
+    });
+
+    test("ignores trailing separators on Windows Path entries with either slash", () => {
+        expect(isExecutableDirectoryOnPath(
+            "C:\\Users\\Demo\\.local\\bin",
+            {
+                Path: "C:\\WINDOWS\\System32;C:\\Users\\Demo\\.local\\bin\\",
+            },
+            "win32",
+        )).toBeTrue();
+        expect(isExecutableDirectoryOnPath(
+            "C:\\Users\\Demo\\.local\\bin",
+            {
+                Path: "C:\\WINDOWS\\System32;C:/Users/Demo/.local/bin/",
+            },
+            "win32",
+        )).toBeTrue();
+    });
+});
+
+function countOccurrences(value: string, searchValue: string): number {
+    return value.split(searchValue).length - 1;
+}
+
+function toPortablePath(path: string): string {
+    return path.replaceAll("\\", "/");
+}

--- a/src/application/self-update/path-configuration.test.ts
+++ b/src/application/self-update/path-configuration.test.ts
@@ -224,11 +224,12 @@ describe("ensureExecutableDirectoryOnPath", () => {
         }
     });
 
-    test("uses an existing bash profile before creating the platform-preferred fallback", async () => {
+    test("creates the bash interactive fallback when only a login profile exists", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-path-bash");
         const homeDirectory = toPortablePath(rootDirectory);
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");
-        const bashProfilePath = posix.join(homeDirectory, ".bash_profile");
+        const bashLoginPath = posix.join(homeDirectory, ".bash_login");
+        const bashrcPath = posix.join(homeDirectory, ".bashrc");
         const logCapture = createLogCapture();
         const env = {
             HOME: homeDirectory,
@@ -237,7 +238,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
         };
 
         trackDirectory(rootDirectory);
-        await Bun.write(bashProfilePath, "# existing bash profile\n");
+        await Bun.write(bashLoginPath, "# existing bash login profile\n");
 
         try {
             const result = await ensureExecutableDirectoryOnPath({
@@ -253,9 +254,55 @@ describe("ensureExecutableDirectoryOnPath", () => {
                 },
             });
 
-            expect(result.target).toEqual([bashProfilePath]);
-            expect(await readFile(bashProfilePath, "utf8")).toContain(
-                "# existing bash profile\n# Added by oo CLI\n",
+            expect(result.target).toEqual([bashLoginPath, bashrcPath]);
+            expect(await readFile(bashLoginPath, "utf8")).toContain(
+                "# existing bash login profile\n# Added by oo CLI\n",
+            );
+            expect(await readFile(bashrcPath, "utf8")).toContain(
+                "# Added by oo CLI\n",
+            );
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("creates the bash login fallback when only .bashrc exists", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-bashrc-only");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const bashrcPath = posix.join(homeDirectory, ".bashrc");
+        const profilePath = posix.join(homeDirectory, ".profile");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/bin/bash",
+        };
+
+        trackDirectory(rootDirectory);
+        await Bun.write(bashrcPath, "# existing bashrc\n");
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "bash" ? "/mock/bin/bash" : null,
+                },
+            });
+
+            expect(result.target).toEqual([bashrcPath, profilePath]);
+            expect(await readFile(bashrcPath, "utf8")).toContain(
+                "# existing bashrc\n# Added by oo CLI\n",
+            );
+            expect(await readFile(profilePath, "utf8")).toContain(
+                "# Added by oo CLI\n",
             );
         }
         finally {
@@ -521,9 +568,11 @@ describe("ensureExecutableDirectoryOnPath", () => {
             expect(result.target).toEqual([profilePath]);
             const profileContent = await readFile(profilePath, "utf8");
 
-            expect(profileContent).toContain("Join-Path $HOME '.local/bin'");
+            expect(profileContent).toContain("$pathEntry = Join-Path $HOME '.local/bin'");
+            expect(profileContent).toContain("[string]::IsNullOrEmpty($env:PATH)");
+            expect(profileContent).toContain("$env:PATH.Split([System.IO.Path]::PathSeparator)");
+            expect(profileContent).not.toContain("$env:Path");
             expect(profileContent).not.toContain("$ooCliBin");
-            expect(profileContent).not.toContain("[string]::IsNullOrEmpty");
         }
         finally {
             logCapture.close();

--- a/src/application/self-update/path-configuration.test.ts
+++ b/src/application/self-update/path-configuration.test.ts
@@ -352,6 +352,45 @@ describe("ensureExecutableDirectoryOnPath", () => {
         }
     });
 
+    test("deduplicates the .profile fallback for unknown shells", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-unknown-shell");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const bashrcPath = posix.join(homeDirectory, ".bashrc");
+        const profilePath = posix.join(homeDirectory, ".profile");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: "/usr/bin",
+            SHELL: "/usr/bin/xonsh",
+        };
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "linux",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "linux",
+                    resolveCommandPath: commandName =>
+                        commandName === "bash" ? "/mock/bin/bash" : null,
+                },
+            });
+
+            expect(result).toEqual({
+                status: "configured",
+                target: [bashrcPath, profilePath],
+            });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
     test("fresh macOS bash fallback creates both .bash_profile and .bashrc so nested bash also loads PATH", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-path-darwin-bash");
         const homeDirectory = toPortablePath(rootDirectory);

--- a/src/application/self-update/path-configuration.ts
+++ b/src/application/self-update/path-configuration.ts
@@ -293,25 +293,26 @@ async function resolveShellProfileConfigurations(
         .map(({ installed, profileExists, shellNames, ...configuration }) =>
             configuration,
         );
+    const profileFallbackPath = pathModule.join(homeDirectory, ".profile");
+    const needsProfileFallback = selectedConfigurations.length === 0
+        || (shellName !== undefined && !knownUnixShellNames.has(shellName));
 
-    if (selectedConfigurations.length === 0) {
-        return [
-            await createShellProfileConfiguration(
-                pathModule.join(homeDirectory, ".profile"),
-                options.platform,
-                createPosixPathSnippet(),
-            ),
-        ];
+    if (!needsProfileFallback) {
+        return selectedConfigurations;
     }
 
-    if (shellName === undefined || knownUnixShellNames.has(shellName)) {
+    // bash candidates may already include ~/.profile as the login-shell
+    // fallback, so skip appending a duplicate entry for the same path.
+    if (selectedConfigurations.some(
+        configuration => configuration.profilePath === profileFallbackPath,
+    )) {
         return selectedConfigurations;
     }
 
     return [
         ...selectedConfigurations,
         await createShellProfileConfiguration(
-            pathModule.join(homeDirectory, ".profile"),
+            profileFallbackPath,
             options.platform,
             createPosixPathSnippet(),
         ),

--- a/src/application/self-update/path-configuration.ts
+++ b/src/application/self-update/path-configuration.ts
@@ -328,9 +328,11 @@ async function createBashProfileCandidates(
     // Writing to every rc file that exists matches what rustup/bun do — the
     // runtime duplicate guard in the snippet keeps PATH clean.
     const pathModule = readPathModule(options.platform);
+    const interactiveProfileName = ".bashrc";
+    const loginProfileNames = [".bash_profile", ".bash_login", ".profile"] as const;
     const profileNames = options.platform === "darwin"
-        ? [".bash_profile", ".bashrc", ".profile"]
-        : [".bashrc", ".bash_profile", ".profile"];
+        ? [".bash_profile", ".bash_login", ".bashrc", ".profile"]
+        : [".bashrc", ".bash_profile", ".bash_login", ".profile"];
     const [installed, ...contents] = await Promise.all([
         isShellCommandAvailable("bash", options.runtime),
         ...profileNames.map(name =>
@@ -338,6 +340,24 @@ async function createBashProfileCandidates(
         ),
     ]);
     const existing: ShellProfileCandidate[] = [];
+    const existingProfileNames = new Set<string>();
+    const createCandidate = (
+        profileName: string,
+        content: string,
+        profileExists: boolean,
+    ): ShellProfileCandidate => {
+        const profilePath = pathModule.join(homeDirectory, profileName);
+
+        return {
+            content,
+            installed,
+            profileDirectory: pathModule.dirname(profilePath),
+            profileExists,
+            profilePath,
+            shellNames: bashShellNames,
+            snippet: createPosixPathSnippet(),
+        };
+    };
 
     for (const [index, profileName] of profileNames.entries()) {
         const content = contents[index];
@@ -346,46 +366,40 @@ async function createBashProfileCandidates(
             continue;
         }
 
-        const profilePath = pathModule.join(homeDirectory, profileName);
-
-        existing.push({
-            content,
-            installed,
-            profileDirectory: pathModule.dirname(profilePath),
-            profileExists: true,
-            profilePath,
-            shellNames: bashShellNames,
-            snippet: createPosixPathSnippet(),
-        });
+        existingProfileNames.add(profileName);
+        existing.push(createCandidate(profileName, content, true));
     }
 
-    if (existing.length > 0) {
+    const hasInteractiveProfile = existingProfileNames.has(interactiveProfileName);
+    const hasLoginProfile = loginProfileNames.some(profileName =>
+        existingProfileNames.has(profileName),
+    );
+
+    if (hasInteractiveProfile && hasLoginProfile) {
         return existing;
     }
 
-    // No bash rc file exists — create a pair that together covers both
-    // login and non-login bash. Without this, a fresh container that only
-    // gets .bashrc would miss SSH login shells (which read .bash_profile /
-    // .bash_login / .profile instead).
+    // Fill in the missing side of bash startup so both login and non-login
+    // shells can see oo, even when the user already has one profile type.
     //   Linux: .bashrc (non-login) + .profile (login fallback)
     //   macOS: .bash_profile (login, Terminal default) + .bashrc (nested)
+    const fallbackLoginProfileName = options.platform === "darwin"
+        ? ".bash_profile"
+        : ".profile";
     const fallbackNames = options.platform === "darwin"
-        ? [".bash_profile", ".bashrc"]
-        : [".bashrc", ".profile"];
+        ? [
+                ...(hasLoginProfile ? [] : [fallbackLoginProfileName]),
+                ...(hasInteractiveProfile ? [] : [interactiveProfileName]),
+            ]
+        : [
+                ...(hasInteractiveProfile ? [] : [interactiveProfileName]),
+                ...(hasLoginProfile ? [] : [fallbackLoginProfileName]),
+            ];
 
-    return fallbackNames.map((profileName) => {
-        const profilePath = pathModule.join(homeDirectory, profileName);
-
-        return {
-            content: "",
-            installed,
-            profileDirectory: pathModule.dirname(profilePath),
-            profileExists: false,
-            profilePath,
-            shellNames: bashShellNames,
-            snippet: createPosixPathSnippet(),
-        };
-    });
+    return [
+        ...existing,
+        ...fallbackNames.map(profileName => createCandidate(profileName, "", false)),
+    ];
 }
 
 async function createShellProfileCandidate(
@@ -485,8 +499,12 @@ function createFishPathSnippet(): string {
 function createPowerShellProfilePathSnippet(): string {
     return [
         pathConfigurationSentinel,
-        `if (-not ($env:Path.Split([System.IO.Path]::PathSeparator) -contains (Join-Path $HOME '.local/bin'))) {`,
-        `    $env:Path = (Join-Path $HOME '.local/bin') + [System.IO.Path]::PathSeparator + $env:Path`,
+        "$pathEntry = Join-Path $HOME '.local/bin'",
+        "if ([string]::IsNullOrEmpty($env:PATH)) {",
+        "    $env:PATH = $pathEntry",
+        "}",
+        "elseif (-not ($env:PATH.Split([System.IO.Path]::PathSeparator) -contains $pathEntry)) {",
+        "    $env:PATH = $pathEntry + [System.IO.Path]::PathSeparator + $env:PATH",
         "}",
         "",
     ].join("\n");

--- a/src/application/self-update/path-configuration.ts
+++ b/src/application/self-update/path-configuration.ts
@@ -1,0 +1,735 @@
+import type { Logger } from "pino";
+import type {
+    SelfUpdatePathConfigurationOptions,
+    SelfUpdatePathConfigurationResult,
+    SelfUpdateRuntimeOverrides,
+} from "../contracts/self-update.ts";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import process from "node:process";
+import { resolveHomeDirectory } from "../path/home-directory.ts";
+import { isFileMissingError } from "../shared/fs-errors.ts";
+import {
+    normalizeLoggedCommandOutput,
+    runSelfUpdateCommand,
+} from "./command-runner.ts";
+import { readPathModule } from "./paths.ts";
+
+interface PathConfigurationRuntime extends SelfUpdateRuntimeOverrides {
+    env: Record<string, string | undefined>;
+    logger: Logger;
+    platform: NodeJS.Platform;
+}
+
+interface EnsureExecutableDirectoryOnPathOptions extends SelfUpdatePathConfigurationOptions {
+    runtime: PathConfigurationRuntime;
+}
+
+interface ShellProfileConfiguration {
+    content: string;
+    profileDirectory: string;
+    profilePath: string;
+    snippet: string;
+}
+
+interface ShellProfileCandidate extends ShellProfileConfiguration {
+    installed: boolean;
+    profileExists: boolean;
+    shellNames: readonly string[];
+}
+
+const pathConfigurationMarker = "Added by oo CLI";
+const pathConfigurationSentinel = `# ${pathConfigurationMarker}`;
+const defaultUnixPathExpression = "$HOME/.local/bin";
+const windowsPathConfigurationTimeoutMs = 10_000;
+const windowsPathEntryEnvName = "OO_SELF_UPDATE_PATH_ENTRY";
+
+const zshShellNames = ["zsh"] as const;
+const bashShellNames = ["bash"] as const;
+const fishShellNames = ["fish"] as const;
+const powerShellShellNames = ["pwsh", "powershell"] as const;
+const nuShellNames = ["nu"] as const;
+const knownUnixShellNames = new Set<string>([
+    ...zshShellNames,
+    ...bashShellNames,
+    ...fishShellNames,
+    ...powerShellShellNames,
+    ...nuShellNames,
+]);
+
+export async function ensureExecutableDirectoryOnPath(
+    options: EnsureExecutableDirectoryOnPathOptions,
+): Promise<SelfUpdatePathConfigurationResult> {
+    if (isExecutableDirectoryOnPath(
+        options.executableDirectory,
+        options.env,
+        options.platform,
+    )) {
+        return {
+            status: "already-configured",
+        };
+    }
+
+    if (options.modifyPath === false) {
+        return {
+            status: "skipped",
+        };
+    }
+
+    const overriddenResult = await options.runtime.configurePath?.({
+        env: options.env,
+        executableDirectory: options.executableDirectory,
+        modifyPath: options.modifyPath,
+        platform: options.platform,
+    });
+
+    if (overriddenResult !== undefined) {
+        return overriddenResult;
+    }
+
+    return options.platform === "win32"
+        ? await configureWindowsUserPath(options)
+        : await configureUnixShellProfile(options);
+}
+
+export function isExecutableDirectoryOnPath(
+    executableDirectory: string,
+    env: Record<string, string | undefined>,
+    platform: NodeJS.Platform,
+): boolean {
+    const pathValue = platform === "win32"
+        ? env.Path ?? env.PATH
+        : env.PATH;
+
+    if (pathValue === undefined || pathValue.trim() === "") {
+        return false;
+    }
+
+    const normalizedExecutableDirectory = normalizePathForComparison(
+        executableDirectory,
+        platform,
+    );
+
+    return pathValue
+        .split(readPathModule(platform).delimiter)
+        .some(segment =>
+            normalizePathForComparison(segment, platform)
+            === normalizedExecutableDirectory,
+        );
+}
+
+async function configureUnixShellProfile(
+    options: EnsureExecutableDirectoryOnPathOptions,
+): Promise<SelfUpdatePathConfigurationResult> {
+    try {
+        const configurations = await resolveShellProfileConfigurations(options);
+        const alreadyConfiguredTargets: string[] = [];
+        const configuredTargets: string[] = [];
+
+        for (const configuration of configurations) {
+            if (configuration.content.includes(pathConfigurationSentinel)) {
+                alreadyConfiguredTargets.push(configuration.profilePath);
+                continue;
+            }
+
+            try {
+                await writeShellProfileConfiguration(configuration);
+                configuredTargets.push(configuration.profilePath);
+                options.runtime.logger.info(
+                    {
+                        executableDirectory: options.executableDirectory,
+                        profilePath: configuration.profilePath,
+                    },
+                    "CLI executable directory was added to the shell profile PATH.",
+                );
+            }
+            catch (error) {
+                options.runtime.logger.warn(
+                    {
+                        err: error,
+                        executableDirectory: options.executableDirectory,
+                        profilePath: configuration.profilePath,
+                    },
+                    "CLI executable directory shell profile PATH configuration failed.",
+                );
+            }
+        }
+
+        if (configuredTargets.length > 0) {
+            return {
+                status: "configured",
+                target: configuredTargets,
+            };
+        }
+
+        if (alreadyConfiguredTargets.length > 0) {
+            return {
+                status: "already-configured",
+                target: alreadyConfiguredTargets,
+            };
+        }
+
+        return {
+            status: "failed",
+        };
+    }
+    catch (error) {
+        options.runtime.logger.warn(
+            {
+                err: error,
+                executableDirectory: options.executableDirectory,
+            },
+            "CLI executable directory shell profile PATH configuration failed.",
+        );
+
+        return {
+            status: "failed",
+        };
+    }
+}
+
+async function resolveShellProfileConfigurations(
+    options: EnsureExecutableDirectoryOnPathOptions,
+): Promise<ShellProfileConfiguration[]> {
+    const homeDirectory = resolveHomeDirectory(options.env);
+    const pathModule = readPathModule(options.platform);
+    const xdgConfigHome = options.env.XDG_CONFIG_HOME
+        ?? pathModule.join(homeDirectory, ".config");
+    const shellName = readShellName(options.env.SHELL);
+    const zshDirectory = options.env.ZDOTDIR ?? homeDirectory;
+    const [zshCandidates, bashCandidates, fishCandidate, powerShellCandidate]
+        = await Promise.all([
+            // Cover both the conventional interactive profile and .zshenv —
+            // .zshenv is read by every zsh invocation (login/non-login,
+            // scripts, SSH) so it catches startup paths that .zshrc/.zprofile
+            // miss. Runtime PATH guard keeps the two writes idempotent.
+            Promise.all([
+                createShellProfileCandidate(
+                    {
+                        profilePath: pathModule.join(
+                            zshDirectory,
+                            options.platform === "darwin" ? ".zprofile" : ".zshrc",
+                        ),
+                        shellNames: zshShellNames,
+                        snippet: createPosixPathSnippet(),
+                    },
+                    options,
+                ),
+                createShellProfileCandidate(
+                    {
+                        profilePath: pathModule.join(zshDirectory, ".zshenv"),
+                        shellNames: zshShellNames,
+                        snippet: createPosixPathSnippet(),
+                    },
+                    options,
+                ),
+            ]),
+            createBashProfileCandidates(homeDirectory, options),
+            createShellProfileCandidate(
+                {
+                    // Write to a dedicated conf.d/ file so we never touch the
+                    // user's main config.fish. fish auto-sources everything in
+                    // conf.d/, matching the plugin convention used by rustup.
+                    profilePath: pathModule.join(
+                        xdgConfigHome,
+                        "fish",
+                        "conf.d",
+                        "oo.fish",
+                    ),
+                    shellNames: fishShellNames,
+                    snippet: createFishPathSnippet(),
+                },
+                options,
+            ),
+            createShellProfileCandidate(
+                {
+                    profilePath: pathModule.join(
+                        xdgConfigHome,
+                        "powershell",
+                        "Microsoft.PowerShell_profile.ps1",
+                    ),
+                    shellNames: powerShellShellNames,
+                    snippet: createPowerShellProfilePathSnippet(),
+                },
+                options,
+            ),
+        ]);
+    const nushellCandidate = await createShellProfileCandidate(
+        {
+            profilePath: pathModule.join(
+                xdgConfigHome,
+                "nushell",
+                "config.nu",
+            ),
+            shellNames: nuShellNames,
+            snippet: createNushellPathSnippet(),
+        },
+        options,
+    );
+    const candidates = [
+        ...zshCandidates,
+        ...bashCandidates,
+        fishCandidate,
+        powerShellCandidate,
+        nushellCandidate,
+    ];
+    const selectedConfigurations = candidates
+        .filter(candidate => shouldConfigureShellProfile(candidate, shellName))
+        .map(({ installed, profileExists, shellNames, ...configuration }) =>
+            configuration,
+        );
+
+    if (selectedConfigurations.length === 0) {
+        return [
+            await createShellProfileConfiguration(
+                pathModule.join(homeDirectory, ".profile"),
+                options.platform,
+                createPosixPathSnippet(),
+            ),
+        ];
+    }
+
+    if (shellName === undefined || knownUnixShellNames.has(shellName)) {
+        return selectedConfigurations;
+    }
+
+    return [
+        ...selectedConfigurations,
+        await createShellProfileConfiguration(
+            pathModule.join(homeDirectory, ".profile"),
+            options.platform,
+            createPosixPathSnippet(),
+        ),
+    ];
+}
+
+async function createBashProfileCandidates(
+    homeDirectory: string,
+    options: EnsureExecutableDirectoryOnPathOptions,
+): Promise<ShellProfileCandidate[]> {
+    // bash reads different files for login vs. non-login shells, and a single
+    // machine routinely starts bash both ways (terminal emulator vs. SSH).
+    // Writing to every rc file that exists matches what rustup/bun do — the
+    // runtime duplicate guard in the snippet keeps PATH clean.
+    const pathModule = readPathModule(options.platform);
+    const profileNames = options.platform === "darwin"
+        ? [".bash_profile", ".bashrc", ".profile"]
+        : [".bashrc", ".bash_profile", ".profile"];
+    const [installed, ...contents] = await Promise.all([
+        isShellCommandAvailable("bash", options.runtime),
+        ...profileNames.map(name =>
+            readTextFileIfExists(pathModule.join(homeDirectory, name)),
+        ),
+    ]);
+    const existing: ShellProfileCandidate[] = [];
+
+    for (const [index, profileName] of profileNames.entries()) {
+        const content = contents[index];
+
+        if (content === undefined) {
+            continue;
+        }
+
+        const profilePath = pathModule.join(homeDirectory, profileName);
+
+        existing.push({
+            content,
+            installed,
+            profileDirectory: pathModule.dirname(profilePath),
+            profileExists: true,
+            profilePath,
+            shellNames: bashShellNames,
+            snippet: createPosixPathSnippet(),
+        });
+    }
+
+    if (existing.length > 0) {
+        return existing;
+    }
+
+    // No bash rc file exists — create a pair that together covers both
+    // login and non-login bash. Without this, a fresh container that only
+    // gets .bashrc would miss SSH login shells (which read .bash_profile /
+    // .bash_login / .profile instead).
+    //   Linux: .bashrc (non-login) + .profile (login fallback)
+    //   macOS: .bash_profile (login, Terminal default) + .bashrc (nested)
+    const fallbackNames = options.platform === "darwin"
+        ? [".bash_profile", ".bashrc"]
+        : [".bashrc", ".profile"];
+
+    return fallbackNames.map((profileName) => {
+        const profilePath = pathModule.join(homeDirectory, profileName);
+
+        return {
+            content: "",
+            installed,
+            profileDirectory: pathModule.dirname(profilePath),
+            profileExists: false,
+            profilePath,
+            shellNames: bashShellNames,
+            snippet: createPosixPathSnippet(),
+        };
+    });
+}
+
+async function createShellProfileCandidate(
+    options: {
+        profilePath: string;
+        shellNames: readonly string[];
+        snippet: string;
+    },
+    runtimeOptions: EnsureExecutableDirectoryOnPathOptions,
+): Promise<ShellProfileCandidate> {
+    const pathModule = readPathModule(runtimeOptions.platform);
+    const content = await readTextFileIfExists(options.profilePath);
+    const installedResults = await Promise.all(
+        options.shellNames.map(shellName =>
+            isShellCommandAvailable(shellName, runtimeOptions.runtime),
+        ),
+    );
+
+    return {
+        content: content ?? "",
+        installed: installedResults.some(Boolean),
+        profileDirectory: pathModule.dirname(options.profilePath),
+        profileExists: content !== undefined,
+        profilePath: options.profilePath,
+        shellNames: options.shellNames,
+        snippet: options.snippet,
+    };
+}
+
+function shouldConfigureShellProfile(
+    candidate: ShellProfileCandidate,
+    currentShellName: string | undefined,
+): boolean {
+    return candidate.installed
+        || candidate.profileExists
+        || (
+            currentShellName !== undefined
+            && candidate.shellNames.includes(currentShellName)
+        );
+}
+
+async function createShellProfileConfiguration(
+    profilePath: string,
+    platform: NodeJS.Platform,
+    snippet: string,
+): Promise<ShellProfileConfiguration> {
+    const pathModule = readPathModule(platform);
+
+    return {
+        content: await readTextFileIfExists(profilePath) ?? "",
+        profileDirectory: pathModule.dirname(profilePath),
+        profilePath,
+        snippet,
+    };
+}
+
+async function writeShellProfileConfiguration(
+    configuration: ShellProfileConfiguration,
+): Promise<void> {
+    const separator = configuration.content === ""
+        || configuration.content.endsWith("\n")
+        ? ""
+        : "\n";
+
+    await mkdir(configuration.profileDirectory, {
+        recursive: true,
+    });
+    await writeFile(
+        configuration.profilePath,
+        `${configuration.content}${separator}${configuration.snippet}`,
+    );
+}
+
+function createPosixPathSnippet(): string {
+    return [
+        pathConfigurationSentinel,
+        `case ":$PATH:" in`,
+        `    *":${defaultUnixPathExpression}:"*) ;;`,
+        `    *) export PATH="${defaultUnixPathExpression}:$PATH" ;;`,
+        "esac",
+        "",
+    ].join("\n");
+}
+
+function createFishPathSnippet(): string {
+    return [
+        pathConfigurationSentinel,
+        "if type -q fish_add_path",
+        `    fish_add_path "${defaultUnixPathExpression}"`,
+        `else if not contains "${defaultUnixPathExpression}" $PATH`,
+        `    set -gx PATH "${defaultUnixPathExpression}" $PATH`,
+        "end",
+        "",
+    ].join("\n");
+}
+
+function createPowerShellProfilePathSnippet(): string {
+    return [
+        pathConfigurationSentinel,
+        `if (-not ($env:Path.Split([System.IO.Path]::PathSeparator) -contains (Join-Path $HOME '.local/bin'))) {`,
+        `    $env:Path = (Join-Path $HOME '.local/bin') + [System.IO.Path]::PathSeparator + $env:Path`,
+        "}",
+        "",
+    ].join("\n");
+}
+
+function createNushellPathSnippet(): string {
+    // `path add` from nushell's stdlib handles the list-vs-string PATH
+    // representation, deduping, and platform separators for us. Requires
+    // nushell 0.87+ (September 2023) — the same baseline rustup targets.
+    return [
+        pathConfigurationSentinel,
+        `use std/util "path add"`,
+        `path add ($env.HOME | path join ".local/bin")`,
+        "",
+    ].join("\n");
+}
+
+async function configureWindowsUserPath(
+    options: EnsureExecutableDirectoryOnPathOptions,
+): Promise<SelfUpdatePathConfigurationResult> {
+    if (options.env !== process.env) {
+        options.runtime.logger.debug(
+            {
+                executableDirectory: options.executableDirectory,
+            },
+            "Windows user PATH configuration skipped for a non-process environment.",
+        );
+
+        return {
+            status: "failed",
+        };
+    }
+
+    const commandPath = resolvePowerShellCommandPath(options.runtime);
+
+    if (commandPath === null) {
+        options.runtime.logger.warn(
+            {
+                executableDirectory: options.executableDirectory,
+            },
+            "Windows user PATH configuration skipped because PowerShell was not found.",
+        );
+
+        return {
+            status: "failed",
+        };
+    }
+
+    try {
+        const result = await (options.runtime.runCommand ?? runSelfUpdateCommand)({
+            commandArguments: [
+                "-NoLogo",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                createWindowsUserPathScript(),
+            ],
+            commandPath,
+            env: {
+                ...options.env,
+                [windowsPathEntryEnvName]: options.executableDirectory,
+            },
+            timeoutMs: windowsPathConfigurationTimeoutMs,
+        });
+
+        if (result.exitCode !== 0 || result.signalCode !== null) {
+            options.runtime.logger.warn(
+                {
+                    commandPath,
+                    executableDirectory: options.executableDirectory,
+                    exitCode: result.exitCode,
+                    signalCode: result.signalCode,
+                    stderr: normalizeLoggedCommandOutput(result.stderr),
+                    stdout: normalizeLoggedCommandOutput(result.stdout),
+                },
+                "Windows user PATH configuration command failed.",
+            );
+
+            return {
+                status: "failed",
+            };
+        }
+
+        options.runtime.logger.info(
+            {
+                commandPath,
+                executableDirectory: options.executableDirectory,
+            },
+            "CLI executable directory was added to the Windows user PATH.",
+        );
+
+        return {
+            status: "configured",
+            target: ["Windows user PATH"],
+        };
+    }
+    catch (error) {
+        options.runtime.logger.warn(
+            {
+                commandPath,
+                err: error,
+                executableDirectory: options.executableDirectory,
+            },
+            "Windows user PATH configuration failed.",
+        );
+
+        return {
+            status: "failed",
+        };
+    }
+}
+
+function resolvePowerShellCommandPath(
+    runtime: PathConfigurationRuntime,
+): string | null {
+    for (const commandName of ["powershell.exe", "powershell", "pwsh.exe", "pwsh"]) {
+        const commandPath = runtime.resolveCommandPath?.(commandName)
+            ?? Bun.which(commandName);
+
+        if (commandPath !== null) {
+            return commandPath;
+        }
+    }
+
+    return null;
+}
+
+function createWindowsUserPathScript(): string {
+    return [
+        "$ErrorActionPreference = 'Stop'",
+        `$bin = [Environment]::GetEnvironmentVariable('${windowsPathEntryEnvName}', 'Process')`,
+        "if ([string]::IsNullOrWhiteSpace($bin)) { throw 'Missing PATH entry.' }",
+        "$sep = [System.IO.Path]::PathSeparator",
+        // Writing via the registry directly preserves the REG_EXPAND_SZ kind so
+        // pre-existing %VAR% references in Path keep expanding for other apps.
+        "$key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)",
+        "if ($null -eq $key) { $key = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Environment') }",
+        "$changed = $false",
+        "try {",
+        "    $hasValue = $null -ne $key.GetValue('Path', $null)",
+        "    if ($hasValue) {",
+        "        $current = [string]$key.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)",
+        "        $kind = $key.GetValueKind('Path')",
+        "    }",
+        "    else {",
+        "        $current = ''",
+        "        $kind = [Microsoft.Win32.RegistryValueKind]::ExpandString",
+        "    }",
+        "    $trimmedBin = $bin.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)",
+        "    $alreadyPresent = $false",
+        "    if ($hasValue -and -not [string]::IsNullOrEmpty($current)) {",
+        "        foreach ($entry in $current.Split($sep)) {",
+        "            $expandedEntry = [Environment]::ExpandEnvironmentVariables($entry.Trim())",
+        "            $trimmedEntry = $expandedEntry.TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)",
+        "            if ([string]::Equals($trimmedEntry, $trimmedBin, [System.StringComparison]::OrdinalIgnoreCase)) {",
+        "                $alreadyPresent = $true",
+        "                break",
+        "            }",
+        "        }",
+        "    }",
+        "    if (-not $alreadyPresent) {",
+        "        if ([string]::IsNullOrEmpty($current)) { $next = $bin } else { $next = \"$bin$sep$current\" }",
+        "        $key.SetValue('Path', $next, $kind)",
+        "        $changed = $true",
+        "    }",
+        "}",
+        "finally {",
+        "    $key.Close()",
+        "}",
+        // Broadcast WM_SETTINGCHANGE so already-running processes (Explorer,
+        // other shells) pick up the Path change without requiring logoff.
+        "if ($changed) {",
+        "    Add-Type -Namespace OoCliNative -Name User32 -MemberDefinition @'",
+        "[System.Runtime.InteropServices.DllImport(\"user32.dll\", CharSet = System.Runtime.InteropServices.CharSet.Auto, SetLastError = true)]",
+        "public static extern System.IntPtr SendMessageTimeout(System.IntPtr hWnd, uint Msg, System.IntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out System.IntPtr lpdwResult);",
+        "'@",
+        "    $broadcastResult = [System.IntPtr]::Zero",
+        "    [OoCliNative.User32]::SendMessageTimeout([System.IntPtr]0xFFFF, 0x001A, [System.IntPtr]::Zero, 'Environment', 0x0002, 5000, [ref]$broadcastResult) | Out-Null",
+        "}",
+    ].join("\n");
+}
+
+async function isShellCommandAvailable(
+    shellName: string,
+    runtime: PathConfigurationRuntime,
+): Promise<boolean> {
+    if (runtime.resolveCommandPath !== undefined) {
+        return runtime.resolveCommandPath(shellName) !== null;
+    }
+
+    return Bun.which(shellName) !== null;
+}
+
+function readShellName(rawShell: string | undefined): string | undefined {
+    if (rawShell === undefined || rawShell.trim() === "") {
+        return undefined;
+    }
+
+    const shellSegments = rawShell
+        .trim()
+        .replaceAll("\\", "/")
+        .split("/")
+        .filter(Boolean);
+    let shellName = shellSegments.at(-1)?.toLowerCase();
+
+    if (shellName === undefined) {
+        return undefined;
+    }
+
+    while (shellName.startsWith("-")) {
+        shellName = shellName.slice(1);
+    }
+
+    return shellName.endsWith(".exe")
+        ? shellName.slice(0, -4)
+        : shellName;
+}
+
+function normalizePathForComparison(
+    value: string,
+    platform: NodeJS.Platform,
+): string {
+    const pathModule = readPathModule(platform);
+    const trimmedValue = value.trim();
+
+    if (trimmedValue === "") {
+        return "";
+    }
+
+    let resolvedValue = pathModule.normalize(
+        pathModule.isAbsolute(trimmedValue)
+            ? trimmedValue
+            : pathModule.resolve(trimmedValue),
+    );
+
+    // path.normalize keeps any trailing separator, but "/foo/bar/" and
+    // "/foo/bar" must compare equal when checking PATH membership. Windows
+    // accepts both "/" and "\" so strip either.
+    while (
+        resolvedValue.length > 1
+        && (resolvedValue.endsWith("/") || resolvedValue.endsWith("\\"))
+    ) {
+        resolvedValue = resolvedValue.slice(0, -1);
+    }
+
+    return platform === "win32"
+        ? resolvedValue.toLowerCase()
+        : resolvedValue;
+}
+
+async function readTextFileIfExists(path: string): Promise<string | undefined> {
+    try {
+        return await readFile(path, "utf8");
+    }
+    catch (error) {
+        if (isFileMissingError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
+}

--- a/src/application/self-update/path-configuration.ts
+++ b/src/application/self-update/path-configuration.ts
@@ -5,9 +5,8 @@ import type {
     SelfUpdateRuntimeOverrides,
 } from "../contracts/self-update.ts";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import process from "node:process";
 import { resolveHomeDirectory } from "../path/home-directory.ts";
-import { isFileMissingError } from "../shared/fs-errors.ts";
+import { isDirectoryReadError, isFileMissingError } from "../shared/fs-errors.ts";
 import {
     normalizeLoggedCommandOutput,
     runSelfUpdateCommand,
@@ -124,6 +123,7 @@ async function configureUnixShellProfile(
         const configurations = await resolveShellProfileConfigurations(options);
         const alreadyConfiguredTargets: string[] = [];
         const configuredTargets: string[] = [];
+        const failedTargets: string[] = [];
 
         for (const configuration of configurations) {
             if (configuration.content.includes(pathConfigurationSentinel)) {
@@ -143,6 +143,7 @@ async function configureUnixShellProfile(
                 );
             }
             catch (error) {
+                failedTargets.push(configuration.profilePath);
                 options.runtime.logger.warn(
                     {
                         err: error,
@@ -154,10 +155,25 @@ async function configureUnixShellProfile(
             }
         }
 
+        if (configuredTargets.length > 0 && failedTargets.length > 0) {
+            return {
+                status: "partial-configured",
+                target: configuredTargets,
+                failedTargets,
+            };
+        }
+
         if (configuredTargets.length > 0) {
             return {
                 status: "configured",
                 target: configuredTargets,
+            };
+        }
+
+        if (failedTargets.length > 0) {
+            return {
+                status: "failed",
+                failedTargets,
             };
         }
 
@@ -490,12 +506,12 @@ function createNushellPathSnippet(): string {
 async function configureWindowsUserPath(
     options: EnsureExecutableDirectoryOnPathOptions,
 ): Promise<SelfUpdatePathConfigurationResult> {
-    if (options.env !== process.env) {
+    if (options.runtime.allowWindowsRegistryWrite !== true) {
         options.runtime.logger.debug(
             {
                 executableDirectory: options.executableDirectory,
             },
-            "Windows user PATH configuration skipped for a non-process environment.",
+            "Windows user PATH configuration skipped because allowWindowsRegistryWrite is not set.",
         );
 
         return {
@@ -726,7 +742,10 @@ async function readTextFileIfExists(path: string): Promise<string | undefined> {
         return await readFile(path, "utf8");
     }
     catch (error) {
-        if (isFileMissingError(error)) {
+        // Treat "missing file" and "path is a directory" as "no prior content"
+        // — the subsequent writeFile will surface any write-time conflict so
+        // the caller can report a real failure instead of an earlier read one.
+        if (isFileMissingError(error) || isDirectoryReadError(error)) {
             return undefined;
         }
 

--- a/src/application/shared/env-boolean.test.ts
+++ b/src/application/shared/env-boolean.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { readEnvBoolean } from "./env-boolean.ts";
+
+describe("readEnvBoolean", () => {
+    test("returns undefined when the variable is unset", () => {
+        expect(readEnvBoolean(undefined)).toBeUndefined();
+    });
+
+    test("reads common truthy strings regardless of case or padding", () => {
+        for (const raw of ["1", "true", "TRUE", "  yes  ", "On", "On\n"]) {
+            expect(readEnvBoolean(raw)).toBeTrue();
+        }
+    });
+
+    test("reads common falsy strings regardless of case or padding", () => {
+        for (const raw of ["0", "false", "No", "off", "", "   "]) {
+            expect(readEnvBoolean(raw)).toBeFalse();
+        }
+    });
+
+    test("returns undefined for unrecognized values so callers can decide", () => {
+        for (const raw of ["maybe", "2", "banana"]) {
+            expect(readEnvBoolean(raw)).toBeUndefined();
+        }
+    });
+});

--- a/src/application/shared/env-boolean.ts
+++ b/src/application/shared/env-boolean.ts
@@ -1,0 +1,20 @@
+const truthyValues = new Set(["1", "true", "yes", "on"]);
+const falsyValues = new Set(["", "0", "false", "no", "off"]);
+
+export function readEnvBoolean(value: string | undefined): boolean | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    const normalized = value.trim().toLowerCase();
+
+    if (truthyValues.has(normalized)) {
+        return true;
+    }
+
+    if (falsyValues.has(normalized)) {
+        return false;
+    }
+
+    return undefined;
+}

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -474,6 +474,12 @@ export const enMessages = {
     "selfUpdate.install.executable": "Executable: {path}",
     "selfUpdate.pathConfiguredNote":
         "Added {path} to PATH. Restart your shell to reload PATH and use oo.",
+    "selfUpdate.pathPartiallyConfigured.updatedHeader":
+        "Updated PATH in:",
+    "selfUpdate.pathPartiallyConfigured.failedHeader":
+        "Could not update:",
+    "selfUpdate.pathPartiallyConfigured.restart":
+        "Restart your shell to reload PATH and use oo.",
     "selfUpdate.install.pathNote":
         "Add {path} to PATH to run oo in new shells.",
     "selfUpdate.progress.install.header": "Installing oo",
@@ -1071,6 +1077,12 @@ export const zhMessages = {
     "selfUpdate.install.executable": "可执行入口：{path}",
     "selfUpdate.pathConfiguredNote":
         "已将 {path} 加入 PATH。请重启 shell 以重新加载 PATH 后使用 oo。",
+    "selfUpdate.pathPartiallyConfigured.updatedHeader":
+        "已为以下 profile 配置 PATH：",
+    "selfUpdate.pathPartiallyConfigured.failedHeader":
+        "以下 profile 写入失败：",
+    "selfUpdate.pathPartiallyConfigured.restart":
+        "请重启 shell 以重新加载 PATH 后使用 oo。",
     "selfUpdate.install.pathNote":
         "请把 {path} 加入 PATH，新的 shell 才能直接运行 oo。",
     "selfUpdate.progress.install.header": "正在安装 oo",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -446,6 +446,8 @@ export const enMessages = {
     "options.force":
         "Force reinstallation even when the target version already exists",
     "options.help": "Show help for command",
+    "options.noModifyPath":
+        "Do not add the executable directory to PATH automatically",
     "options.limit": "Specify the maximum number of items to return",
     "options.format": "Specify output format (use json for structured output)",
     "options.json": "Alias for --format=json",
@@ -470,6 +472,8 @@ export const enMessages = {
     "options.version": "Show the current version",
     "selfUpdate.install.success": "Installed oo {version}.",
     "selfUpdate.install.executable": "Executable: {path}",
+    "selfUpdate.pathConfiguredNote":
+        "Added {path} to PATH. Restart your shell to reload PATH and use oo.",
     "selfUpdate.install.pathNote":
         "Add {path} to PATH to run oo in new shells.",
     "selfUpdate.progress.install.header": "Installing oo",
@@ -1040,6 +1044,8 @@ export const zhMessages = {
     "options.force":
         "即使目标版本已存在也强制重新安装",
     "options.help": "显示命令帮助",
+    "options.noModifyPath":
+        "不要自动将可执行目录加入 PATH",
     "options.limit": "指定最多返回多少条记录",
     "options.format": "指定输出格式（使用 json 返回结构化内容）",
     "options.json": "--format=json 的别名",
@@ -1063,6 +1069,8 @@ export const zhMessages = {
     "options.version": "显示当前版本",
     "selfUpdate.install.success": "已安装 oo {version}。",
     "selfUpdate.install.executable": "可执行入口：{path}",
+    "selfUpdate.pathConfiguredNote":
+        "已将 {path} 加入 PATH。请重启 shell 以重新加载 PATH 后使用 oo。",
     "selfUpdate.install.pathNote":
         "请把 {path} 加入 PATH，新的 shell 才能直接运行 oo。",
     "selfUpdate.progress.install.header": "正在安装 oo",


### PR DESCRIPTION
Self-managed installs could succeed while leaving future shells unable to find `oo` until users edited PATH manually. Persist the managed bin directory across supported shells, print a restart note when that succeeds, and keep an explicit opt-out with `--no-modify-path` and `OO_NO_MODIFY_PATH`.

fixed: #99