### PR TITLE
feat(skills): add oo-create-skill skill, `oo skills init` and `oo skills validate`.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit",
+    "source.addMissingImports": "explicit",
+    "source.organizeImports": "never"
+  },
+  "cSpell.enabled": true,
+  "eslint.enable": true,
+  "prettier.enable": false,
+  "biome.enabled": false,
+  "conventionalCommits.gitmoji": false,
+  "conventionalCommits.promptFooter": false,
+  "git.branchProtection": ["main"],
+  "git.branchRandomName.enable": true,
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
+}

--- a/contrib/install/install-unix.test.ts
+++ b/contrib/install/install-unix.test.ts
@@ -248,7 +248,7 @@ async function runInstallerFromStdin(
 
 async function runBashCommand(script: string): Promise<CliRunResult> {
     return runCommand(
-        ["bash", "-lc", script],
+        ["bash", "-c", script],
         import.meta.dir,
     );
 }

--- a/contrib/skills/claude/oo-create-skill/SKILL.md
+++ b/contrib/skills/claude/oo-create-skill/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: oo-create-skill
+description: >-
+  Create or update a local agent skill for a known OOMOL package workflow. Use
+  when the user already knows which oo package or block should power the
+  workflow and wants reusable skill instructions.
+allowed-tools: ["Bash(oo *)"]
+---
+
+# oo Create Skill
+
+Use this skill when the user wants to create or update a local skill around an
+OOMOL package workflow.
+
+## Workflow
+
+### 1. Collect only the information needed
+
+Ask for missing authoring inputs only when they are needed:
+
+- skill name
+- workflow purpose
+- known package names
+- stable block names, when the user knows them
+- user inputs the skill should collect
+- workflow ordering and expected outputs
+- optional display title and icon preference
+
+### 2. Resolve concrete package and block references
+
+If the user provides only package-level information, inspect the package before
+writing the skill:
+
+```bash
+oo packages info "<packageName>" --json
+```
+
+Use the returned metadata to identify stable block references, input concepts,
+and output concepts. Prefer the most specific safe reference:
+`oo::packageName::blockName` when a block is clearly part of the intended
+workflow, or `oo::packageName` only when the block must remain a deliberate
+runtime choice based on user intent.
+
+If the user does not know the package name, or the workflow clearly needs an
+additional package, use `oo search` to find candidate packages before authoring.
+After choosing packages and blocks, do not leave package discovery to the
+generated skill.
+
+### 3. Initialize the local skill
+
+When creating a new skill, run `oo skills init <name>` with a required
+`--description` value. Also pass `--title` and `--icon` when those values are
+known. Pass `--title` only when the user provided or confirmed a concise display
+title. If initialization fails because the local canonical directory or an agent
+target directory already exists, ask the user for a different skill name instead
+of overwriting.
+
+### 4. Author the workflow instructions
+
+Write the generated skill in domain terms: when to use it, what to ask the
+user, which workflow steps to follow, and what outputs to report. Reference
+packages with `oo::packageName` and stable blocks with
+`oo::packageName::blockName`.
+
+Preserve the generated frontmatter `metadata.title` field when it exists. If
+you change the skill's displayed title or first heading, update
+`metadata.title` to the same human-readable title. If the field is absent, do
+not add it by deriving a title from the skill name.
+
+The final generated skill must contain concrete package or block references. It
+must not instruct the future agent to run `oo search` or discover packages at
+execution time.
+
+Do not duplicate oo execution mechanics in authored prose. The initialized
+`SKILL.md` already contains the managed OO notice that tells agents how to
+inspect and run referenced packages.
+
+Keep `SKILL.md` concise. Use `references/workflow.md` only when the workflow
+has several steps, decision rules, or examples. Use `references/packages.json`
+only when captured package metadata will help future updates.
+
+### 5. Validate before finishing
+
+After editing the skill, run `oo skills validate "<skill-directory>"`. If
+validation fails, fix the generic skill contract before reporting completion.

--- a/contrib/skills/codex/oo-create-skill/SKILL.md
+++ b/contrib/skills/codex/oo-create-skill/SKILL.md
@@ -26,7 +26,7 @@ commands:
 Then run the dedicated preflight for the Codex host:
 
 ```bash
-oo skills check --agent codex
+oo skills preflight --agent codex
 ```
 
 This command checks that the Codex home exists and that the configured local
@@ -35,7 +35,7 @@ writable location when it fails.
 
 If the session is read-only, blocks writes outside the needed skill/config
 directories, blocks network access, cannot run `oo` commands with the needed
-permissions, or `oo skills check --agent codex` fails, request elevated or
+permissions, or `oo skills preflight --agent codex` fails, request elevated or
 out-of-sandbox execution before continuing. The commands that commonly need this
 are:
 

--- a/contrib/skills/codex/oo-create-skill/SKILL.md
+++ b/contrib/skills/codex/oo-create-skill/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: oo-create-skill
+description: >-
+  Create or update a local agent skill for a known OOMOL package workflow. Use
+  when the user already knows which oo package or block should power the
+  workflow and wants reusable skill instructions.
+---
+
+# oo Create Skill
+
+Use this skill when the user wants to create or update a local skill around an
+OOMOL package workflow.
+
+## Workflow
+
+### 1. Check Codex execution permissions
+
+This skill needs `oo` commands that may write local skill files and call OOMOL
+services. In Codex, check the current session permissions before running those
+commands:
+
+- filesystem sandbox mode
+- network access
+- approval policy or whether elevated command execution can be requested
+
+Then run the dedicated preflight for the Codex host:
+
+```bash
+oo skills check --agent codex
+```
+
+This command checks that the Codex home exists and that the configured local
+skill canonical storage can be created and written. Do not use a different
+writable location when it fails.
+
+If the session is read-only, blocks writes outside the needed skill/config
+directories, blocks network access, cannot run `oo` commands with the needed
+permissions, or `oo skills check --agent codex` fails, request elevated or
+out-of-sandbox execution before continuing. The commands that commonly need this
+are:
+
+```bash
+oo skills init <name> ...
+oo packages info "<packageName>" --json
+oo search "<query>" --json
+```
+
+If Codex cannot request the needed permission, or the user denies it, stop and
+ask the user to open the required permission before continuing. Name the blocked
+command, explain the missing access, and ask for the smallest sufficient
+permission, such as write access to the configured oo skill storage, network
+access for `oo packages info` or `oo search`, or permission to rerun the command
+outside the current sandbox. Do not continue in the restricted sandbox and do
+not guess package names, block names, inputs, or outputs.
+
+Never work around a blocked `oo skills init` by manually creating a skill
+directory in the repository, a temporary directory, or any other writable path.
+Manual skeleton creation is not equivalent to `oo skills init`: it bypasses the
+managed canonical location, metadata writing, agent publication links, and OO
+notice insertion. If `oo skills init` cannot write to the configured oo skill
+storage, request permission to rerun it with the required access or stop.
+
+### 2. Collect only the information needed
+
+Ask for missing authoring inputs only when they are needed:
+
+- skill name
+- workflow purpose
+- known package names
+- stable block names, when the user knows them
+- user inputs the skill should collect
+- workflow ordering and expected outputs
+- optional display title and icon preference
+
+### 3. Resolve concrete package and block references
+
+If the user provides only package-level information, inspect the package before
+writing the skill:
+
+```bash
+oo packages info "<packageName>" --json
+```
+
+Use the returned metadata to identify stable block references, input concepts,
+and output concepts. Prefer the most specific safe reference:
+`oo::packageName::blockName` when a block is clearly part of the intended
+workflow, or `oo::packageName` only when the block must remain a deliberate
+runtime choice based on user intent.
+
+If the user does not know the package name, or the workflow clearly needs an
+additional package, use `oo search` to find candidate packages before authoring.
+After choosing packages and blocks, do not leave package discovery to the
+generated skill.
+
+### 4. Initialize the local skill
+
+When creating a new skill, run `oo skills init <name>` with a required
+`--description` value. Also pass `--title` and `--icon` when those values are
+known. Pass `--title` only when the user provided or confirmed a concise display
+title. If initialization fails because the local canonical directory or an agent
+target directory already exists, ask the user for a different skill name instead
+of overwriting.
+
+Do not substitute manual file creation for this step. The initialized skill
+directory must come from a successful `oo skills init` invocation before you
+edit its workflow instructions or run validation.
+
+### 5. Author the workflow instructions
+
+Write the generated skill in domain terms: when to use it, what to ask the
+user, which workflow steps to follow, and what outputs to report. Reference
+packages with `oo::packageName` and stable blocks with
+`oo::packageName::blockName`.
+
+Preserve the generated frontmatter `metadata.title` field when it exists. If
+you change the skill's displayed title or first heading, update
+`metadata.title` to the same human-readable title. If the field is absent, do
+not add it by deriving a title from the skill name.
+
+The final generated skill must contain concrete package or block references. It
+must not instruct the future agent to run `oo search` or discover packages at
+execution time.
+
+Do not duplicate oo execution mechanics in authored prose. The initialized
+`SKILL.md` already contains the managed OO notice that tells agents how to
+inspect and run referenced packages.
+
+Keep `SKILL.md` concise. Use `references/workflow.md` only when the workflow
+has several steps, decision rules, or examples. Use `references/packages.json`
+only when captured package metadata will help future updates.
+
+### 6. Validate before finishing
+
+After editing the skill, run `oo skills validate "<skill-directory>"`. If
+validation fails, fix the generic skill contract before reporting completion.

--- a/contrib/skills/codex/oo-create-skill/agents/openai.yaml
+++ b/contrib/skills/codex/oo-create-skill/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: oo Create Skill
+  short_description: Create local OOMOL package workflow skills
+  default_prompt: Use $oo-create-skill when the user wants to create or update a local agent skill for a known OOMOL/oo package workflow and already knows the package or block references. Do not use it for discovering unknown packages or finding published skills.
+
+policy:
+  allow_implicit_invocation: true

--- a/contrib/skills/openclaw/oo-create-skill/SKILL.md
+++ b/contrib/skills/openclaw/oo-create-skill/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: oo-create-skill
+description: >-
+  Create or update a local agent skill for a known OOMOL package workflow. Use
+  when the user already knows which oo package or block should power the
+  workflow and wants reusable skill instructions.
+---
+
+# oo Create Skill
+
+Use this skill when the user wants to create or update a local skill around an
+OOMOL package workflow.
+
+## Workflow
+
+### 1. Collect only the information needed
+
+Ask for missing authoring inputs only when they are needed:
+
+- skill name
+- workflow purpose
+- known package names
+- stable block names, when the user knows them
+- user inputs the skill should collect
+- workflow ordering and expected outputs
+- optional display title and icon preference
+
+### 2. Resolve concrete package and block references
+
+If the user provides only package-level information, inspect the package before
+writing the skill:
+
+```bash
+oo packages info "<packageName>" --json
+```
+
+Use the returned metadata to identify stable block references, input concepts,
+and output concepts. Prefer the most specific safe reference:
+`oo::packageName::blockName` when a block is clearly part of the intended
+workflow, or `oo::packageName` only when the block must remain a deliberate
+runtime choice based on user intent.
+
+If the user does not know the package name, or the workflow clearly needs an
+additional package, use `oo search` to find candidate packages before authoring.
+After choosing packages and blocks, do not leave package discovery to the
+generated skill.
+
+### 3. Initialize the local skill
+
+When creating a new skill, run `oo skills init <name>` with a required
+`--description` value. Also pass `--title` and `--icon` when those values are
+known. Pass `--title` only when the user provided or confirmed a concise display
+title. If initialization fails because the local canonical directory or an agent
+target directory already exists, ask the user for a different skill name instead
+of overwriting.
+
+### 4. Author the workflow instructions
+
+Write the generated skill in domain terms: when to use it, what to ask the
+user, which workflow steps to follow, and what outputs to report. Reference
+packages with `oo::packageName` and stable blocks with
+`oo::packageName::blockName`.
+
+Preserve the generated frontmatter `metadata.title` field when it exists. If
+you change the skill's displayed title or first heading, update
+`metadata.title` to the same human-readable title. If the field is absent, do
+not add it by deriving a title from the skill name.
+
+The final generated skill must contain concrete package or block references. It
+must not instruct the future agent to run `oo search` or discover packages at
+execution time.
+
+Do not duplicate oo execution mechanics in authored prose. The initialized
+`SKILL.md` already contains the managed OO notice that tells agents how to
+inspect and run referenced packages.
+
+Keep `SKILL.md` concise. Use `references/workflow.md` only when the workflow
+has several steps, decision rules, or examples. Use `references/packages.json`
+only when captured package metadata will help future updates.
+
+### 5. Validate before finishing
+
+After editing the skill, run `oo skills validate "<skill-directory>"`. If
+validation fails, fix the generic skill contract before reporting completion.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -288,9 +288,9 @@ List oo-managed skills from supported local skill directories.
 - Notes: when a folded skill is installed in multiple supported hosts, the
   `Host` field lists all matching hosts.
 
-### `oo skills check`
+### `oo skills preflight`
 
-Check whether local skill authoring can use the managed local skill storage.
+Check whether this environment has permission to edit local skills.
 
 - Options: `--agent <agent>` restricts the host check to one supported agent:
   `codex`, `claude`, or `openclaw`.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -312,6 +312,8 @@ directory that already exists.
   `name`.
 - Options: `--description <text>` is required and writes the generated
   `SKILL.md` frontmatter description.
+- Generated `SKILL.md` frontmatter includes `compatibility: "Requires the oo
+  CLI."`.
 - Options: `--icon <icon>` writes an opaque non-empty icon reference to
   `.oo-metadata.json`.
 - Options: `--title <title>` writes `metadata.title` to the generated

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -336,13 +336,8 @@ Validate a local skill directory against the generic skill contract.
 - Validation: `SKILL.md` must start with YAML frontmatter delimited by `---`.
   The frontmatter must be a dictionary with string `name` and `description`
   fields.
-- Validation: supported frontmatter keys are `name`, `description`, `license`,
-  `allowed-tools`, and `metadata`.
-- Validation: `name` must be lowercase hyphen-case using letters, digits, and
-  hyphens only. It cannot start or end with a hyphen, contain consecutive
-  hyphens, or exceed 64 characters.
-- Validation: `description` must not contain angle brackets and cannot exceed
-  1024 characters.
+- Validation: nested `metadata.title` is optional, but when present it must be a
+  non-empty string.
 - Output: on success, the command prints a concise success message. On failure,
   it prints the validation error and exits non-zero.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -280,13 +280,71 @@ List oo-managed skills from supported local skill directories.
   skill identity. Identical `name`/source/version installs across multiple
   hosts are folded into one block.
 - Ordering: bundled skills are listed first when present, with `oo` before
-  `oo-find-skills`; the remaining skills are ordered by skill name. Host names
-  within a block follow `Codex`,
+  `oo-find-skills` before `oo-create-skill`; the remaining skills are ordered
+  by skill name. Host names within a block follow `Codex`,
   `Claude Code`, `OpenClaw` order.
 - Output: each skill block shows the skill name, host, source package or
-  bundled marker, and recorded version.
+  bundled/local marker, and recorded version.
 - Notes: when a folded skill is installed in multiple supported hosts, the
   `Host` field lists all matching hosts.
+
+### `oo skills check`
+
+Check whether local skill authoring can use the managed local skill storage.
+
+- Options: `--agent <agent>` restricts the host check to one supported agent:
+  `codex`, `claude`, or `openclaw`.
+- Host check: without `--agent`, at least one supported agent home directory
+  must already exist. With `--agent`, that specific agent home directory must
+  exist.
+- Storage check: the command creates `<config-dir>/skills/local` when needed,
+  writes a temporary probe file there, and removes the probe file.
+- Output: on success, text output prints the writable storage path and number
+  of checked supported hosts. On failure, the command exits non-zero.
+
+### `oo skills init <name>`
+
+Initialize one local skill and publish it to every supported agent home
+directory that already exists.
+
+- Arguments: `<name>` is normalized to lowercase hyphen-case and used as the
+  skill id, canonical directory name, target directory name, and frontmatter
+  `name`.
+- Options: `--description <text>` is required and writes the generated
+  `SKILL.md` frontmatter description.
+- Options: `--icon <icon>` writes an opaque non-empty icon reference to
+  `.oo-metadata.json`.
+- Options: `--title <title>` writes `metadata.title` to the generated
+  `SKILL.md` frontmatter. When omitted, `metadata.title` is not generated.
+- Canonical directory: the skill is created under
+  `<config-dir>/skills/local/<skill-id>`, where `<config-dir>` is the directory
+  containing the oo settings file.
+- Target directories: the command publishes directory links to each existing
+  supported agent skill directory:
+  `${CODEX_HOME:-~/.codex}/skills/<skill-id>`, `~/.claude/skills/<skill-id>`,
+  and `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`.
+- Failure behavior: if no supported agent home exists, or if the canonical
+  local directory or any target directory already exists, the command exits
+  non-zero before writing the skill.
+- Output: text output prints one success line per published target path.
+
+### `oo skills validate <path>`
+
+Validate a local skill directory against the generic skill contract.
+
+- Arguments: `<path>` is the skill directory containing `SKILL.md`.
+- Validation: `SKILL.md` must start with YAML frontmatter delimited by `---`.
+  The frontmatter must be a dictionary with string `name` and `description`
+  fields.
+- Validation: supported frontmatter keys are `name`, `description`, `license`,
+  `allowed-tools`, and `metadata`.
+- Validation: `name` must be lowercase hyphen-case using letters, digits, and
+  hyphens only. It cannot start or end with a hyphen, contain consecutive
+  hyphens, or exceed 64 characters.
+- Validation: `description` must not contain angle brackets and cannot exceed
+  1024 characters.
+- Output: on success, the command prints a concise success message. On failure,
+  it prints the validation error and exits non-zero.
 
 ### `oo skills search <text>`
 
@@ -311,8 +369,8 @@ Install bundled or published skills into supported local skill directories.
 - Alias: `oo skills add [packageName]`.
 - Arguments: `[packageName]` is optional.
 - Arguments: when omitted, the command installs all bundled skills.
-- Arguments: when `[packageName]` is `oo` or `oo-find-skills`, the command
-  installs the corresponding bundled skill.
+- Arguments: when `[packageName]` is `oo`, `oo-find-skills`, or
+  `oo-create-skill`, the command installs the corresponding bundled skill.
 - Arguments: when `[packageName]` is a published package name, the command
   installs skills from that package.
 - Options: `-s, --skill <skills...>` installs one or more named published

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -297,8 +297,9 @@ Check whether local skill authoring can use the managed local skill storage.
 - Host check: without `--agent`, at least one supported agent home directory
   must already exist. With `--agent`, that specific agent home directory must
   exist.
-- Storage check: the command creates `<config-dir>/skills/local` when needed,
-  writes a temporary probe file there, and removes the probe file.
+- Storage check: the command creates `<config-dir>/skills/local` and each
+  checked host publish root, such as `<agent-home>/skills`, when needed. It
+  writes and removes a temporary probe file in each checked directory.
 - Output: on success, text output prints the writable storage path and number
   of checked supported hosts. On failure, the command exits non-zero.
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -257,9 +257,9 @@ skills。
 - 说明：如果折叠后的 skill 安装在多个受支持宿主中，`宿主` 字段会列出所有
   匹配的宿主。
 
-### `oo skills check`
+### `oo skills preflight`
 
-检查本地 skill 创建是否可以使用受管理的本地 skill 存储。
+检查当前环境是否有权限编辑本地 skills。
 
 - 选项：`--agent <agent>` 将宿主检查限制为一个受支持 agent：`codex`、
   `claude` 或 `openclaw`。

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -278,6 +278,7 @@ skills。
   目标目录名以及 frontmatter `name`。
 - 选项：`--description <text>` 为必填项，并写入生成的 `SKILL.md`
   frontmatter description。
+- 生成的 `SKILL.md` frontmatter 包含 `compatibility: "Requires the oo CLI."`。
 - 选项：`--icon <icon>` 将非空不透明 icon 引用写入 `.oo-metadata.json`。
 - 选项：`--title <title>` 将 `metadata.title` 写入生成的 `SKILL.md`
   frontmatter。未提供时不会生成 `metadata.title`。

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -250,12 +250,59 @@ skills。
 - 输出：文本输出会先打印摘要行，再为每个唯一的可见 skill 身份打印一个块。
   如果多个宿主中的安装具有相同 `name`、来源和版本，则会折叠到同一个块中。
 - 排序：bundled skills 会排在最前面；其中 `oo` 优先，其次
-  `oo-find-skills`；其余 skill 按名称排序。每个块内的宿主名称按 `Codex`、
+  `oo-find-skills`，再其次 `oo-create-skill`；其余 skill 按名称排序。每个块内的宿主名称按 `Codex`、
   `Claude Code`、`OpenClaw` 顺序显示。
-- 输出：每个 skill 块会显示 skill 名称、宿主、来源 package 或内置标记，以
+- 输出：每个 skill 块会显示 skill 名称、宿主、来源 package、内置或本地标记，以
   及记录的版本号。
 - 说明：如果折叠后的 skill 安装在多个受支持宿主中，`宿主` 字段会列出所有
   匹配的宿主。
+
+### `oo skills check`
+
+检查本地 skill 创建是否可以使用受管理的本地 skill 存储。
+
+- 选项：`--agent <agent>` 将宿主检查限制为一个受支持 agent：`codex`、
+  `claude` 或 `openclaw`。
+- 宿主检查：未提供 `--agent` 时，至少需要存在一个受支持 agent home 目录。
+  提供 `--agent` 时，该指定 agent home 目录必须存在。
+- 存储检查：命令会在需要时创建 `<config-dir>/skills/local`，在其中写入临时
+  探针文件，然后移除该探针文件。
+- 输出：成功时，文本输出会打印可写存储路径和已检查的受支持宿主数量。失败时
+  命令以非零状态退出。
+
+### `oo skills init <name>`
+
+初始化一个本地 skill，并发布到所有已存在的受支持 agent home 目录。
+
+- 参数：`<name>` 会规范化为小写短横线格式，并用作 skill id、canonical 目录名、
+  目标目录名以及 frontmatter `name`。
+- 选项：`--description <text>` 为必填项，并写入生成的 `SKILL.md`
+  frontmatter description。
+- 选项：`--icon <icon>` 将非空不透明 icon 引用写入 `.oo-metadata.json`。
+- 选项：`--title <title>` 将 `metadata.title` 写入生成的 `SKILL.md`
+  frontmatter。未提供时不会生成 `metadata.title`。
+- canonical 目录：skill 创建在 `<config-dir>/skills/local/<skill-id>` 下，
+  其中 `<config-dir>` 是 oo settings 文件所在目录。
+- 目标目录：命令会向每个已存在的受支持 agent skill 目录发布目录链接：
+  `${CODEX_HOME:-~/.codex}/skills/<skill-id>`、`~/.claude/skills/<skill-id>`，
+  以及 `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`。
+- 失败行为：如果没有受支持的 agent home，或 canonical 本地目录、任意目标目录
+  已存在，命令会在写入 skill 前以非零状态退出。
+- 输出：文本输出会为每个发布目标路径打印一行成功消息。
+
+### `oo skills validate <path>`
+
+按照通用 skill 契约校验本地 skill 目录。
+
+- 参数：`<path>` 是包含 `SKILL.md` 的 skill 目录。
+- 校验：`SKILL.md` 必须以 `---` 分隔的 YAML frontmatter 开头。frontmatter
+  必须是字典，并包含字符串 `name` 和 `description` 字段。
+- 校验：支持的 frontmatter key 为 `name`、`description`、`license`、
+  `allowed-tools` 和 `metadata`。
+- 校验：`name` 必须是仅包含小写字母、数字和短横线的短横线格式。不能以短横线
+  开头或结尾，不能包含连续短横线，且不能超过 64 个字符。
+- 校验：`description` 不能包含尖括号，且不能超过 1024 个字符。
+- 输出：成功时命令会打印简短成功消息。失败时打印校验错误并以非零状态退出。
 
 ### `oo skills search <text>`
 
@@ -279,8 +326,8 @@ skills。
 - 别名：`oo skills add [packageName]`。
 - 参数：`[packageName]` 可选。
 - 参数：未提供时，该命令会安装全部内置 skill。
-- 参数：当 `[packageName]` 为 `oo` 或 `oo-find-skills` 时，命令安装对应
-  的内置 skill。
+- 参数：当 `[packageName]` 为 `oo`、`oo-find-skills` 或 `oo-create-skill` 时，
+  命令安装对应的内置 skill。
 - 参数：当 `[packageName]` 为已发布 package 名称时，命令从该 package 中
   安装 skill。
 - 选项：`-s, --skill <skills...>` 用于安装 package 中一个或多个指定的

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -297,11 +297,7 @@ skills。
 - 参数：`<path>` 是包含 `SKILL.md` 的 skill 目录。
 - 校验：`SKILL.md` 必须以 `---` 分隔的 YAML frontmatter 开头。frontmatter
   必须是字典，并包含字符串 `name` 和 `description` 字段。
-- 校验：支持的 frontmatter key 为 `name`、`description`、`license`、
-  `allowed-tools` 和 `metadata`。
-- 校验：`name` 必须是仅包含小写字母、数字和短横线的短横线格式。不能以短横线
-  开头或结尾，不能包含连续短横线，且不能超过 64 个字符。
-- 校验：`description` 不能包含尖括号，且不能超过 1024 个字符。
+- 校验：嵌套的 `metadata.title` 可以省略；如果提供，则必须是非空字符串。
 - 输出：成功时命令会打印简短成功消息。失败时打印校验错误并以非零状态退出。
 
 ### `oo skills search <text>`

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -265,8 +265,9 @@ skills。
   `claude` 或 `openclaw`。
 - 宿主检查：未提供 `--agent` 时，至少需要存在一个受支持 agent home 目录。
   提供 `--agent` 时，该指定 agent home 目录必须存在。
-- 存储检查：命令会在需要时创建 `<config-dir>/skills/local`，在其中写入临时
-  探针文件，然后移除该探针文件。
+- 存储检查：命令会在需要时创建 `<config-dir>/skills/local` 和每个已检查宿主
+  的发布根目录（如 `<agent-home>/skills`），并在每个已检查目录中写入再移除
+  临时探针文件。
 - 输出：成功时，文本输出会打印可写存储路径和已检查的受支持宿主数量。失败时
   命令以非零状态退出。
 

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -98,6 +98,7 @@ exports[`skills CLI writes explicit skills install and uninstall logs 1`] = `
     "stdout": 
 "Installed skill oo to <HOME>/.codex/skills/oo.
 Installed skill oo-find-skills to <HOME>/.codex/skills/oo-find-skills.
+Installed skill oo-create-skill to <HOME>/.codex/skills/oo-create-skill.
 "
 ,
   },
@@ -107,6 +108,7 @@ Installed skill oo-find-skills to <HOME>/.codex/skills/oo-find-skills.
     "stdout": 
 "Removed skill oo from <HOME>/.codex/skills/oo.
 Removed skill oo-find-skills from <HOME>/.codex/skills/oo-find-skills.
+Removed skill oo-create-skill from <HOME>/.codex/skills/oo-create-skill.
 "
 ,
   },

--- a/src/application/commands/skills/bundled-skill-paths.ts
+++ b/src/application/commands/skills/bundled-skill-paths.ts
@@ -8,6 +8,7 @@ const claudeDirectoryName = ".claude";
 const openClawDirectoryName = ".openclaw";
 export const codexSkillsDirectoryName = "skills";
 export const canonicalBundledSkillsDirectoryName = "bundled";
+export const canonicalLocalSkillsDirectoryName = "local";
 export const canonicalRegistrySkillsDirectoryName = "registry";
 
 export const bundledSkillMetadataFileName = ".oo-metadata.json";
@@ -58,7 +59,7 @@ export function resolveBundledSkillHomeDirectory(
 
 export function resolveBundledSkillDirectoryPath(
     homeDirectory: string,
-    skillName: BundledSkillName,
+    skillName: string,
 ): string {
     return join(homeDirectory, codexSkillsDirectoryName, skillName);
 }

--- a/src/application/commands/skills/check.test.ts
+++ b/src/application/commands/skills/check.test.ts
@@ -1,4 +1,5 @@
 import { mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
@@ -65,6 +66,33 @@ describe("skills check command", () => {
             expect(result.stdout).toBe("");
             expect(result.stderr).toBe(
                 `Codex is not installed. Expected the Codex home directory at ${codexHomeDirectory}.\n`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("requires the requested agent publish root to be writable", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const publishRootPath = join(codexHomeDirectory, "skills");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await Bun.write(publishRootPath, "not a directory");
+
+            const result = await sandbox.run([
+                "skills",
+                "check",
+                "--agent",
+                "codex",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toContain(
+                `Local skill storage at ${publishRootPath} is not writable:`,
             );
         }
         finally {

--- a/src/application/commands/skills/check.test.ts
+++ b/src/application/commands/skills/check.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./bundled-skill-paths.ts";
 import { resolveLocalSkillCanonicalRootDirectoryPath } from "./managed-skill-paths.ts";
 
-describe("skills check command", () => {
+describe("skills preflight command", () => {
     test("checks the requested agent and local canonical storage", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -30,7 +30,7 @@ describe("skills check command", () => {
 
             const result = await sandbox.run([
                 "skills",
-                "check",
+                "preflight",
                 "--agent",
                 "codex",
             ]);
@@ -38,7 +38,7 @@ describe("skills check command", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
-                `Local skill authoring is ready. Writable storage: ${canonicalRootDirectoryPath}. Supported hosts: 1.\n`,
+                `Local skill editing is ready. Writable storage: ${canonicalRootDirectoryPath}. Supported hosts: 1.\n`,
             );
             expect(await readdir(canonicalRootDirectoryPath)).toEqual([]);
         }
@@ -57,7 +57,7 @@ describe("skills check command", () => {
 
             const result = await sandbox.run([
                 "skills",
-                "check",
+                "preflight",
                 "--agent",
                 "codex",
             ]);
@@ -84,7 +84,7 @@ describe("skills check command", () => {
 
             const result = await sandbox.run([
                 "skills",
-                "check",
+                "preflight",
                 "--agent",
                 "codex",
             ]);

--- a/src/application/commands/skills/check.test.ts
+++ b/src/application/commands/skills/check.test.ts
@@ -1,0 +1,74 @@
+import { mkdir, readdir } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { createCliSandbox } from "../../../../__tests__/helpers.ts";
+import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import {
+    resolveClaudeHomeDirectory,
+    resolveCodexHomeDirectory,
+} from "./bundled-skill-paths.ts";
+import { resolveLocalSkillCanonicalRootDirectoryPath } from "./managed-skill-paths.ts";
+
+describe("skills check command", () => {
+    test("checks the requested agent and local canonical storage", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalRootDirectoryPath = resolveLocalSkillCanonicalRootDirectoryPath(
+            storePaths.settingsFilePath,
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "check",
+                "--agent",
+                "codex",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Local skill authoring is ready. Writable storage: ${canonicalRootDirectoryPath}. Supported hosts: 1.\n`,
+            );
+            expect(await readdir(canonicalRootDirectoryPath)).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("requires the requested agent home directory", async () => {
+        const sandbox = await createCliSandbox();
+        const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(claudeHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "check",
+                "--agent",
+                "codex",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                `Codex is not installed. Expected the Codex home directory at ${codexHomeDirectory}.\n`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/check.ts
+++ b/src/application/commands/skills/check.ts
@@ -1,13 +1,17 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 import type { BundledSkillAgentName } from "./embedded-assets.ts";
 
+import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
 import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { writeLine } from "../shared/output.ts";
 import { directoryExists } from "./bundled-skill-observation.ts";
-import { resolveBundledSkillHomeDirectory } from "./bundled-skill-paths.ts";
+import {
+    codexSkillsDirectoryName,
+    resolveBundledSkillHomeDirectory,
+} from "./bundled-skill-paths.ts";
 import { availableBundledSkillAgentNames } from "./embedded-assets.ts";
 import {
     createMissingManagedSkillHostError,
@@ -73,6 +77,9 @@ export async function checkLocalSkillAuthoringEnvironment(
     );
 
     await verifyWritableDirectory(canonicalRootDirectoryPath);
+    await Promise.all(
+        hosts.map(host => verifyWritableDirectory(resolveManagedSkillHostPublishRoot(host))),
+    );
 
     return {
         canonicalRootDirectoryPath,
@@ -96,6 +103,10 @@ async function resolveRequestedManagedSkillHost(
             homeDirectory,
         },
     ];
+}
+
+function resolveManagedSkillHostPublishRoot(host: ManagedSkillHost): string {
+    return join(host.homeDirectory, codexSkillsDirectoryName);
 }
 
 function createMissingRequestedManagedSkillHostError(
@@ -141,6 +152,11 @@ async function verifyWritableDirectory(directoryPath: string): Promise<void> {
         });
     }
     finally {
-        await rm(probeFilePath, { force: true });
+        try {
+            await rm(probeFilePath, { force: true });
+        }
+        catch {
+            // Preserve the original readiness error when cleanup probes invalid paths.
+        }
     }
 }

--- a/src/application/commands/skills/check.ts
+++ b/src/application/commands/skills/check.ts
@@ -1,0 +1,146 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+import type { BundledSkillAgentName } from "./embedded-assets.ts";
+
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { writeLine } from "../shared/output.ts";
+import { directoryExists } from "./bundled-skill-observation.ts";
+import { resolveBundledSkillHomeDirectory } from "./bundled-skill-paths.ts";
+import { availableBundledSkillAgentNames } from "./embedded-assets.ts";
+import {
+    createMissingManagedSkillHostError,
+    resolveAvailableManagedSkillHosts,
+} from "./managed-skill-hosts.ts";
+import { resolveLocalSkillCanonicalRootDirectoryPath } from "./managed-skill-paths.ts";
+
+interface SkillsCheckInput {
+    agent?: BundledSkillAgentName;
+}
+
+interface SkillsCheckResult {
+    canonicalRootDirectoryPath: string;
+    hostCount: number;
+}
+
+export const skillsCheckCommand: CliCommandDefinition<SkillsCheckInput> = {
+    name: "check",
+    summaryKey: "commands.skills.check.summary",
+    descriptionKey: "commands.skills.check.description",
+    options: [
+        {
+            name: "agent",
+            longFlag: "--agent",
+            valueName: "agent",
+            descriptionKey: "options.agent",
+        },
+    ],
+    inputSchema: z.object({
+        agent: z.enum(availableBundledSkillAgentNames).optional(),
+    }),
+    handler: async (input, context) => {
+        const result = await checkLocalSkillAuthoringEnvironment(context, {
+            agentName: input.agent,
+        });
+
+        writeLine(
+            context.stdout,
+            context.translator.t("skills.check.success", {
+                count: result.hostCount,
+                path: result.canonicalRootDirectoryPath,
+            }),
+        );
+    },
+};
+
+export async function checkLocalSkillAuthoringEnvironment(
+    context: Pick<CliExecutionContext, "env" | "settingsStore">,
+    options: {
+        agentName?: BundledSkillAgentName;
+    } = {},
+): Promise<SkillsCheckResult> {
+    const hosts = options.agentName === undefined
+        ? await resolveAvailableManagedSkillHosts(context.env)
+        : await resolveRequestedManagedSkillHost(context.env, options.agentName);
+
+    if (hosts.length === 0) {
+        throw createMissingManagedSkillHostError(context.env);
+    }
+
+    const canonicalRootDirectoryPath = resolveLocalSkillCanonicalRootDirectoryPath(
+        context.settingsStore.getFilePath(),
+    );
+
+    await verifyWritableDirectory(canonicalRootDirectoryPath);
+
+    return {
+        canonicalRootDirectoryPath,
+        hostCount: hosts.length,
+    };
+}
+
+async function resolveRequestedManagedSkillHost(
+    env: Record<string, string | undefined>,
+    agentName: BundledSkillAgentName,
+): Promise<Array<{ agentName: BundledSkillAgentName; homeDirectory: string }>> {
+    const homeDirectory = resolveBundledSkillHomeDirectory(env, agentName);
+
+    if (!(await directoryExists(homeDirectory))) {
+        throw createMissingRequestedManagedSkillHostError(agentName, homeDirectory);
+    }
+
+    return [
+        {
+            agentName,
+            homeDirectory,
+        },
+    ];
+}
+
+function createMissingRequestedManagedSkillHostError(
+    agentName: BundledSkillAgentName,
+    homeDirectory: string,
+): CliUserError {
+    return new CliUserError(
+        resolveManagedSkillHostMissingErrorKey(agentName),
+        1,
+        {
+            path: homeDirectory,
+        },
+    );
+}
+
+function resolveManagedSkillHostMissingErrorKey(
+    agentName: BundledSkillAgentName,
+): "errors.skills.claudeNotInstalled" | "errors.skills.codexNotInstalled" | "errors.skills.openclawNotInstalled" {
+    switch (agentName) {
+        case "claude":
+            return "errors.skills.claudeNotInstalled";
+        case "codex":
+            return "errors.skills.codexNotInstalled";
+        case "openclaw":
+            return "errors.skills.openclawNotInstalled";
+    }
+}
+
+async function verifyWritableDirectory(directoryPath: string): Promise<void> {
+    const probeFilePath = join(
+        directoryPath,
+        `.oo-skills-check-${Bun.randomUUIDv7()}`,
+    );
+
+    try {
+        await mkdir(directoryPath, { recursive: true });
+        await Bun.write(probeFilePath, "ok");
+    }
+    catch (error) {
+        throw new CliUserError("errors.skills.check.storageNotWritable", 1, {
+            message: error instanceof Error ? error.message : String(error),
+            path: directoryPath,
+        });
+    }
+    finally {
+        await rm(probeFilePath, { force: true });
+    }
+}

--- a/src/application/commands/skills/check.ts
+++ b/src/application/commands/skills/check.ts
@@ -29,7 +29,7 @@ interface SkillsCheckResult {
 }
 
 export const skillsCheckCommand: CliCommandDefinition<SkillsCheckInput> = {
-    name: "check",
+    name: "preflight",
     summaryKey: "commands.skills.check.summary",
     descriptionKey: "commands.skills.check.description",
     options: [

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -8,7 +8,11 @@ import {
 
 describe("embedded skill assets", () => {
     test("keeps the bundled skill file registry aligned with the bundled skill names", () => {
-        expect(availableBundledSkillNames).toEqual(["oo", "oo-find-skills"]);
+        expect(availableBundledSkillNames).toEqual([
+            "oo",
+            "oo-find-skills",
+            "oo-create-skill",
+        ]);
         expect(getBundledSkillFiles("oo", "codex").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "agents/openai.yaml",
@@ -61,6 +65,28 @@ describe("embedded skill assets", () => {
         ).toEqual([
             "SKILL.md",
             "references/oo-cli-contract.md",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-create-skill", "codex").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+            "agents/openai.yaml",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-create-skill", "claude").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-create-skill", "openclaw").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
         ]);
     });
 

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -1,3 +1,4 @@
+import ooCreateSkillClaudeSkillPath from "../../../../contrib/skills/claude/oo-create-skill/SKILL.md" with { type: "file" };
 import ooFindSkillsClaudeCliContractPath from "../../../../contrib/skills/claude/oo-find-skills/references/oo-cli-contract.md" with { type: "file" };
 import ooFindSkillsClaudeSkillPath from "../../../../contrib/skills/claude/oo-find-skills/SKILL.md" with { type: "file" };
 import ooClaudeAuthAndBillingReferencePath from "../../../../contrib/skills/claude/oo/references/auth-and-billing.md" with { type: "file" };
@@ -7,6 +8,8 @@ import ooClaudePackageExecutionReferencePath from "../../../../contrib/skills/cl
 import ooClaudeSearchAndSelectionReferencePath from "../../../../contrib/skills/claude/oo/references/search-and-selection.md" with { type: "file" };
 import ooClaudeTaskLifecycleReferencePath from "../../../../contrib/skills/claude/oo/references/task-lifecycle.md" with { type: "file" };
 import ooClaudeSkillPath from "../../../../contrib/skills/claude/oo/SKILL.md" with { type: "file" };
+import ooCreateSkillOpenAIAgentPath from "../../../../contrib/skills/codex/oo-create-skill/agents/openai.yaml" with { type: "file" };
+import ooCreateSkillPath from "../../../../contrib/skills/codex/oo-create-skill/SKILL.md" with { type: "file" };
 import ooFindSkillsOpenAIAgentPath from "../../../../contrib/skills/codex/oo-find-skills/agents/openai.yaml" with { type: "file" };
 import ooFindSkillsCliContractPath from "../../../../contrib/skills/codex/oo-find-skills/references/oo-cli-contract.md" with { type: "file" };
 import ooFindSkillsSkillPath from "../../../../contrib/skills/codex/oo-find-skills/SKILL.md" with { type: "file" };
@@ -18,6 +21,7 @@ import ooPackageExecutionReferencePath from "../../../../contrib/skills/codex/oo
 import ooSearchAndSelectionReferencePath from "../../../../contrib/skills/codex/oo/references/search-and-selection.md" with { type: "file" };
 import ooTaskLifecycleReferencePath from "../../../../contrib/skills/codex/oo/references/task-lifecycle.md" with { type: "file" };
 import ooSkillPath from "../../../../contrib/skills/codex/oo/SKILL.md" with { type: "file" };
+import ooCreateSkillOpenClawSkillPath from "../../../../contrib/skills/openclaw/oo-create-skill/SKILL.md" with { type: "file" };
 import ooFindSkillsOpenClawCliContractPath from "../../../../contrib/skills/openclaw/oo-find-skills/references/oo-cli-contract.md" with { type: "file" };
 import ooFindSkillsOpenClawSkillPath from "../../../../contrib/skills/openclaw/oo-find-skills/SKILL.md" with { type: "file" };
 import ooOpenClawAuthAndBillingReferencePath from "../../../../contrib/skills/openclaw/oo/references/auth-and-billing.md" with { type: "file" };
@@ -31,7 +35,7 @@ import ooOpenClawSkillPath from "../../../../contrib/skills/openclaw/oo/SKILL.md
 export const availableBundledSkillAgentNames = ["codex", "claude", "openclaw"] as const;
 export type BundledSkillAgentName = (typeof availableBundledSkillAgentNames)[number];
 
-export const availableBundledSkillNames = ["oo", "oo-find-skills"] as const;
+export const availableBundledSkillNames = ["oo", "oo-find-skills", "oo-create-skill"] as const;
 export type BundledSkillName = (typeof availableBundledSkillNames)[number];
 
 interface BundledSkillSourceFile {
@@ -146,6 +150,36 @@ const bundledSkillRegistry = {
                 {
                     relativePath: "references/oo-cli-contract.md",
                     sourcePath: ooFindSkillsOpenClawCliContractPath,
+                },
+            ],
+        },
+    },
+    "oo-create-skill": {
+        codex: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCreateSkillPath,
+                },
+                {
+                    relativePath: "agents/openai.yaml",
+                    sourcePath: ooCreateSkillOpenAIAgentPath,
+                },
+            ],
+        },
+        claude: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCreateSkillClaudeSkillPath,
+                },
+            ],
+        },
+        openclaw: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCreateSkillOpenClawSkillPath,
                 },
             ],
         },

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -17,6 +17,7 @@ import {
     resolveClaudeHomeDirectory,
     resolveCodexHomeDirectory,
 } from "./bundled-skill-paths.ts";
+import { availableBundledSkillNames } from "./embedded-assets.ts";
 import {
     resolveManagedSkillCanonicalDirectoryPath,
     resolveManagedSkillMetadataFilePath,
@@ -138,32 +139,26 @@ describe("skills CLI", () => {
     test("does not auto-refresh installed bundled skills during development-version cli startup", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-        const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
-        const findSkillsDirectoryPath = join(
-            codexHomeDirectory,
-            "skills",
-            "oo-find-skills",
-        );
-        const ooSkillFilePath = join(ooSkillDirectoryPath, "SKILL.md");
-        const findSkillsSkillFilePath = join(findSkillsDirectoryPath, "SKILL.md");
-        const skillDirectoryPaths = [
-            ooSkillDirectoryPath,
-            findSkillsDirectoryPath,
-        ];
+        const skillTargets = availableBundledSkillNames.map(skillName => ({
+            directoryPath: join(codexHomeDirectory, "skills", skillName),
+            name: skillName,
+        }));
         const installedVersion = "9.9.9";
 
         try {
-            for (const skillDirectoryPath of skillDirectoryPaths) {
-                await mkdir(skillDirectoryPath, { recursive: true });
+            for (const skillTarget of skillTargets) {
+                await mkdir(skillTarget.directoryPath, { recursive: true });
                 await Bun.write(
-                    resolveBundledSkillMetadataFilePath(skillDirectoryPath),
+                    resolveBundledSkillMetadataFilePath(skillTarget.directoryPath),
                     renderSkillMetadataJson({
                         version: installedVersion,
                     }),
                 );
+                await Bun.write(
+                    join(skillTarget.directoryPath, "SKILL.md"),
+                    `# Local ${skillTarget.name}\n`,
+                );
             }
-            await Bun.write(ooSkillFilePath, "# Local oo\n");
-            await Bun.write(findSkillsSkillFilePath, "# Local oo-find-skills\n");
 
             const result = await sandbox.run(["--help"], {
                 version: bundledSkillDevelopmentVersion,
@@ -173,16 +168,19 @@ describe("skills CLI", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(result.stdout).toContain("Options:");
-            expect(await readFile(ooSkillFilePath, "utf8")).toBe("# Local oo\n");
-            expect(await readFile(findSkillsSkillFilePath, "utf8")).toBe(
-                "# Local oo-find-skills\n",
-            );
-            expect(
-                await readFile(
-                    resolveBundledSkillMetadataFilePath(ooSkillDirectoryPath),
-                    "utf8",
-                ),
-            ).toBe(renderSkillMetadataJson({ version: installedVersion }));
+            for (const skillTarget of skillTargets) {
+                expect(
+                    await readFile(join(skillTarget.directoryPath, "SKILL.md"), "utf8"),
+                ).toBe(
+                    `# Local ${skillTarget.name}\n`,
+                );
+                expect(
+                    await readFile(
+                        resolveBundledSkillMetadataFilePath(skillTarget.directoryPath),
+                        "utf8",
+                    ),
+                ).toBe(renderSkillMetadataJson({ version: installedVersion }));
+            }
             expect(content).toContain(
                 `"msg":"Bundled skill startup synchronization skipped because the current CLI version is a development version."`,
             );

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -280,6 +280,7 @@ describe("skills CLI", () => {
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
+        const createSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-create-skill");
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -294,6 +295,7 @@ describe("skills CLI", () => {
                 [
                     `Removed skill oo from ${ooSkillDirectoryPath}.`,
                     `Removed skill oo-find-skills from ${findSkillsDirectoryPath}.`,
+                    `Removed skill oo-create-skill from ${createSkillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );
@@ -309,6 +311,7 @@ describe("skills CLI", () => {
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
+        const createSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-create-skill");
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -322,6 +325,7 @@ describe("skills CLI", () => {
                 [
                     `Installed skill oo to ${ooSkillDirectoryPath}.`,
                     `Installed skill oo-find-skills to ${findSkillsDirectoryPath}.`,
+                    `Installed skill oo-create-skill to ${createSkillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -49,6 +49,7 @@ describe("skills commands", () => {
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
+        const createSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-create-skill");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
@@ -61,6 +62,13 @@ describe("skills commands", () => {
         const findSkillsCanonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
             storePaths.settingsFilePath,
             "oo-find-skills",
+        );
+        const createSkillCanonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo-create-skill",
+        );
+        const createSkillMetadataFilePath = resolveBundledSkillMetadataFilePath(
+            createSkillDirectoryPath,
         );
         const ooMetadataFilePath = resolveBundledSkillMetadataFilePath(ooSkillDirectoryPath);
         const findSkillsMetadataFilePath = resolveBundledSkillMetadataFilePath(
@@ -80,6 +88,7 @@ describe("skills commands", () => {
                 [
                     `Installed skill oo to ${ooSkillDirectoryPath}.`,
                     `Installed skill oo-find-skills to ${findSkillsDirectoryPath}.`,
+                    `Installed skill oo-create-skill to ${createSkillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );
@@ -89,6 +98,9 @@ describe("skills commands", () => {
             );
             expect(await realpath(findSkillsDirectoryPath)).toBe(
                 await realpath(findSkillsCanonicalSkillDirectoryPath),
+            );
+            expect(await realpath(createSkillDirectoryPath)).toBe(
+                await realpath(createSkillCanonicalSkillDirectoryPath),
             );
 
             for (const file of getBundledSkillFiles("oo")) {
@@ -101,10 +113,18 @@ describe("skills commands", () => {
                     await readFile(join(findSkillsDirectoryPath, file.relativePath), "utf8"),
                 ).toBe(await Bun.file(file.sourcePath).text());
             }
+            for (const file of getBundledSkillFiles("oo-create-skill")) {
+                expect(
+                    await readFile(join(createSkillDirectoryPath, file.relativePath), "utf8"),
+                ).toBe(await Bun.file(file.sourcePath).text());
+            }
             expect(await readFile(ooMetadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: resultVersion }),
             );
             expect(await readFile(findSkillsMetadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson({ version: resultVersion }),
+            );
+            expect(await readFile(createSkillMetadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: resultVersion }),
             );
         }
@@ -510,6 +530,7 @@ describe("skills commands", () => {
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
+        const createSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-create-skill");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
@@ -522,6 +543,10 @@ describe("skills commands", () => {
         const findSkillsCanonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
             storePaths.settingsFilePath,
             "oo-find-skills",
+        );
+        const createSkillCanonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo-create-skill",
         );
 
         try {
@@ -537,6 +562,7 @@ describe("skills commands", () => {
                 [
                     `Removed skill oo from ${ooSkillDirectoryPath}.`,
                     `Removed skill oo-find-skills from ${findSkillsDirectoryPath}.`,
+                    `Removed skill oo-create-skill from ${createSkillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );
@@ -547,10 +573,16 @@ describe("skills commands", () => {
             await expect(stat(findSkillsDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
+            await expect(stat(createSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
             await expect(stat(ooCanonicalSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
             await expect(stat(findSkillsCanonicalSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(createSkillCanonicalSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
         }
@@ -679,6 +711,7 @@ describe("skills commands", () => {
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
+        const createSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-create-skill");
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -693,6 +726,7 @@ describe("skills commands", () => {
                 [
                     `Removed skill oo from ${ooSkillDirectoryPath}.`,
                     `Removed skill oo-find-skills from ${findSkillsDirectoryPath}.`,
+                    `Removed skill oo-create-skill from ${createSkillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );
@@ -701,6 +735,9 @@ describe("skills commands", () => {
                 code: "ENOENT",
             });
             await expect(stat(findSkillsDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(createSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
         }

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -1,10 +1,13 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
+import { skillsCheckCommand } from "./check.ts";
+import { skillsInitCommand } from "./init.ts";
 import { skillsInstallCommand } from "./install.ts";
 import { skillsListCommand } from "./list.ts";
 import { skillsSearchCommand } from "./search.ts";
 import { skillsUninstallCommand } from "./uninstall.ts";
 import { skillsUpdateCommand } from "./update.ts";
+import { skillsValidateCommand } from "./validate.ts";
 
 export const skillsCommand: CliCommandDefinition = {
     name: "skills",
@@ -13,6 +16,9 @@ export const skillsCommand: CliCommandDefinition = {
     children: [
         skillsSearchCommand,
         skillsListCommand,
+        skillsCheckCommand,
+        skillsInitCommand,
+        skillsValidateCommand,
         skillsInstallCommand,
         skillsUpdateCommand,
         skillsUninstallCommand,

--- a/src/application/commands/skills/init.test.ts
+++ b/src/application/commands/skills/init.test.ts
@@ -6,7 +6,10 @@ import { describe, expect, test } from "bun:test";
 import { createCliSandbox } from "../../../../__tests__/helpers.ts";
 import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../config/app-config.ts";
-import { resolveCodexHomeDirectory } from "./bundled-skill-paths.ts";
+import {
+    resolveClaudeHomeDirectory,
+    resolveCodexHomeDirectory,
+} from "./bundled-skill-paths.ts";
 import { resolveLocalSkillCanonicalDirectoryPath } from "./managed-skill-paths.ts";
 import {
     installedRegistrySkillCompatibility,
@@ -199,6 +202,93 @@ describe("skills init command", () => {
             ).rejects.toMatchObject({
                 code: "ENOENT",
             });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("removes already published targets when a later target fails", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
+        const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "rollback-skill");
+        const claudePublishRootPath = join(claudeHomeDirectory, "skills");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "rollback-skill",
+        );
+
+        try {
+            await Promise.all([
+                mkdir(codexHomeDirectory, { recursive: true }),
+                mkdir(claudeHomeDirectory, { recursive: true }),
+            ]);
+            await Bun.write(claudePublishRootPath, "not a directory");
+
+            const result = await sandbox.run([
+                "skills",
+                "init",
+                "rollback-skill",
+                "--description",
+                "Use a known package workflow.",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            await expect(
+                stat(codexSkillDirectoryPath),
+            ).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(
+                stat(canonicalSkillDirectoryPath),
+            ).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not leave a trailing hyphen after truncating the normalized name", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const normalizedSkillName = "a".repeat(63);
+        const inputName = `${"A".repeat(63)} B`;
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            normalizedSkillName,
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "init",
+                inputName,
+                "--description",
+                "Use a known package workflow.",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Initialized skill ${normalizedSkillName} at ${join(codexHomeDirectory, "skills", normalizedSkillName)}.\n`,
+            );
+            expect(
+                await readFile(join(canonicalSkillDirectoryPath, "SKILL.md"), "utf8"),
+            ).toContain(`name: ${normalizedSkillName}\n`);
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/init.test.ts
+++ b/src/application/commands/skills/init.test.ts
@@ -1,0 +1,202 @@
+import { mkdir, readFile, realpath, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { createCliSandbox } from "../../../../__tests__/helpers.ts";
+import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import { resolveCodexHomeDirectory } from "./bundled-skill-paths.ts";
+import { resolveLocalSkillCanonicalDirectoryPath } from "./managed-skill-paths.ts";
+import { renderOoPackageExecutionGuidance } from "./registry-skill-markdown.ts";
+import { renderSkillMetadataJson } from "./skill-metadata.ts";
+
+describe("skills init command", () => {
+    test("initializes a local skill and publishes it to existing supported hosts", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "campaign-writer");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "campaign-writer",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "init",
+                "Campaign Writer",
+                "--description",
+                "Write campaign briefs using a known package workflow.",
+                "--icon",
+                ":lucide:wrench:",
+                "--title",
+                "Campaign Writer",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Initialized skill campaign-writer at ${skillDirectoryPath}.\n`,
+            );
+            expect(result.stderr).toBe("");
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect(
+                await readFile(join(canonicalSkillDirectoryPath, ".oo-metadata.json"), "utf8"),
+            ).toBe(renderSkillMetadataJson({
+                icon: ":lucide:wrench:",
+                version: "0.0.1",
+            }));
+            expect(
+                await readFile(join(canonicalSkillDirectoryPath, "SKILL.md"), "utf8"),
+            ).toBe([
+                "---",
+                "name: campaign-writer",
+                "description: \"Write campaign briefs using a known package workflow.\"",
+                "metadata:",
+                "  title: \"Campaign Writer\"",
+                "---",
+                "",
+                "# Campaign Writer",
+                "",
+                renderOoPackageExecutionGuidance(),
+                "",
+                "TODO: Describe the workflow this skill should follow.",
+                "",
+            ].join("\n"));
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("omits metadata title when no title is provided", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "minimal-skill",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "init",
+                "minimal-skill",
+                "--description",
+                "Use a known package workflow.",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(
+                await readFile(join(canonicalSkillDirectoryPath, "SKILL.md"), "utf8"),
+            ).toBe([
+                "---",
+                "name: minimal-skill",
+                "description: \"Use a known package workflow.\"",
+                "---",
+                "",
+                "# Minimal Skill",
+                "",
+                renderOoPackageExecutionGuidance(),
+                "",
+                "TODO: Describe the workflow this skill should follow.",
+                "",
+            ].join("\n"));
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("requires a description before writing", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "missing-description",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "init",
+                "missing-description",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Missing required --description. Provide a concise trigger description for the generated skill.\n",
+            );
+            await expect(
+                stat(canonicalSkillDirectoryPath),
+            ).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails before writing when the local canonical directory already exists", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "existing-skill",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "init",
+                "existing-skill",
+                "--description",
+                "Use an existing package workflow.",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("already occupied");
+            await expect(
+                stat(join(canonicalSkillDirectoryPath, "SKILL.md")),
+            ).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/init.test.ts
+++ b/src/application/commands/skills/init.test.ts
@@ -8,7 +8,10 @@ import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import { resolveCodexHomeDirectory } from "./bundled-skill-paths.ts";
 import { resolveLocalSkillCanonicalDirectoryPath } from "./managed-skill-paths.ts";
-import { renderOoPackageExecutionGuidance } from "./registry-skill-markdown.ts";
+import {
+    installedRegistrySkillCompatibility,
+    renderOoPackageExecutionGuidance,
+} from "./registry-skill-markdown.ts";
 import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 describe("skills init command", () => {
@@ -61,6 +64,7 @@ describe("skills init command", () => {
                 "---",
                 "name: campaign-writer",
                 "description: \"Write campaign briefs using a known package workflow.\"",
+                `compatibility: ${JSON.stringify(installedRegistrySkillCompatibility)}`,
                 "metadata:",
                 "  title: \"Campaign Writer\"",
                 "---",
@@ -109,6 +113,7 @@ describe("skills init command", () => {
                 "---",
                 "name: minimal-skill",
                 "description: \"Use a known package workflow.\"",
+                `compatibility: ${JSON.stringify(installedRegistrySkillCompatibility)}`,
                 "---",
                 "",
                 "# Minimal Skill",

--- a/src/application/commands/skills/init.ts
+++ b/src/application/commands/skills/init.ts
@@ -147,6 +147,8 @@ async function initializeLocalSkill(
 
     await mkdir(canonicalSkillDirectoryPath, { recursive: true });
 
+    const publishedTargets: LocalSkillHostPublicationTarget[] = [];
+
     try {
         await Promise.all([
             Bun.write(
@@ -170,6 +172,8 @@ async function initializeLocalSkill(
                 publicationMode: "symlink-or-copy",
             });
 
+            publishedTargets.push(target);
+
             writeLine(
                 context.stdout,
                 context.translator.t("skills.init.success", {
@@ -190,7 +194,10 @@ async function initializeLocalSkill(
         }
     }
     catch (error) {
-        await removePath(canonicalSkillDirectoryPath);
+        await Promise.all([
+            ...publishedTargets.map(target => removePath(target.installedSkillDirectoryPath)),
+            removePath(canonicalSkillDirectoryPath),
+        ]);
         throw error;
     }
 }
@@ -319,7 +326,13 @@ function normalizeSkillName(value: string): string {
         normalizedCharacters.pop();
     }
 
-    return normalizedCharacters.join("").slice(0, 64);
+    let result = normalizedCharacters.join("").slice(0, 64);
+
+    while (result.endsWith("-")) {
+        result = result.slice(0, -1);
+    }
+
+    return result;
 }
 
 function renderSkillTitle(skillName: string): string {

--- a/src/application/commands/skills/init.ts
+++ b/src/application/commands/skills/init.ts
@@ -1,0 +1,345 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+import type { BundledSkillAgentName } from "./embedded-assets.ts";
+
+import { lstat, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { writeLine } from "../shared/output.ts";
+import {
+    isNodeNotFoundError,
+    publishBundledSkillInstallation,
+    removePath,
+} from "./bundled-skill-filesystem.ts";
+import {
+    directoryExists,
+} from "./bundled-skill-observation.ts";
+import {
+    resolveBundledSkillDirectoryPath,
+    resolveBundledSkillHomeDirectory,
+} from "./bundled-skill-paths.ts";
+import { availableBundledSkillAgentNames } from "./embedded-assets.ts";
+import {
+    isLocalSkillPathContained,
+    resolveLocalSkillCanonicalDirectoryPath,
+} from "./managed-skill-paths.ts";
+import { renderOoPackageExecutionGuidance } from "./registry-skill-markdown.ts";
+import { renderSkillMetadataJson } from "./skill-metadata.ts";
+
+interface SkillsInitInput {
+    description?: string;
+    icon?: string;
+    name: string;
+    title?: string;
+}
+
+interface LocalSkillHostPublicationTarget {
+    agentName: BundledSkillAgentName;
+    homeDirectory: string;
+    installedSkillDirectoryPath: string;
+}
+
+const initializedSkillVersion = "0.0.1";
+
+export const skillsInitCommand: CliCommandDefinition<SkillsInitInput> = {
+    name: "init",
+    summaryKey: "commands.skills.init.summary",
+    descriptionKey: "commands.skills.init.description",
+    arguments: [
+        {
+            name: "name",
+            descriptionKey: "arguments.skill",
+            required: true,
+        },
+    ],
+    options: [
+        {
+            name: "description",
+            longFlag: "--description",
+            valueName: "text",
+            descriptionKey: "options.description",
+        },
+        {
+            name: "icon",
+            longFlag: "--icon",
+            valueName: "icon",
+            descriptionKey: "options.icon",
+        },
+        {
+            name: "title",
+            longFlag: "--title",
+            valueName: "title",
+            descriptionKey: "options.title",
+        },
+    ],
+    inputSchema: z.object({
+        description: z.string().optional(),
+        icon: z.string().optional(),
+        name: z.string(),
+        title: z.string().optional(),
+    }),
+    handler: async (input, context) => {
+        await initializeLocalSkill(input, context);
+    },
+};
+
+async function initializeLocalSkill(
+    input: SkillsInitInput,
+    context: CliExecutionContext,
+): Promise<void> {
+    const skillName = normalizeSkillName(input.name);
+
+    if (skillName === "") {
+        throw new CliUserError("errors.skills.init.invalidName", 1, {
+            value: input.name,
+        });
+    }
+
+    const description = input.description?.trim();
+    const icon = input.icon?.trim();
+    const title = input.title?.trim();
+
+    if (description === undefined || description === "") {
+        throw new CliUserError("errors.skills.init.descriptionRequired", 1);
+    }
+
+    if (input.icon !== undefined && icon === "") {
+        throw new CliUserError("errors.skills.init.invalidIcon", 1);
+    }
+
+    if (input.title !== undefined && title === "") {
+        throw new CliUserError("errors.skills.init.invalidTitle", 1);
+    }
+
+    const settingsFilePath = context.settingsStore.getFilePath();
+    const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+        settingsFilePath,
+        skillName,
+    );
+    const targets = await resolveLocalSkillPublicationTargets(context.env, skillName);
+
+    if (targets.length === 0) {
+        throw new CliUserError("errors.skills.noSupportedBundledSkillHosts", 1, {
+            paths: availableBundledSkillAgentNames
+                .map(agentName => resolveBundledSkillHomeDirectory(context.env, agentName))
+                .join(", "),
+        });
+    }
+
+    if (!isLocalSkillPathContained(
+        targets[0]!.homeDirectory,
+        settingsFilePath,
+        skillName,
+    )) {
+        throw new CliUserError("errors.skills.invalidPath", 1, {
+            name: skillName,
+        });
+    }
+
+    await validateLocalSkillInitTargets(
+        skillName,
+        canonicalSkillDirectoryPath,
+        targets,
+    );
+
+    await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+
+    try {
+        await Promise.all([
+            Bun.write(
+                join(canonicalSkillDirectoryPath, "SKILL.md"),
+                renderInitializedSkillMarkdown(skillName, description, title),
+            ),
+            Bun.write(
+                join(canonicalSkillDirectoryPath, ".oo-metadata.json"),
+                renderSkillMetadataJson(
+                    icon === undefined
+                        ? { version: initializedSkillVersion }
+                        : { icon, version: initializedSkillVersion },
+                ),
+            ),
+        ]);
+
+        for (const target of targets) {
+            const published = await publishBundledSkillInstallation({
+                canonicalSkillDirectoryPath,
+                installedSkillDirectoryPath: target.installedSkillDirectoryPath,
+                publicationMode: "symlink-or-copy",
+            });
+
+            writeLine(
+                context.stdout,
+                context.translator.t("skills.init.success", {
+                    name: skillName,
+                    path: published.path,
+                }),
+            );
+            context.logger.info(
+                {
+                    agentName: target.agentName,
+                    canonicalPath: canonicalSkillDirectoryPath,
+                    installMode: published.mode,
+                    path: published.path,
+                    skillName,
+                },
+                "Local skill initialized.",
+            );
+        }
+    }
+    catch (error) {
+        await removePath(canonicalSkillDirectoryPath);
+        throw error;
+    }
+}
+
+async function resolveLocalSkillPublicationTargets(
+    env: Record<string, string | undefined>,
+    skillName: string,
+): Promise<LocalSkillHostPublicationTarget[]> {
+    const targets = await Promise.all(
+        availableBundledSkillAgentNames.map(async (agentName) => {
+            const homeDirectory = resolveBundledSkillHomeDirectory(env, agentName);
+
+            if (!(await directoryExists(homeDirectory))) {
+                return undefined;
+            }
+
+            return {
+                agentName,
+                homeDirectory,
+                installedSkillDirectoryPath: resolveBundledSkillDirectoryPath(
+                    homeDirectory,
+                    skillName,
+                ),
+            } satisfies LocalSkillHostPublicationTarget;
+        }),
+    );
+
+    return targets.filter(target => target !== undefined);
+}
+
+async function validateLocalSkillInitTargets(
+    skillName: string,
+    canonicalSkillDirectoryPath: string,
+    targets: readonly LocalSkillHostPublicationTarget[],
+): Promise<void> {
+    if (await pathExists(canonicalSkillDirectoryPath)) {
+        throw new CliUserError("errors.skills.storageConflict", 1, {
+            name: skillName,
+            path: canonicalSkillDirectoryPath,
+        });
+    }
+
+    const conflictingTarget = (
+        await Promise.all(
+            targets.map(async target =>
+                (await pathExists(target.installedSkillDirectoryPath))
+                    ? target
+                    : undefined,
+            ),
+        )
+    ).find(target => target !== undefined);
+
+    if (conflictingTarget !== undefined) {
+        throw new CliUserError("errors.skills.nameConflict", 1, {
+            name: skillName,
+            path: conflictingTarget.installedSkillDirectoryPath,
+        });
+    }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+    try {
+        await lstat(path);
+        return true;
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+function renderInitializedSkillMarkdown(
+    skillName: string,
+    description: string,
+    title: string | undefined,
+): string {
+    const frontmatterLines = [
+        "---",
+        `name: ${skillName}`,
+        `description: ${JSON.stringify(description)}`,
+    ];
+
+    if (title !== undefined) {
+        frontmatterLines.push(
+            "metadata:",
+            `  title: ${JSON.stringify(title)}`,
+        );
+    }
+
+    frontmatterLines.push(
+        "---",
+        "",
+        `# ${title ?? renderSkillTitle(skillName)}`,
+        "",
+        renderOoPackageExecutionGuidance(),
+        "",
+        "TODO: Describe the workflow this skill should follow.",
+        "",
+    );
+
+    return frontmatterLines.join("\n");
+}
+
+function normalizeSkillName(value: string): string {
+    const normalizedCharacters: string[] = [];
+    let previousWasHyphen = false;
+
+    for (const char of value.trim().toLowerCase()) {
+        if (isLowercaseAsciiLetter(char) || isAsciiDigit(char)) {
+            normalizedCharacters.push(char);
+            previousWasHyphen = false;
+            continue;
+        }
+
+        if (!previousWasHyphen && normalizedCharacters.length > 0) {
+            normalizedCharacters.push("-");
+            previousWasHyphen = true;
+        }
+    }
+
+    if (normalizedCharacters.at(-1) === "-") {
+        normalizedCharacters.pop();
+    }
+
+    return normalizedCharacters.join("").slice(0, 64);
+}
+
+function renderSkillTitle(skillName: string): string {
+    return skillName
+        .split("-")
+        .filter(part => part !== "")
+        .map(capitalizeAsciiWord)
+        .join(" ");
+}
+
+function capitalizeAsciiWord(value: string): string {
+    const firstChar = value[0];
+
+    if (firstChar === undefined) {
+        return value;
+    }
+
+    return `${firstChar.toUpperCase()}${value.slice(1)}`;
+}
+
+function isLowercaseAsciiLetter(char: string): boolean {
+    return char >= "a" && char <= "z";
+}
+
+function isAsciiDigit(char: string): boolean {
+    return char >= "0" && char <= "9";
+}

--- a/src/application/commands/skills/init.ts
+++ b/src/application/commands/skills/init.ts
@@ -23,7 +23,10 @@ import {
     isLocalSkillPathContained,
     resolveLocalSkillCanonicalDirectoryPath,
 } from "./managed-skill-paths.ts";
-import { renderOoPackageExecutionGuidance } from "./registry-skill-markdown.ts";
+import {
+    installedRegistrySkillCompatibility,
+    renderOoPackageExecutionGuidance,
+} from "./registry-skill-markdown.ts";
 import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 interface SkillsInitInput {
@@ -271,6 +274,7 @@ function renderInitializedSkillMarkdown(
         "---",
         `name: ${skillName}`,
         `description: ${JSON.stringify(description)}`,
+        `compatibility: ${JSON.stringify(installedRegistrySkillCompatibility)}`,
     ];
 
     if (title !== undefined) {

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -95,7 +95,7 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 2 oo-managed skills.",
+                    "✓ Found 3 oo-managed skills.",
                     "",
                     "oo",
                     "  Host: OpenClaw",
@@ -103,6 +103,11 @@ describe("skills list CLI", () => {
                     "  Version: 9.9.9",
                     "",
                     "oo-find-skills",
+                    "  Host: OpenClaw",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-create-skill",
                     "  Host: OpenClaw",
                     "  Source: bundled",
                     "  Version: 9.9.9",

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -47,7 +47,7 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 3 oo-managed skills.",
+                    "✓ Found 4 oo-managed skills.",
                     "",
                     "oo",
                     "  Host: Codex",
@@ -55,6 +55,11 @@ describe("skills list CLI", () => {
                     "  Version: 9.9.9",
                     "",
                     "oo-find-skills",
+                    "  Host: Codex",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-create-skill",
                     "  Host: Codex",
                     "  Source: bundled",
                     "  Version: 9.9.9",
@@ -130,7 +135,7 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 2 oo-managed skills.",
+                    "✓ Found 3 oo-managed skills.",
                     "",
                     "oo",
                     "  Host: Codex, Claude Code",
@@ -138,6 +143,11 @@ describe("skills list CLI", () => {
                     "  Version: 9.9.9",
                     "",
                     "oo-find-skills",
+                    "  Host: Codex, Claude Code",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-create-skill",
                     "  Host: Codex, Claude Code",
                     "  Source: bundled",
                     "  Version: 9.9.9",

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -4,7 +4,7 @@ import type { BundledSkillAgentName } from "./embedded-assets.ts";
 import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
 
 import type { ManagedSkillMetadata } from "./managed-skill-metadata.ts";
-import { readdir, readFile } from "node:fs/promises";
+import { readdir, readFile, realpath } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
 import { compareSemver } from "../../semver.ts";
@@ -16,6 +16,8 @@ import {
 } from "./managed-skill-hosts.ts";
 import { parseManagedSkillMetadataContent } from "./managed-skill-metadata.ts";
 import {
+    isPathWithinDirectory,
+    resolveLocalSkillCanonicalRootDirectoryPath,
     resolveManagedSkillMetadataFilePath,
     resolveManagedSkillsDirectoryPath,
 } from "./managed-skill-paths.ts";
@@ -34,6 +36,7 @@ export interface ManagedSkillListItem {
     metadata?: ManagedSkillMetadata;
     name: string;
     path: string;
+    source?: "local";
 }
 
 export interface ManagedSkillHostListItem extends ManagedSkillListItem {
@@ -45,6 +48,7 @@ interface ManagedSkillOutputListItem {
     metadata?: ManagedSkillMetadata;
     name: string;
     paths: string[];
+    source?: "local";
 }
 
 type ManagedSkillListTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
@@ -56,7 +60,7 @@ export const skillsListCommand: CliCommandDefinition<Record<string, never>> = {
     inputSchema: z.object({}),
     handler: async (_, context) => {
         const skills = groupManagedSkillInstallationsByIdentity(
-            await listManagedSkillInstallationsByHost(context.env),
+            await listManagedSkillInstallationsByHost(context),
         );
 
         context.logger.info(
@@ -79,20 +83,23 @@ export const skillsListCommand: CliCommandDefinition<Record<string, never>> = {
 };
 
 async function listManagedSkillInstallationsByHost(
-    env: Record<string, string | undefined>,
+    context: Pick<CliExecutionContext, "env" | "settingsStore">,
 ): Promise<ManagedSkillHostListItem[]> {
     return listManagedSkillInstallationsForHosts(
-        await resolveAvailableManagedSkillHosts(env),
+        await resolveAvailableManagedSkillHosts(context.env),
+        context.settingsStore.getFilePath(),
     );
 }
 
 export async function listManagedSkillInstallationsForHosts(
     hosts: readonly ManagedSkillHost[],
+    settingsFilePath?: string,
 ): Promise<ManagedSkillHostListItem[]> {
     const skillsByHost = await Promise.all(
         hosts.map(host =>
             listManagedSkillInstallations(
                 resolveManagedSkillsDirectoryPath(host.homeDirectory),
+                settingsFilePath,
             )
                 .then(skills => skills.map(skill => ({
                     ...skill,
@@ -122,6 +129,7 @@ function groupManagedSkillInstallationsByIdentity(
                 metadata: installation.metadata,
                 name: installation.name,
                 paths: [installation.path],
+                source: installation.source,
             });
             continue;
         }
@@ -135,6 +143,7 @@ function groupManagedSkillInstallationsByIdentity(
 
 export async function listManagedSkillInstallations(
     skillsDirectoryPath: string,
+    settingsFilePath?: string,
 ): Promise<ManagedSkillListItem[]> {
     const entries = await readSkillsDirectoryEntries(skillsDirectoryPath);
     const skills: Array<ManagedSkillListItem | undefined> = await Promise.all(
@@ -161,6 +170,10 @@ export async function listManagedSkillInstallations(
                 metadata: parseManagedSkillMetadataContent(metadataContent),
                 name: entryName,
                 path: skillDirectoryPath,
+                source: await readManagedSkillLocalSource(
+                    skillDirectoryPath,
+                    settingsFilePath,
+                ),
             } satisfies ManagedSkillListItem;
         }),
     );
@@ -255,11 +268,15 @@ function formatManagedSkillDetailLine(
 }
 
 function readManagedSkillSource(
-    skill: Pick<ManagedSkillListItem, "metadata" | "name">,
+    skill: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
     context: Pick<CliExecutionContext, "translator">,
 ): string {
     if (skill.metadata?.packageName !== undefined) {
         return skill.metadata.packageName;
+    }
+
+    if ("source" in skill && skill.source === "local") {
+        return context.translator.t("skills.list.source.local");
     }
 
     if (isBundledSkillName(skill.name)) {
@@ -270,10 +287,14 @@ function readManagedSkillSource(
 }
 
 function readManagedSkillSourceIdentity(
-    skill: Pick<ManagedSkillListItem, "metadata" | "name">,
+    skill: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
 ): string {
     if (skill.metadata?.packageName !== undefined) {
         return `package:${skill.metadata.packageName}`;
+    }
+
+    if (skill.source === "local") {
+        return "local";
     }
 
     if (isBundledSkillName(skill.name)) {
@@ -309,8 +330,8 @@ function readManagedSkillHostLabel(
 }
 
 function hasSameManagedSkillIdentity(
-    left: Pick<ManagedSkillListItem, "metadata" | "name">,
-    right: Pick<ManagedSkillListItem, "metadata" | "name">,
+    left: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
+    right: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
 ): boolean {
     return left.name === right.name
         && readManagedSkillSourceIdentity(left) === readManagedSkillSourceIdentity(right)
@@ -318,8 +339,8 @@ function hasSameManagedSkillIdentity(
 }
 
 function compareManagedSkillListItems(
-    left: Pick<ManagedSkillListItem, "metadata" | "name">,
-    right: Pick<ManagedSkillListItem, "metadata" | "name">,
+    left: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
+    right: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
 ): number {
     const leftBundledOrder = readBundledSkillNameOrder(left);
     const rightBundledOrder = readBundledSkillNameOrder(right);
@@ -340,13 +361,44 @@ function compareManagedSkillListItems(
 }
 
 function readBundledSkillNameOrder(
-    skill: Pick<ManagedSkillListItem, "metadata" | "name">,
+    skill: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
 ): number | undefined {
-    if (skill.metadata?.packageName !== undefined || !isBundledSkillName(skill.name)) {
+    if (
+        skill.metadata?.packageName !== undefined
+        || skill.source === "local"
+        || !isBundledSkillName(skill.name)
+    ) {
         return undefined;
     }
 
     return availableBundledSkillNames.indexOf(skill.name);
+}
+
+async function readManagedSkillLocalSource(
+    skillDirectoryPath: string,
+    settingsFilePath?: string,
+): Promise<"local" | undefined> {
+    if (settingsFilePath === undefined) {
+        return undefined;
+    }
+
+    try {
+        const realSkillDirectoryPath = await realpath(skillDirectoryPath);
+
+        return isPathWithinDirectory(
+            resolveLocalSkillCanonicalRootDirectoryPath(settingsFilePath),
+            realSkillDirectoryPath,
+        )
+            ? "local"
+            : undefined;
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
 }
 
 function compareManagedSkillOutputListItems(

--- a/src/application/commands/skills/managed-skill-metadata.ts
+++ b/src/application/commands/skills/managed-skill-metadata.ts
@@ -7,6 +7,7 @@ import {
 } from "./skill-metadata.ts";
 
 export interface ManagedSkillMetadata {
+    icon?: string;
     packageName?: string;
     version: string;
 }
@@ -20,7 +21,17 @@ export function parseManagedSkillMetadataContent(
         return undefined;
     }
     const rawPackageName = parsedMetadata.fields.packageName;
+    const rawIcon = parsedMetadata.fields.icon;
+    let icon: string | undefined;
     let packageName: string | undefined;
+
+    if (rawIcon !== undefined) {
+        if (typeof rawIcon !== "string" || rawIcon.trim() === "") {
+            return undefined;
+        }
+
+        icon = rawIcon;
+    }
 
     if (rawPackageName !== undefined) {
         if (typeof rawPackageName !== "string" || rawPackageName.trim() === "") {
@@ -28,6 +39,14 @@ export function parseManagedSkillMetadataContent(
         }
 
         packageName = rawPackageName;
+    }
+
+    if (icon !== undefined) {
+        return {
+            icon,
+            packageName,
+            version: parsedMetadata.version,
+        };
     }
 
     return {

--- a/src/application/commands/skills/managed-skill-paths.ts
+++ b/src/application/commands/skills/managed-skill-paths.ts
@@ -1,6 +1,7 @@
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
     bundledSkillMetadataFileName,
+    canonicalLocalSkillsDirectoryName,
     canonicalRegistrySkillsDirectoryName,
     codexSkillsDirectoryName,
 } from "./bundled-skill-paths.ts";
@@ -54,6 +55,26 @@ export function resolveManagedSkillCanonicalDirectoryPath(
     );
 }
 
+export function resolveLocalSkillCanonicalRootDirectoryPath(
+    settingsFilePath: string,
+): string {
+    return join(
+        dirname(settingsFilePath),
+        codexSkillsDirectoryName,
+        canonicalLocalSkillsDirectoryName,
+    );
+}
+
+export function resolveLocalSkillCanonicalDirectoryPath(
+    settingsFilePath: string,
+    skillName: string,
+): string {
+    return join(
+        resolveLocalSkillCanonicalRootDirectoryPath(settingsFilePath),
+        skillName,
+    );
+}
+
 export function isPathWithinDirectory(
     baseDirectoryPath: string,
     targetPath: string,
@@ -82,6 +103,20 @@ export function isManagedSkillPathContained(
     ) && isPathWithinDirectory(
         resolveManagedSkillCanonicalRootDirectoryPath(settingsFilePath),
         resolveManagedSkillCanonicalDirectoryPath(settingsFilePath, skillName),
+    );
+}
+
+export function isLocalSkillPathContained(
+    codexHomeDirectory: string,
+    settingsFilePath: string,
+    skillName: string,
+): boolean {
+    return isPathWithinDirectory(
+        resolveManagedSkillsDirectoryPath(codexHomeDirectory),
+        resolveManagedSkillDirectoryPath(codexHomeDirectory, skillName),
+    ) && isPathWithinDirectory(
+        resolveLocalSkillCanonicalRootDirectoryPath(settingsFilePath),
+        resolveLocalSkillCanonicalDirectoryPath(settingsFilePath, skillName),
     );
 }
 

--- a/src/application/commands/skills/registry-skill-markdown.ts
+++ b/src/application/commands/skills/registry-skill-markdown.ts
@@ -259,6 +259,8 @@ function isTopLevelHeading(line: string): boolean {
 }
 export function renderOoPackageExecutionGuidance(): string {
     return [
+        "<!-- OO NOTICE START -->",
+        "",
         "Important:",
         "If this skill mentions `oo::packageName` or `oo::packageName::blockName`,",
         "follow the `oo` CLI path instead of reimplementing the capability locally.",
@@ -288,5 +290,7 @@ export function renderOoPackageExecutionGuidance(): string {
         "If the metadata is not sufficient to choose a safe block or construct safe",
         "arguments, stop and inspect further; do not guess parameters and do not run",
         "yet.",
+        "",
+        "<!-- OO NOTICE END -->",
     ].join("\n");
 }

--- a/src/application/commands/skills/validate.test.ts
+++ b/src/application/commands/skills/validate.test.ts
@@ -36,9 +36,9 @@ describe("skills validate command", () => {
         }
     });
 
-    test("rejects unsupported frontmatter keys", async () => {
+    test("accepts unsupported frontmatter keys and loose field values", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-skills-validate");
-        const skillDirectoryPath = join(rootDirectory, "invalid-skill");
+        const skillDirectoryPath = join(rootDirectory, "loose-skill");
 
         try {
             await mkdir(skillDirectoryPath, { recursive: true });
@@ -46,16 +46,68 @@ describe("skills validate command", () => {
                 join(skillDirectoryPath, "SKILL.md"),
                 [
                     "---",
-                    "name: invalid-skill",
-                    "description: Use this skill for an invalid workflow.",
+                    "name: Loose Skill Name",
+                    "description: Use this skill with <loose> wording.",
                     "compatibility: Requires the oo CLI.",
+                    "metadata:",
+                    "  title: Loose Skill",
+                    "---",
+                    "",
+                ].join("\n"),
+            );
+
+            await expect(validateSkillDirectory(skillDirectoryPath)).resolves.toEqual({});
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("accepts missing metadata title", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-skills-validate");
+        const skillDirectoryPath = join(rootDirectory, "missing-title-skill");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(skillDirectoryPath, "SKILL.md"),
+                [
+                    "---",
+                    "name: missing-title-skill",
+                    "description: Use this skill for a workflow.",
+                    "---",
+                    "",
+                ].join("\n"),
+            );
+
+            await expect(validateSkillDirectory(skillDirectoryPath)).resolves.toEqual({});
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("rejects empty metadata title", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-skills-validate");
+        const skillDirectoryPath = join(rootDirectory, "empty-title-skill");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(skillDirectoryPath, "SKILL.md"),
+                [
+                    "---",
+                    "name: empty-title-skill",
+                    "description: Use this skill for a workflow.",
+                    "metadata:",
+                    "  title: \"\"",
                     "---",
                     "",
                 ].join("\n"),
             );
 
             await expect(validateSkillDirectory(skillDirectoryPath)).resolves.toEqual({
-                error: "Unsupported frontmatter key: compatibility.",
+                error: "Frontmatter metadata.title cannot be empty.",
             });
         }
         finally {
@@ -75,6 +127,8 @@ describe("skills validate command", () => {
                     "---",
                     "name: valid-skill",
                     "description: Use this skill for a valid workflow.",
+                    "metadata:",
+                    "  title: Valid Skill",
                     "---",
                     "",
                 ].join("\n"),

--- a/src/application/commands/skills/validate.test.ts
+++ b/src/application/commands/skills/validate.test.ts
@@ -1,0 +1,93 @@
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { createCliSandbox, createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
+import { validateSkillDirectory } from "./validate.ts";
+
+describe("skills validate command", () => {
+    test("accepts a skill with valid frontmatter", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-skills-validate");
+        const skillDirectoryPath = join(rootDirectory, "valid-skill");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(skillDirectoryPath, "SKILL.md"),
+                [
+                    "---",
+                    "name: valid-skill",
+                    "description: >-",
+                    "  Use this skill for a valid workflow.",
+                    "metadata:",
+                    "  title: Valid Skill",
+                    "---",
+                    "",
+                    "# Valid Skill",
+                    "",
+                ].join("\n"),
+            );
+
+            await expect(validateSkillDirectory(skillDirectoryPath)).resolves.toEqual({});
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("rejects unsupported frontmatter keys", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-skills-validate");
+        const skillDirectoryPath = join(rootDirectory, "invalid-skill");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(skillDirectoryPath, "SKILL.md"),
+                [
+                    "---",
+                    "name: invalid-skill",
+                    "description: Use this skill for an invalid workflow.",
+                    "compatibility: Requires the oo CLI.",
+                    "---",
+                    "",
+                ].join("\n"),
+            );
+
+            await expect(validateSkillDirectory(skillDirectoryPath)).resolves.toEqual({
+                error: "Unsupported frontmatter key: compatibility.",
+            });
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("prints a success message from the CLI", async () => {
+        const sandbox = await createCliSandbox();
+        const skillDirectoryPath = join(sandbox.cwd, "valid-skill");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(skillDirectoryPath, "SKILL.md"),
+                [
+                    "---",
+                    "name: valid-skill",
+                    "description: Use this skill for a valid workflow.",
+                    "---",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["skills", "validate", skillDirectoryPath]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(`Skill at ${skillDirectoryPath} is valid.\n`);
+            expect(result.stderr).toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/validate.ts
+++ b/src/application/commands/skills/validate.ts
@@ -17,15 +17,8 @@ interface SkillValidationResult {
 
 interface ParsedFrontmatter {
     fields: Map<string, string | undefined>;
+    metadataFields: Map<string, string | undefined>;
 }
-
-const supportedFrontmatterKeys = [
-    "allowed-tools",
-    "description",
-    "license",
-    "metadata",
-    "name",
-] as const;
 
 export const skillsValidateCommand: CliCommandDefinition<SkillsValidateInput> = {
     name: "validate",
@@ -86,14 +79,6 @@ export async function validateSkillDirectory(
         };
     }
 
-    for (const key of frontmatter.fields.keys()) {
-        if (!supportedFrontmatterKeys.includes(key as typeof supportedFrontmatterKeys[number])) {
-            return {
-                error: `Unsupported frontmatter key: ${key}.`,
-            };
-        }
-    }
-
     const name = frontmatter.fields.get("name");
 
     if (name === undefined) {
@@ -126,6 +111,16 @@ export async function validateSkillDirectory(
         };
     }
 
+    const title = frontmatter.metadataFields.get("title");
+
+    const titleError = validateSkillTitleValue(title);
+
+    if (titleError !== undefined) {
+        return {
+            error: titleError,
+        };
+    }
+
     return {};
 }
 
@@ -150,6 +145,7 @@ function parseSkillFrontmatter(content: string): ParsedFrontmatter | string {
     }
 
     const fields = new Map<string, string | undefined>();
+    const metadataFields = new Map<string, string | undefined>();
     const frontmatterLines = lines.slice(1, endIndex);
     let currentBlockKey: string | undefined;
     let currentBlockLines: string[] = [];
@@ -195,9 +191,46 @@ function parseSkillFrontmatter(content: string): ParsedFrontmatter | string {
         fields.set(currentBlockKey, currentBlockLines.join(" ").trim());
     }
 
+    const metadataLines = readMetadataBlockLines(frontmatterLines);
+
+    for (const line of metadataLines) {
+        const field = readTopLevelFrontmatterField(line.trim());
+
+        if (field === undefined) {
+            continue;
+        }
+
+        if (metadataFields.has(field.key)) {
+            return `Duplicate metadata key: ${field.key}.`;
+        }
+
+        metadataFields.set(field.key, parseYamlScalar(field.value));
+    }
+
     return {
         fields,
+        metadataFields,
     };
+}
+
+function readMetadataBlockLines(frontmatterLines: readonly string[]): string[] {
+    const metadataLines: string[] = [];
+    let insideMetadata = false;
+
+    for (const line of frontmatterLines) {
+        const topLevelField = readTopLevelFrontmatterField(line);
+
+        if (topLevelField !== undefined) {
+            insideMetadata = topLevelField.key === "metadata";
+            continue;
+        }
+
+        if (insideMetadata && isIndentedLine(line)) {
+            metadataLines.push(line);
+        }
+    }
+
+    return metadataLines;
 }
 
 function readTopLevelFrontmatterField(
@@ -259,35 +292,8 @@ function validateSkillNameValue(name: string | undefined): string | undefined {
         return "Frontmatter name must be a string.";
     }
 
-    if (name.length > 64) {
-        return "Frontmatter name must be no longer than 64 characters.";
-    }
-
     if (name === "") {
         return "Frontmatter name cannot be empty.";
-    }
-
-    if (name.startsWith("-") || name.endsWith("-")) {
-        return "Frontmatter name cannot start or end with a hyphen.";
-    }
-
-    let previousWasHyphen = false;
-
-    for (const char of name) {
-        if (char === "-") {
-            if (previousWasHyphen) {
-                return "Frontmatter name cannot contain consecutive hyphens.";
-            }
-
-            previousWasHyphen = true;
-            continue;
-        }
-
-        previousWasHyphen = false;
-
-        if (!isLowercaseAsciiLetter(char) && !isAsciiDigit(char)) {
-            return "Frontmatter name must use lowercase hyphen-case with letters, digits, and hyphens only.";
-        }
     }
 
     return undefined;
@@ -300,21 +306,17 @@ function validateSkillDescriptionValue(
         return "Frontmatter description must be a string.";
     }
 
-    if (description.length > 1024) {
-        return "Frontmatter description must be no longer than 1024 characters.";
-    }
-
-    if (description.includes("<") || description.includes(">")) {
-        return "Frontmatter description cannot contain angle brackets.";
-    }
-
     return undefined;
 }
 
-function isLowercaseAsciiLetter(char: string): boolean {
-    return char >= "a" && char <= "z";
-}
+function validateSkillTitleValue(title: string | undefined): string | undefined {
+    if (title === undefined) {
+        return undefined;
+    }
 
-function isAsciiDigit(char: string): boolean {
-    return char >= "0" && char <= "9";
+    if (title === "") {
+        return "Frontmatter metadata.title cannot be empty.";
+    }
+
+    return undefined;
 }

--- a/src/application/commands/skills/validate.ts
+++ b/src/application/commands/skills/validate.ts
@@ -1,0 +1,320 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { writeLine } from "../shared/output.ts";
+import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
+
+interface SkillsValidateInput {
+    path: string;
+}
+
+interface SkillValidationResult {
+    error?: string;
+}
+
+interface ParsedFrontmatter {
+    fields: Map<string, string | undefined>;
+}
+
+const supportedFrontmatterKeys = [
+    "allowed-tools",
+    "description",
+    "license",
+    "metadata",
+    "name",
+] as const;
+
+export const skillsValidateCommand: CliCommandDefinition<SkillsValidateInput> = {
+    name: "validate",
+    summaryKey: "commands.skills.validate.summary",
+    descriptionKey: "commands.skills.validate.description",
+    arguments: [
+        {
+            name: "path",
+            descriptionKey: "arguments.filePath",
+            required: true,
+        },
+    ],
+    inputSchema: z.object({
+        path: z.string(),
+    }),
+    handler: async (input, context) => {
+        const skillDirectoryPath = resolve(context.cwd, input.path);
+        const result = await validateSkillDirectory(skillDirectoryPath);
+
+        if (result.error !== undefined) {
+            throw new CliUserError("errors.skills.validate.failed", 1, {
+                message: result.error,
+            });
+        }
+
+        writeLine(
+            context.stdout,
+            context.translator.t("skills.validate.success", {
+                path: skillDirectoryPath,
+            }),
+        );
+    },
+};
+
+export async function validateSkillDirectory(
+    skillDirectoryPath: string,
+): Promise<SkillValidationResult> {
+    let content: string;
+
+    try {
+        content = await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8");
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return {
+                error: "SKILL.md does not exist.",
+            };
+        }
+
+        throw error;
+    }
+
+    const frontmatter = parseSkillFrontmatter(content);
+
+    if (typeof frontmatter === "string") {
+        return {
+            error: frontmatter,
+        };
+    }
+
+    for (const key of frontmatter.fields.keys()) {
+        if (!supportedFrontmatterKeys.includes(key as typeof supportedFrontmatterKeys[number])) {
+            return {
+                error: `Unsupported frontmatter key: ${key}.`,
+            };
+        }
+    }
+
+    const name = frontmatter.fields.get("name");
+
+    if (name === undefined) {
+        return {
+            error: "Frontmatter must include a string name field.",
+        };
+    }
+
+    const nameError = validateSkillNameValue(name);
+
+    if (nameError !== undefined) {
+        return {
+            error: nameError,
+        };
+    }
+
+    const description = frontmatter.fields.get("description");
+
+    if (description === undefined) {
+        return {
+            error: "Frontmatter must include a string description field.",
+        };
+    }
+
+    const descriptionError = validateSkillDescriptionValue(description);
+
+    if (descriptionError !== undefined) {
+        return {
+            error: descriptionError,
+        };
+    }
+
+    return {};
+}
+
+function parseSkillFrontmatter(content: string): ParsedFrontmatter | string {
+    const normalizedContent = content
+        .replaceAll("\r\n", "\n")
+        .replaceAll("\r", "\n");
+    const lines = normalizedContent.split("\n");
+
+    if (lines[0] !== "---") {
+        return "SKILL.md must start with YAML frontmatter delimited by ---.";
+    }
+
+    let endIndex = 1;
+
+    while (endIndex < lines.length && lines[endIndex] !== "---") {
+        endIndex += 1;
+    }
+
+    if (endIndex >= lines.length) {
+        return "Frontmatter must end with a --- delimiter.";
+    }
+
+    const fields = new Map<string, string | undefined>();
+    const frontmatterLines = lines.slice(1, endIndex);
+    let currentBlockKey: string | undefined;
+    let currentBlockLines: string[] = [];
+
+    for (const line of frontmatterLines) {
+        const topLevelField = readTopLevelFrontmatterField(line);
+
+        if (topLevelField === undefined) {
+            if (currentBlockKey !== undefined && isIndentedLine(line)) {
+                currentBlockLines.push(line.trim());
+                continue;
+            }
+
+            if (line.trim() === "") {
+                continue;
+            }
+
+            return "Frontmatter must be a YAML dictionary.";
+        }
+
+        if (currentBlockKey !== undefined) {
+            fields.set(currentBlockKey, currentBlockLines.join(" ").trim());
+            currentBlockKey = undefined;
+            currentBlockLines = [];
+        }
+
+        if (fields.has(topLevelField.key)) {
+            return `Duplicate frontmatter key: ${topLevelField.key}.`;
+        }
+
+        const parsedValue = parseYamlScalar(topLevelField.value);
+
+        if (parsedValue === "block" || topLevelField.value === "") {
+            currentBlockKey = topLevelField.key;
+            currentBlockLines = [];
+            continue;
+        }
+
+        fields.set(topLevelField.key, parsedValue);
+    }
+
+    if (currentBlockKey !== undefined) {
+        fields.set(currentBlockKey, currentBlockLines.join(" ").trim());
+    }
+
+    return {
+        fields,
+    };
+}
+
+function readTopLevelFrontmatterField(
+    line: string,
+): { key: string; value: string } | undefined {
+    if (isIndentedLine(line)) {
+        return undefined;
+    }
+
+    const separatorIndex = line.indexOf(":");
+
+    if (separatorIndex <= 0) {
+        return undefined;
+    }
+
+    return {
+        key: line.slice(0, separatorIndex).trim(),
+        value: line.slice(separatorIndex + 1).trim(),
+    };
+}
+
+function isIndentedLine(line: string): boolean {
+    return line.startsWith(" ") || line.startsWith("\t");
+}
+
+function parseYamlScalar(value: string): string | undefined | "block" {
+    if (value === "") {
+        return undefined;
+    }
+
+    if (value === ">" || value === ">-" || value === "|" || value === "|-") {
+        return "block";
+    }
+
+    if (value.startsWith("\"") && value.endsWith("\"")) {
+        try {
+            const parsedValue: unknown = JSON.parse(value);
+
+            return typeof parsedValue === "string" ? parsedValue : undefined;
+        }
+        catch {
+            return undefined;
+        }
+    }
+
+    if (value.startsWith("'") && value.endsWith("'")) {
+        return value.slice(1, -1).replaceAll("''", "'");
+    }
+
+    if (value.startsWith("[") || value.startsWith("{")) {
+        return undefined;
+    }
+
+    return value;
+}
+
+function validateSkillNameValue(name: string | undefined): string | undefined {
+    if (name === undefined) {
+        return "Frontmatter name must be a string.";
+    }
+
+    if (name.length > 64) {
+        return "Frontmatter name must be no longer than 64 characters.";
+    }
+
+    if (name === "") {
+        return "Frontmatter name cannot be empty.";
+    }
+
+    if (name.startsWith("-") || name.endsWith("-")) {
+        return "Frontmatter name cannot start or end with a hyphen.";
+    }
+
+    let previousWasHyphen = false;
+
+    for (const char of name) {
+        if (char === "-") {
+            if (previousWasHyphen) {
+                return "Frontmatter name cannot contain consecutive hyphens.";
+            }
+
+            previousWasHyphen = true;
+            continue;
+        }
+
+        previousWasHyphen = false;
+
+        if (!isLowercaseAsciiLetter(char) && !isAsciiDigit(char)) {
+            return "Frontmatter name must use lowercase hyphen-case with letters, digits, and hyphens only.";
+        }
+    }
+
+    return undefined;
+}
+
+function validateSkillDescriptionValue(
+    description: string | undefined,
+): string | undefined {
+    if (description === undefined) {
+        return "Frontmatter description must be a string.";
+    }
+
+    if (description.length > 1024) {
+        return "Frontmatter description must be no longer than 1024 characters.";
+    }
+
+    if (description.includes("<") || description.includes(">")) {
+        return "Frontmatter description cannot contain angle brackets.";
+    }
+
+    return undefined;
+}
+
+function isLowercaseAsciiLetter(char: string): boolean {
+    return char >= "a" && char <= "z";
+}
+
+function isAsciiDigit(char: string): boolean {
+    return char >= "0" && char <= "9";
+}

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -129,8 +129,8 @@ export const enMessages = {
     "commands.skills.list.summary":
         "List oo-managed skills",
     "commands.skills.check.description":
-        "Check whether local skill authoring can write to managed storage.",
-    "commands.skills.check.summary": "Check local skill authoring",
+        "Check whether this environment can edit local skills.",
+    "commands.skills.check.summary": "Preflight local skill editing",
     "commands.skills.init.description":
         "Initialize a local skill and publish it to supported local skill directories.",
     "commands.skills.init.summary": "Initialize a local skill",
@@ -536,7 +536,7 @@ export const enMessages = {
     "skills.install.allSelected":
         "Installing all {count} skills.",
     "skills.check.success":
-        "Local skill authoring is ready. Writable storage: {path}. Supported hosts: {count}.",
+        "Local skill editing is ready. Writable storage: {path}. Supported hosts: {count}.",
     "skills.list.noResults":
         "No oo-managed skills were found.",
     "skills.list.host": "Host",
@@ -781,8 +781,8 @@ export const zhMessages = {
     "commands.skills.list.summary":
         "列出由 oo 管理的 skill",
     "commands.skills.check.description":
-        "检查本地 skill 创建是否可以写入受管理存储。",
-    "commands.skills.check.summary": "检查本地 skill 创建环境",
+        "检查当前环境是否有权限编辑本地 skills。",
+    "commands.skills.check.summary": "预检本地 skill 编辑环境",
     "commands.skills.init.description":
         "初始化本地 skill，并发布到受支持的本地 skill 目录。",
     "commands.skills.init.summary": "初始化本地 skill",
@@ -1171,7 +1171,7 @@ export const zhMessages = {
     "skills.install.allSelected":
         "将安装全部 {count} 个 skill。",
     "skills.check.success":
-        "本地 skill 创建环境可用。可写存储：{path}。受支持宿主数：{count}。",
+        "本地 skill 编辑环境可用。可写存储：{path}。受支持宿主数：{count}。",
     "skills.list.noResults":
         "未找到由 oo 管理的 skill。",
     "skills.list.host": "宿主",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -128,6 +128,15 @@ export const enMessages = {
         "List oo-managed skills from supported local skill directories.",
     "commands.skills.list.summary":
         "List oo-managed skills",
+    "commands.skills.check.description":
+        "Check whether local skill authoring can write to managed storage.",
+    "commands.skills.check.summary": "Check local skill authoring",
+    "commands.skills.init.description":
+        "Initialize a local skill and publish it to supported local skill directories.",
+    "commands.skills.init.summary": "Initialize a local skill",
+    "commands.skills.validate.description":
+        "Validate a local skill directory against the generic skill contract.",
+    "commands.skills.validate.summary": "Validate a skill directory",
     "commands.skills.install.description":
         "Install bundled or published skills into supported local skill directories.",
     "commands.skills.install.summary": "Install skills",
@@ -283,6 +292,14 @@ export const enMessages = {
         "Unsupported skill: {value}. Use {choices}.",
     "errors.skills.invalidPath":
         "Skill name {name} resolves outside the local skill directories.",
+    "errors.skills.init.invalidIcon":
+        "Invalid value for --icon. Use a non-empty icon reference.",
+    "errors.skills.init.invalidTitle":
+        "Invalid value for --title. Use a non-empty display title.",
+    "errors.skills.init.descriptionRequired":
+        "Missing required --description. Provide a concise trigger description for the generated skill.",
+    "errors.skills.init.invalidName":
+        "Invalid skill name: {value}. Use a name that can be normalized to lowercase hyphen-case.",
     "errors.fileDownload.downloadFailed":
         "Failed to download the file at {path}: {message}",
     "errors.fileDownload.invalidExt":
@@ -377,6 +394,10 @@ export const enMessages = {
         "Skill {name} is not installed at {path}.",
     "errors.skills.notManaged":
         "{name} is not managed by oo and cannot be removed.",
+    "errors.skills.check.storageNotWritable":
+        "Local skill storage at {path} is not writable: {message}",
+    "errors.skills.validate.failed":
+        "Skill validation failed: {message}",
     "errors.store.invalidToml":
         "The settings file at {path} is not valid TOML.",
     "errors.store.invalidSchema":
@@ -442,6 +463,7 @@ export const enMessages = {
     "options.data": "Provide JSON input values or @path to a JSON file",
     "options.dryRun": "Validate the request without creating a task",
     "options.debug": "Print the current log file path when the CLI exits",
+    "options.description": "Set the required generated skill description",
     "options.fileDownloadExt": "Specify the saved file extension",
     "options.fileDownloadName": "Specify the saved file name without the extension",
     "options.fileStatus": "Filter by upload status",
@@ -455,11 +477,14 @@ export const enMessages = {
     "options.json": "Alias for --format=json",
     "options.keywords":
         "Specify comma-separated keywords to refine the skill search",
+    "options.icon": "Set the generated skill icon reference",
+    "options.title": "Set the generated skill display title",
     "options.skill":
         "Specify skill names to install (use * for all skills)",
     "options.onlyPackageId": "Return only package ids",
     "options.all":
         "Install all published skills without prompting for skill selection",
+    "options.agent": "Check one supported skill host",
     "options.nextToken": "Specify the pagination token for the next page",
     "options.packageId": "Filter by package id",
     "options.packageName": "Alias for --package-id",
@@ -510,6 +535,8 @@ export const enMessages = {
         "Updated oo from {currentVersion} to {version}.",
     "skills.install.allSelected":
         "Installing all {count} skills.",
+    "skills.check.success":
+        "Local skill authoring is ready. Writable storage: {path}. Supported hosts: {count}.",
     "skills.list.noResults":
         "No oo-managed skills were found.",
     "skills.list.host": "Host",
@@ -518,11 +545,13 @@ export const enMessages = {
     "skills.list.host.openclaw": "OpenClaw",
     "skills.list.source": "Source",
     "skills.list.source.bundled": "bundled",
+    "skills.list.source.local": "local",
     "skills.list.summary":
         "Found {count} oo-managed skills.",
     "labels.blocks": "Blocks:",
     "labels.status": "Status",
     "labels.version": "Version",
+    "skills.init.success": "Initialized skill {name} at {path}.",
     "skills.install.success": "Installed skill {name} to {path}.",
     "skills.install.overwrite.invalid":
         "Invalid choice. Enter y/yes or n/no.",
@@ -561,6 +590,7 @@ export const enMessages = {
     "skills.update.progress.failed": "failed",
     "skills.update.success": "Updated skill {name} to {path}.",
     "skills.uninstall.success": "Removed skill {name} from {path}.",
+    "skills.validate.success": "Skill at {path} is valid.",
     "versionInfo.buildTime": "Build Time",
     "versionInfo.commit": "Commit",
     "versionInfo.unknown": "unknown",
@@ -750,6 +780,15 @@ export const zhMessages = {
         "列出受支持的本地 skill 目录中由 oo 管理的 skill。",
     "commands.skills.list.summary":
         "列出由 oo 管理的 skill",
+    "commands.skills.check.description":
+        "检查本地 skill 创建是否可以写入受管理存储。",
+    "commands.skills.check.summary": "检查本地 skill 创建环境",
+    "commands.skills.init.description":
+        "初始化本地 skill，并发布到受支持的本地 skill 目录。",
+    "commands.skills.init.summary": "初始化本地 skill",
+    "commands.skills.validate.description":
+        "按照通用 skill 契约校验本地 skill 目录。",
+    "commands.skills.validate.summary": "校验 skill 目录",
     "commands.skills.install.description":
         "将内置或已发布 skill 安装到受支持的本地 skill 目录。",
     "commands.skills.install.summary": "安装 skill",
@@ -894,6 +933,14 @@ export const zhMessages = {
         "不支持的 skill：{value}。请使用 {choices}。",
     "errors.skills.invalidPath":
         "skill 名称 {name} 解析到了本地 skill 目录之外。",
+    "errors.skills.init.invalidIcon":
+        "--icon 的值无效。请使用非空 icon 引用。",
+    "errors.skills.init.invalidTitle":
+        "--title 的值无效。请使用非空显示标题。",
+    "errors.skills.init.descriptionRequired":
+        "缺少必填的 --description。请为生成的 skill 提供简洁的触发描述。",
+    "errors.skills.init.invalidName":
+        "无效的 skill 名称：{value}。请使用可规范化为小写短横线格式的名称。",
     "errors.fileDownload.downloadFailed":
         "下载文件到 {path} 失败：{message}",
     "errors.fileDownload.invalidExt":
@@ -988,6 +1035,10 @@ export const zhMessages = {
         "Skill {name} 未安装在 {path}。",
     "errors.skills.notManaged":
         "{name} 不是由 oo 管理的 skill，无法移除。",
+    "errors.skills.check.storageNotWritable":
+        "本地 skill 存储目录 {path} 不可写：{message}",
+    "errors.skills.validate.failed":
+        "Skill 校验失败：{message}",
     "errors.store.invalidToml": "配置文件 {path} 不是有效的 TOML。",
     "errors.store.invalidSchema": "配置文件 {path} 的结构不受支持。",
     "errors.store.readFailed": "读取配置文件 {path} 失败。",
@@ -1048,6 +1099,7 @@ export const zhMessages = {
     "options.data": "提供 JSON 输入值，或使用 @路径 读取 JSON 文件",
     "options.dryRun": "仅校验请求，不真正创建任务",
     "options.debug": "在 CLI 退出时打印当前日志文件路径",
+    "options.description": "设置必填的生成 skill 描述",
     "options.fileDownloadExt": "指定保存文件的扩展名",
     "options.fileDownloadName": "指定不带扩展名的保存文件名",
     "options.fileStatus": "按上传状态过滤",
@@ -1061,11 +1113,14 @@ export const zhMessages = {
     "options.json": "--format=json 的别名",
     "options.keywords":
         "指定用于细化 skill 搜索的逗号分隔关键词",
+    "options.icon": "设置生成的 skill icon 引用",
+    "options.title": "设置生成的 skill 显示标题",
     "options.skill":
         "指定要安装的 skill 名称（使用 * 表示全部）",
     "options.onlyPackageId": "仅返回 package id",
     "options.all":
         "安装全部已发布 skill，并跳过 skill 选择提示",
+    "options.agent": "检查一个受支持的 skill 宿主",
     "options.nextToken": "指定下一页分页令牌",
     "options.packageId": "按 package id 过滤",
     "options.packageName": "--package-id 的别名",
@@ -1115,6 +1170,8 @@ export const zhMessages = {
         "已将 oo 从 {currentVersion} 更新到 {version}。",
     "skills.install.allSelected":
         "将安装全部 {count} 个 skill。",
+    "skills.check.success":
+        "本地 skill 创建环境可用。可写存储：{path}。受支持宿主数：{count}。",
     "skills.list.noResults":
         "未找到由 oo 管理的 skill。",
     "skills.list.host": "宿主",
@@ -1123,11 +1180,13 @@ export const zhMessages = {
     "skills.list.host.openclaw": "OpenClaw",
     "skills.list.source": "来源",
     "skills.list.source.bundled": "内置",
+    "skills.list.source.local": "本地",
     "skills.list.summary":
         "找到 {count} 个由 oo 管理的 skill。",
     "labels.blocks": "功能块：",
     "labels.status": "状态",
     "labels.version": "版本",
+    "skills.init.success": "已在 {path} 初始化 skill {name}。",
     "skills.install.success": "已将 skill {name} 安装到 {path}。",
     "skills.install.overwrite.invalid":
         "输入无效。请输入 y/yes 或 n/no。",
@@ -1166,6 +1225,7 @@ export const zhMessages = {
     "skills.update.progress.failed": "失败",
     "skills.update.success": "已将 skill {name} 更新到 {path}。",
     "skills.uninstall.success": "已从 {path} 移除 skill {name}。",
+    "skills.validate.success": "{path} 中的 skill 有效。",
     "versionInfo.buildTime": "构建时间",
     "versionInfo.commit": "提交",
     "versionInfo.unknown": "未知",


### PR DESCRIPTION
[oo-create-skill.md](https://github.com/user-attachments/files/27158555/oo-create-skill.md)

- Implemented `skills init` command to initialize and publish local skills with metadata.
- Added `skills validate` command to validate local skill directories against the required frontmatter.
- Enhanced skill listing to include local skills and updated tests accordingly.
- Introduced error handling for invalid skill names, descriptions, and icons.
- Updated internationalization catalog with new messages for the added commands and error handling.