### PR TITLE
feat(skills): publish registry skills to all hosts

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -377,6 +377,9 @@ Update installed oo-managed published skills.
 - Bundled skills: bundled skills such as `oo` and `oo-find-skills` are
   excluded from this command. Refresh them with `oo skills add`, or let a
   successful `oo install` or `oo update` refresh them automatically.
+- Ownership rule: a skill is considered managed for update only when its
+  `.oo-metadata.json` file can be parsed and contains a non-empty `version`;
+  otherwise the command treats the existing target as unmanaged.
 - Published skills: registry-backed skills derive their package identity from
   `.oo-metadata.json`, then fetch package info without an explicit version to
   determine the latest available package version.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -252,7 +252,7 @@ Search packages and connector actions with one free-form query.
 - Notes: connector matches still cache their schemas locally and report the
   cache path in text and JSON output.
 
-## Codex Skills
+## AI Agent Skills
 
 ### `oo skills list`
 
@@ -292,8 +292,7 @@ Search published skills with free-form text.
 
 ### `oo skills install [packageName]`
 
-Install bundled skills into supported local skill directories, or install
-published skills into the local Codex skills directory.
+Install bundled or published skills into supported local skill directories.
 
 - Alias: `oo skills add [packageName]`.
 - Arguments: `[packageName]` is optional.
@@ -329,19 +328,19 @@ published skills into the local Codex skills directory.
   lived directly under `skills/`). Bundled skills are rebuilt automatically in
   the new layout; previously-installed published skills must be reinstalled
   with `oo skills install <packageName>`.
-- Target directory: bundled skills are published to each existing supported
-  host directory, currently `${CODEX_HOME:-~/.codex}/skills/<skill-id>`,
+- Target directory: bundled and published skills are published to each existing
+  supported host directory, currently
+  `${CODEX_HOME:-~/.codex}/skills/<skill-id>`,
   `~/.claude/skills/<skill-id>`, and
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`.
-- Target directory: published skills are published to
-  `${CODEX_HOME:-~/.codex}/skills/<skill-id>`.
 - Path rule: published skill names are accepted only when their resolved
   canonical and target directories remain under those local `skills` roots.
-- Installation mode: bundled Codex and Claude Code skills are published to the
-  target directory as a symlink to the canonical directory when the current
-  platform and environment allow it. When symlink creation fails, `oo` falls
-  back to copying the canonical files into the target skills directory.
-- Installation mode: bundled OpenClaw skills are copied into
+- Installation mode: bundled and published Codex and Claude Code skills are
+  published to the target directory as a symlink to the canonical directory
+  when the current platform and environment allow it. When symlink creation
+  fails, `oo` falls back to copying the canonical files into the target skills
+  directory.
+- Installation mode: bundled and published OpenClaw skills are copied into
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>` so the installed skill
   stays inside OpenClaw's managed skills root.
 - Metadata: bundled skills write a hidden `.oo-metadata.json` file whose
@@ -356,6 +355,8 @@ published skills into the local Codex skills directory.
 - Notes: when an explicitly requested published skill conflicts with an
   existing same-name skill, the command asks for `yes` or `no` before
   overwriting it in an interactive terminal.
+- Notes: existing target directories without valid `oo` metadata are treated as
+  non-OOMOL skills and are not overwritten.
 - Notes: in the interactive picker, conflicting skills are marked in the list;
   selecting one means it will be overwritten.
 - Notes: the command exits with an error when none of the supported Codex,
@@ -367,7 +368,7 @@ published skills into the local Codex skills directory.
 
 ### `oo skills update [skills...]`
 
-Update installed oo-managed Codex skills.
+Update installed oo-managed published skills.
 
 - Arguments: when omitted, the command checks every installed oo-managed
   published skill.
@@ -381,15 +382,15 @@ Update installed oo-managed Codex skills.
   determine the latest available package version.
 - Update order: the command refreshes the canonical
   `<config-dir>/skills/registry/<skill-id>` copy before republishing to
-  `${CODEX_HOME:-~/.codex}/skills/<skill-id>`.
+  each existing supported host directory.
 - Interactive terminals: renders live progress while checking and updating
   skills.
-- Non-interactive terminals: prints one status line per processed skill.
+- Non-interactive terminals: prints one status line for each current or failed
+  skill, and one success line for each updated host target path.
 
 ### `oo skills uninstall [skill]`
 
-Remove bundled skills from supported local skill directories, or remove one
-oo-managed published skill from the local Codex skills directory.
+Remove oo-managed skills from supported local skill directories.
 
 - Alias: `oo skills remove [skill]`.
 - Arguments: when `[skill]` is omitted, the command removes all bundled skills.
@@ -399,16 +400,15 @@ oo-managed published skill from the local Codex skills directory.
 - Canonical directory removed: bundled skills remove
   `<config-dir>/skills/bundled/<agent>/<skill>` for each installed agent, and
   published skills remove `<config-dir>/skills/registry/<skill>`.
-- Target directory removed: bundled skills are removed from every existing
-  supported host directory, currently `${CODEX_HOME:-~/.codex}/skills/<skill>`,
-  `~/.claude/skills/<skill>`, and
-  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`. Published skills are removed
-  from `${CODEX_HOME:-~/.codex}/skills/<skill>`.
+- Target directory removed: bundled and published skills are removed from every
+  existing supported host directory, currently
+  `${CODEX_HOME:-~/.codex}/skills/<skill>`, `~/.claude/skills/<skill>`, and
+  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`.
 - Path rule: `[skill]` must resolve to child directories under those local
   `skills` roots. Names that escape those roots are rejected.
-- Notes: when the target directory is missing, or its `.oo-metadata.json` file
-  is missing or invalid, the command exits with an error and does not remove
-  anything.
+- Notes: when no supported target has a managed installation for the requested
+  skill, or an existing same-name target is not managed by `oo`, the command
+  exits with an error and does not remove anything.
 
 ## Logs
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -331,6 +331,8 @@
 - 内置 skill：bundled `oo`、`oo-find-skills` 等内置 skill 不在此命令处理
   范围内。请使用 `oo skills add` 刷新，或让成功的 `oo install` / `oo update`
   自动刷新它们。
+- 所有权规则：只有当 skill 的 `.oo-metadata.json` 可以被解析，且包含非空
+  `version` 时，update 才会认为它由 oo 管理；否则会把现有目标视为非托管。
 - 已发布 skill：registry skill 会从 `.oo-metadata.json` 读取所属包名，再通过
   不带显式版本的 package info 请求判断最新可用版本。
 - 更新顺序：命令会先刷新 canonical 目录

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -224,7 +224,7 @@
 - 说明：connector 命中结果仍会在本地缓存 schema，并在文本与 JSON 输出中
   报告其缓存路径。
 
-## Codex Skill
+## AI Agent Skill
 
 ### `oo skills list`
 
@@ -261,8 +261,7 @@
 
 ### `oo skills install [packageName]`
 
-将内置 skill 安装到受支持的本地 skill 目录，或将已发布 skill 安装到本地
-Codex skills 目录。
+将内置或已发布 skill 安装到受支持的本地 skill 目录。
 
 - 别名：`oo skills add [packageName]`。
 - 参数：`[packageName]` 可选。
@@ -292,16 +291,14 @@ Codex skills 目录。
   目录（`claude-skills/`、`openclaw-skills/`，以及直接位于 `skills/` 下的旧
   Codex 内置 / 已发布 skill 目录）。内置 skill 会自动以新布局重建；之前安装
   的已发布 skill 需要通过 `oo skills install <packageName>` 重新安装。
-- 目标目录：内置 skill 会发布到所有已存在的受支持宿主目录，目前包括
+- 目标目录：内置和已发布 skill 会发布到所有已存在的受支持宿主目录，目前包括
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>` 和
   `~/.claude/skills/<skill-id>`，以及
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`。
-- 目标目录：已发布 skill 会发布到
-  `${CODEX_HOME:-~/.codex}/skills/<skill-id>`。
-- 安装方式：内置 Codex 和 Claude Code skill 会优先把目标目录发布为指向
-  canonical 目录的软连接。如果当前平台或环境下创建软连接失败，则会回退为把
-  canonical 目录内容复制到目标 skills 目录。
-- 安装方式：内置 OpenClaw skill 会直接复制到
+- 安装方式：内置和已发布的 Codex / Claude Code skill 会优先把目标目录发布
+  为指向 canonical 目录的软连接。如果当前平台或环境下创建软连接失败，则会
+  回退为把 canonical 目录内容复制到目标 skills 目录。
+- 安装方式：内置和已发布的 OpenClaw skill 会直接复制到
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`，以确保安装后的 skill
   保持在 OpenClaw 管理的 skills 根目录内。
 - 元数据：内置 skill 会写入一个隐藏的 `.oo-metadata.json` 文件，其中
@@ -315,6 +312,8 @@ Codex skills 目录。
   `--skill <name>` 或 `--all -y`。
 - 说明：如果显式安装的已发布 skill 与现有同名 skill 冲突，命令会在交互终
   端中要求用户输入 `yes` 或 `no` 决定是否覆盖。
+- 说明：如果目标目录已存在但没有有效的 `oo` 元数据，会被视为非 OOMOL
+  skill，命令不会覆盖它。
 - 说明：在交互选择页面中，存在重名冲突的 skill 会在列表中显示状态标记；
   只要用户仍然选择该项，就会执行覆盖。
 - 说明：当 Codex、Claude Code 和 OpenClaw 的受支持根目录都不存在时，命令
@@ -325,7 +324,7 @@ Codex skills 目录。
 
 ### `oo skills update [skills...]`
 
-更新已安装且由 oo 管理的 Codex skill。
+更新已安装且由 oo 管理的已发布 skill。
 
 - 参数：省略时，会检查所有已安装且由 oo 管理的已发布 skill。
 - 参数：提供一个或多个 skill 名称时，只会检查并更新这些指定 skill。
@@ -335,15 +334,14 @@ Codex skills 目录。
 - 已发布 skill：registry skill 会从 `.oo-metadata.json` 读取所属包名，再通过
   不带显式版本的 package info 请求判断最新可用版本。
 - 更新顺序：命令会先刷新 canonical 目录
-  `<config-dir>/skills/registry/<skill-id>`，再同步到
-  `${CODEX_HOME:-~/.codex}/skills/<skill-id>`。
+  `<config-dir>/skills/registry/<skill-id>`，再同步到所有已存在的受支持宿主目录。
 - 交互式终端：会显示实时进度。
-- 非交互式终端：每个处理过的 skill 输出一行状态信息。
+- 非交互式终端：对每个已是最新或失败的 skill 输出一行状态信息；对每个已更新
+  的宿主目标路径输出一行成功信息。
 
 ### `oo skills uninstall [skill]`
 
-从受支持的本地 skill 目录移除内置 skill，或从本地 Codex skills 目录移除
-一个由 oo 管理的已发布 skill。
+从受支持的本地 skill 目录移除由 oo 管理的 skill。
 
 - 别名：`oo skills remove [skill]`。
 - 参数：省略 `[skill]` 时，命令会移除全部内置 skill。
@@ -352,15 +350,14 @@ Codex skills 目录。
 - 会同时移除 canonical 目录：内置 skill 会移除
   `<config-dir>/skills/bundled/<agent>/<skill>`（每个已安装宿主各一份），
   已发布 skill 会移除 `<config-dir>/skills/registry/<skill>`。
-- 会同时移除目标目录：内置 skill 会从所有已存在的受支持宿主目录中移除，目
-  前包括 `${CODEX_HOME:-~/.codex}/skills/<skill>` 和
+- 会同时移除目标目录：内置和已发布 skill 会从所有已存在的受支持宿主目录中
+  移除，目前包括 `${CODEX_HOME:-~/.codex}/skills/<skill>` 和
   `~/.claude/skills/<skill>`，以及
-  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`；已发布 skill 会从
-  `${CODEX_HOME:-~/.codex}/skills/<skill>` 中移除。
+  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`。
 - 路径规则：`[skill]` 解析后必须仍然落在这些本地 `skills` 根目录的子目录中。
   任何会逃出这些根目录的名称都会被拒绝。
-- 说明：如果目标目录不存在，或者其 `.oo-metadata.json` 缺失或无效，
-  命令会直接报错，不会删除任何内容。
+- 说明：如果请求的 skill 在任何受支持目标中都不存在受管理安装，或某个已存在
+  的同名目标不是由 `oo` 管理，命令会直接报错，不会删除任何内容。
 
 ## 日志
 

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -49,7 +49,7 @@ Commands:
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
-  skills                    Manage Codex skills
+  skills                    Manage AI agent skills
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
@@ -83,7 +83,7 @@ Commands:
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
-  skills                    Manage Codex skills
+  skills                    Manage AI agent skills
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
@@ -120,7 +120,7 @@ Commands:
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
-  skills                    Manage Codex skills
+  skills                    Manage AI agent skills
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
@@ -155,7 +155,7 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
   logout                    登出当前账号（auth logout 的别名）
   completion <shell>        生成 shell 补全脚本
   config                    管理持久化配置
-  skills                    管理 Codex skill
+  skills                    管理 AI Agent skill
   log                       管理持久化 debug 日志
   search [options] <text>   搜索 package 与 connector action
   packages                  包相关工具
@@ -186,7 +186,7 @@ Commands:
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
-  skills                    Manage Codex skills
+  skills                    Manage AI agent skills
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
@@ -221,7 +221,7 @@ Commands:
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
-  skills                    Manage Codex skills
+  skills                    Manage AI agent skills
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -35,7 +35,7 @@ Commands:
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
-  skills                    Manage Codex skills
+  skills                    Manage AI agent skills
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
@@ -66,7 +66,7 @@ Commands:
   logout                    登出当前账号（auth logout 的别名）
   completion <shell>        生成 shell 补全脚本
   config                    管理持久化配置
-  skills                    管理 Codex skill
+  skills                    管理 AI Agent skill
   log                       管理持久化 debug 日志
   search [options] <text>   搜索 package 与 connector action
   packages                  包相关工具

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -45,7 +45,7 @@ Commands:
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
-  skills                    Manage Codex skills
+  skills                    Manage AI agent skills
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
@@ -79,7 +79,7 @@ Commands:
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
-  skills                    Manage Codex skills
+  skills                    Manage AI agent skills
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -259,7 +259,7 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(1);
             expect(result.stdout).toBe("");
             expect(result.stderr).toBe(
-                `No supported bundled skill host is installed. Expected one of: ${expectedHomeDirectories}.\n`,
+                `No supported skill host is installed. Expected one of: ${expectedHomeDirectories}.\n`,
             );
         }
         finally {
@@ -559,10 +559,12 @@ describe("skills commands", () => {
         }
     });
 
-    test("uninstalls a published skill from the Codex skills directory", async () => {
+    test("uninstalls a published skill from every existing supported host", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-        const skillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
+        const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const claudeSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
@@ -572,25 +574,40 @@ describe("skills commands", () => {
             storePaths.settingsFilePath,
             "chatgpt",
         );
-        const metadataFilePath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
 
         try {
-            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await mkdir(join(codexSkillDirectoryPath, "agents"), { recursive: true });
+            await mkdir(join(claudeSkillDirectoryPath, "agents"), { recursive: true });
             await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
                 recursive: true,
             });
-            await Bun.write(metadataFilePath, renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }));
-            await Bun.write(join(skillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
+            for (const skillDirectoryPath of [
+                codexSkillDirectoryPath,
+                claudeSkillDirectoryPath,
+            ]) {
+                await Bun.write(
+                    resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+                    renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
+                );
+                await Bun.write(join(skillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
+            }
             await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
 
             const result = await sandbox.run(["skills", "uninstall", "chatgpt"]);
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
-                `Removed skill chatgpt from ${skillDirectoryPath}.\n`,
+                [
+                    `Removed skill chatgpt from ${codexSkillDirectoryPath}.`,
+                    `Removed skill chatgpt from ${claudeSkillDirectoryPath}.`,
+                    "",
+                ].join("\n"),
             );
             expect(result.stderr).toBe("");
-            await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
+            await expect(stat(codexSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(claudeSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
             await expect(stat(canonicalSkillDirectoryPath)).rejects.toMatchObject({
@@ -602,7 +619,7 @@ describe("skills commands", () => {
         }
     });
 
-    test("rejects uninstall when the skill path escapes the Codex skills directory", async () => {
+    test("rejects uninstall when the skill path escapes the local skills directory", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const storePaths = resolveStorePaths({
@@ -643,7 +660,7 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(1);
             expect(result.stdout).toBe("");
             expect(result.stderr).toBe(
-                "Skill name ../../outside resolves outside the local Codex skills directory.\n",
+                "Skill name ../../outside resolves outside the local skill directories.\n",
             );
             await expect(stat(installedSentinelPath)).resolves.toMatchObject({
                 isFile: expect.any(Function),
@@ -1010,7 +1027,225 @@ describe("skills commands", () => {
         }
     });
 
-    test("rejects published registry skills that escape the Codex skills directory", async () => {
+    test("installs a published registry skill into every existing supported host", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
+        const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
+        const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const claudeSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
+        const openClawSkillDirectoryPath = join(openClawHomeDirectory, "skills", "chatgpt");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+
+        try {
+            await Promise.all([
+                mkdir(codexHomeDirectory, { recursive: true }),
+                mkdir(claudeHomeDirectory, { recursive: true }),
+                mkdir(openClawHomeDirectory, { recursive: true }),
+            ]);
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "--skill", "chatgpt"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.3",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/openai/-/meta/openai-0.0.3.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    `Installed skill chatgpt to ${codexSkillDirectoryPath}.`,
+                    `Installed skill chatgpt to ${claudeSkillDirectoryPath}.`,
+                    `Installed skill chatgpt to ${openClawSkillDirectoryPath}.`,
+                    "",
+                ].join("\n"),
+            );
+            expect(await realpath(codexSkillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect(await realpath(claudeSkillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect(await realpath(openClawSkillDirectoryPath)).not.toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect((await lstat(openClawSkillDirectoryPath)).isSymbolicLink()).toBeFalse();
+            for (const skillDirectoryPath of [
+                codexSkillDirectoryPath,
+                claudeSkillDirectoryPath,
+                openClawSkillDirectoryPath,
+            ]) {
+                expect(await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8")).toContain(
+                    "# ChatGPT",
+                );
+                expect(await readFile(
+                    resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+                    "utf8",
+                )).toBe(
+                    renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
+                );
+            }
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("installs a published registry skill when only Claude Code is installed", async () => {
+        const sandbox = await createCliSandbox();
+        const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+
+        try {
+            await mkdir(claudeHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "--skill", "chatgpt"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.3",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/openai/-/meta/openai-0.0.3.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Installed skill chatgpt to ${skillDirectoryPath}.\n`,
+            );
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not install a published registry skill over an unmanaged host target", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
+        const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const claudeSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
+
+        try {
+            await Promise.all([
+                mkdir(codexHomeDirectory, { recursive: true }),
+                mkdir(claudeSkillDirectoryPath, { recursive: true }),
+            ]);
+            await Bun.write(join(claudeSkillDirectoryPath, "SKILL.md"), "# Existing\n");
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "openai"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.3",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("Skill: chatgpt\n");
+            expect(result.stderr).toBe(
+                `Skill name chatgpt is already used by a non-OOMOL skill at ${claudeSkillDirectoryPath}.\n`,
+            );
+            expect(await readFile(join(claudeSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
+                "# Existing\n",
+            );
+            await expect(stat(codexSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects published registry skills that escape the local skills directory", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const requests: Request[] = [];
@@ -1049,7 +1284,7 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(1);
             expect(result.stdout).toBe("Skill: ../../outside\n");
             expect(result.stderr).toBe(
-                "Skill name ../../outside resolves outside the local Codex skills directory.\n",
+                "Skill name ../../outside resolves outside the local skill directories.\n",
             );
             expect(requests).toHaveLength(1);
         }

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -1,6 +1,7 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 import type { TerminalColors } from "../../terminal-colors.ts";
 import type { BundledSkillAgentName } from "./embedded-assets.ts";
+import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
 
 import type { ManagedSkillMetadata } from "./managed-skill-metadata.ts";
 import { readdir, readFile } from "node:fs/promises";
@@ -9,20 +10,14 @@ import { z } from "zod";
 import { compareSemver } from "../../semver.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
+import { availableBundledSkillNames } from "./embedded-assets.ts";
 import {
-    directoryExists,
-} from "./bundled-skill-observation.ts";
-import {
-    codexSkillsDirectoryName,
-    resolveBundledSkillHomeDirectory,
-} from "./bundled-skill-paths.ts";
-import {
-    availableBundledSkillAgentNames,
-    availableBundledSkillNames,
-} from "./embedded-assets.ts";
+    resolveAvailableManagedSkillHosts,
+} from "./managed-skill-hosts.ts";
 import { parseManagedSkillMetadataContent } from "./managed-skill-metadata.ts";
 import {
     resolveManagedSkillMetadataFilePath,
+    resolveManagedSkillsDirectoryPath,
 } from "./managed-skill-paths.ts";
 import { isBundledSkillName } from "./shared.ts";
 
@@ -41,7 +36,7 @@ export interface ManagedSkillListItem {
     path: string;
 }
 
-interface ManagedSkillHostListItem extends ManagedSkillListItem {
+export interface ManagedSkillHostListItem extends ManagedSkillListItem {
     hostName: BundledSkillAgentName;
 }
 
@@ -86,27 +81,22 @@ export const skillsListCommand: CliCommandDefinition<Record<string, never>> = {
 async function listManagedSkillInstallationsByHost(
     env: Record<string, string | undefined>,
 ): Promise<ManagedSkillHostListItem[]> {
-    const hostDirectories = await Promise.all(
-        availableBundledSkillAgentNames.map(async (hostName) => {
-            const homeDirectory = resolveBundledSkillHomeDirectory(env, hostName);
+    return listManagedSkillInstallationsForHosts(
+        await resolveAvailableManagedSkillHosts(env),
+    );
+}
 
-            return await directoryExists(homeDirectory)
-                ? {
-                        hostName,
-                        skillsDirectoryPath: join(homeDirectory, codexSkillsDirectoryName),
-                    }
-                : undefined;
-        }),
-    );
-    const existingHostDirectories = hostDirectories.filter(
-        hostDirectory => hostDirectory !== undefined,
-    );
+export async function listManagedSkillInstallationsForHosts(
+    hosts: readonly ManagedSkillHost[],
+): Promise<ManagedSkillHostListItem[]> {
     const skillsByHost = await Promise.all(
-        existingHostDirectories.map(hostDirectory =>
-            listManagedSkillInstallations(hostDirectory.skillsDirectoryPath)
+        hosts.map(host =>
+            listManagedSkillInstallations(
+                resolveManagedSkillsDirectoryPath(host.homeDirectory),
+            )
                 .then(skills => skills.map(skill => ({
                     ...skill,
-                    hostName: hostDirectory.hostName,
+                    hostName: host.agentName,
                 }) satisfies ManagedSkillHostListItem)),
         ),
     );

--- a/src/application/commands/skills/managed-skill-hosts.ts
+++ b/src/application/commands/skills/managed-skill-hosts.ts
@@ -1,0 +1,67 @@
+import type { BundledSkillAgentName } from "./embedded-assets.ts";
+
+import { CliUserError } from "../../contracts/cli.ts";
+import { directoryExists } from "./bundled-skill-observation.ts";
+import { resolveBundledSkillHomeDirectory } from "./bundled-skill-paths.ts";
+import { availableBundledSkillAgentNames } from "./embedded-assets.ts";
+import { resolveManagedSkillDirectoryPath } from "./managed-skill-paths.ts";
+
+export interface ManagedSkillHost {
+    agentName: BundledSkillAgentName;
+    homeDirectory: string;
+}
+
+export interface ManagedSkillHostInstallation extends ManagedSkillHost {
+    installedSkillDirectoryPath: string;
+}
+
+export async function resolveAvailableManagedSkillHosts(
+    env: Record<string, string | undefined>,
+): Promise<ManagedSkillHost[]> {
+    const hosts = await Promise.all(
+        availableBundledSkillAgentNames.map(async (agentName) => {
+            const homeDirectory = resolveBundledSkillHomeDirectory(env, agentName);
+
+            if (!(await directoryExists(homeDirectory))) {
+                return undefined;
+            }
+
+            return {
+                agentName,
+                homeDirectory,
+            } satisfies ManagedSkillHost;
+        }),
+    );
+
+    return hosts.filter(host => host !== undefined);
+}
+
+export function resolveManagedSkillHostInstallation(
+    host: ManagedSkillHost,
+    skillName: string,
+): ManagedSkillHostInstallation {
+    return {
+        ...host,
+        installedSkillDirectoryPath: resolveManagedSkillDirectoryPath(
+            host.homeDirectory,
+            skillName,
+        ),
+    };
+}
+
+export function resolveManagedSkillHostInstallations(
+    hosts: readonly ManagedSkillHost[],
+    skillName: string,
+): ManagedSkillHostInstallation[] {
+    return hosts.map(host => resolveManagedSkillHostInstallation(host, skillName));
+}
+
+export function createMissingManagedSkillHostError(
+    env: Record<string, string | undefined>,
+): CliUserError {
+    return new CliUserError("errors.skills.noSupportedBundledSkillHosts", 1, {
+        paths: availableBundledSkillAgentNames
+            .map(agentName => resolveBundledSkillHomeDirectory(env, agentName))
+            .join(", "),
+    });
+}

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -1,5 +1,6 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
+import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
 import type { RegistryPackageSkillInfo, RegistrySkillSummary } from "./registry-skill-source.ts";
 
 import { CliUserError } from "../../contracts/cli.ts";
@@ -7,24 +8,29 @@ import { withPackageIdentity } from "../../logging/log-fields.ts";
 
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { writeLine } from "../shared/output.ts";
-import { directoryExists, requireCodexHomeDirectory } from "./bundled-skill-observation.ts";
+import { directoryExists } from "./bundled-skill-observation.ts";
 import { SkillsInstallProgressReporter } from "./install-progress.ts";
 import {
     confirmInteractiveValue,
     selectInteractiveSkills,
 } from "./interactive-prompts.ts";
 import {
+    createMissingManagedSkillHostError,
+    resolveAvailableManagedSkillHosts,
+    resolveManagedSkillHostInstallations,
+} from "./managed-skill-hosts.ts";
+import {
     readManagedSkillMetadata,
 } from "./managed-skill-metadata.ts";
 import {
     isManagedSkillPathContained,
     resolveManagedSkillCanonicalDirectoryPath,
-    resolveManagedSkillDirectoryPath,
 } from "./managed-skill-paths.ts";
 import { extractRegistryPackageArchive } from "./registry-skill-archive.ts";
 import {
     prepareRegistrySkillPublication,
     publishPreparedRegistrySkillPublication,
+    validateRegistrySkillPublicationTargets,
 } from "./registry-skill-publication.ts";
 import {
     downloadRegistryPackageTarball,
@@ -68,7 +74,12 @@ export async function installRegistrySkills(
     context: CliExecutionContext,
 ): Promise<void> {
     const account = await requireCurrentAccount(context);
-    const codexHomeDirectory = await requireCodexHomeDirectory(context);
+    const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
+
+    if (availableHosts.length === 0) {
+        throw createMissingManagedSkillHostError(context.env);
+    }
+
     const packageInfo = await loadRegistryPackageSkillInfo(
         request.packageName,
         account,
@@ -84,7 +95,7 @@ export async function installRegistrySkills(
     const selectionActions = await resolveSelectionActions(
         request,
         packageInfo,
-        codexHomeDirectory,
+        availableHosts,
         context,
     );
 
@@ -95,10 +106,17 @@ export async function installRegistrySkills(
     const settingsFilePath = context.settingsStore.getFilePath();
 
     for (const { skillName } of selectionActions.actions) {
-        if (!isManagedSkillPathContained(
-            codexHomeDirectory,
-            settingsFilePath,
+        const hostInstallations = resolveManagedSkillHostInstallations(
+            availableHosts,
             skillName,
+        );
+
+        if (hostInstallations.some(installation =>
+            !isManagedSkillPathContained(
+                installation.homeDirectory,
+                settingsFilePath,
+                skillName,
+            ),
         )) {
             throw new CliUserError("errors.skills.invalidPath", 1, {
                 name: skillName,
@@ -126,7 +144,7 @@ export async function installRegistrySkills(
                     installActions,
                     packageInfo,
                     account,
-                    codexHomeDirectory,
+                    availableHosts,
                     settingsFilePath,
                     selectionActions.isInteractive,
                     context,
@@ -168,11 +186,21 @@ async function executeInstallActions(
     installActions: readonly RegistrySkillSelectionAction[],
     packageInfo: RegistryPackageSkillInfo,
     account: AuthAccount,
-    codexHomeDirectory: string,
+    availableHosts: readonly ManagedSkillHost[],
     settingsFilePath: string,
     isInteractive: boolean,
     context: CliExecutionContext,
 ): Promise<void> {
+    for (const { skillName } of installActions) {
+        await validateRegistrySkillPublicationTargets({
+            hostInstallations: resolveManagedSkillHostInstallations(
+                availableHosts,
+                skillName,
+            ),
+            skillName,
+        });
+    }
+
     const packageBytes = await downloadRegistryPackageTarball(
         packageInfo.packageName,
         packageInfo.packageVersion,
@@ -184,10 +212,14 @@ async function executeInstallActions(
     try {
         for (const { skillName } of installActions) {
             const skill = findPackageSkillOrThrow(packageInfo.skills, skillName, packageInfo.packageName);
-            const installation = await publishPreparedRegistrySkillPublication(
+            const hostInstallations = resolveManagedSkillHostInstallations(
+                availableHosts,
+                skillName,
+            );
+            const publications = await publishPreparedRegistrySkillPublication(
                 await prepareRegistrySkillPublication({
-                    codexHomeDirectory,
                     extractedPackage,
+                    hostInstallations,
                     packageName: packageInfo.packageName,
                     packageVersion: packageInfo.packageVersion,
                     settingsFilePath,
@@ -197,27 +229,32 @@ async function executeInstallActions(
             );
 
             if (!isInteractive) {
-                writeLine(
-                    context.stdout,
-                    context.translator.t("skills.install.success", {
-                        name: skillName,
-                        path: installation.path,
-                    }),
-                );
+                for (const publication of publications) {
+                    writeLine(
+                        context.stdout,
+                        context.translator.t("skills.install.success", {
+                            name: skillName,
+                            path: publication.path,
+                        }),
+                    );
+                }
             }
 
-            context.logger.info(
-                {
-                    ...withPackageIdentity(
-                        packageInfo.packageName,
-                        packageInfo.packageVersion,
-                    ),
-                    installMode: installation.mode,
-                    path: installation.path,
-                    skillName,
-                },
-                "Registry Codex skill installed explicitly.",
-            );
+            for (const publication of publications) {
+                context.logger.info(
+                    {
+                        ...withPackageIdentity(
+                            packageInfo.packageName,
+                            packageInfo.packageVersion,
+                        ),
+                        agentName: publication.agentName,
+                        installMode: publication.mode,
+                        path: publication.path,
+                        skillName,
+                    },
+                    "Registry skill installed explicitly.",
+                );
+            }
         }
     }
     finally {
@@ -228,7 +265,7 @@ async function executeInstallActions(
 async function resolveSelectionActions(
     request: RegistrySkillInstallRequest,
     packageInfo: RegistryPackageSkillInfo,
-    codexHomeDirectory: string,
+    availableHosts: readonly ManagedSkillHost[],
     context: Pick<
         CliExecutionContext,
         "settingsStore" | "stdin" | "stdout" | "translator"
@@ -258,7 +295,7 @@ async function resolveSelectionActions(
                 await filterConfirmedSkillNames(
                     packageInfo.packageName,
                     request.skillNames,
-                    codexHomeDirectory,
+                    availableHosts,
                     context,
                 ),
             ),
@@ -304,7 +341,7 @@ async function resolveSelectionActions(
 
     const skillStates = await readRegistrySkillStates(
         packageInfo,
-        codexHomeDirectory,
+        availableHosts,
         context.settingsStore.getFilePath(),
     );
     const selectedSkillNames = await selectInteractiveSkills(
@@ -349,7 +386,7 @@ async function resolveSelectionActions(
 async function filterConfirmedSkillNames(
     packageName: string,
     skillNames: readonly string[],
-    codexHomeDirectory: string,
+    availableHosts: readonly ManagedSkillHost[],
     context: Pick<
         CliExecutionContext,
         "settingsStore" | "stdin" | "stdout" | "translator"
@@ -361,7 +398,7 @@ async function filterConfirmedSkillNames(
         const status = await readRegistrySkillInstallStatus(
             packageName,
             skillName,
-            codexHomeDirectory,
+            availableHosts,
             context.settingsStore.getFilePath(),
         );
 
@@ -430,7 +467,7 @@ export function findPackageSkillOrThrow(
 
 async function readRegistrySkillStates(
     packageInfo: RegistryPackageSkillInfo,
-    codexHomeDirectory: string,
+    availableHosts: readonly ManagedSkillHost[],
     settingsFilePath: string,
 ): Promise<RegistrySkillState[]> {
     return await Promise.all(
@@ -440,7 +477,7 @@ async function readRegistrySkillStates(
             status: await readRegistrySkillInstallStatus(
                 packageInfo.packageName,
                 skill.name,
-                codexHomeDirectory,
+                availableHosts,
                 settingsFilePath,
             ),
             title: skill.title,
@@ -451,32 +488,36 @@ async function readRegistrySkillStates(
 async function readRegistrySkillInstallStatus(
     packageName: string,
     skillName: string,
-    codexHomeDirectory: string,
+    availableHosts: readonly ManagedSkillHost[],
     settingsFilePath: string,
 ): Promise<RegistrySkillInstallStatus> {
     const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
         settingsFilePath,
         skillName,
     );
-    const installedSkillDirectoryPath = resolveManagedSkillDirectoryPath(
-        codexHomeDirectory,
+    const hostInstallations = resolveManagedSkillHostInstallations(
+        availableHosts,
         skillName,
     );
-    const [canonicalState, installedState] = await Promise.all([
+    const [canonicalState, installedStates] = await Promise.all([
         readManagedSkillPathState(canonicalSkillDirectoryPath),
-        readManagedSkillPathState(installedSkillDirectoryPath),
+        Promise.all(hostInstallations.map(installation =>
+            readManagedSkillPathState(installation.installedSkillDirectoryPath),
+        )),
     ]);
 
     if (
         hasManagedSkillPathConflict(canonicalState, packageName)
-        || hasManagedSkillPathConflict(installedState, packageName)
+        || installedStates.some(state =>
+            hasManagedSkillPathConflict(state, packageName),
+        )
     ) {
         return "conflict";
     }
 
     if (
         canonicalState.metadataPackageName === packageName
-        || installedState.metadataPackageName === packageName
+        || installedStates.some(state => state.metadataPackageName === packageName)
     ) {
         return "installed";
     }

--- a/src/application/commands/skills/registry-skill-publication.ts
+++ b/src/application/commands/skills/registry-skill-publication.ts
@@ -1,32 +1,42 @@
 import type { BundledSkillPublicationResult } from "./bundled-skill-filesystem.ts";
+import type { BundledSkillAgentName } from "./embedded-assets.ts";
+import type { ManagedSkillHostInstallation } from "./managed-skill-hosts.ts";
 import type { ExtractedRegistryPackageArchive } from "./registry-skill-archive.ts";
 import type { RegistrySkillSummary } from "./registry-skill-source.ts";
 
 import { cp, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
+import { CliUserError } from "../../contracts/cli.ts";
 import {
     publishBundledSkillInstallation,
     removePath,
 } from "./bundled-skill-filesystem.ts";
-import { writeManagedSkillMetadata } from "./managed-skill-metadata.ts";
+import { directoryExists } from "./bundled-skill-observation.ts";
+import {
+    readManagedSkillMetadata,
+    writeManagedSkillMetadata,
+} from "./managed-skill-metadata.ts";
 import {
     resolveManagedSkillCanonicalDirectoryPath,
-    resolveManagedSkillDirectoryPath,
 } from "./managed-skill-paths.ts";
 import { requireExtractedRegistrySkillDirectory } from "./registry-skill-archive.ts";
 import { rewriteInstalledRegistrySkillMarkdown } from "./registry-skill-markdown.ts";
 
 export interface PreparedRegistrySkillPublication {
     canonicalSkillDirectoryPath: string;
-    installedSkillDirectoryPath: string;
+    hostInstallations: ManagedSkillHostInstallation[];
     packageName: string;
     packageVersion: string;
     skillName: string;
 }
 
+export interface RegistrySkillPublicationResult extends BundledSkillPublicationResult {
+    agentName: BundledSkillAgentName;
+}
+
 export async function prepareRegistrySkillPublication(options: {
-    codexHomeDirectory: string;
     extractedPackage: ExtractedRegistryPackageArchive;
+    hostInstallations: readonly ManagedSkillHostInstallation[];
     packageName: string;
     packageVersion: string;
     settingsFilePath: string;
@@ -35,10 +45,6 @@ export async function prepareRegistrySkillPublication(options: {
 }): Promise<PreparedRegistrySkillPublication> {
     const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
         options.settingsFilePath,
-        options.skillName,
-    );
-    const installedSkillDirectoryPath = resolveManagedSkillDirectoryPath(
-        options.codexHomeDirectory,
         options.skillName,
     );
 
@@ -70,7 +76,7 @@ export async function prepareRegistrySkillPublication(options: {
 
     return {
         canonicalSkillDirectoryPath,
-        installedSkillDirectoryPath,
+        hostInstallations: [...options.hostInstallations],
         packageName: options.packageName,
         packageVersion: options.packageVersion,
         skillName: options.skillName,
@@ -79,9 +85,58 @@ export async function prepareRegistrySkillPublication(options: {
 
 export async function publishPreparedRegistrySkillPublication(
     preparedPublication: PreparedRegistrySkillPublication,
-): Promise<BundledSkillPublicationResult> {
-    return publishBundledSkillInstallation({
-        canonicalSkillDirectoryPath: preparedPublication.canonicalSkillDirectoryPath,
-        installedSkillDirectoryPath: preparedPublication.installedSkillDirectoryPath,
+): Promise<RegistrySkillPublicationResult[]> {
+    await validateRegistrySkillPublicationTargets(preparedPublication);
+
+    return Promise.all(
+        preparedPublication.hostInstallations.map(async (installation) => {
+            const publication = await publishBundledSkillInstallation({
+                canonicalSkillDirectoryPath: preparedPublication.canonicalSkillDirectoryPath,
+                installedSkillDirectoryPath: installation.installedSkillDirectoryPath,
+                publicationMode: installation.agentName === "openclaw"
+                    ? "copy"
+                    : "symlink-or-copy",
+            });
+
+            return {
+                ...publication,
+                agentName: installation.agentName,
+            };
+        }),
+    );
+}
+
+export async function validateRegistrySkillPublicationTargets(options: {
+    hostInstallations: readonly ManagedSkillHostInstallation[];
+    skillName: string;
+}): Promise<void> {
+    const targetStates = await Promise.all(
+        options.hostInstallations.map(async (installation) => {
+            const installedDirectoryExists = await directoryExists(
+                installation.installedSkillDirectoryPath,
+            );
+
+            return {
+                installation,
+                installedDirectoryExists,
+                metadata: installedDirectoryExists
+                    ? await readManagedSkillMetadata(
+                            installation.installedSkillDirectoryPath,
+                        )
+                    : undefined,
+            };
+        }),
+    );
+    const unmanagedTarget = targetStates.find(
+        target => target.installedDirectoryExists && target.metadata === undefined,
+    );
+
+    if (unmanagedTarget === undefined) {
+        return;
+    }
+
+    throw new CliUserError("errors.skills.nameConflict", 1, {
+        name: options.skillName,
+        path: unmanagedTarget.installation.installedSkillDirectoryPath,
     });
 }

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -5,6 +5,7 @@ import type {
     BundledSkillAgentName,
     BundledSkillName,
 } from "./embedded-assets.ts";
+import type { ManagedSkillHostInstallation } from "./managed-skill-hosts.ts";
 import {
     mkdir,
 } from "node:fs/promises";
@@ -23,32 +24,31 @@ import {
     directoryExists,
     isManagedBundledSkillInstallation,
     readInstalledBundledSkillMetadata,
-    requireCodexHomeDirectory,
     writeInstalledBundledSkillMetadata,
 } from "./bundled-skill-observation.ts";
 import {
     resolveBundledSkillCanonicalDirectoryPath,
     resolveBundledSkillDirectoryPath,
-    resolveBundledSkillHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import {
-    availableBundledSkillAgentNames,
     availableBundledSkillNames,
     getBundledSkillFiles,
 } from "./embedded-assets.ts";
+import {
+    createMissingManagedSkillHostError,
+    resolveAvailableManagedSkillHosts,
+    resolveManagedSkillHostInstallation,
+    resolveManagedSkillHostInstallations,
+} from "./managed-skill-hosts.ts";
 import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
 
 import {
     isManagedSkillPathContained,
     resolveManagedSkillCanonicalDirectoryPath,
-    resolveManagedSkillDirectoryPath,
 } from "./managed-skill-paths.ts";
 
-interface BundledSkillHostInstallation {
-    agentName: BundledSkillAgentName;
+interface BundledSkillHostInstallation extends ManagedSkillHostInstallation {
     canonicalSkillDirectoryPath: string;
-    homeDirectory: string;
-    installedSkillDirectoryPath: string;
 }
 
 export async function installBundledSkill(
@@ -61,7 +61,7 @@ export async function installBundledSkill(
     );
 
     if (installations.length === 0) {
-        throw createMissingBundledSkillHostError(context.env);
+        throw createMissingManagedSkillHostError(context.env);
     }
 
     for (const installation of installations) {
@@ -112,7 +112,7 @@ export async function uninstallBundledSkill(
     );
 
     if (installations.length === 0) {
-        throw createMissingBundledSkillHostError(context.env);
+        throw createMissingManagedSkillHostError(context.env);
     }
 
     const uninstallTargets: Array<
@@ -275,34 +275,16 @@ async function resolveAvailableBundledSkillHostInstallations(
     skillName: BundledSkillName,
 ): Promise<BundledSkillHostInstallation[]> {
     const settingsFilePath = context.settingsStore.getFilePath();
-    const installations = await Promise.all(
-        availableBundledSkillAgentNames.map(async (agentName) => {
-            const homeDirectory = resolveBundledSkillHomeDirectory(
-                context.env,
-                agentName,
-            );
+    const hosts = await resolveAvailableManagedSkillHosts(context.env);
 
-            if (!(await directoryExists(homeDirectory))) {
-                return undefined;
-            }
-
-            return {
-                agentName,
-                canonicalSkillDirectoryPath: resolveBundledSkillCanonicalDirectoryPath(
-                    settingsFilePath,
-                    skillName,
-                    agentName,
-                ),
-                homeDirectory,
-                installedSkillDirectoryPath: resolveBundledSkillDirectoryPath(
-                    homeDirectory,
-                    skillName,
-                ),
-            } satisfies BundledSkillHostInstallation;
-        }),
-    );
-
-    return installations.filter(installation => installation !== undefined);
+    return hosts.map(host => ({
+        ...resolveManagedSkillHostInstallation(host, skillName),
+        canonicalSkillDirectoryPath: resolveBundledSkillCanonicalDirectoryPath(
+            settingsFilePath,
+            skillName,
+            host.agentName,
+        ),
+    }) satisfies BundledSkillHostInstallation);
 }
 
 async function validateBundledSkillInstallationTarget(
@@ -377,16 +359,6 @@ async function validateBundledSkillInstallationTarget(
     });
 }
 
-function createMissingBundledSkillHostError(
-    env: Record<string, string | undefined>,
-): CliUserError {
-    return new CliUserError("errors.skills.noSupportedBundledSkillHosts", 1, {
-        paths: availableBundledSkillAgentNames
-            .map(agentName => resolveBundledSkillHomeDirectory(env, agentName))
-            .join(", "),
-    });
-}
-
 async function uninstallRegistrySkill(
     skillName: string,
     context: CliExecutionContext,
@@ -394,70 +366,113 @@ async function uninstallRegistrySkill(
         silent?: boolean;
     },
 ): Promise<void> {
-    const codexHomeDirectory = await requireCodexHomeDirectory(context);
-    const settingsFilePath = context.settingsStore.getFilePath();
+    const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
 
-    if (!isManagedSkillPathContained(
-        codexHomeDirectory,
-        settingsFilePath,
+    if (availableHosts.length === 0) {
+        throw createMissingManagedSkillHostError(context.env);
+    }
+
+    const settingsFilePath = context.settingsStore.getFilePath();
+    const hostInstallations = resolveManagedSkillHostInstallations(
+        availableHosts,
         skillName,
+    );
+
+    if (hostInstallations.some(installation =>
+        !isManagedSkillPathContained(
+            installation.homeDirectory,
+            settingsFilePath,
+            skillName,
+        ),
     )) {
         throw new CliUserError("errors.skills.invalidPath", 1, {
             name: skillName,
         });
     }
 
-    const skillDirectoryPath = resolveManagedSkillDirectoryPath(
-        codexHomeDirectory,
-        skillName,
-    );
     const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
         settingsFilePath,
         skillName,
     );
-    const metadata = await readManagedSkillMetadata(skillDirectoryPath);
+    const uninstallTargets: Array<
+        ManagedSkillHostInstallation & {
+            packageName: string | undefined;
+            previousVersion: string | undefined;
+        }
+    > = [];
 
-    if (metadata === undefined) {
-        const installedSkillDirectoryExists = await directoryExists(skillDirectoryPath);
-
-        context.logger.warn(
-            {
-                path: skillDirectoryPath,
-                skillName,
-            },
-            "Managed Codex skill uninstall skipped because no OOMOL metadata was found.",
+    for (const installation of hostInstallations) {
+        const installedSkillDirectoryExists = await directoryExists(
+            installation.installedSkillDirectoryPath,
         );
+        const metadata = installedSkillDirectoryExists
+            ? await readManagedSkillMetadata(installation.installedSkillDirectoryPath)
+            : undefined;
+
+        if (metadata === undefined) {
+            if (!installedSkillDirectoryExists) {
+                continue;
+            }
+
+            context.logger.warn(
+                {
+                    agentName: installation.agentName,
+                    path: installation.installedSkillDirectoryPath,
+                    skillName,
+                },
+                "Managed registry skill uninstall skipped because no OOMOL metadata was found.",
+            );
+            throw createManagedSkillUninstallError({
+                installedDirectoryExists: true,
+                path: installation.installedSkillDirectoryPath,
+                skillName,
+            });
+        }
+
+        uninstallTargets.push({
+            ...installation,
+            packageName: metadata.packageName,
+            previousVersion: metadata.version,
+        });
+    }
+
+    if (uninstallTargets.length === 0) {
         throw createManagedSkillUninstallError({
-            installedDirectoryExists: installedSkillDirectoryExists,
-            path: skillDirectoryPath,
+            installedDirectoryExists: false,
+            path: hostInstallations[0]!.installedSkillDirectoryPath,
             skillName,
         });
     }
 
     await Promise.all([
-        removePath(skillDirectoryPath),
+        ...uninstallTargets.map(target =>
+            removePath(target.installedSkillDirectoryPath),
+        ),
         removePath(canonicalSkillDirectoryPath),
     ]);
 
-    if (options?.silent !== true) {
-        writeLine(
-            context.stdout,
-            context.translator.t("skills.uninstall.success", {
-                name: skillName,
-                path: skillDirectoryPath,
-            }),
+    for (const target of uninstallTargets) {
+        if (options?.silent !== true) {
+            writeLine(
+                context.stdout,
+                context.translator.t("skills.uninstall.success", {
+                    name: skillName,
+                    path: target.installedSkillDirectoryPath,
+                }),
+            );
+        }
+        context.logger.info(
+            {
+                agentName: target.agentName,
+                canonicalPath: canonicalSkillDirectoryPath,
+                packageName: target.packageName,
+                path: target.installedSkillDirectoryPath,
+                previousVersion: target.previousVersion ?? "unknown",
+                skillName,
+            },
+            "Managed registry skill removed explicitly.",
         );
     }
-    context.logger.info(
-        {
-            canonicalPath: canonicalSkillDirectoryPath,
-            packageName: metadata.packageName,
-            path: skillDirectoryPath,
-            previousVersion: metadata.version ?? "unknown",
-            skillName,
-        },
-        "Managed Codex skill removed explicitly.",
-    );
 }
 
 function createManagedSkillUninstallError(options: {

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -107,6 +107,48 @@ describe("skills update command", () => {
         }
     });
 
+    test("ignores installed skills with unparseable metadata when updating all skills", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const installedSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeUnparseableManagedSkillInstallation(installedSkillDirectoryPath);
+
+            const result = await sandbox.run(["skills", "update"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe("No updatable oo-managed skills were found.\n");
+            expect(result.stderr).toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects an explicit update target with unparseable metadata as unmanaged", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const installedSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeUnparseableManagedSkillInstallation(installedSkillDirectoryPath);
+
+            const result = await sandbox.run(["skills", "update", "chatgpt"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Skill chatgpt in host codex is not managed by oo and cannot be updated.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("updates a published managed skill to the latest version", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -604,27 +646,37 @@ describe("skills update command", () => {
     test("fails when a non-bundled managed skill is missing package metadata", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
             platform: process.platform,
         });
         const installedSkillDirectoryPath = join(codexHomeDirectory, "skills", "custom");
+        const claudeInstalledSkillDirectoryPath = join(claudeHomeDirectory, "skills", "custom");
         const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
             storePaths.settingsFilePath,
             "custom",
         );
 
         try {
-            await mkdir(codexHomeDirectory, { recursive: true });
+            await Promise.all([
+                mkdir(codexHomeDirectory, { recursive: true }),
+                mkdir(claudeHomeDirectory, { recursive: true }),
+            ]);
             await mkdir(canonicalSkillDirectoryPath, { recursive: true });
             await mkdir(installedSkillDirectoryPath, { recursive: true });
+            await mkdir(claudeInstalledSkillDirectoryPath, { recursive: true });
             await Bun.write(
                 join(canonicalSkillDirectoryPath, "SKILL.md"),
                 "# Custom\n",
             );
             await Bun.write(
                 join(installedSkillDirectoryPath, "SKILL.md"),
+                "# Custom\n",
+            );
+            await Bun.write(
+                join(claudeInstalledSkillDirectoryPath, "SKILL.md"),
                 "# Custom\n",
             );
             await Bun.write(
@@ -635,15 +687,19 @@ describe("skills update command", () => {
                 resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
                 renderSkillMetadataJson({ version: "1.0.0" }),
             );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(claudeInstalledSkillDirectoryPath),
+                renderSkillMetadataJson({ version: "1.0.0" }),
+            );
 
             const result = await sandbox.run(["skills", "update", "custom"]);
 
             expect(result.exitCode).toBe(1);
             expect(result.stdout).toBe(
-                "Failed to update skill custom: Managed skill custom cannot be updated because its package metadata is missing.\n",
+                "Failed to update skill custom: Managed skill custom cannot be updated in codex, claude because its package metadata is missing.\n",
             );
             expect(result.stderr).toBe(
-                "Managed skill custom cannot be updated because its package metadata is missing.\n",
+                "Managed skill custom cannot be updated in codex, claude because its package metadata is missing.\n",
             );
         }
         finally {
@@ -677,4 +733,12 @@ async function writeManagedRegistrySkillInstallation(options: {
         resolveManagedSkillMetadataFilePath(options.installedSkillDirectoryPath),
         renderSkillMetadataJson({ packageName: options.packageName, version: options.version }),
     );
+}
+
+async function writeUnparseableManagedSkillInstallation(
+    skillDirectoryPath: string,
+): Promise<void> {
+    await mkdir(skillDirectoryPath, { recursive: true });
+    await Bun.write(join(skillDirectoryPath, "SKILL.md"), "# Broken\n");
+    await Bun.write(resolveManagedSkillMetadataFilePath(skillDirectoryPath), "{\n");
 }

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -16,7 +16,10 @@ import {
 import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { executeCli } from "../../bootstrap/run-cli.ts";
 import { APP_NAME } from "../../config/app-config.ts";
-import { resolveCodexHomeDirectory } from "./bundled-skill-paths.ts";
+import {
+    resolveClaudeHomeDirectory,
+    resolveCodexHomeDirectory,
+} from "./bundled-skill-paths.ts";
 import {
     resolveManagedSkillCanonicalDirectoryPath,
     resolveManagedSkillMetadataFilePath,
@@ -107,27 +110,41 @@ describe("skills update command", () => {
     test("updates a published managed skill to the latest version", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
             platform: process.platform,
         });
-        const installedSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const codexInstalledSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const claudeInstalledSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
         const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
             storePaths.settingsFilePath,
             "chatgpt",
         );
 
         try {
-            await mkdir(codexHomeDirectory, { recursive: true });
+            await Promise.all([
+                mkdir(codexHomeDirectory, { recursive: true }),
+                mkdir(claudeHomeDirectory, { recursive: true }),
+            ]);
             await writeAuthFile(sandbox);
             await writeManagedRegistrySkillInstallation({
                 canonicalSkillDirectoryPath,
-                installedSkillDirectoryPath,
+                installedSkillDirectoryPath: codexInstalledSkillDirectoryPath,
                 packageName: "openai",
                 skillMarkdown: "# ChatGPT stale\n",
                 version: "0.0.3",
             });
+            await mkdir(claudeInstalledSkillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(claudeInstalledSkillDirectoryPath, "SKILL.md"),
+                "# ChatGPT stale\n",
+            );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(claudeInstalledSkillDirectoryPath),
+                renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
+            );
 
             const result = await sandbox.run(
                 ["skills", "update", "chatgpt"],
@@ -163,7 +180,96 @@ describe("skills update command", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
-                `Updated Codex skill chatgpt to ${installedSkillDirectoryPath}.\n`,
+                [
+                    `Updated skill chatgpt to ${codexInstalledSkillDirectoryPath}.`,
+                    `Updated skill chatgpt to ${claudeInstalledSkillDirectoryPath}.`,
+                    "",
+                ].join("\n"),
+            );
+            expect(await readFile(
+                resolveManagedSkillMetadataFilePath(codexInstalledSkillDirectoryPath),
+                "utf8",
+            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }));
+            expect(await readFile(join(codexInstalledSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
+                "# ChatGPT fresh",
+            );
+            expect(await readFile(
+                resolveManagedSkillMetadataFilePath(claudeInstalledSkillDirectoryPath),
+                "utf8",
+            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }));
+            expect(await readFile(join(claudeInstalledSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
+                "# ChatGPT fresh",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("updates a host target when canonical metadata is already current", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const installedSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+            await writeManagedRegistrySkillInstallation({
+                canonicalSkillDirectoryPath,
+                installedSkillDirectoryPath,
+                packageName: "openai",
+                skillMarkdown: "# ChatGPT stale\n",
+                version: "0.0.3",
+            });
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath),
+                renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }),
+            );
+
+            const result = await sandbox.run(
+                ["skills", "update", "chatgpt"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.4",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/openai/-/meta/openai-0.0.4.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT fresh\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Updated skill chatgpt to ${installedSkillDirectoryPath}.\n`,
             );
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
@@ -534,7 +640,7 @@ describe("skills update command", () => {
 
             expect(result.exitCode).toBe(1);
             expect(result.stdout).toBe(
-                "Failed to update Codex skill custom: Managed skill custom cannot be updated because its package metadata is missing.\n",
+                "Failed to update skill custom: Managed skill custom cannot be updated because its package metadata is missing.\n",
             );
             expect(result.stderr).toBe(
                 "Managed skill custom cannot be updated because its package metadata is missing.\n",

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -1,5 +1,6 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
+import type { BundledSkillAgentName } from "./embedded-assets.ts";
 import type { ManagedSkillListItem } from "./list.ts";
 import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
 import type { PreparedRegistrySkillPublication } from "./registry-skill-publication.ts";
@@ -10,7 +11,6 @@ import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { writeLine } from "../shared/output.ts";
 import {
     directoryExists,
-    fileExists,
 } from "./bundled-skill-observation.ts";
 import {
     listManagedSkillInstallations,
@@ -25,7 +25,6 @@ import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
 import {
     isManagedSkillPathContained,
     resolveManagedSkillCanonicalRootDirectoryPath,
-    resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
 import { extractRegistryPackageArchive } from "./registry-skill-archive.ts";
 import {
@@ -49,7 +48,11 @@ interface SkillsUpdateInput {
 
 interface RegistrySkillGroup {
     packageName: string;
-    skills: ManagedSkillListItem[];
+    skills: ManagedSkillUpdateItem[];
+}
+
+interface ManagedSkillUpdateItem extends ManagedSkillListItem {
+    hostNames: BundledSkillAgentName[];
 }
 
 interface CurrentSkillUpdate {
@@ -155,6 +158,7 @@ export async function updateManagedSkills(
                         "errors.skills.update.packageNameMissing",
                         1,
                         {
+                            hostNames: formatManagedSkillUpdateHostNames(skill.hostNames),
                             name: skill.name,
                         },
                     ),
@@ -271,7 +275,7 @@ export async function updateManagedSkills(
 async function readKnownManagedSkillInstallations(
     availableHosts: readonly ManagedSkillHost[],
     settingsFilePath: string,
-): Promise<ManagedSkillListItem[]> {
+): Promise<ManagedSkillUpdateItem[]> {
     const [canonicalSkills, hostSkills] = await Promise.all([
         listManagedSkillInstallations(
             resolveManagedSkillCanonicalRootDirectoryPath(settingsFilePath),
@@ -280,46 +284,97 @@ async function readKnownManagedSkillInstallations(
     ]);
 
     return mergeManagedSkillInstallationsByName([
-        ...hostSkills,
-        ...canonicalSkills,
+        ...hostSkills.map(skill => ({
+            metadata: skill.metadata,
+            name: skill.name,
+            path: skill.path,
+            hostNames: [skill.hostName],
+        } satisfies ManagedSkillUpdateItem)),
+        ...canonicalSkills.map(skill => ({
+            ...skill,
+            hostNames: [],
+        } satisfies ManagedSkillUpdateItem)),
     ]);
 }
 
 function mergeManagedSkillInstallationsByName(
-    skills: readonly ManagedSkillListItem[],
-): ManagedSkillListItem[] {
-    const skillsByName = new Map<string, ManagedSkillListItem>();
+    skills: readonly ManagedSkillUpdateItem[],
+): ManagedSkillUpdateItem[] {
+    const skillsByName = new Map<string, ManagedSkillUpdateItem>();
 
     for (const skill of skills) {
+        if (skill.metadata === undefined) {
+            continue;
+        }
+
         const existingSkill = skillsByName.get(skill.name);
 
-        if (
-            existingSkill === undefined
-            || (
-                existingSkill.metadata?.packageName === undefined
-                && skill.metadata?.packageName !== undefined
-            )
-        ) {
+        if (existingSkill === undefined) {
             skillsByName.set(skill.name, skill);
+            continue;
         }
+
+        const hostNames = mergeManagedSkillHostNames(
+            existingSkill.hostNames,
+            skill.hostNames,
+        );
+
+        if (
+            existingSkill.metadata?.packageName === undefined
+            && skill.metadata.packageName !== undefined
+        ) {
+            skillsByName.set(skill.name, {
+                ...skill,
+                hostNames,
+            });
+            continue;
+        }
+
+        skillsByName.set(skill.name, {
+            ...existingSkill,
+            hostNames,
+        });
     }
 
     return Array.from(skillsByName.values());
 }
 
+function mergeManagedSkillHostNames(
+    left: readonly BundledSkillAgentName[],
+    right: readonly BundledSkillAgentName[],
+): BundledSkillAgentName[] {
+    const hostNames = new Set(left);
+
+    for (const hostName of right) {
+        hostNames.add(hostName);
+    }
+
+    return Array.from(hostNames);
+}
+
+function formatManagedSkillUpdateHostNames(
+    hostNames: readonly BundledSkillAgentName[],
+): string {
+    if (hostNames.length === 0) {
+        return "canonical";
+    }
+
+    return hostNames.join(", ");
+}
+
 async function resolveSelectedManagedSkills(
     requestedSkillNames: readonly string[],
-    installedSkills: readonly ManagedSkillListItem[],
+    installedSkills: readonly ManagedSkillUpdateItem[],
     availableHosts: readonly ManagedSkillHost[],
     settingsFilePath: string,
-): Promise<ManagedSkillListItem[]> {
+): Promise<ManagedSkillUpdateItem[]> {
     if (requestedSkillNames.length === 0) {
         return installedSkills.filter(
             skill => !isBundledSkillName(skill.name),
         );
     }
 
-    const selectedSkills: ManagedSkillListItem[] = [];
+    const selectedSkills: ManagedSkillUpdateItem[] = [];
     const installedSkillIndex = new Map(
         installedSkills.map(skill => [skill.name, skill] as const),
     );
@@ -371,15 +426,16 @@ async function resolveSelectedManagedSkills(
                 const installedDirectoryExists = await directoryExists(
                     installation.installedSkillDirectoryPath,
                 );
+                const metadata = installedDirectoryExists
+                    ? await readManagedSkillMetadata(
+                            installation.installedSkillDirectoryPath,
+                        )
+                    : undefined;
 
                 return {
                     ...installation,
                     hasDirectoryWithoutMetadata: installedDirectoryExists
-                        && !(await fileExists(
-                            resolveManagedSkillMetadataFilePath(
-                                installation.installedSkillDirectoryPath,
-                            ),
-                        )),
+                        && metadata === undefined,
                 };
             }),
         );
@@ -390,10 +446,12 @@ async function resolveSelectedManagedSkills(
 
         throw new CliUserError(
             unmanagedTarget !== undefined
-                ? "errors.skills.notManaged"
+                ? "errors.skills.update.notManaged"
                 : "errors.skills.notInstalled",
             1,
             {
+                hostName: unmanagedTarget?.agentName
+                    ?? firstTarget.agentName,
                 name: requestedSkillName,
                 path: unmanagedTarget?.installedSkillDirectoryPath
                     ?? firstTarget.installedSkillDirectoryPath,
@@ -405,9 +463,9 @@ async function resolveSelectedManagedSkills(
 }
 
 function groupRegistrySkills(
-    skills: readonly ManagedSkillListItem[],
+    skills: readonly ManagedSkillUpdateItem[],
 ): RegistrySkillGroup[] {
-    const groups = new Map<string, ManagedSkillListItem[]>();
+    const groups = new Map<string, ManagedSkillUpdateItem[]>();
 
     for (const skill of skills) {
         const packageName = skill.metadata?.packageName;

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -1,6 +1,7 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
 import type { ManagedSkillListItem } from "./list.ts";
+import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
 import type { PreparedRegistrySkillPublication } from "./registry-skill-publication.ts";
 
 import { z } from "zod";
@@ -10,14 +11,21 @@ import { writeLine } from "../shared/output.ts";
 import {
     directoryExists,
     fileExists,
-    requireCodexHomeDirectory,
 } from "./bundled-skill-observation.ts";
-import { listManagedSkillInstallations } from "./list.ts";
+import {
+    listManagedSkillInstallations,
+    listManagedSkillInstallationsForHosts,
+} from "./list.ts";
+import {
+    createMissingManagedSkillHostError,
+    resolveAvailableManagedSkillHosts,
+    resolveManagedSkillHostInstallations,
+} from "./managed-skill-hosts.ts";
+import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
 import {
     isManagedSkillPathContained,
-    resolveManagedSkillDirectoryPath,
+    resolveManagedSkillCanonicalRootDirectoryPath,
     resolveManagedSkillMetadataFilePath,
-    resolveManagedSkillsDirectoryPath,
 } from "./managed-skill-paths.ts";
 import { extractRegistryPackageArchive } from "./registry-skill-archive.ts";
 import {
@@ -26,6 +34,7 @@ import {
 import {
     prepareRegistrySkillPublication,
     publishPreparedRegistrySkillPublication,
+    validateRegistrySkillPublicationTargets,
 } from "./registry-skill-publication.ts";
 import {
     downloadRegistryPackageTarball,
@@ -97,15 +106,21 @@ export async function updateManagedSkills(
     },
     context: CliExecutionContext,
 ): Promise<void> {
-    const codexHomeDirectory = await requireCodexHomeDirectory(context);
+    const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
+
+    if (availableHosts.length === 0) {
+        throw createMissingManagedSkillHostError(context.env);
+    }
+
     const settingsFilePath = context.settingsStore.getFilePath();
-    const installedSkills = await listManagedSkillInstallations(
-        resolveManagedSkillsDirectoryPath(codexHomeDirectory),
+    const installedSkills = await readKnownManagedSkillInstallations(
+        availableHosts,
+        settingsFilePath,
     );
     const selectedSkills = await resolveSelectedManagedSkills(
         request.skillNames,
         installedSkills,
-        codexHomeDirectory,
+        availableHosts,
         settingsFilePath,
     );
 
@@ -155,7 +170,7 @@ export async function updateManagedSkills(
                     group,
                     {
                         account: account!,
-                        codexHomeDirectory,
+                        availableHosts,
                         progressReporter,
                         settingsFilePath,
                     },
@@ -194,21 +209,21 @@ export async function updateManagedSkills(
                 installationPath: string;
                 skillName: string;
             }
-        > = await Promise.all(
+        > = (await Promise.all(
             publications.map(async (publication) => {
                 try {
                     progressReporter?.updateSkill(
                         publication.preparedPublication.skillName,
                         "publishing",
                     );
-                    const installation = await publishPreparedRegistrySkillPublication(
+                    const installations = await publishPreparedRegistrySkillPublication(
                         publication.preparedPublication,
                     );
 
-                    return {
+                    return installations.map(installation => ({
                         installationPath: installation.path,
                         skillName: publication.preparedPublication.skillName,
-                    };
+                    }));
                 }
                 catch (error) {
                     const normalizedError = normalizeSkillUpdateError(error);
@@ -221,7 +236,7 @@ export async function updateManagedSkills(
                     };
                 }
             }),
-        );
+        )).flat();
 
         for (const result of publicationResults) {
             if ("error" in result) {
@@ -253,10 +268,49 @@ export async function updateManagedSkills(
     }
 }
 
+async function readKnownManagedSkillInstallations(
+    availableHosts: readonly ManagedSkillHost[],
+    settingsFilePath: string,
+): Promise<ManagedSkillListItem[]> {
+    const [canonicalSkills, hostSkills] = await Promise.all([
+        listManagedSkillInstallations(
+            resolveManagedSkillCanonicalRootDirectoryPath(settingsFilePath),
+        ),
+        listManagedSkillInstallationsForHosts(availableHosts),
+    ]);
+
+    return mergeManagedSkillInstallationsByName([
+        ...hostSkills,
+        ...canonicalSkills,
+    ]);
+}
+
+function mergeManagedSkillInstallationsByName(
+    skills: readonly ManagedSkillListItem[],
+): ManagedSkillListItem[] {
+    const skillsByName = new Map<string, ManagedSkillListItem>();
+
+    for (const skill of skills) {
+        const existingSkill = skillsByName.get(skill.name);
+
+        if (
+            existingSkill === undefined
+            || (
+                existingSkill.metadata?.packageName === undefined
+                && skill.metadata?.packageName !== undefined
+            )
+        ) {
+            skillsByName.set(skill.name, skill);
+        }
+    }
+
+    return Array.from(skillsByName.values());
+}
+
 async function resolveSelectedManagedSkills(
     requestedSkillNames: readonly string[],
     installedSkills: readonly ManagedSkillListItem[],
-    codexHomeDirectory: string,
+    availableHosts: readonly ManagedSkillHost[],
     settingsFilePath: string,
 ): Promise<ManagedSkillListItem[]> {
     if (requestedSkillNames.length === 0) {
@@ -288,13 +342,18 @@ async function resolveSelectedManagedSkills(
             );
         }
 
-        if (
+        const hostInstallations = resolveManagedSkillHostInstallations(
+            availableHosts,
+            requestedSkillName,
+        );
+
+        if (hostInstallations.some(installation =>
             !isManagedSkillPathContained(
-                codexHomeDirectory,
+                installation.homeDirectory,
                 settingsFilePath,
                 requestedSkillName,
-            )
-        ) {
+            ),
+        )) {
             throw new CliUserError("errors.skills.invalidPath", 1, {
                 name: requestedSkillName,
             });
@@ -307,26 +366,37 @@ async function resolveSelectedManagedSkills(
             continue;
         }
 
-        const installedSkillDirectoryPath = resolveManagedSkillDirectoryPath(
-            codexHomeDirectory,
-            requestedSkillName,
+        const targetStates = await Promise.all(
+            hostInstallations.map(async (installation) => {
+                const installedDirectoryExists = await directoryExists(
+                    installation.installedSkillDirectoryPath,
+                );
+
+                return {
+                    ...installation,
+                    hasDirectoryWithoutMetadata: installedDirectoryExists
+                        && !(await fileExists(
+                            resolveManagedSkillMetadataFilePath(
+                                installation.installedSkillDirectoryPath,
+                            ),
+                        )),
+                };
+            }),
         );
-        const installedDirectoryExists = await directoryExists(
-            installedSkillDirectoryPath,
+        const unmanagedTarget = targetStates.find(
+            target => target.hasDirectoryWithoutMetadata,
         );
-        const hasDirectoryWithoutMetadata = installedDirectoryExists
-            && !(await fileExists(
-                resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
-            ));
+        const firstTarget = targetStates[0]!;
 
         throw new CliUserError(
-            hasDirectoryWithoutMetadata
+            unmanagedTarget !== undefined
                 ? "errors.skills.notManaged"
                 : "errors.skills.notInstalled",
             1,
             {
                 name: requestedSkillName,
-                path: installedSkillDirectoryPath,
+                path: unmanagedTarget?.installedSkillDirectoryPath
+                    ?? firstTarget.installedSkillDirectoryPath,
             },
         );
     }
@@ -366,7 +436,7 @@ async function prepareRegistrySkillGroupUpdate(
     group: RegistrySkillGroup,
     options: {
         account: AuthAccount;
-        codexHomeDirectory: string;
+        availableHosts: readonly ManagedSkillHost[];
         progressReporter?: SkillsUpdateProgressReporter;
         settingsFilePath: string;
     },
@@ -382,12 +452,18 @@ async function prepareRegistrySkillGroupUpdate(
             options.account,
             context,
         );
+        const targetCurrentStates = await Promise.all(
+            group.skills.map(skill =>
+                isRegistrySkillCurrentInAllHosts(
+                    skill.name,
+                    packageInfo.packageName,
+                    packageInfo.packageVersion,
+                    options.availableHosts,
+                ),
+            ),
+        );
 
-        if (
-            group.skills.every(
-                skill => skill.metadata?.version === packageInfo.packageVersion,
-            )
-        ) {
+        if (targetCurrentStates.every(isCurrent => isCurrent)) {
             return {
                 events: group.skills.map(skill => ({
                     kind: "current",
@@ -401,6 +477,18 @@ async function prepareRegistrySkillGroupUpdate(
         for (const skill of group.skills) {
             options.progressReporter?.updateSkill(skill.name, "preparing");
         }
+
+        await Promise.all(
+            group.skills.map(skill =>
+                validateRegistrySkillPublicationTargets({
+                    hostInstallations: resolveManagedSkillHostInstallations(
+                        options.availableHosts,
+                        skill.name,
+                    ),
+                    skillName: skill.name,
+                }),
+            ),
+        );
 
         const packageBytes = await downloadRegistryPackageTarball(
             packageInfo.packageName,
@@ -416,8 +504,11 @@ async function prepareRegistrySkillGroupUpdate(
                 publications: await Promise.all(
                     group.skills.map(async skill => ({
                         preparedPublication: await prepareRegistrySkillPublication({
-                            codexHomeDirectory: options.codexHomeDirectory,
                             extractedPackage,
+                            hostInstallations: resolveManagedSkillHostInstallations(
+                                options.availableHosts,
+                                skill.name,
+                            ),
                             packageName: packageInfo.packageName,
                             packageVersion: packageInfo.packageVersion,
                             settingsFilePath: options.settingsFilePath,
@@ -448,6 +539,34 @@ async function prepareRegistrySkillGroupUpdate(
             publications: [],
         };
     }
+}
+
+async function isRegistrySkillCurrentInAllHosts(
+    skillName: string,
+    packageName: string,
+    packageVersion: string,
+    availableHosts: readonly ManagedSkillHost[],
+): Promise<boolean> {
+    const hostInstallations = resolveManagedSkillHostInstallations(
+        availableHosts,
+        skillName,
+    );
+    const targetStates = await Promise.all(
+        hostInstallations.map(async (installation) => {
+            if (!(await directoryExists(installation.installedSkillDirectoryPath))) {
+                return undefined;
+            }
+
+            return await readManagedSkillMetadata(
+                installation.installedSkillDirectoryPath,
+            );
+        }),
+    );
+
+    return targetStates.every(metadata =>
+        metadata?.packageName === packageName
+        && metadata.version === packageVersion,
+    );
 }
 
 function normalizeSkillUpdateError(error: unknown): Error {

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -366,7 +366,9 @@ export const enMessages = {
     "errors.skills.update.bundledUnsupported":
         "Bundled skill {name} is managed by oo and cannot be updated with skills update. Use oo skills add {name} instead.",
     "errors.skills.update.packageNameMissing":
-        "Managed skill {name} cannot be updated because its package metadata is missing.",
+        "Managed skill {name} cannot be updated in {hostNames} because its package metadata is missing.",
+    "errors.skills.update.notManaged":
+        "Skill {name} in host {hostName} is not managed by oo and cannot be updated.",
     "errors.skills.nameConflict":
         "Skill name {name} is already used by a non-OOMOL skill at {path}.",
     "errors.skills.storageConflict":
@@ -975,7 +977,9 @@ export const zhMessages = {
     "errors.skills.update.bundledUnsupported":
         "内置 skill {name} 由 oo 管理，不能通过 skills update 更新。请改用 oo skills add {name}。",
     "errors.skills.update.packageNameMissing":
-        "由 oo 管理的 skill {name} 缺少 package 元数据，无法更新。",
+        "无法在 {hostNames} 中更新由 oo 管理的 skill {name}，因为缺少 package 元数据。",
+    "errors.skills.update.notManaged":
+        "host {hostName} 中的 skill {name} 不是由 oo 管理的 skill，无法更新。",
     "errors.skills.nameConflict":
         "Skill 名称 {name} 已被 {path} 中的非 OOMOL skill 占用。",
     "errors.skills.storageConflict":

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -118,8 +118,8 @@ export const enMessages = {
         "Search packages with free-form text against the intent search API.",
     "commands.search.summary": "Search packages by intent",
     "commands.skills.description":
-        "Manage Codex skills.",
-    "commands.skills.summary": "Manage Codex skills",
+        "Manage local AI agent skills.",
+    "commands.skills.summary": "Manage AI agent skills",
     "commands.skills.search.description":
         "Search published skills against the skills search API.",
     "commands.skills.search.summary":
@@ -129,13 +129,13 @@ export const enMessages = {
     "commands.skills.list.summary":
         "List oo-managed skills",
     "commands.skills.install.description":
-        "Install bundled skills into supported local skill directories, or install published skills into the local Codex skills directory.",
+        "Install bundled or published skills into supported local skill directories.",
     "commands.skills.install.summary": "Install skills",
     "commands.skills.update.description":
-        "Update installed oo-managed Codex skills to the latest available version.",
-    "commands.skills.update.summary": "Update oo-managed Codex skills",
+        "Update installed oo-managed published skills to the latest available version.",
+    "commands.skills.update.summary": "Update oo-managed skills",
     "commands.skills.uninstall.description":
-        "Remove bundled skills from supported local skill directories, or remove one oo-managed published skill from the local Codex skills directory.",
+        "Remove oo-managed skills from supported local skill directories.",
     "commands.skills.uninstall.summary": "Remove a managed skill",
     "config.set.success": "Set {key} to {value}.",
     "config.unset.success": "Removed {key}.",
@@ -282,7 +282,7 @@ export const enMessages = {
     "errors.skills.invalidName":
         "Unsupported skill: {value}. Use {choices}.",
     "errors.skills.invalidPath":
-        "Skill name {name} resolves outside the local Codex skills directory.",
+        "Skill name {name} resolves outside the local skill directories.",
     "errors.fileDownload.downloadFailed":
         "Failed to download the file at {path}: {message}",
     "errors.fileDownload.invalidExt":
@@ -342,7 +342,7 @@ export const enMessages = {
     "errors.skills.openclawNotInstalled":
         "OpenClaw is not installed. Expected the OpenClaw home directory at {path}.",
     "errors.skills.noSupportedBundledSkillHosts":
-        "No supported bundled skill host is installed. Expected one of: {paths}.",
+        "No supported skill host is installed. Expected one of: {paths}.",
     "errors.skills.install.confirmationRequired":
         "Skill {name} already exists and requires interactive confirmation.",
     "errors.skills.install.invalidArchive":
@@ -547,17 +547,17 @@ export const enMessages = {
     "skills.update.noResults":
         "No updatable oo-managed skills were found.",
     "skills.update.current":
-        "Codex skill {name} is already up to date at {version}.",
+        "Skill {name} is already up to date at {version}.",
     "skills.update.failure":
-        "Failed to update Codex skill {name}: {message}",
+        "Failed to update skill {name}: {message}",
     "skills.update.progress.header": "Updating installed skills",
     "skills.update.progress.checking": "checking for updates",
     "skills.update.progress.preparing": "updating canonical files",
-    "skills.update.progress.publishing": "publishing to Codex",
+    "skills.update.progress.publishing": "publishing to supported hosts",
     "skills.update.progress.current": "up to date",
     "skills.update.progress.updated": "updated",
     "skills.update.progress.failed": "failed",
-    "skills.update.success": "Updated Codex skill {name} to {path}.",
+    "skills.update.success": "Updated skill {name} to {path}.",
     "skills.uninstall.success": "Removed skill {name} from {path}.",
     "versionInfo.buildTime": "Build Time",
     "versionInfo.commit": "Commit",
@@ -738,8 +738,8 @@ export const zhMessages = {
         "搜索 package 与 connector action",
     "commands.search.description": "使用自由文本通过意图搜索 API 搜索包。",
     "commands.search.summary": "按意图搜索包",
-    "commands.skills.description": "管理 Codex skill。",
-    "commands.skills.summary": "管理 Codex skill",
+    "commands.skills.description": "管理本地 AI Agent skill。",
+    "commands.skills.summary": "管理 AI Agent skill",
     "commands.skills.search.description":
         "使用自由文本通过 skills search API 搜索已发布的 skill。",
     "commands.skills.search.summary":
@@ -749,12 +749,12 @@ export const zhMessages = {
     "commands.skills.list.summary":
         "列出由 oo 管理的 skill",
     "commands.skills.install.description":
-        "将内置 skill 安装到受支持的本地 skill 目录，或将已发布 skill 安装到本地 Codex skills 目录。",
+        "将内置或已发布 skill 安装到受支持的本地 skill 目录。",
     "commands.skills.install.summary": "安装 skill",
     "commands.skills.update.description":
-        "将已安装且由 oo 管理的 Codex skill 更新到最新可用版本。",
-    "commands.skills.update.summary": "更新由 oo 管理的 Codex skill",
-    "commands.skills.uninstall.description": "从受支持的本地 skill 目录移除内置 skill，或从本地 Codex skills 目录移除一个由 oo 管理的已发布 skill。",
+        "将已安装且由 oo 管理的已发布 skill 更新到最新可用版本。",
+    "commands.skills.update.summary": "更新由 oo 管理的 skill",
+    "commands.skills.uninstall.description": "从受支持的本地 skill 目录移除由 oo 管理的 skill。",
     "commands.skills.uninstall.summary": "移除一个受管理的 skill",
     "config.set.success": "已将 {key} 设置为 {value}。",
     "config.unset.success": "已移除 {key}。",
@@ -891,7 +891,7 @@ export const zhMessages = {
     "errors.skills.invalidName":
         "不支持的 skill：{value}。请使用 {choices}。",
     "errors.skills.invalidPath":
-        "skill 名称 {name} 解析到了本地 Codex skills 目录之外。",
+        "skill 名称 {name} 解析到了本地 skill 目录之外。",
     "errors.fileDownload.downloadFailed":
         "下载文件到 {path} 失败：{message}",
     "errors.fileDownload.invalidExt":
@@ -951,7 +951,7 @@ export const zhMessages = {
     "errors.skills.openclawNotInstalled":
         "未检测到 OpenClaw 安装。期望的 OpenClaw 根目录为 {path}。",
     "errors.skills.noSupportedBundledSkillHosts":
-        "未检测到已安装的受支持内置 skill 宿主。期望其中之一位于：{paths}。",
+        "未检测到已安装的受支持 skill 宿主。期望其中之一位于：{paths}。",
     "errors.skills.install.confirmationRequired":
         "Skill {name} 已存在，且需要在交互终端中确认覆盖。",
     "errors.skills.install.invalidArchive":
@@ -1150,17 +1150,17 @@ export const zhMessages = {
     "skills.update.noResults":
         "未找到可更新的 oo-managed skill。",
     "skills.update.current":
-        "Codex skill {name} 已是最新版本 {version}。",
+        "skill {name} 已是最新版本 {version}。",
     "skills.update.failure":
-        "更新 Codex skill {name} 失败：{message}",
+        "更新 skill {name} 失败：{message}",
     "skills.update.progress.header": "正在更新已安装的 skill",
     "skills.update.progress.checking": "检查更新中",
     "skills.update.progress.preparing": "更新 canonical 文件中",
-    "skills.update.progress.publishing": "同步到 Codex 中",
+    "skills.update.progress.publishing": "同步到受支持宿主中",
     "skills.update.progress.current": "已是最新",
     "skills.update.progress.updated": "已更新",
     "skills.update.progress.failed": "失败",
-    "skills.update.success": "已将 Codex skill {name} 更新到 {path}。",
+    "skills.update.success": "已将 skill {name} 更新到 {path}。",
     "skills.uninstall.success": "已从 {path} 移除 skill {name}。",
     "versionInfo.buildTime": "构建时间",
     "versionInfo.commit": "提交",


### PR DESCRIPTION
Registry skills now follow the same host-aware installation model as bundled skills. This keeps Codex, Claude Code, and OpenClaw targets consistent during install, update, and uninstall, while rejecting unmanaged same-name directories before publication.