### PR TITLE
feat(skills): enable implicit oo skill discovery

### DIFF
--- a/contrib/skills/claude/oo-find-skills/SKILL.md
+++ b/contrib/skills/claude/oo-find-skills/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: oo-find-skills
-disable-model-invocation: true
 description: >-
-  Search the published OOMOL skill catalog, compare candidate skills, and
-  install chosen results using the oo CLI. Do not use for generic skill
-  discovery outside the oo or OOMOL ecosystem.
+  Find, compare, and install published OOMOL/oo skills. Use when the user asks
+  to find, search for, discover, recommend, compare, choose, or install an
+  existing skill for a task; asks whether there is a skill that can do
+  something; or explicitly mentions the OOMOL/oo skill catalog. Do not use for
+  creating or editing local skills, generic skill design, or non-OOMOL skill
+  catalogs.
 allowed-tools: ["Bash(oo *)"]
 ---
 

--- a/contrib/skills/claude/oo/SKILL.md
+++ b/contrib/skills/claude/oo/SKILL.md
@@ -19,6 +19,9 @@ allowed-tools: ["Bash(oo *)"]
 Use `oo` to complete a hosted task through an existing `oo` capability, not to
 build a local workaround.
 
+If the user wants to find, compare, or install published skills, use
+`oo-find-skills` instead of this skill.
+
 Read only the reference file needed for the current step.
 
 ## When to use this skill

--- a/contrib/skills/claude/oo/SKILL.md
+++ b/contrib/skills/claude/oo/SKILL.md
@@ -19,7 +19,7 @@ allowed-tools: ["Bash(oo *)"]
 Use `oo` to complete a hosted task through an existing `oo` capability, not to
 build a local workaround.
 
-If the user wants to find, compare, or install published skills, use
+If the user wants to find, compare, or install published OOMOL/oo skills, use
 `oo-find-skills` instead of this skill.
 
 Read only the reference file needed for the current step.

--- a/contrib/skills/codex/oo-find-skills/SKILL.md
+++ b/contrib/skills/codex/oo-find-skills/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: oo-find-skills
 description: >-
-  Use when the user wants to search the published OOMOL or oo skill catalog,
-  compare candidate skills, and install one or two chosen results. Do not use
-  for generic skill discovery outside the oo or OOMOL ecosystem.
+  Find, compare, and install published OOMOL/oo skills. Use when the user asks
+  to find, search for, discover, recommend, compare, choose, or install an
+  existing skill for a task; asks whether there is a skill that can do
+  something; or explicitly mentions the OOMOL/oo skill catalog. Do not use for
+  creating or editing local skills, generic skill design, or non-OOMOL skill
+  catalogs.
 ---
 
 # oo Find Skills

--- a/contrib/skills/codex/oo-find-skills/agents/openai.yaml
+++ b/contrib/skills/codex/oo-find-skills/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: oo Find Skills
-  short_description: Search OOMOL/oo skills for installation
-  default_prompt: "Use $oo-find-skills when I want to search the OOMOL or oo skill catalog, compare likely matches for my current need, and install the selected published skill or skills."
+  short_description: Find and install OOMOL/oo skills
+  default_prompt: "Use $oo-find-skills when I ask to find, compare, or install a published OOMOL/oo skill for a task, or ask whether a skill exists for a capability."
 
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/contrib/skills/codex/oo-find-skills/agents/openai.yaml
+++ b/contrib/skills/codex/oo-find-skills/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: oo Find Skills
   short_description: Find and install OOMOL/oo skills
-  default_prompt: "Use $oo-find-skills when I ask to find, compare, or install a published OOMOL/oo skill for a task, or ask whether a skill exists for a capability."
+  default_prompt: "Use $oo-find-skills when the user asks to find, search for, discover, recommend, compare, choose, or install a published OOMOL/oo skill for a task, asks whether such a skill exists for a capability, or explicitly mentions the OOMOL/oo skill catalog. Do not use it for creating or editing local skills, generic skill design, or non-OOMOL skill catalogs."
 
 policy:
   allow_implicit_invocation: true

--- a/contrib/skills/codex/oo/SKILL.md
+++ b/contrib/skills/codex/oo/SKILL.md
@@ -18,6 +18,9 @@ description: >-
 Use `oo` to complete a hosted task through an existing `oo` capability, not to
 build a local workaround.
 
+If the user wants to find, compare, or install published skills, use
+`oo-find-skills` instead of this skill.
+
 Read only the reference file needed for the current step.
 
 ## Runtime note

--- a/contrib/skills/codex/oo/SKILL.md
+++ b/contrib/skills/codex/oo/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 Use `oo` to complete a hosted task through an existing `oo` capability, not to
 build a local workaround.
 
-If the user wants to find, compare, or install published skills, use
+If the user wants to find, compare, or install published OOMOL/oo skills, use
 `oo-find-skills` instead of this skill.
 
 Read only the reference file needed for the current step.

--- a/contrib/skills/openclaw/oo-find-skills/SKILL.md
+++ b/contrib/skills/openclaw/oo-find-skills/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: oo-find-skills
-disable-model-invocation: true
-description: Search the published OOMOL skill catalog, compare candidate skills, and install chosen results using the oo CLI. Do not use for generic skill discovery outside the oo or OOMOL ecosystem.
+description: >-
+  Find, compare, and install published OOMOL/oo skills. Use when the user asks
+  to find, search for, discover, recommend, compare, choose, or install an
+  existing skill for a task; asks whether there is a skill that can do
+  something; or explicitly mentions the OOMOL/oo skill catalog. Do not use for
+  creating or editing local skills, generic skill design, or non-OOMOL skill
+  catalogs.
 ---
 
 # oo Find Skills

--- a/contrib/skills/openclaw/oo/SKILL.md
+++ b/contrib/skills/openclaw/oo/SKILL.md
@@ -18,6 +18,9 @@ description: >-
 Use `oo` to complete a hosted task through an existing `oo` capability, not to
 build a local workaround.
 
+If the user wants to find, compare, or install published skills, use
+`oo-find-skills` instead of this skill.
+
 Read only the reference file needed for the current step.
 
 ## When to use this skill

--- a/contrib/skills/openclaw/oo/SKILL.md
+++ b/contrib/skills/openclaw/oo/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 Use `oo` to complete a hosted task through an existing `oo` capability, not to
 build a local workaround.
 
-If the user wants to find, compare, or install published skills, use
+If the user wants to find, compare, or install published OOMOL/oo skills, use
 `oo-find-skills` instead of this skill.
 
 Read only the reference file needed for the current step.


### PR DESCRIPTION
Users should be able to ask naturally for skill discovery without naming the routing skill first. The updated metadata and guidance make oo-find-skills the explicit path for catalog lookup across Codex, Claude, and OpenClaw integrations.