### PR TITLE
feat(auth): add session token login

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,10 +33,16 @@ Project overview: [README.md](../README.md)
 
 ### `oo auth login`
 
-Start a device login flow and save the authenticated account.
+Start a device login flow or authenticate with a session token, then save the
+authenticated account.
 
 - Notes: the CLI prints the verification URL and user code, then polls until
-  the device login is verified or times out.
+  the device login is verified or times out when `--session-token` is not
+  provided.
+- Options:
+  - `--session-token <session-token>`: Authenticate with an existing session
+    token. The CLI does not print a device-login URL or poll for verification
+    when this option is provided.
 
 ### `oo auth logout`
 
@@ -52,7 +58,8 @@ Switch to the next saved account.
 
 ### `oo login`
 
-Alias for `oo auth login`.
+Alias for `oo auth login`. Supports the same `--session-token <session-token>`
+option.
 
 ### `oo logout`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -28,9 +28,13 @@
 
 ### `oo auth login`
 
-启动 device login 流程，并保存登录成功后的账号。
+启动 device login 流程，或使用 session token 登录，并保存登录成功后的账号。
 
-- 说明：CLI 会打印验证地址和用户 code，然后轮询直到 device login 验证成功或超时。
+- 说明：未传入 `--session-token` 时，CLI 会打印验证地址和用户 code，然后轮询直到
+  device login 验证成功或超时。
+- 选项：
+  - `--session-token <session-token>`：使用已有 session token 登录。传入后 CLI 不会
+    打印 device-login URL，也不会轮询验证结果。
 
 ### `oo auth logout`
 
@@ -46,7 +50,7 @@
 
 ### `oo login`
 
-`oo auth login` 的别名。
+`oo auth login` 的别名。支持相同的 `--session-token <session-token>` 选项。
 
 ### `oo logout`
 

--- a/src/application/auth/login-flow.test.ts
+++ b/src/application/auth/login-flow.test.ts
@@ -6,7 +6,10 @@ import {
     toRequest,
 } from "../../../__tests__/helpers.ts";
 import { createTranslator } from "../../i18n/translator.ts";
-import { startAuthLoginSession } from "./login-flow.ts";
+import {
+    requestAuthAccountWithSessionToken,
+    startAuthLoginSession,
+} from "./login-flow.ts";
 
 describe("startAuthLoginSession", () => {
     test("creates a device login session and returns the verified account", async () => {
@@ -189,6 +192,106 @@ describe("startAuthLoginSession", () => {
                         "network down\n当前环境可能在网络受限的沙箱中，请尝试提权。",
                 },
             });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("requests a fast login profile with a session token", async () => {
+        const logCapture = createLogCapture();
+        const requests: Request[] = [];
+
+        try {
+            const account = await requestAuthAccountWithSessionToken({
+                endpoint: "oomol.dev",
+                fetcher: async (input, init) => {
+                    const request = toRequest(input, init);
+                    const requestUrl = new URL(request.url);
+
+                    requests.push(request);
+
+                    if (
+                        request.method === "GET"
+                        && requestUrl.host === "oomol.dev"
+                        && requestUrl.pathname === "/v1/auth/fast_login/profile_with_session_token"
+                        && requestUrl.searchParams.get("session_token") === "session-1"
+                    ) {
+                        return new Response(JSON.stringify({
+                            api_key: "secret-1",
+                            endpoint: "oomol.dev",
+                            id: "0193438c-238f-703c-8754-e4a04e0be0c1",
+                            name: "Alice",
+                        }));
+                    }
+
+                    throw new Error(`Unexpected request: ${request.method} ${requestUrl}`);
+                },
+                logger: logCapture.logger,
+                sessionToken: "session-1",
+                translator: createTranslator("en"),
+            });
+
+            expect(requests).toHaveLength(1);
+            expect(account).toEqual({
+                apiKey: "secret-1",
+                endpoint: "oomol.dev",
+                id: "0193438c-238f-703c-8754-e4a04e0be0c1",
+                name: "Alice",
+            });
+
+            const request = requests[0];
+
+            expect(request?.method).toBe("GET");
+            expect(new URL(request!.url).searchParams.get("session_token")).toBe(
+                "session-1",
+            );
+
+            const logs = logCapture.read();
+
+            expect(logs).toContain("\"msg\":\"Auth fast login request started.\"");
+            expect(logs).toContain("\"msg\":\"Auth fast login completed successfully.\"");
+            expect(logs).not.toContain("session-1");
+            expect(logs).not.toContain("secret-1");
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("redacts the session token from fast login failures", async () => {
+        const logCapture = createLogCapture();
+        const sessionToken = "token with/sensitive value";
+        const encodedSessionToken = encodeURIComponent(sessionToken);
+        const searchEncodedSessionToken = new URLSearchParams({
+            session_token: sessionToken,
+        }).toString().slice("session_token=".length);
+
+        try {
+            await expect(requestAuthAccountWithSessionToken({
+                endpoint: "oomol.dev",
+                fetcher: async () => {
+                    throw new Error(
+                        `Failed to fetch https://oomol.dev/v1/auth/fast_login/profile_with_session_token?session_token=${searchEncodedSessionToken}`,
+                    );
+                },
+                logger: logCapture.logger,
+                sessionToken,
+                translator: createTranslator("en"),
+            })).rejects.toMatchObject({
+                key: "errors.auth.loginRequestError",
+                params: {
+                    message:
+                        "Failed to fetch https://oomol.dev/v1/auth/fast_login/profile_with_session_token?session_token=<redacted>",
+                },
+            });
+
+            const logs = logCapture.read();
+
+            expect(logs).not.toContain(sessionToken);
+            expect(logs).not.toContain(encodedSessionToken);
+            expect(logs).not.toContain(searchEncodedSessionToken);
+            expect(logs).toContain("session_token=<redacted>");
         }
         finally {
             logCapture.close();

--- a/src/application/auth/login-flow.ts
+++ b/src/application/auth/login-flow.ts
@@ -36,8 +36,28 @@ const deviceLoginResultResponseSchema = z.union([
     deviceLoginVerifiedResponseSchema,
 ]);
 
+const fastLoginProfileResponseSchema = z.object({
+    api_key: z.string().min(1),
+    endpoint: z.string().min(1),
+    id: z.string().min(1),
+    name: z.string().min(1),
+}).passthrough();
+
 type DeviceLoginCodeResponse = z.output<typeof deviceLoginCodeResponseSchema>;
 type DeviceLoginResultResponse = z.output<typeof deviceLoginResultResponseSchema>;
+
+interface AuthAccountResponse {
+    api_key: string;
+    endpoint: string;
+    id: string;
+    name: string;
+}
+
+interface AuthLoginRequestOptions {
+    fetcher: Fetcher;
+    logger: Logger;
+    translator: Pick<CliExecutionContext["translator"], "t">;
+}
 
 export interface AuthLoginSession {
     code: string;
@@ -46,14 +66,16 @@ export interface AuthLoginSession {
     waitForAccount: () => Promise<AuthAccount>;
 }
 
-interface StartAuthLoginSessionOptions {
+interface StartAuthLoginSessionOptions extends AuthLoginRequestOptions {
     endpoint: string;
-    fetcher: Fetcher;
-    logger: Logger;
-    translator: Pick<CliExecutionContext["translator"], "t">;
     now?: () => number;
     sleep?: (ms: number) => Promise<void>;
     pollIntervalMs?: number;
+}
+
+interface RequestAuthAccountWithSessionTokenOptions extends AuthLoginRequestOptions {
+    endpoint: string;
+    sessionToken: string;
 }
 
 export async function startAuthLoginSession(
@@ -86,6 +108,39 @@ export async function startAuthLoginSession(
     };
 }
 
+export async function requestAuthAccountWithSessionToken(
+    options: RequestAuthAccountWithSessionTokenOptions,
+): Promise<AuthAccount> {
+    const requestUrl = createFastLoginProfileWithSessionTokenUrl(
+        options.endpoint,
+        options.sessionToken,
+    );
+    const rawResponse = await requestAuthLogin(
+        requestUrl,
+        options,
+        {
+            kind: "profile_with_session_token",
+            method: "GET",
+            redactedValues: [options.sessionToken],
+            requestDescription: "fast login",
+        },
+    );
+    const profile = parseAuthLoginResponse(
+        rawResponse,
+        fastLoginProfileResponseSchema,
+    );
+
+    options.logger.info(
+        {
+            ...withAccountIdentity(profile.id, profile.endpoint),
+            name: profile.name,
+        },
+        "Auth fast login completed successfully.",
+    );
+
+    return createAuthAccount(profile);
+}
+
 async function waitForVerifiedAccount(
     state: string,
     expiresAt: number,
@@ -111,12 +166,7 @@ async function waitForVerifiedAccount(
                 "Auth device login completed successfully.",
             );
 
-            return {
-                apiKey: result.api_key,
-                endpoint: result.endpoint,
-                id: result.id,
-                name: result.name,
-            };
+            return createAuthAccount(result);
         }
 
         const remainingMs = expiresAt - resolved.now();
@@ -141,7 +191,7 @@ async function requestDeviceLoginCode(
     state: string,
     options: StartAuthLoginSessionOptions,
 ): Promise<DeviceLoginCodeResponse> {
-    const rawResponse = await requestDeviceLogin(
+    const rawResponse = await requestAuthLogin(
         createDeviceLoginCodeUrl(options.endpoint),
         options,
         {
@@ -150,10 +200,11 @@ async function requestDeviceLoginCode(
             }),
             kind: "code",
             method: "POST",
+            requestDescription: "device login",
         },
     );
 
-    return parseDeviceLoginResponse(
+    return parseAuthLoginResponse(
         rawResponse,
         deviceLoginCodeResponseSchema,
     );
@@ -164,33 +215,34 @@ async function requestDeviceLoginResult(
     options: StartAuthLoginSessionOptions,
 ): Promise<DeviceLoginResultResponse> {
     const requestUrl = createDeviceLoginResultUrl(options.endpoint, state);
-    const rawResponse = await requestDeviceLogin(
+    const rawResponse = await requestAuthLogin(
         requestUrl,
         options,
         {
             kind: "result",
             method: "GET",
+            requestDescription: "device login",
         },
     );
 
-    return parseDeviceLoginResponse(
+    return parseAuthLoginResponse(
         rawResponse,
         deviceLoginResultResponseSchema,
     );
 }
 
-async function requestDeviceLogin(
+async function requestAuthLogin(
     requestUrl: URL,
-    options: Pick<
-        StartAuthLoginSessionOptions,
-        "fetcher" | "logger" | "translator"
-    >,
+    options: AuthLoginRequestOptions,
     requestOptions: {
         body?: string;
-        kind: "code" | "result";
+        kind: "code" | "profile_with_session_token" | "result";
         method: "GET" | "POST";
+        redactedValues?: readonly string[];
+        requestDescription: "device login" | "fast login";
     },
 ): Promise<string> {
+    const redactedValues = requestOptions.redactedValues ?? [];
     const requestStartedAt = Date.now();
 
     options.logger.debug(
@@ -201,7 +253,7 @@ async function requestDeviceLogin(
             method: requestOptions.method,
             ...withRequestTarget(requestUrl.host, requestUrl.pathname),
         },
-        "Auth device login request started.",
+        `Auth ${requestOptions.requestDescription} request started.`,
     );
 
     try {
@@ -225,7 +277,7 @@ async function requestDeviceLogin(
                     status: response.status,
                     ...withRequestTarget(requestUrl.host, requestUrl.pathname),
                 },
-                "Auth device login request returned a non-success status.",
+                `Auth ${requestOptions.requestDescription} request returned a non-success status.`,
             );
             throw new CliUserError("errors.auth.loginRequestFailed", 1, {
                 status: response.status,
@@ -240,7 +292,7 @@ async function requestDeviceLogin(
                 status: response.status,
                 ...withRequestTarget(requestUrl.host, requestUrl.pathname),
             },
-            "Auth device login request completed.",
+            `Auth ${requestOptions.requestDescription} request completed.`,
         );
 
         return await response.text();
@@ -253,21 +305,24 @@ async function requestDeviceLogin(
         options.logger.warn(
             {
                 durationMs: Date.now() - requestStartedAt,
-                err: error,
+                err: createRedactedError(error, redactedValues),
                 kind: requestOptions.kind,
                 method: requestOptions.method,
                 ...withRequestTarget(requestUrl.host, requestUrl.pathname),
             },
-            "Auth device login request failed unexpectedly.",
+            `Auth ${requestOptions.requestDescription} request failed unexpectedly.`,
         );
 
         throw new CliUserError("errors.auth.loginRequestError", 1, {
-            message: getUnexpectedRequestErrorMessage(error, options.translator),
+            message: redactSensitiveValues(
+                getUnexpectedRequestErrorMessage(error, options.translator),
+                redactedValues,
+            ),
         });
     }
 }
 
-function parseDeviceLoginResponse<TValue>(
+function parseAuthLoginResponse<TValue>(
     rawResponse: string,
     schema: z.ZodType<TValue>,
 ): TValue {
@@ -277,6 +332,15 @@ function parseDeviceLoginResponse<TValue>(
     catch {
         throw new CliUserError("errors.auth.loginInvalidResponse", 1);
     }
+}
+
+function createAuthAccount(response: AuthAccountResponse): AuthAccount {
+    return {
+        apiKey: response.api_key,
+        endpoint: response.endpoint,
+        id: response.id,
+        name: response.name,
+    };
 }
 
 function createDeviceLoginCodeUrl(endpoint: string): URL {
@@ -290,4 +354,60 @@ function createDeviceLoginResultUrl(endpoint: string, state: string): URL {
 
     requestUrl.searchParams.set("stat", state);
     return requestUrl;
+}
+
+function createFastLoginProfileWithSessionTokenUrl(
+    endpoint: string,
+    sessionToken: string,
+): URL {
+    const requestUrl = new URL(
+        `https://${endpoint}/v1/auth/fast_login/profile_with_session_token`,
+    );
+
+    requestUrl.searchParams.set("session_token", sessionToken);
+    return requestUrl;
+}
+
+function createRedactedError(
+    error: unknown,
+    sensitiveValues: readonly string[],
+): unknown {
+    if (!(error instanceof Error)) {
+        return redactSensitiveValues(String(error), sensitiveValues);
+    }
+
+    return {
+        message: redactSensitiveValues(error.message, sensitiveValues),
+        name: error.name,
+        stack: error.stack === undefined
+            ? undefined
+            : redactSensitiveValues(error.stack, sensitiveValues),
+    };
+}
+
+function redactSensitiveValues(
+    value: string,
+    sensitiveValues: readonly string[],
+): string {
+    let redactedValue = value;
+
+    for (const sensitiveValue of sensitiveValues) {
+        if (sensitiveValue === "") {
+            continue;
+        }
+
+        redactedValue = redactedValue
+            .replaceAll(sensitiveValue, "<redacted>")
+            .replaceAll(encodeURIComponent(sensitiveValue), "<redacted>")
+            .replaceAll(encodeSearchParamValue(sensitiveValue), "<redacted>");
+    }
+
+    return redactedValue;
+}
+
+function encodeSearchParamValue(value: string): string {
+    const params = new URLSearchParams();
+
+    params.set("value", value);
+    return params.toString().slice("value=".length);
 }

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -45,7 +45,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
-  login                     Log in with device login (alias for auth login)
+  login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
@@ -79,7 +79,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
-  login                     Log in with device login (alias for auth login)
+  login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
@@ -116,7 +116,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
-  login                     Log in with device login (alias for auth login)
+  login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
@@ -151,7 +151,7 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
   cloud-task                管理云任务
   connector                 管理 connector action
   file                      管理临时文件传输
-  login                     通过 device login 登录（auth login 的别名）
+  login [options]           登录 OOMOL 账号（auth login 的别名）
   logout                    登出当前账号（auth logout 的别名）
   completion <shell>        生成 shell 补全脚本
   config                    管理持久化配置
@@ -182,7 +182,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
-  login                     Log in with device login (alias for auth login)
+  login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
@@ -217,7 +217,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
-  login                     Log in with device login (alias for auth login)
+  login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -88,6 +88,9 @@ interface CreateCliExecutionContextOptions {
     version: string;
 }
 
+const redactedCliArgumentValue = "<redacted>";
+const sensitiveCliOptionLongFlags = ["--session-token"] as const;
+
 export async function runCli(argv: string[]): Promise<number> {
     return executeCli({
         argv,
@@ -138,11 +141,12 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
     });
     const { logger, logFilePath } = loggerHandle;
     const currentExecPath = invocation.execPath ?? process.execPath;
+    const loggedArgv = redactSensitiveCliArguments(invocation.argv);
 
     logger.info(
         {
-            argv: [...invocation.argv],
-            command: invocation.argv.join(" "),
+            argv: loggedArgv,
+            command: loggedArgv.join(" "),
         },
         "CLI command received.",
     );
@@ -492,4 +496,42 @@ function getSystemLocale(): string | undefined {
     catch {
         return undefined;
     }
+}
+
+function redactSensitiveCliArguments(argv: readonly string[]): string[] {
+    const redactedArguments: string[] = [];
+    let shouldRedactNextValue = false;
+
+    for (const argument of argv) {
+        if (shouldRedactNextValue) {
+            redactedArguments.push(redactedCliArgumentValue);
+            shouldRedactNextValue = false;
+            continue;
+        }
+
+        const sensitiveAssignmentFlag = readSensitiveOptionAssignmentFlag(argument);
+
+        if (sensitiveAssignmentFlag !== undefined) {
+            redactedArguments.push(`${sensitiveAssignmentFlag}=${redactedCliArgumentValue}`);
+            continue;
+        }
+
+        redactedArguments.push(argument);
+
+        if (sensitiveCliOptionLongFlags.includes(argument as typeof sensitiveCliOptionLongFlags[number])) {
+            shouldRedactNextValue = true;
+        }
+    }
+
+    return redactedArguments;
+}
+
+function readSensitiveOptionAssignmentFlag(argument: string): string | undefined {
+    for (const optionFlag of sensitiveCliOptionLongFlags) {
+        if (argument.startsWith(`${optionFlag}=`)) {
+            return optionFlag;
+        }
+    }
+
+    return undefined;
 }

--- a/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
@@ -34,15 +34,18 @@ exports[`auth CLI renders alias descriptions in login and logout help 1`] = `
     "exitCode": 0,
     "stderr": "",
     "stdout": 
-"Log in with an OOMOL account using device login. Alias for auth login.
+"Log in with an OOMOL account using device login or a session token. Alias for
+auth login.
 
 Options:
-  -h, --help     Show help for command
+  --session-token <session-token>  Log in with a session token
+  -h, --help                       Show help for command
 
 Global Options:
-  -V, --version  Show the current version
-  --debug        Print the current log file path when the CLI exits
-  --lang <lang>  Specify the display language
+  -V, --version                    Show the current version
+  --debug                          Print the current log file path when the CLI
+                                   exits
+  --lang <lang>                    Specify the display language
 "
 ,
   },

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -188,6 +188,72 @@ describe("auth CLI", () => {
         }
     });
 
+    test("supports login with a session token", async () => {
+        const sandbox = await createCliSandbox();
+        const sessionToken = "session-1";
+        const requests: Request[] = [];
+
+        try {
+            const authFilePath = join(
+                sandbox.env.XDG_CONFIG_HOME!,
+                APP_NAME,
+                "auth.toml",
+            );
+            const result = await sandbox.run(
+                ["login", "--session-token", sessionToken],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+                        const requestUrl = new URL(request.url);
+
+                        requests.push(request);
+
+                        if (
+                            request.method === "GET"
+                            && requestUrl.host === defaultAuthEndpoint
+                            && requestUrl.pathname === "/v1/auth/fast_login/profile_with_session_token"
+                            && requestUrl.searchParams.get("session_token") === sessionToken
+                        ) {
+                            return new Response(JSON.stringify({
+                                api_key: "secret-1",
+                                endpoint: defaultAuthEndpoint,
+                                id: "0193438c-238f-703c-8754-e4a04e0be0c1",
+                                name: "Alice",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected auth fast login request: ${request.method} ${requestUrl}`);
+                    },
+                },
+            );
+            const authFileContent = await readFile(authFilePath, "utf8");
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(1);
+            expect(result.stdout).not.toContain("Open this URL");
+            expect(result.stdout).not.toContain("Enter this code");
+            expect(result.stdout).not.toContain("Waiting for the device login");
+            expect(createCliSnapshot(result)).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout:
+                    "✓ Logged in to oomol.com account Alice\n  - Active account: true\n",
+            });
+            expect(authFileContent).toContain("id = \"0193438c-238f-703c-8754-e4a04e0be0c1\"");
+            expect(authFileContent).toContain("api_key = \"secret-1\"");
+            expect(authFileContent).toContain("endpoint = \"oomol.com\"");
+            expect(content).toContain(`"msg":"Auth fast login request started."`);
+            expect(content).toContain(`"msg":"Auth fast login completed successfully."`);
+            expect(content).toContain(`"msg":"Auth account persisted after fast login."`);
+            expect(content).not.toContain(sessionToken);
+            expect(content).not.toContain("secret-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("renders the auth login url and success block with color styling when stdout supports colors", async () => {
         const sandbox = await createCliSandbox();
         const colors = createTerminalColors(true);

--- a/src/application/commands/auth/login.ts
+++ b/src/application/commands/auth/login.ts
@@ -2,13 +2,18 @@ import type {
     CliCommandDefinition,
     CliExecutionContext,
 } from "../../contracts/cli.ts";
+import type { AuthAccount } from "../../schemas/auth.ts";
 
-import { startAuthLoginSession } from "../../auth/login-flow.ts";
+import { z } from "zod";
+import {
+    requestAuthAccountWithSessionToken,
+    startAuthLoginSession,
+} from "../../auth/login-flow.ts";
+import { CliUserError } from "../../contracts/cli.ts";
 import { upsertAuthAccount } from "../../schemas/auth.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { writeLine } from "../shared/output.ts";
 import {
-    emptyAuthCommandInputSchema,
     formatAuthStrong,
     writeAuthBlock,
 } from "./shared.ts";
@@ -16,46 +21,40 @@ import {
 const loginUrlColor = "#c09ff5";
 const defaultAuthEndpoint = "oomol.com";
 
-export const authLoginCommand: CliCommandDefinition = {
+const authLoginCommandInputSchema = z.object({
+    sessionToken: z.string().trim().min(1).optional(),
+});
+
+export type AuthLoginCommandInput = z.output<typeof authLoginCommandInputSchema>;
+
+export const authLoginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
     name: "login",
     summaryKey: "commands.auth.login.summary",
     descriptionKey: "commands.auth.login.description",
-    inputSchema: emptyAuthCommandInputSchema,
-    handler: async (_, context) => {
+    options: [
+        {
+            name: "sessionToken",
+            longFlag: "--session-token",
+            valueName: "session-token",
+            descriptionKey: "options.sessionToken",
+        },
+    ],
+    inputSchema: authLoginCommandInputSchema,
+    mapInputError: () => new CliUserError("errors.auth.sessionTokenRequired", 2),
+    handler: async (input: AuthLoginCommandInput, context) => {
         const authEndpoint = readAuthEndpoint(context.env);
-        const session = await startAuthLoginSession({
-            endpoint: authEndpoint,
-            fetcher: context.fetcher,
-            logger: context.logger,
-            translator: context.translator,
-        });
-        const colors = createWriterColors(context.stdout);
-
-        context.logger.debug(
-            {
-                authEndpoint,
-                expiresInSeconds: session.expiresInSeconds,
-            },
-            "Auth device login session prepared.",
-        );
-        writeLine(
-            context.stdout,
-            context.translator.t("auth.login.openManually", {
-                url: colors.hex(loginUrlColor)(session.verificationUrl),
-            }),
-        );
-        writeLine(
-            context.stdout,
-            context.translator.t("auth.login.code", {
-                code: colors.bold(session.code),
-            }),
-        );
-        writeLine(
-            context.stdout,
-            context.translator.t("auth.login.waiting"),
-        );
-
-        const account = await session.waitForAccount();
+        const loginMethod = input.sessionToken === undefined
+            ? "device_login" as const
+            : "session_token" as const;
+        const account = loginMethod === "device_login"
+            ? await runDeviceLogin(authEndpoint, context)
+            : await requestAuthAccountWithSessionToken({
+                    endpoint: authEndpoint,
+                    fetcher: context.fetcher,
+                    logger: context.logger,
+                    sessionToken: input.sessionToken!,
+                    translator: context.translator,
+                });
 
         await context.authStore.update(authFile =>
             upsertAuthAccount(authFile, account),
@@ -64,9 +63,12 @@ export const authLoginCommand: CliCommandDefinition = {
             {
                 accountId: account.id,
                 endpoint: account.endpoint,
+                loginMethod,
                 name: account.name,
             },
-            "Auth account persisted after device login.",
+            loginMethod === "device_login"
+                ? "Auth account persisted after device login."
+                : "Auth account persisted after fast login.",
         );
 
         writeAuthBlock(context, {
@@ -84,6 +86,45 @@ export const authLoginCommand: CliCommandDefinition = {
         });
     },
 };
+
+async function runDeviceLogin(
+    authEndpoint: string,
+    context: CliExecutionContext,
+): Promise<AuthAccount> {
+    const session = await startAuthLoginSession({
+        endpoint: authEndpoint,
+        fetcher: context.fetcher,
+        logger: context.logger,
+        translator: context.translator,
+    });
+    const colors = createWriterColors(context.stdout);
+
+    context.logger.debug(
+        {
+            authEndpoint,
+            expiresInSeconds: session.expiresInSeconds,
+        },
+        "Auth device login session prepared.",
+    );
+    writeLine(
+        context.stdout,
+        context.translator.t("auth.login.openManually", {
+            url: colors.hex(loginUrlColor)(session.verificationUrl),
+        }),
+    );
+    writeLine(
+        context.stdout,
+        context.translator.t("auth.login.code", {
+            code: colors.bold(session.code),
+        }),
+    );
+    writeLine(
+        context.stdout,
+        context.translator.t("auth.login.waiting"),
+    );
+
+    return session.waitForAccount();
+}
 
 function readAuthEndpoint(
     env: CliExecutionContext["env"],

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -31,7 +31,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
-  login                     Log in with device login (alias for auth login)
+  login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
   config                    Manage persisted configuration
@@ -62,7 +62,7 @@ Commands:
   cloud-task                管理云任务
   connector                 管理 connector action
   file                      管理临时文件传输
-  login                     通过 device login 登录（auth login 的别名）
+  login [options]           登录 OOMOL 账号（auth login 的别名）
   logout                    登出当前账号（auth logout 的别名）
   completion <shell>        生成 shell 补全脚本
   config                    管理持久化配置

--- a/src/application/commands/login.ts
+++ b/src/application/commands/login.ts
@@ -1,8 +1,9 @@
 import type { CliCommandDefinition } from "../contracts/cli.ts";
 
+import type { AuthLoginCommandInput } from "./auth/login.ts";
 import { authLoginCommand } from "./auth/login.ts";
 
-export const loginCommand: CliCommandDefinition = {
+export const loginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
     ...authLoginCommand,
     summaryKey: "commands.login.summary",
     descriptionKey: "commands.login.description",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -20,8 +20,9 @@ export const enMessages = {
     "auth.status.loggedOut": "Not logged in to any OOMOL account.",
     "auth.switch.success": "Switched active account for {endpoint} to {name}",
     "commands.auth.description": "Manage CLI authentication accounts.",
-    "commands.auth.login.description": "Log in with an OOMOL account using device login.",
-    "commands.auth.login.summary": "Log in with device login",
+    "commands.auth.login.description":
+        "Log in with an OOMOL account using device login or a session token.",
+    "commands.auth.login.summary": "Log in with an OOMOL account",
     "commands.auth.logout.description": "Remove the current account from persisted auth data.",
     "commands.auth.logout.summary": "Log out the current account",
     "commands.auth.status.description": "Show the current auth account and validate its API key.",
@@ -98,8 +99,8 @@ export const enMessages = {
         "Print one previous persisted debug log file by index.",
     "commands.log.print.summary": "Print a previous debug log",
     "commands.login.description":
-        "Log in with an OOMOL account using device login. Alias for auth login.",
-    "commands.login.summary": "Log in with device login (alias for auth login)",
+        "Log in with an OOMOL account using device login or a session token. Alias for auth login.",
+    "commands.login.summary": "Log in with an OOMOL account (alias for auth login)",
     "commands.logout.description":
         "Remove the current account from persisted auth data. Alias for auth logout.",
     "commands.logout.summary":
@@ -150,17 +151,19 @@ export const enMessages = {
     "errors.commander.unknownCommand": "Unknown command: {value}.",
     "errors.commander.unknownOption": "Unknown option: {value}.",
     "errors.auth.loginInvalidResponse":
-        "The device login service returned an unsupported response body.",
+        "The auth login service returned an unsupported response body.",
     "errors.auth.loginRequestError":
-        "The device login request failed: {message}",
+        "The auth login request failed: {message}",
     "errors.auth.loginRequestFailed":
-        "The device login request returned HTTP {status}.",
+        "The auth login request returned HTTP {status}.",
     "errors.auth.loginTimeout":
         "Timed out waiting for the device login to complete.",
     "errors.auth.noSavedAccounts":
         "There are no auth accounts to switch to.",
     "errors.auth.required":
         "You must log in before using this command.",
+    "errors.auth.sessionTokenRequired":
+        "Session token must not be empty.",
     "errors.authStore.invalidToml":
         "The auth file at {path} is not valid TOML.",
     "errors.authStore.invalidSchema":
@@ -467,6 +470,7 @@ export const enMessages = {
     "options.showUrl": "Include download URLs in text output",
     "options.size": "Specify the number of items per page",
     "options.status": "Filter by task status",
+    "options.sessionToken": "Log in with a session token",
     "options.timeout":
         "Set how long to wait before timing out (default 6h, range 10s to 24h)",
     "options.yes": "Skip confirmation prompts",
@@ -658,8 +662,8 @@ export const zhMessages = {
     "auth.status.loggedOut": "当前没有登录任何 OOMOL 账号。",
     "auth.switch.success": "已将 {endpoint} 的当前激活账号切换为 {name}",
     "commands.auth.description": "管理 CLI 的认证账号。",
-    "commands.auth.login.description": "通过 device login 登录 OOMOL 账号。",
-    "commands.auth.login.summary": "通过 device login 登录",
+    "commands.auth.login.description": "通过 device login 或 session token 登录 OOMOL 账号。",
+    "commands.auth.login.summary": "登录 OOMOL 账号",
     "commands.auth.logout.description": "从持久化认证数据中移除当前账号。",
     "commands.auth.logout.summary": "登出当前账号",
     "commands.auth.status.description": "显示当前认证账号并校验其 API key。",
@@ -726,8 +730,8 @@ export const zhMessages = {
     "commands.log.path.summary": "显示日志目录路径",
     "commands.log.print.description": "按序号打印某一份更早的持久化 debug 日志文件内容。",
     "commands.log.print.summary": "输出某一份更早的 debug 日志",
-    "commands.login.description": "通过 device login 登录 OOMOL 账号。是 auth login 的别名。",
-    "commands.login.summary": "通过 device login 登录（auth login 的别名）",
+    "commands.login.description": "通过 device login 或 session token 登录 OOMOL 账号。是 auth login 的别名。",
+    "commands.login.summary": "登录 OOMOL 账号（auth login 的别名）",
     "commands.logout.description": "从持久化认证数据中移除当前账号。是 auth logout 的别名。",
     "commands.logout.summary": "登出当前账号（auth logout 的别名）",
     "commands.package.description": "查看包注册表元数据及相关资源。",
@@ -769,13 +773,14 @@ export const zhMessages = {
     "errors.commander.suggestion": "你是想输入 {value} 吗？",
     "errors.commander.unknownCommand": "未知命令：{value}。",
     "errors.commander.unknownOption": "未知选项：{value}。",
-    "errors.auth.loginInvalidResponse": "device login 服务返回了不受支持的响应内容。",
-    "errors.auth.loginRequestError": "device login 请求失败：{message}",
-    "errors.auth.loginRequestFailed": "device login 请求返回了 HTTP {status}。",
+    "errors.auth.loginInvalidResponse": "auth login 服务返回了不受支持的响应内容。",
+    "errors.auth.loginRequestError": "auth login 请求失败：{message}",
+    "errors.auth.loginRequestFailed": "auth login 请求返回了 HTTP {status}。",
     "errors.auth.loginTimeout": "等待 device login 完成超时。",
     "errors.auth.noSavedAccounts": "没有可切换的认证账号。",
     "errors.auth.required":
         "使用此命令前请先登录。",
+    "errors.auth.sessionTokenRequired": "session token 不能为空。",
     "errors.authStore.invalidToml": "认证文件 {path} 不是有效的 TOML。",
     "errors.authStore.invalidSchema": "认证文件 {path} 的结构不受支持。",
     "errors.authStore.readFailed": "读取认证文件 {path} 失败。",
@@ -1073,6 +1078,7 @@ export const zhMessages = {
     "options.showUrl": "在文本输出中包含下载 URL",
     "options.size": "指定每页数量",
     "options.status": "按任务状态过滤",
+    "options.sessionToken": "使用 session token 登录",
     "options.timeout": "设置等待超时时间（默认 6h，范围 10s 到 24h）",
     "options.yes": "跳过确认提示",
     "options.lang": "指定显示语言",


### PR DESCRIPTION
Allow users to authenticate non-interactively with an existing session token when the device login flow is unnecessary. The shared login request path now redacts sensitive token values from failures and keeps the new CLI option documented for both auth login entry points.