### PR TITLE
feat(skills): synchronize managed skills at startup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,11 @@ bun run dev --help
 ```
 
 This is the fastest way to verify argument parsing and command output while
-iterating on local changes. Source-based development runs do not auto-install
-or auto-synchronize the bundled Codex skill into `${CODEX_HOME:-~/.codex}`.
+iterating on local changes. Source-based development runs use the same startup
+skill synchronization path as packaged runs: if a supported host directory such
+as `${CODEX_HOME:-~/.codex}` already exists, missing bundled skills may be
+installed there before the requested command executes. Existing bundled skill
+targets are not refreshed while the current version is `0.0.0-development`.
 
 Useful commands:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -254,6 +254,20 @@ Search packages and connector actions with one free-form query.
 
 ## AI Agent Skills
 
+Before running a command, `oo` silently synchronizes managed skills for every
+supported host directory that already exists.
+
+- Bundled skills: `oo` ensures `oo` and `oo-find-skills` are installed for
+  each detected Codex, Claude Code, and OpenClaw host. Existing oo-managed
+  bundled skill targets are refreshed to the current `oo` version, except that
+  `0.0.0-development` startup runs do not refresh existing bundled targets.
+- Published skills: when a published skill already has a local canonical copy
+  under `<config-dir>/skills/registry/<skill-id>`, `oo` publishes that copy to
+  any newly detected supported host that is missing it.
+- Safety: startup synchronization does not fetch registry data, does not
+  require authentication, does not print additional command output, and does
+  not overwrite same-name targets that are not managed by `oo`.
+
 ### `oo skills list`
 
 List oo-managed skills from supported local skill directories.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -226,6 +226,19 @@
 
 ## AI Agent Skill
 
+在执行具体命令前，`oo` 会为已经存在的受支持宿主目录静默同步受管理的
+skills。
+
+- 内置 skill：`oo` 会确保每个检测到的 Codex、Claude Code 和 OpenClaw 宿主
+  都安装了 `oo` 与 `oo-find-skills`。已经由 oo 管理的内置 skill 目标会刷新
+  到当前 `oo` 版本；但当启动中的当前版本为 `0.0.0-development` 时，不会刷新
+  已存在的内置 skill 目标。
+- 已发布 skill：如果某个已发布 skill 已经有本地 canonical 副本
+  `<config-dir>/skills/registry/<skill-id>`，`oo` 会把该副本发布到任何新检测
+  到且尚未安装它的受支持宿主。
+- 安全规则：启动同步不会请求 registry，不要求登录，不会产生额外命令输出，也
+  不会覆盖不由 `oo` 管理的同名目标。
+
 ### `oo skills list`
 
 列出受支持的本地 skill 目录中由 oo 管理的 skill。

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -30,6 +30,7 @@ import {
 } from "../../i18n/locale.ts";
 import { createTranslator } from "../../i18n/translator.ts";
 import { createCliCatalog } from "../commands/catalog.ts";
+import { synchronizeManagedSkillsForAvailableHosts } from "../commands/skills/auto-sync.ts";
 import { APP_NAME } from "../config/app-config.ts";
 import {
     formatCliVersionText,
@@ -226,6 +227,8 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
         });
 
         const adapter = new CommanderCliAdapter();
+
+        await synchronizeManagedSkillsForAvailableHosts(context);
 
         exitCode = await adapter.run({
             argv: invocation.argv,

--- a/src/application/commands/skills/auto-sync.ts
+++ b/src/application/commands/skills/auto-sync.ts
@@ -1,0 +1,443 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+import type { BundledSkillName } from "./embedded-assets.ts";
+import type {
+    ManagedSkillHost,
+    ManagedSkillHostInstallation,
+} from "./managed-skill-hosts.ts";
+import type { ManagedSkillMetadata } from "./managed-skill-metadata.ts";
+
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { pathExists } from "../../shared/fs-utils.ts";
+import {
+    isNodeNotFoundError,
+    publishBundledSkillInstallation,
+} from "./bundled-skill-filesystem.ts";
+import {
+    bundledSkillDevelopmentVersion,
+} from "./bundled-skill-model.ts";
+import {
+    directoryExists,
+    isManagedBundledSkillInstallation,
+    readInstalledBundledSkillMetadata,
+} from "./bundled-skill-observation.ts";
+import {
+    resolveBundledSkillCanonicalDirectoryPath,
+} from "./bundled-skill-paths.ts";
+import {
+    availableBundledSkillNames,
+} from "./embedded-assets.ts";
+import {
+    resolveAvailableManagedSkillHosts,
+    resolveManagedSkillHostInstallation,
+    resolveManagedSkillHostInstallations,
+} from "./managed-skill-hosts.ts";
+import {
+    readManagedSkillMetadata,
+} from "./managed-skill-metadata.ts";
+import {
+    isManagedSkillPathContained,
+    resolveManagedSkillCanonicalRootDirectoryPath,
+} from "./managed-skill-paths.ts";
+import { publishManagedBundledSkill } from "./shared.ts";
+
+interface ManagedSkillTargetState<Metadata> {
+    kind: "managed" | "missing" | "unmanaged";
+    metadata?: Metadata;
+}
+
+interface CanonicalRegistrySkill {
+    metadata: ManagedSkillMetadata & {
+        packageName: string;
+    };
+    name: string;
+    path: string;
+}
+
+type SkillSyncContext = Pick<
+    CliExecutionContext,
+    "env" | "logger" | "settingsStore" | "version"
+>;
+
+export async function synchronizeManagedSkillsForAvailableHosts(
+    context: SkillSyncContext,
+): Promise<void> {
+    try {
+        const hosts = await resolveAvailableManagedSkillHosts(context.env);
+
+        if (hosts.length === 0) {
+            return;
+        }
+
+        await Promise.all([
+            synchronizeBundledSkills(hosts, context),
+            synchronizeRegistrySkills(hosts, context),
+        ]);
+    }
+    catch (error) {
+        context.logger.warn(
+            {
+                err: error,
+            },
+            "Managed skill startup synchronization failed.",
+        );
+    }
+}
+
+async function synchronizeBundledSkills(
+    hosts: readonly ManagedSkillHost[],
+    context: SkillSyncContext,
+): Promise<void> {
+    await Promise.all(
+        hosts.flatMap(host =>
+            availableBundledSkillNames.map(skillName =>
+                synchronizeBundledSkill(host, skillName, context),
+            ),
+        ),
+    );
+}
+
+async function synchronizeBundledSkill(
+    host: ManagedSkillHost,
+    skillName: BundledSkillName,
+    context: SkillSyncContext,
+): Promise<void> {
+    const settingsFilePath = context.settingsStore.getFilePath();
+    const installation = resolveManagedSkillHostInstallation(host, skillName);
+
+    try {
+        const targetState = await readManagedSkillTargetState(
+            installation.installedSkillDirectoryPath,
+            readInstalledBundledSkillMetadata,
+        );
+
+        if (targetState.kind === "unmanaged") {
+            context.logger.warn(
+                {
+                    agentName: host.agentName,
+                    path: installation.installedSkillDirectoryPath,
+                    skillName,
+                },
+                "Bundled skill startup synchronization skipped because the target is not managed by oo.",
+            );
+            return;
+        }
+
+        if (
+            targetState.kind === "managed"
+            && targetState.metadata?.version === context.version
+        ) {
+            return;
+        }
+
+        if (
+            targetState.kind === "managed"
+            && context.version === bundledSkillDevelopmentVersion
+        ) {
+            context.logger.info(
+                {
+                    agentName: host.agentName,
+                    path: installation.installedSkillDirectoryPath,
+                    previousVersion: targetState.metadata?.version,
+                    skillName,
+                    version: context.version,
+                },
+                "Bundled skill startup synchronization skipped because the current CLI version is a development version.",
+            );
+            return;
+        }
+
+        const canonicalSkillDirectoryPath
+            = resolveBundledSkillCanonicalDirectoryPath(
+                settingsFilePath,
+                skillName,
+                host.agentName,
+            );
+
+        if (
+            !(await canWriteBundledCanonicalSkill(
+                canonicalSkillDirectoryPath,
+                host,
+                skillName,
+                context,
+            ))
+        ) {
+            return;
+        }
+
+        const publication = await publishManagedBundledSkill({
+            agentName: host.agentName,
+            homeDirectory: host.homeDirectory,
+            settingsFilePath,
+            skillName,
+            version: context.version,
+        });
+
+        context.logger.info(
+            {
+                agentName: host.agentName,
+                canonicalPath: canonicalSkillDirectoryPath,
+                installMode: publication.mode,
+                path: publication.path,
+                previousVersion: targetState.metadata?.version,
+                skillName,
+                version: context.version,
+            },
+            "Bundled skill synchronized during CLI startup.",
+        );
+    }
+    catch (error) {
+        context.logger.warn(
+            {
+                agentName: host.agentName,
+                err: error,
+                path: installation.installedSkillDirectoryPath,
+                skillName,
+            },
+            "Bundled skill startup synchronization failed.",
+        );
+    }
+}
+
+async function canWriteBundledCanonicalSkill(
+    canonicalSkillDirectoryPath: string,
+    host: ManagedSkillHost,
+    skillName: BundledSkillName,
+    context: SkillSyncContext,
+): Promise<boolean> {
+    if (!(await pathExists(canonicalSkillDirectoryPath))) {
+        return true;
+    }
+
+    if (
+        await directoryExists(canonicalSkillDirectoryPath)
+        && await isManagedBundledSkillInstallation(canonicalSkillDirectoryPath)
+    ) {
+        return true;
+    }
+
+    context.logger.warn(
+        {
+            agentName: host.agentName,
+            path: canonicalSkillDirectoryPath,
+            skillName,
+        },
+        "Bundled skill startup synchronization skipped because canonical storage is not managed by oo.",
+    );
+
+    return false;
+}
+
+async function synchronizeRegistrySkills(
+    hosts: readonly ManagedSkillHost[],
+    context: SkillSyncContext,
+): Promise<void> {
+    const skills = await listCanonicalRegistrySkills(context);
+
+    await Promise.all(
+        skills.flatMap(skill =>
+            resolveManagedSkillHostInstallations(hosts, skill.name).map(
+                installation =>
+                    synchronizeRegistrySkill(installation, skill, context),
+            ),
+        ),
+    );
+}
+
+async function synchronizeRegistrySkill(
+    installation: ManagedSkillHostInstallation,
+    skill: CanonicalRegistrySkill,
+    context: SkillSyncContext,
+): Promise<void> {
+    try {
+        if (
+            !isManagedSkillPathContained(
+                installation.homeDirectory,
+                context.settingsStore.getFilePath(),
+                skill.name,
+            )
+        ) {
+            context.logger.warn(
+                {
+                    agentName: installation.agentName,
+                    skillName: skill.name,
+                },
+                "Registry skill startup synchronization skipped because the target path is outside the managed skills directory.",
+            );
+            return;
+        }
+
+        const targetState = await readManagedSkillTargetState(
+            installation.installedSkillDirectoryPath,
+            readManagedSkillMetadata,
+        );
+
+        if (targetState.kind === "unmanaged") {
+            context.logger.warn(
+                {
+                    agentName: installation.agentName,
+                    path: installation.installedSkillDirectoryPath,
+                    skillName: skill.name,
+                },
+                "Registry skill startup synchronization skipped because the target is not managed by oo.",
+            );
+            return;
+        }
+
+        if (targetState.kind === "managed") {
+            if (
+                targetState.metadata?.packageName === skill.metadata.packageName
+                && targetState.metadata.version === skill.metadata.version
+            ) {
+                return;
+            }
+
+            context.logger.warn(
+                {
+                    agentName: installation.agentName,
+                    canonicalPackageName: skill.metadata.packageName,
+                    canonicalVersion: skill.metadata.version,
+                    path: installation.installedSkillDirectoryPath,
+                    skillName: skill.name,
+                    targetPackageName: targetState.metadata?.packageName,
+                    targetVersion: targetState.metadata?.version,
+                },
+                "Registry skill startup synchronization skipped because the target metadata does not match canonical metadata.",
+            );
+            return;
+        }
+
+        const publication = await publishBundledSkillInstallation({
+            canonicalSkillDirectoryPath: skill.path,
+            installedSkillDirectoryPath: installation.installedSkillDirectoryPath,
+            publicationMode: installation.agentName === "openclaw"
+                ? "copy"
+                : "symlink-or-copy",
+        });
+
+        context.logger.info(
+            {
+                agentName: installation.agentName,
+                canonicalPath: skill.path,
+                installMode: publication.mode,
+                packageName: skill.metadata.packageName,
+                path: publication.path,
+                skillName: skill.name,
+                version: skill.metadata.version,
+            },
+            "Registry skill synchronized during CLI startup.",
+        );
+    }
+    catch (error) {
+        context.logger.warn(
+            {
+                agentName: installation.agentName,
+                err: error,
+                path: installation.installedSkillDirectoryPath,
+                skillName: skill.name,
+            },
+            "Registry skill startup synchronization failed.",
+        );
+    }
+}
+
+async function listCanonicalRegistrySkills(
+    context: Pick<SkillSyncContext, "logger" | "settingsStore">,
+): Promise<CanonicalRegistrySkill[]> {
+    const canonicalRootDirectoryPath
+        = resolveManagedSkillCanonicalRootDirectoryPath(
+            context.settingsStore.getFilePath(),
+        );
+    let entries: string[];
+
+    try {
+        entries = (await readdir(canonicalRootDirectoryPath, {
+            withFileTypes: true,
+        }))
+            .filter(entry => entry.isDirectory() || entry.isSymbolicLink())
+            .map(entry => entry.name);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return [];
+        }
+
+        throw error;
+    }
+
+    const skills = await Promise.all(
+        entries.map(async (entryName) => {
+            const canonicalSkillDirectoryPath = join(
+                canonicalRootDirectoryPath,
+                entryName,
+            );
+
+            try {
+                if (!(await directoryExists(canonicalSkillDirectoryPath))) {
+                    return undefined;
+                }
+
+                const metadata = await readManagedSkillMetadata(
+                    canonicalSkillDirectoryPath,
+                );
+
+                if (metadata?.packageName === undefined) {
+                    return undefined;
+                }
+
+                return {
+                    metadata: {
+                        packageName: metadata.packageName,
+                        version: metadata.version,
+                    },
+                    name: entryName,
+                    path: canonicalSkillDirectoryPath,
+                } satisfies CanonicalRegistrySkill;
+            }
+            catch (error) {
+                context.logger.warn(
+                    {
+                        err: error,
+                        path: canonicalSkillDirectoryPath,
+                        skillName: entryName,
+                    },
+                    "Canonical registry skill inspection failed during startup synchronization.",
+                );
+
+                return undefined;
+            }
+        }),
+    );
+
+    return skills.filter(skill => skill !== undefined);
+}
+
+async function readManagedSkillTargetState<Metadata>(
+    skillDirectoryPath: string,
+    readMetadata: (path: string) => Promise<Metadata | undefined>,
+): Promise<ManagedSkillTargetState<Metadata>> {
+    if (!(await pathExists(skillDirectoryPath))) {
+        return {
+            kind: "missing",
+        };
+    }
+
+    if (!(await directoryExists(skillDirectoryPath))) {
+        return {
+            kind: "unmanaged",
+        };
+    }
+
+    const metadata = await readMetadata(skillDirectoryPath);
+
+    if (metadata === undefined) {
+        return {
+            kind: "unmanaged",
+        };
+    }
+
+    return {
+        kind: "managed",
+        metadata,
+    };
+}

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -8,10 +8,19 @@ import {
     createCliSnapshot,
     readLatestLogContent,
 } from "../../../../__tests__/helpers.ts";
+import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import { getBundledSkillSourcePath } from "./__tests__/helpers.ts";
+import { bundledSkillDevelopmentVersion } from "./bundled-skill-model.ts";
 import {
     resolveBundledSkillMetadataFilePath,
+    resolveClaudeHomeDirectory,
     resolveCodexHomeDirectory,
 } from "./bundled-skill-paths.ts";
+import {
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillMetadataFilePath,
+} from "./managed-skill-paths.ts";
 import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 describe("skills CLI", () => {
@@ -46,7 +55,7 @@ describe("skills CLI", () => {
         }
     });
 
-    test("does not auto-install bundled skills during cli startup", async () => {
+    test("auto-installs bundled skills during cli startup", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
@@ -60,25 +69,29 @@ describe("skills CLI", () => {
             });
             const content = await readLatestLogContent(sandbox);
 
-            expect(createCliSnapshot(result)).toMatchSnapshot();
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain("Options:");
             expect(result.stdout).not.toContain("Installed skill");
-            await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
-                code: "ENOENT",
+            await expect(stat(skillDirectoryPath)).resolves.toMatchObject({
+                isDirectory: expect.any(Function),
             });
-            await expect(stat(findSkillsDirectoryPath)).rejects.toMatchObject({
-                code: "ENOENT",
+            await expect(stat(findSkillsDirectoryPath)).resolves.toMatchObject({
+                isDirectory: expect.any(Function),
             });
             expect(content).not.toContain(
                 `"msg":"Bundled skill installed during first-run bootstrap."`,
             );
-            expect(content).not.toContain(`"msg":"Bundled skill synchronized."`);
+            expect(content).toContain(
+                `"msg":"Bundled skill synchronized during CLI startup."`,
+            );
         }
         finally {
             await sandbox.cleanup();
         }
     });
 
-    test("does not auto-refresh installed bundled skills during cli startup", async () => {
+    test("auto-refreshes installed bundled skills during cli startup", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
@@ -102,14 +115,160 @@ describe("skills CLI", () => {
             });
             const content = await readLatestLogContent(sandbox);
 
-            expect(createCliSnapshot(result)).toMatchSnapshot();
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain("Options:");
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({
-                    version: "0.0.1",
+                    version: "9.9.9",
                 }),
             );
-            expect(await readFile(skillFilePath, "utf8")).toBe("stale\n");
-            expect(content).not.toContain(`"msg":"Bundled skill synchronized."`);
+            expect(await readFile(skillFilePath, "utf8")).toBe(
+                await readFile(getBundledSkillSourcePath("oo", "SKILL.md"), "utf8"),
+            );
+            expect(content).toContain(
+                `"msg":"Bundled skill synchronized during CLI startup."`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not auto-refresh installed bundled skills during development-version cli startup", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const findSkillsDirectoryPath = join(
+            codexHomeDirectory,
+            "skills",
+            "oo-find-skills",
+        );
+        const ooSkillFilePath = join(ooSkillDirectoryPath, "SKILL.md");
+        const findSkillsSkillFilePath = join(findSkillsDirectoryPath, "SKILL.md");
+        const skillDirectoryPaths = [
+            ooSkillDirectoryPath,
+            findSkillsDirectoryPath,
+        ];
+        const installedVersion = "9.9.9";
+
+        try {
+            for (const skillDirectoryPath of skillDirectoryPaths) {
+                await mkdir(skillDirectoryPath, { recursive: true });
+                await Bun.write(
+                    resolveBundledSkillMetadataFilePath(skillDirectoryPath),
+                    renderSkillMetadataJson({
+                        version: installedVersion,
+                    }),
+                );
+            }
+            await Bun.write(ooSkillFilePath, "# Local oo\n");
+            await Bun.write(findSkillsSkillFilePath, "# Local oo-find-skills\n");
+
+            const result = await sandbox.run(["--help"], {
+                version: bundledSkillDevelopmentVersion,
+            });
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain("Options:");
+            expect(await readFile(ooSkillFilePath, "utf8")).toBe("# Local oo\n");
+            expect(await readFile(findSkillsSkillFilePath, "utf8")).toBe(
+                "# Local oo-find-skills\n",
+            );
+            expect(
+                await readFile(
+                    resolveBundledSkillMetadataFilePath(ooSkillDirectoryPath),
+                    "utf8",
+                ),
+            ).toBe(renderSkillMetadataJson({ version: installedVersion }));
+            expect(content).toContain(
+                `"msg":"Bundled skill startup synchronization skipped because the current CLI version is a development version."`,
+            );
+            expect(content).not.toContain(
+                `"msg":"Bundled skill synchronized during CLI startup."`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("publishes canonical registry skills during cli startup", async () => {
+        const sandbox = await createCliSandbox();
+        const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
+        const claudeSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+
+        try {
+            await mkdir(claudeHomeDirectory, { recursive: true });
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(canonicalSkillDirectoryPath, "SKILL.md"),
+                "# ChatGPT\n",
+            );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath),
+                renderSkillMetadataJson({
+                    packageName: "openai",
+                    version: "0.0.3",
+                }),
+            );
+
+            const result = await sandbox.run(["--help"], {
+                fetcher: async () => {
+                    throw new Error("startup synchronization should not fetch");
+                },
+            });
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain("Options:");
+            expect(result.stdout).not.toContain("Installed skill");
+            expect(await readFile(join(claudeSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
+                "# ChatGPT\n",
+            );
+            expect(content).toContain(
+                `"msg":"Registry skill synchronized during CLI startup."`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not overwrite unmanaged bundled skill targets during cli startup", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const skillFilePath = join(skillDirectoryPath, "SKILL.md");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(skillFilePath, "# Custom\n");
+
+            const result = await sandbox.run(["--help"], {
+                version: "9.9.9",
+            });
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain("Options:");
+            expect(await readFile(skillFilePath, "utf8")).toBe("# Custom\n");
+            expect(content).toContain(
+                `"msg":"Bundled skill startup synchronization skipped because the target is not managed by oo."`,
+            );
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -39,7 +39,9 @@ describe("skills list CLI", () => {
                 }),
             );
 
-            const result = await sandbox.run(["skills", "list"]);
+            const result = await sandbox.run(["skills", "list"], {
+                version: "9.9.9",
+            });
 
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
@@ -70,7 +72,7 @@ describe("skills list CLI", () => {
         }
     });
 
-    test("lists bundled OpenClaw installs when Codex is not installed", async () => {
+    test("lists startup-synchronized OpenClaw bundled installs when Codex is not installed", async () => {
         const sandbox = await createCliSandbox();
         const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
 
@@ -80,15 +82,22 @@ describe("skills list CLI", () => {
                 version: "9.9.9",
             });
 
-            const result = await sandbox.run(["skills", "list"]);
+            const result = await sandbox.run(["skills", "list"], {
+                version: "9.9.9",
+            });
 
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 1 oo-managed skills.",
+                    "✓ Found 2 oo-managed skills.",
                     "",
                     "oo",
+                    "  Host: OpenClaw",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-find-skills",
                     "  Host: OpenClaw",
                     "  Source: bundled",
                     "  Version: 9.9.9",
@@ -113,7 +122,9 @@ describe("skills list CLI", () => {
                 version: "9.9.9",
             });
 
-            const result = await sandbox.run(["skills", "list"]);
+            const result = await sandbox.run(["skills", "list"], {
+                version: "9.9.9",
+            });
 
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
@@ -139,13 +150,10 @@ describe("skills list CLI", () => {
         }
     });
 
-    test("prints a no-results message when no oo-managed skills are installed", async () => {
+    test("prints a no-results message when no supported host is installed", async () => {
         const sandbox = await createCliSandbox();
-        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
 
         try {
-            await mkdir(codexHomeDirectory, { recursive: true });
-
             const result = await sandbox.run(["skills", "list"]);
 
             expect(result.exitCode).toBe(0);

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -73,7 +73,7 @@ export async function installBundledSkill(
     }
 
     for (const installation of installations) {
-        const publishedInstallation = await writeBundledSkillInstallation({
+        const publishedInstallation = await publishManagedBundledSkill({
             agentName: installation.agentName,
             homeDirectory: installation.homeDirectory,
             settingsFilePath: context.settingsStore.getFilePath(),
@@ -209,7 +209,7 @@ export async function uninstallManagedSkill(
     await uninstallRegistrySkill(skillName, context, options);
 }
 
-async function writeBundledSkillInstallation(options: {
+export async function publishManagedBundledSkill(options: {
     agentName: BundledSkillAgentName;
     homeDirectory: string;
     settingsFilePath: string;


### PR DESCRIPTION
Keep supported agent hosts aligned before command execution so bundled skills and locally cached registry skills are available without an explicit install step. The startup path stays silent, avoids network fetches, and preserves unmanaged skill targets.