### PR TITLE
fix(auth): route session token login through API host

### DIFF
--- a/src/application/auth/login-flow.test.ts
+++ b/src/application/auth/login-flow.test.ts
@@ -213,7 +213,7 @@ describe("startAuthLoginSession", () => {
 
                     if (
                         request.method === "GET"
-                        && requestUrl.host === "oomol.dev"
+                        && requestUrl.host === "api.oomol.dev"
                         && requestUrl.pathname === "/v1/auth/fast_login/profile_with_session_token"
                         && requestUrl.searchParams.get("session_token") === "session-1"
                     ) {
@@ -272,7 +272,7 @@ describe("startAuthLoginSession", () => {
                 endpoint: "oomol.dev",
                 fetcher: async () => {
                     throw new Error(
-                        `Failed to fetch https://oomol.dev/v1/auth/fast_login/profile_with_session_token?session_token=${searchEncodedSessionToken}`,
+                        `Failed to fetch https://api.oomol.dev/v1/auth/fast_login/profile_with_session_token?session_token=${searchEncodedSessionToken}`,
                     );
                 },
                 logger: logCapture.logger,
@@ -282,7 +282,7 @@ describe("startAuthLoginSession", () => {
                 key: "errors.auth.loginRequestError",
                 params: {
                     message:
-                        "Failed to fetch https://oomol.dev/v1/auth/fast_login/profile_with_session_token?session_token=<redacted>",
+                        "Failed to fetch https://api.oomol.dev/v1/auth/fast_login/profile_with_session_token?session_token=<redacted>",
                 },
             });
 

--- a/src/application/auth/login-flow.ts
+++ b/src/application/auth/login-flow.ts
@@ -361,7 +361,7 @@ function createFastLoginProfileWithSessionTokenUrl(
     sessionToken: string,
 ): URL {
     const requestUrl = new URL(
-        `https://${endpoint}/v1/auth/fast_login/profile_with_session_token`,
+        `https://api.${endpoint}/v1/auth/fast_login/profile_with_session_token`,
     );
 
     requestUrl.searchParams.set("session_token", sessionToken);

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -210,7 +210,7 @@ describe("auth CLI", () => {
 
                         if (
                             request.method === "GET"
-                            && requestUrl.host === defaultAuthEndpoint
+                            && requestUrl.host === `api.${defaultAuthEndpoint}`
                             && requestUrl.pathname === "/v1/auth/fast_login/profile_with_session_token"
                             && requestUrl.searchParams.get("session_token") === sessionToken
                         ) {


### PR DESCRIPTION
Session token login should use the same API host convention as device login. Using the bare endpoint can hit the site host instead, which may fail TLS validation for environment-specific domains.