### PR TITLE
feat(skills): add QoderWork skill host

### DIFF
--- a/contrib/skills/qoderwork/oo-create-skill/SKILL.md
+++ b/contrib/skills/qoderwork/oo-create-skill/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: oo-create-skill
+description: >-
+  Create or update a local agent skill for a known OOMOL package workflow. Use
+  when the user already knows which oo package or block should power the
+  workflow and wants reusable skill instructions.
+---
+
+# oo Create Skill
+
+Use this skill when the user wants to create or update a local skill around an
+OOMOL package workflow.
+
+## Workflow
+
+### 1. Collect only the information needed
+
+Ask for missing authoring inputs only when they are needed:
+
+- skill name
+- workflow purpose
+- known package names
+- stable block names, when the user knows them
+- user inputs the skill should collect
+- workflow ordering and expected outputs
+- optional display title and icon preference
+
+If the user does not provide a display title or icon preference, choose them
+yourself from the workflow purpose and package metadata instead of asking only
+for cosmetic details. Use a concise human-readable title and an icon reference
+that fits the workflow. The icon may be an emoji, an image URL, or
+`:collection:icon:` where `collection` and `icon` are names from
+https://icones.js.org/.
+
+### 2. Resolve concrete package and block references
+
+If the user provides only package-level information, inspect the package before
+writing the skill:
+
+```bash
+oo packages info "<packageName>" --json
+```
+
+Use the returned metadata to identify stable block references, input concepts,
+and output concepts. Prefer the most specific safe reference:
+`oo::packageName::blockName` when a block is clearly part of the intended
+workflow, or `oo::packageName` only when the block must remain a deliberate
+runtime choice based on user intent.
+
+If the user does not know the package name, or the workflow clearly needs an
+additional package, use `oo search` to find candidate packages before authoring.
+After choosing packages and blocks, do not leave package discovery to the
+generated skill.
+
+### 3. Initialize the local skill
+
+When creating a new skill, run `oo skills init <name>` with a required
+`--description` value. Also pass `--title` and `--icon`. If the user did not
+provide them, derive a concise display title and suitable icon reference from
+the workflow purpose and resolved package metadata before running
+initialization. If initialization fails because the local canonical directory or
+an agent target directory already exists, ask the user for a different skill
+name instead of overwriting.
+
+### 4. Author the workflow instructions
+
+Write the generated skill in domain terms: when to use it, what to ask the
+user, which workflow steps to follow, and what outputs to report. Reference
+packages with `oo::packageName` and stable blocks with
+`oo::packageName::blockName`.
+
+Preserve the generated frontmatter `metadata.title` field when it exists. If
+you change the skill's displayed title or first heading, update
+`metadata.title` to the same human-readable title. If `metadata.title` or
+`metadata.icon` is absent, add a suitable value rather than leaving the
+generated skill without presentation metadata.
+
+The final generated skill must contain concrete package or block references. It
+must not instruct the future agent to run `oo search` or discover packages at
+execution time.
+
+Do not duplicate oo execution mechanics in authored prose. The initialized
+`SKILL.md` already contains the managed OO notice that tells agents how to
+inspect and run referenced packages.
+
+Keep `SKILL.md` concise. Use `references/workflow.md` only when the workflow
+has several steps, decision rules, or examples. Use `references/packages.json`
+only when captured package metadata will help future updates.
+
+### 5. Validate before finishing
+
+After editing the skill, run `oo skills validate "<skill-directory>"`. If
+validation fails, fix the generic skill contract before reporting completion.

--- a/contrib/skills/qoderwork/oo-find-skills/SKILL.md
+++ b/contrib/skills/qoderwork/oo-find-skills/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: oo-find-skills
+description: >-
+  Find, compare, and install published OOMOL/oo skills. Use when the user asks
+  to find, search for, discover, recommend, compare, choose, or install an
+  existing skill for a task; asks whether there is a skill that can do
+  something; or explicitly mentions the OOMOL/oo skill catalog. Do not use for
+  creating or editing local skills, generic skill design, or non-OOMOL skill
+  catalogs.
+---
+
+# oo Find Skills
+
+Use this skill when the user wants to discover and install existing published
+skills from the OOMOL or `oo` skill catalog through `oo skills search` and
+`oo skills install`.
+
+Read [references/oo-cli-contract.md](references/oo-cli-contract.md) when you
+need exact `oo skills search` or `oo skills install` command forms, JSON
+expectations, output-shape rules, or failure-handling details.
+
+## Workflow
+
+### 1. Normalize the request into English search terms
+
+Convert the user request into:
+
+- one short internal intent statement
+- one concise English sentence for the search text
+- `0` to `3` English keywords or short phrases for the optional `--keywords`
+  filter
+
+Rules:
+
+- The sentence and keywords must always be in English, regardless of the
+  user's language.
+- The sentence should describe only the user's need itself.
+- Prefer a short sentence built from task + capability + domain or constraint.
+- Do not add meta words such as `skill`, `skills`, `search`, `install`, or
+  `Codex` unless the user's actual need depends on those words.
+- Avoid filler words.
+- Use keywords only when they add extra filtering signal that the sentence does
+  not already capture.
+- Prefer `0` to `3` keywords. Do not exceed `3`.
+
+Examples:
+
+- Sentence: `translate scanned images from Japanese to English`
+  Keywords: `Japanese`, `image translation`
+- Sentence: `generate a QR code from text`
+  Keywords: `QR code`
+- Sentence: `convert speech to text`
+  Keywords: `transcription`
+- Sentence: `write Markdown more effectively`
+  Keywords: `Markdown`, `writing`
+
+Use the sentence as the main search text. Add `--keywords` only when the extra
+keywords help narrow the search.
+
+### 2. Search for candidate skills
+
+Run:
+
+```bash
+oo skills search "<english query>" --json
+```
+
+Or, when helpful:
+
+```bash
+oo skills search "<english sentence>" --keywords "<comma-separated keywords>" --json
+```
+
+Then:
+
+- Rank only from the returned JSON array.
+- Prefer semantic matches between the original user goal and the returned
+  `description`, `skillDisplayName`, or `name`.
+- Keep one primary skill.
+- Keep one fallback skill only if it is genuinely plausible.
+
+If the returned array is empty, tell the user there is no matching skill
+available right now and stop. Do not present a menu.
+
+### 3. Filter installable results
+
+- Treat a search item as installable only when it includes both `packageName`
+  and `name`.
+- If the JSON array is non-empty but no installable items exist, stop and tell
+  the user that no installable skill could be derived from the search results.
+  Do not present a menu.
+
+### 4. Rank the installable results
+
+6. Rank the installable JSON items using only the fields in the response.
+7. Pick one primary skill and, only if credible, one fallback skill.
+
+### 5. Ask the user to choose
+
+8. Only when at least one installable result exists, ask the user to choose
+   between the available actions.
+   Do not stop at a plain existence summary when installable results exist.
+   Even if the user first asks whether a matching skill exists, this skill
+   should still continue into the chooser step after confirming the matches.
+
+Interaction rules:
+
+- If a credible fallback exists, offer these actions:
+  1. Install the primary skill as `primarySkillName (primaryPackageName)`
+  2. Install the fallback skill as `fallbackSkillName (fallbackPackageName)`
+  3. Install both
+  4. Install neither
+- If no credible fallback exists, offer only these actions:
+  1. Install the primary skill as `primarySkillName (primaryPackageName)`
+  2. Install neither
+- First, try to use the `AskUserQuestion` tool with one short multiple-choice
+  question that includes only the actions that are actually available.
+- If the `AskUserQuestion` tool is unavailable in the current mode or the
+  tool call fails, fall back to plain text.
+- If the `AskUserQuestion` UI returns `None of the above`, treat that as
+  the same outcome as `Install neither`.
+- In either UI or text form, the label for every install action must include
+  the concrete `skillName (packageName)` text.
+
+Fallback text format:
+
+```text
+1. Install <skillName> (<packageName>)
+2. Install <skillName2> (<packageName2>)
+3. Install both
+4. Install neither
+
+Reply with: 1, 2, 3, or 4
+```
+
+If no credible fallback exists, use:
+
+```text
+1. Install <skillName> (<packageName>)
+2. Install neither
+
+Reply with: 1 or 2
+```
+
+If the user reply is not one of the explicit numbers that correspond to the
+currently available options, do not install anything. Ask the user to reply
+with one of the displayed numbers.
+
+### 6. Install after confirmation
+
+9. After the user chooses, install only the selected skill or skills with
+   `oo skills install`.
+   If the user chooses `Install neither` or the UI returns `None of the above`,
+   do not install anything. Reply with exactly one short acknowledgement in the
+   user's language that no skill was installed, then stop. Do not continue with
+   extra result explanation, matched-result recap, ranking recap, package names,
+   skill names, descriptions, or repeated summaries.
+10. Batch by package:
+   - If both selected skills come from the same package, install them with one
+     command and multiple `-s` flags.
+   - If they come from different packages, run one install command per package.
+   If `Install both` requires multiple `oo skills install` commands across
+   different packages and a later command fails after an earlier one succeeded,
+   report the partial completion accurately: say which package/skill
+   installation(s) succeeded, say which command failed, say that no rollback
+   was attempted, and then stop.
+
+Install examples:
+
+- Single skill install:
+
+```bash
+oo skills install "<packageName>" -s "<skillName>" -y
+```
+
+- Two skills from the same package:
+
+```bash
+oo skills install "<packageName>" -s "<skillName1>" -s "<skillName2>" -y
+```
+
+- Two skills from different packages:
+
+```bash
+oo skills install "<packageName1>" -s "<skillName1>" -y
+oo skills install "<packageName2>" -s "<skillName2>" -y
+```
+
+11. Use each search result's `name` field as the `-s` value. Use
+   `skillDisplayName` only for display text.
+12. Never invent package names, skill names, versions, or extra metadata.
+13. If `oo skills search` or `oo skills install` fails for any reason other
+   than the explicit HTTP `402` billing case, stop immediately and report the
+   exact command failure. Do not invent recommendations, do not claim an
+   install succeeded, and do not continue silently.
+14. If the command output shows HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`,
+   stop immediately, tell the user their current account has insufficient
+   credit or is overdue, and direct them to
+   `https://console.oomol.com/billing/recharge` before retrying.
+
+## Behavior Notes
+
+- `oo skills search --json` returns at most `5` results because that is the CLI
+  behavior for this command; do not try to enforce or emulate a different
+  limit in the skill text.
+- Use `skillDisplayName` when present, otherwise fall back to `name`.
+- Prefer the closest semantic match for the primary skill.
+- Break ranking ties deterministically by preferring the result whose
+  `description` or display text more directly matches the same user request.
+- Prefer non-duplicate results over near-duplicates.
+- If the semantic match is still tied, prefer the result with clearer install
+  identifiers (`packageName` plus `name`) and richer explanatory text.
+- You may compare response text fields against the original user request, but
+  you must not use external metadata or guessed fields to break ties.
+- Treat a fallback as credible only when it is the next-best result that still
+  plausibly solves the same user request, not merely a loosely related or
+  duplicate-looking match.
+- Do not install anything before the user explicitly chooses one of the four
+  options.

--- a/contrib/skills/qoderwork/oo-find-skills/references/oo-cli-contract.md
+++ b/contrib/skills/qoderwork/oo-find-skills/references/oo-cli-contract.md
@@ -1,0 +1,106 @@
+# oo CLI Contract for Skill Discovery
+
+Use this reference when you need the concrete `oo` command forms for finding
+and installing skills.
+
+## `oo skills search`
+
+Canonical form:
+
+```bash
+oo skills search "<text>" --json
+```
+
+Optional keyword-refined form:
+
+```bash
+oo skills search "<text>" --keywords "<comma-separated keywords>" --json
+```
+
+Facts:
+
+- `--json` is an alias for `--format=json`.
+- `--keywords` is optional and accepts a comma-separated list.
+- The command returns a raw JSON array.
+- Search results may include `description`, `name`, `packageName`,
+  `packageVersion`, and `skillDisplayName`.
+- The CLI returns at most `5` results for this command.
+- Treat an empty array as no matching capability.
+- An item is installable only when it includes both `packageName` and `name`.
+- If the JSON array is non-empty but no items are installable, stop and explain
+  that no installable skill could be derived from the search results.
+
+## `oo skills install`
+
+Canonical forms:
+
+```bash
+oo skills install <packageName> -s "<skillName>" -y
+```
+
+```bash
+oo skills install <packageName> -s "<skillName1>" -s "<skillName2>" -y
+```
+
+Facts:
+
+- Bundled skill names can be installed directly by package name.
+- When both chosen skills come from the same package, install them with one
+  command and multiple `-s` flags.
+- When the chosen skills come from different packages, run one install command
+  per package.
+- If `Install both` requires multiple `oo skills install` commands across
+  different packages and a later command fails after an earlier one succeeded,
+  report the partial completion accurately: say which package/skill
+  installation(s) succeeded, say which command failed, say that no rollback was
+  attempted, and then stop.
+- Use only the package and `name` fields returned by `oo skills search --json`.
+- Use `skillDisplayName` only for user-facing labels, never as a `-s` value.
+- If the `AskUserQuestion` UI returns `None of the above`, treat that as
+  the same outcome as `Install neither`.
+- If the user reply is not one of the explicit numbers that correspond to the
+  currently displayed options, do not install anything. Ask the user to reply
+  with one of the displayed numbers.
+- Every install option label must include the concrete
+  `skillName (packageName)` text.
+
+Output shape:
+
+- When a credible fallback exists, show four numbered choices:
+  `Install <primarySkillName> (<primaryPackageName>)`,
+  `Install <fallbackSkillName> (<fallbackPackageName>)`,
+  `Install both`, `Install neither`.
+- Do not stop at a plain existence confirmation when installable results exist.
+  Even if the user's first question is only whether a matching skill exists,
+  continue into the chooser step after confirming the matches.
+- When no credible fallback exists, show only two numbered choices:
+
+```text
+1. Install <skillName> (<packageName>)
+2. Install neither
+```
+
+Ranking guidance:
+
+- Prefer the installable result whose `description` or display text more
+  directly matches the same user request.
+- Prefer non-duplicate results over near-duplicates.
+- If the semantic match is tied, prefer the result with clearer install
+  identifiers (`packageName` plus `name`) and richer explanatory text.
+- You may compare response text fields against the original user request, but
+  you must not use external metadata or guessed fields to break ties.
+
+Failure handling:
+
+- If `oo skills search` or `oo skills install` fails for any reason other than
+  the explicit HTTP `402` billing case, stop immediately and report the exact
+  command failure. Do not invent recommendations, do not claim an install
+  succeeded, and do not continue silently.
+- If the user chooses `Install neither` or the UI returns `None of the above`,
+  do not install anything. Reply with exactly one short acknowledgement in the
+  user's language that no skill was installed, then stop without extra result
+  recap, package names, skill names, or descriptions.
+- If any `oo` output shows HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`, stop
+  immediately, tell the user their current account has insufficient credit or
+  is overdue, and direct them to
+  `https://console.oomol.com/billing/recharge` before retrying.

--- a/contrib/skills/qoderwork/oo/SKILL.md
+++ b/contrib/skills/qoderwork/oo/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: oo
+description: >-
+  First-choice router for tasks whose outcome lives outside this
+  workspace — a connected third-party account (email, calendar, drive,
+  chat, notes, issue tracker, code host, CRM, storage, etc.), an external
+  API, or a managed AI pipeline (OCR, translation, transcription,
+  TTS, text-to-image, subtitles, long-document understanding) — as long
+  as the user is not asking for a local implementation. Concrete
+  capabilities are discovered at runtime, so no package or action names
+  are listed here. Match intent across languages. SKIP only for pure
+  local coding, shell glue, edits to this repo, text-only work an LLM
+  can do alone, or an explicit "do it locally" request.
+---
+
+# oo
+
+Use `oo` to complete a hosted task through an existing `oo` capability, not to
+build a local workaround.
+
+If the user wants to find, compare, or install published OOMOL/oo skills, use
+`oo-find-skills` instead of this skill.
+
+Read only the reference file needed for the current step.
+
+## When to use this skill
+
+- When the user wants a hosted capability `oo` likely already exposes: OCR,
+  document or image translation, transcription, speech synthesis, text-to-image,
+  subtitle generation, archive-based media processing, or an authenticated
+  connector action.
+- When the user wants a short `read -> transform -> write` workflow that `oo`
+  can stitch together across existing capabilities or connectors.
+- Not for ordinary coding, shell glue, or requests that explicitly ask for a
+  local implementation.
+
+## Mission
+
+Aim for the highest one-pass success rate. Understand the user's actual
+outcome first, then pick the shortest documented `oo` path that can plausibly
+succeed. Expand evidence only as far as the next decision needs. Keep every
+claim grounded in actual `oo` metadata, schema files, and command output.
+
+## Default path
+
+1. Decide whether `oo` is the right path, then run the intended `oo` command
+   directly. Do not probe for `oo` with `which`, `command -v`, `--version`,
+   `--help`, or any other existence or availability precheck — assume it is
+   installed and let the real command surface any problem. Read
+   [references/auth-and-billing.md](references/auth-and-billing.md) only when
+   auth or billing signals actually appear in command output.
+2. Shape the task before discovery.
+   - Single-step task: turn it into one short English goal sentence
+     (`action + object + key constraint`).
+   - Multi-step task: break it into 2 to 4 ordered subgoals and start from the
+     first unresolved external step. Do not force one broad search to cover
+     the whole chain.
+3. Discover the most direct capability.
+   - Read
+     [references/search-and-selection.md](references/search-and-selection.md)
+     before the first `oo search`.
+   - If current context already proves a narrower documented path, use it
+     instead of rediscovering.
+   - Inspect the first result set before refining. Keep one primary candidate
+     and, only if useful, one materially different fallback.
+4. Inspect only the chosen path.
+   - Package-backed: [references/package-execution.md](references/package-execution.md).
+   - Connector-backed: [references/connector-execution.md](references/connector-execution.md).
+   - File-like inputs or artifact downloads: [references/file-transfer.md](references/file-transfer.md).
+5. Build the smallest payload that expresses the user's real intent. Prefer
+   concrete user values over defaults, samples, and placeholders. Reuse a
+   user-provided remote URL when it already satisfies the input. Ask one
+   focused follow-up only when a required value is missing or risky to infer.
+6. Expand evidence gradually. For list, inbox, or browse style steps, start
+   with the lightest output that reveals scale, identifiers, and the next
+   decision; hydrate bodies only when the current step needs them.
+7. Execute the selected path. For package tasks, read
+   [references/task-lifecycle.md](references/task-lifecycle.md) only after a
+   `taskID` exists.
+8. Materialize outputs only when a local copy helps the user and the selected
+   path exposes an explicit artifact URL.
+9. Report in task terms. Lead with the useful result on success; on a running
+   task, share the `taskID` and the next sensible action; on failure, name the
+   concrete blocker and the next best move. If you group or summarize by some
+   attribute, make sure the payload actually used it.
+
+## Selection heuristics
+
+- Prefer the capability that directly matches the user's outcome over a
+  multi-step decomposition.
+- Prefer preserving decisive user constraints (language pair, file type,
+  output format, target service) in both the search goal and the payload.
+- In a tie, prefer an already-authenticated connector — lower friction, no
+  package cost.
+- Prefer one targeted follow-up question over guessing a risky required value.
+- Prefer reporting a precise blocker over inventing a workaround inside this
+  skill.
+
+## Constitution
+
+Three rules that override every heuristic above:
+
+1. Never invent package IDs, versions, block IDs, connector services, action
+   names, defaults, required fields, or task results. Every claim must come
+   from actual `oo` output or a cached schema file.
+2. Remote capability execution stays inside documented `oo` commands for this
+   skill run. Do not substitute ad hoc HTTP calls, alternate SDKs, or direct
+   third-party APIs. Between `oo` steps, local work is limited to filtering,
+   grouping, ranking, deduplicating, summarizing, or shaping the next `oo`
+   payload — never replacing a remote capability with custom code.
+3. If auth, billing, or input-shape limits block the current path, stop the
+   path, explain the blocker, and offer the next useful action — do not retry
+   blindly or pretend a workaround will succeed.
+
+## Worked cases
+
+These illustrate the three execution shapes. Use them as templates for
+shaping the goal, picking the reference to open next, and framing the result.
+
+### Single package: extract text from a scanned PDF
+
+- User request: `Extract text from this scanned Chinese PDF and save it as Markdown.`
+- Search goal: `extract text from a scanned Chinese PDF and save it as Markdown`
+- Why this shape: one capability turns the input into the final artifact.
+- Inspect next: `search-and-selection`, then `package-execution`; add
+  `file-transfer` if the PDF is local, `task-lifecycle` if the task is async.
+- Payload mindset: preserve the user's source language and output format;
+  override placeholders with the real file.
+
+### Single connector: send an email
+
+- User request: `Send this summary to alice@example.com with Gmail.`
+- Search goal: `send an email through Gmail`
+- Why this shape: a direct connector send action is a better match than a
+  generic messaging package.
+- Inspect next: `search-and-selection`, then `connector-execution`.
+- Payload mindset: ask one follow-up only when a required field such as
+  recipients, subject, or body is genuinely missing; otherwise send the
+  smallest payload that satisfies the schema.
+
+### Short orchestration: read, transform, write
+
+- User request: a `read -> transform -> write` across two services (for
+  example, collect items from a source connector, organize them locally, then
+  create an entry in a destination connector).
+- Ordered subgoals:
+  1. `locate or collect the source items`
+  2. `organize the result set locally` (filter, rank, summarize, dedupe)
+  3. `write the digest into the destination`
+- Discovery mindset: search the current unresolved external step only. Switch
+  to the destination service when the write step becomes active.
+- Data mindset: start with the lightest source output that reveals scale and
+  stable identifiers; hydrate full bodies only when the transform really needs
+  them.
+- Reporting mindset: describe the basis of the digest in terms of the field
+  the payload actually used (message id, file id, row id — not display text).
+
+## Repair a weak search goal
+
+Before running `oo search`, check whether the goal sentence carries the
+user's real constraints. Weak goals cost extra searches.
+
+- Weak: `translate image` → Better: `translate text in a Japanese image to English`
+- Weak: `gmail` → Better: `send an email through Gmail`
+- Weak: `ocr pdf then markdown` → Better: `extract text from a scanned PDF and save it as Markdown`
+
+The repair pattern: add the missing medium, language pair, target service, or
+output format; replace implementation guesses with the user's desired outcome.

--- a/contrib/skills/qoderwork/oo/references/auth-and-billing.md
+++ b/contrib/skills/qoderwork/oo/references/auth-and-billing.md
@@ -1,0 +1,51 @@
+# Auth and Billing
+
+Read this file only when command availability, authentication, or billing state
+becomes relevant.
+
+## Operating principle
+
+- Try the intended remote `oo` command first.
+- Do not run `oo auth status` as a routine precheck.
+- Check auth only when command output suggests auth may be the blocker.
+
+## Remote commands that depend on the current account
+
+- `oo search`
+- `oo packages info`
+- `oo connector search`
+- `oo connector run`
+- `oo file upload`
+- `oo cloud-task run`
+- `oo cloud-task result`
+- `oo cloud-task wait`
+
+## If auth may be the blocker
+
+Run:
+
+```bash
+oo auth status
+```
+
+Interpret the result this way:
+
+- If the output confirms a valid active account, continue troubleshooting the
+  selected `oo` path instead of blaming auth.
+- If the status is logged out, missing, invalid, or the request fails, stop the
+  current `oo` path and ask the user to repair authentication first.
+
+When the user needs to repair auth, guide them to:
+
+```bash
+oo auth login
+```
+
+## Billing is a separate blocker
+
+- If any `oo` command output shows HTTP `402` or includes the string
+  `OOMOL_INSUFFICIENT_CREDIT`, stop immediately.
+- Treat that signal as a billing problem, not as a normal auth failure.
+- Explain that the current account has insufficient credit or is overdue.
+- Ask the user to recharge before retrying at
+  https://console.oomol.com/billing/recharge.

--- a/contrib/skills/qoderwork/oo/references/connector-execution.md
+++ b/contrib/skills/qoderwork/oo/references/connector-execution.md
@@ -1,0 +1,137 @@
+# Connector Execution
+
+Read this file only after selecting a connector-backed candidate.
+
+## Goal
+
+Confirm the connector action from the cached schema, then send the smallest
+JSON payload that matches the user's real intent.
+
+## Confirm the action from the cached schema
+
+- Use the chosen search result's `service`, `name`, and `schemaPath` as the
+  starting point.
+- Read the cached JSON file at `schemaPath` before building any payload.
+- Use the cache file's exact `service`, `name`, `description`, `inputSchema`,
+  and `outputSchema` to confirm the action fit.
+- Never invent connector names, action names, defaults, or task results.
+- Prefer the action whose description most directly matches the user's desired
+  outcome, especially when the user named the target service.
+
+Representative cache file shape:
+
+```json
+{
+  "description": "Send a Gmail message.",
+  "inputSchema": {},
+  "name": "send_mail",
+  "outputSchema": {},
+  "service": "gmail"
+}
+```
+
+## Build the smallest valid payload
+
+- Use the action's cached `inputSchema` and normal JSON Schema required-field
+  semantics before submitting data.
+- Prefer concrete user values over broad placeholders or guessed defaults.
+- If an input can accept a URI and the user only has a local file, read
+  [file-transfer.md](file-transfer.md) before executing.
+- If the task depends on raw file bytes, local paths, or unsupported
+  special-media handles that cannot be submitted safely through normal JSON,
+  stop the current `oo` path instead of pretending it will work.
+
+## Execute the connector path
+
+Canonical form:
+
+```bash
+oo connector run "<serviceName>" \
+  --action "<actionName>" \
+  --data '<json object>' \
+  --json
+```
+
+Facts:
+
+- `serviceName` is the only positional argument.
+- `--action` is required and selects the connector action name.
+- `--data` must be a JSON object string or `@path/to/file.json`.
+- If `--data` is omitted, the CLI uses `{}`.
+- `--json` returns a stable JSON object for execution output.
+- Once the payload is ready, execute the action directly instead of stopping at
+  a validation-only preflight.
+- In execution responses, the execution id is nested under
+  `meta.executionId`, not a top-level field.
+
+Expected execution JSON:
+
+```json
+{
+  "data": {},
+  "meta": {
+    "executionId": "execution-id"
+  }
+}
+```
+
+## Known connector caveats
+
+- Unknown input handles, missing required values, wrong types, or non-object
+  `--data` payloads are rejected.
+- If an input schema contains `contentMediaType` and the value is not
+  `oomol/secret`, current local validation rejects it.
+
+## Interpret outputs by meaning, not by URL shape
+
+- If a handle is URI-compatible, a previously uploaded file's `downloadUrl`
+  may be submitted as the JSON value.
+- Interpret connector output fields by their documented meaning, not by URL
+  shape alone.
+- Treat browse metadata such as `webViewLink`, edit URLs, folder URLs, or
+  console URLs as non-downloadable unless the schema or action description says
+  they return file content.
+- For authenticated storage connectors, if the user wants a local copy of a
+  private file, prefer a dedicated action whose `description` identifies it as
+  a download or export action and whose `outputSchema` exposes a download URL
+  field before `oo file download`.
+
+## Storage-style connectors
+
+### Goal
+
+When the connector manages user files (for example Google Drive, Dropbox,
+OneDrive), separate locating the target from materializing its bytes so the
+download step receives a real file URL, not a browse link.
+
+### Heuristics
+
+- Treat `find_*` and `list_*` outputs as metadata: they answer "which file",
+  not "give me the bytes".
+- Reach for a dedicated download or export action whose `description` says it
+  returns file content and whose `outputSchema` exposes a download URL field
+  (for example `transitUrl` on `googledrive.download_file`).
+- Feed that download URL — not `webViewLink`, edit URLs, or folder URLs — to
+  `oo file download`.
+- If the same connector offers several find-style actions, prefer the one whose
+  filters match the user's locator (by name, by id, by folder) so the result is
+  a single file rather than a list to pick from later.
+
+## Re-authorization branches
+
+Inspect `errorCode` before broader troubleshooting:
+
+- `scope_missing`: explain that the connector authorization is missing the
+  required scope and must be re-authorized
+- `credential_expired`: explain that the connector authorization has expired
+  and must be re-authorized
+- `app_not_ready` / `app_not_found`: explain that the connector has not been
+  authorized yet and must be authorized before retrying
+
+For those cases, guide the user to:
+
+```text
+https://console.oomol.com/app-connections?provider=${serviceName}
+```
+
+Replace `${serviceName}` with the selected connector service.

--- a/contrib/skills/qoderwork/oo/references/file-transfer.md
+++ b/contrib/skills/qoderwork/oo/references/file-transfer.md
@@ -1,0 +1,108 @@
+# File Transfer
+
+Read this file only when a selected input needs a file-like value or when a
+remote result artifact should be saved locally.
+
+## Goal
+
+Move files into or out of the selected `oo` path without inventing alternate
+transfer workflows.
+
+## Default transfer rules
+
+- Upload only when the selected `oo` input expects a URI-like value and the
+  user currently has a local file.
+- Download only when the current `oo` path exposes an explicit artifact URL.
+- Reuse an existing suitable remote URL instead of uploading the same content
+  again.
+- For transfers within this skill, use `oo file upload` and `oo file download`
+  rather than ad hoc downloaders or uploaders.
+
+## Upload a local file for a URI-compatible input
+
+Canonical form:
+
+```bash
+oo file upload "<filePath>" --json
+```
+
+Facts:
+
+- `<filePath>` is a local file path.
+- `--json` is an alias for `--format=json`.
+- Successful JSON output includes `downloadUrl`, `expiresAt`, `fileName`,
+  `fileSize`, `id`, `status`, and `uploadedAt`.
+- The uploaded file expires after one day.
+- Files larger than `512 MiB` are rejected.
+
+Use this command when:
+
+- The selected package handle or connector input can safely accept a URI string
+- The user currently has only a local file path
+
+Rules:
+
+- Reuse a user-provided remote URL when it already satisfies the same URI input.
+- Submit the returned `downloadUrl` in `--data`.
+- Do not treat file upload as a way to pass raw bytes or bypass unsupported
+  `contentMediaType` validation.
+
+## Download a remote artifact locally
+
+Canonical form:
+
+```bash
+oo file download "<url>" [outDir] [--name "<name>"] [--ext "<ext>"]
+```
+
+Facts:
+
+- `<url>` must use the `http` or `https` scheme.
+- `[outDir]` is optional. When omitted, the CLI uses the configured
+  `file.download.out_dir` value if present, otherwise `~/Downloads`.
+- Missing directories are created automatically.
+- This command does not support `--json` or `--format=json`.
+- Successful saves print one localized human-readable line on stdout that
+  includes the absolute saved path.
+
+## What counts as a downloadable artifact
+
+- Use `oo file download` only for explicit download artifacts exposed by the
+  current `oo` execution path.
+- For package tasks (`oo cloud-task`): the artifact is the `resultURL` field
+  returned by `oo cloud-task result --json`. See
+  [task-lifecycle.md](task-lifecycle.md). When `resultURL` is `null` or
+  absent, there is no downloadable artifact. Do not synthesize one from
+  `resultData` or logs.
+- For connector actions (`oo connector run`): the artifact is whatever the
+  action's `outputSchema` documents as a download URL, for example
+  `transitUrl` on `googledrive.download_file`. Treat browse metadata such as
+  `webViewLink`, edit URLs, folder URLs, or console pages as non-downloadable.
+  If only metadata came back, run a connector action whose `description`
+  identifies it as a download or export action and whose `outputSchema`
+  exposes a download URL field first — see
+  [connector-execution.md](connector-execution.md) for the storage-connector
+  decision tree.
+
+## Naming guidance
+
+- Pass `--name "<descriptive base name>"` when the inferred filename would be
+  opaque, such as a UUID, hash, task id, or generic `download` label.
+- Preserve the inferred extension unless the user explicitly needs a different
+  one.
+- Omit `[outDir]` unless the user asked for a specific destination.
+
+## Execution rules
+
+- Use `oo file download` as the only downloader for remote artifacts produced by
+  `oo`.
+- Do not probe the same URL first with `curl`, `wget`, Python, browser
+  automation, or any other downloader.
+- Do not run `oo file download` in parallel with another download command for
+  the same artifact.
+
+Failure cases:
+
+- invalid URL
+- non-directory `outDir`
+- non-success HTTP response

--- a/contrib/skills/qoderwork/oo/references/package-execution.md
+++ b/contrib/skills/qoderwork/oo/references/package-execution.md
@@ -1,0 +1,137 @@
+# Package Execution
+
+Read this file only after selecting a package-backed candidate.
+
+## Goal
+
+Use package metadata to confirm that the package and block really match the
+user's requested outcome, then build the smallest payload that expresses the
+real user inputs.
+
+## Confirm the package and block fit
+
+Canonical form:
+
+```bash
+oo packages info "<packageSpecifier>" --json
+```
+
+Supported package specifier examples:
+
+- `pdf`
+- `pdf@1.0.0`
+- `@foo/epub`
+- `@foo/epub@1.0.0`
+
+Facts:
+
+- If no version is provided, the CLI resolves the latest version.
+- `@latest` is accepted by `oo packages info`, but `oo cloud-task run` rejects
+  it and requires an explicit semver version.
+- For execution, always use the resolved `packageVersion`.
+- Use `blocks[].blockName` for `--block-id`.
+- Do not confuse block `title` with `blockName`.
+- Never invent package IDs, versions, block IDs, defaults, or task results.
+- Use the package and block descriptions to confirm fit before building data.
+
+Expected JSON shape:
+
+```json
+{
+  "blocks": [
+    {
+      "blockName": "main",
+      "description": "string",
+      "inputHandle": {
+        "inputName": {
+          "description": "string",
+          "nullable": false,
+          "schema": {
+            "type": "string"
+          },
+          "value": "optional default value"
+        }
+      },
+      "outputHandle": {
+        "outputName": {
+          "description": "string",
+          "schema": {
+            "type": "string"
+          }
+        }
+      },
+      "title": "Main"
+    }
+  ],
+  "description": "string",
+  "displayName": "Readable package title",
+  "packageName": "package-name",
+  "packageVersion": "1.2.3"
+}
+```
+
+## Choose the right block
+
+- Prefer the block whose description and expected output most directly match the
+  user's requested result.
+- Do not assume `main` is automatically the right block unless the metadata
+  supports that.
+- If two blocks are plausible, keep one primary block and at most one fallback.
+
+## Build the smallest valid payload
+
+Treat an input handle as optional only when metadata proves it:
+
+- `value` exists and is not `null`
+- `nullable` is `true` and `value` is `null`
+- `schema.default` exists
+
+These signals only show that omission may pass local validation. They do not
+prove that the package-provided value is correct for the current user request.
+
+- Override sample values, placeholders, empty strings, and defaults whenever
+  the user request implies a specific input.
+- Use only fields the selected block actually exposes.
+- Prefer the user's exact file type, language pair, target format, or style
+  constraint over generic defaults.
+- Stop when the selected block depends on an input shape that `oo-cli` cannot
+  safely submit.
+- If a file-like handle expects a URI-compatible string, read
+  [file-transfer.md](file-transfer.md) before building the payload.
+
+## Execute the package path
+
+Canonical form:
+
+```bash
+oo cloud-task run "<packageName>@<version>" \
+  --block-id "<blockName>" \
+  --data '<json object>' \
+  --json
+```
+
+Facts:
+
+- The package specifier must contain an explicit semver version.
+- `--block-id` is required.
+- `--data` must be a JSON object string or `@path/to/file.json`.
+- If `--data` is omitted, the CLI uses `{}`.
+
+Expected success JSON:
+
+```json
+{
+  "taskID": "task-id"
+}
+```
+
+## Known package caveats
+
+- Unknown input handles, missing required values, wrong types, or non-object
+  `--data` payloads are rejected.
+- File-like inputs usually need a remote URI string, not a local path or raw
+  bytes.
+- If an input handle schema contains `contentMediaType` and the value is not
+  `oomol/secret`, current local validation rejects it.
+- After a successful run returns `taskID`, read
+  [task-lifecycle.md](task-lifecycle.md).

--- a/contrib/skills/qoderwork/oo/references/search-and-selection.md
+++ b/contrib/skills/qoderwork/oo/references/search-and-selection.md
@@ -1,0 +1,159 @@
+# Search and Selection
+
+Read this file before the first `oo search` call and whenever choosing between a
+package path and a connector path.
+
+## Goal
+
+Find the most direct documented `oo` capability with as little search churn as
+possible.
+
+## Start with one English goal sentence for the current external step
+
+Turn the user request into one short English sentence that describes the
+desired outcome for the current search step.
+
+For short multi-step workflows, do not force the whole workflow into one search
+query. Break the task into a short ordered chain of subgoals and search the
+current unresolved external step first.
+
+Guidance:
+
+- Prefer `action + object + key constraint or target service`.
+- Keep the first search intent outcome-oriented rather than implementation-led.
+- Preserve useful constraint words such as language pair, file type, output
+  format, or target service.
+- Avoid meta words such as `oo`, `CLI`, `search`, or `skill` unless the user
+  actually asked about them.
+
+Examples:
+
+- `extract text from a scanned Chinese PDF`
+- `translate a Japanese menu photo into English`
+- `send an email through Gmail with a PDF attachment`
+- `find a Google Drive file by name and download it`
+- `collect Gmail messages from yesterday`
+- `create a Notion page from prepared content`
+
+## Repair a weak first query
+
+Revise the first query when the result set shows that the query was too broad,
+too implementation-led, or missing a decisive constraint.
+
+Common repair moves:
+
+- Add the missing medium or file type.
+- Add the missing language pair, target service, or output format.
+- Replace implementation guesses with the user's actual desired outcome.
+- Remove filler words that do not narrow the capability choice.
+
+Examples:
+
+- Too broad: `translate image`
+  Better: `translate text in a Japanese image to English`
+- Too vague: `gmail`
+  Better: `send an email through Gmail`
+- Too implementation-led: `ocr pdf then markdown`
+  Better: `extract text from a scanned PDF and save it as Markdown`
+- Missing output target: `find Drive file`
+  Better: `find a Google Drive file by name and download it`
+- Missing format constraint: `translate contract PDF`
+  Better: `translate a scanned German contract PDF into English and return a DOCX`
+
+## Mixed discovery entrypoint
+
+Canonical form:
+
+```bash
+oo search "<text>" --json
+```
+
+Facts:
+
+- `oo search` performs one mixed discovery pass over package intent search and
+  connector action search.
+- `<text>` is one free-form query string, not multiple positional keywords.
+- `--json` returns a raw array, not an object wrapper.
+- The array mixes `package` and `connector` entries and uses `kind` as the
+  discriminator.
+- Package entries include stable fields such as `packageId`, `displayName`,
+  `description`, and `blocks`.
+- Connector entries include stable fields such as `service`, `name`,
+  `description`, `authenticated`, and `schemaPath`.
+- `--keywords` is optional and refines the connector side while keeping the
+  same free-form text query.
+
+Representative JSON example:
+
+```json
+[
+  {
+    "blocks": [
+      {
+        "description": "",
+        "name": "main",
+        "title": "Generate QR Code"
+      }
+    ],
+    "description": "Generate a QR code image.",
+    "displayName": "QR Tools",
+    "kind": "package",
+    "packageId": "@oomol/qr-tools@1.2.3"
+  },
+  {
+    "authenticated": true,
+    "description": "Send an email through Gmail.",
+    "kind": "connector",
+    "name": "send_mail",
+    "schemaPath": "<XDG_CONFIG_HOME>/oo/connector-actions/gmail/send_mail.json",
+    "service": "gmail"
+  }
+]
+```
+
+## How to rank the first result set
+
+- Use `oo search` as the default first substantive lookup.
+- The first search call should use one quoted free-form query string plus
+  `--json`.
+- For short multi-step workflows, the query should describe the current
+  external step, not the whole chain.
+- Inspect the first result set before trying alternative searches.
+- Revise the query only when the first result set clearly missed a decisive
+  constraint or pulled the search toward the wrong capability family.
+- Usually keep one primary candidate and at most one materially different
+  fallback.
+- If a package and a connector are equally direct, prefer the authenticated
+  connector as a tie-breaker because it is usually lower friction and cheaper.
+- If the returned array is empty or no candidate clearly fits, explain that the
+  current `oo` catalog does not expose a good match and stop the current `oo`
+  path.
+
+Rank mixed results in this order:
+
+1. Directness of the action or block relative to the user's goal
+2. Whether the service or output target is explicitly named or strongly implied
+3. Whether the candidate is already authenticated and ready to run
+4. How many required inputs and follow-up questions it adds
+5. How closely the expected output matches the user's desired outcome
+
+## Refinement moves
+
+- Inspect only the shortlisted candidates.
+- For package-backed candidates, inspect with `oo packages info` before
+  execution.
+- For connector-backed candidates, read the cached schema file at `schemaPath`
+  before building any payload.
+- If extra refinement is needed, use `--keywords` or a later follow-up search
+  after inspecting the first result set.
+- Do not pass normalized keywords as extra positional arguments.
+- Use `--keywords` when the first search captured the general task but missed an
+  important service, format, or language constraint.
+- If connector signal is still ambiguous after shortlisting, refine with:
+
+```bash
+oo connector search "<text>" --json
+```
+
+- Use `oo connector search` only to refine a chosen connector path, not to
+  restart broad discovery from scratch.

--- a/contrib/skills/qoderwork/oo/references/task-lifecycle.md
+++ b/contrib/skills/qoderwork/oo/references/task-lifecycle.md
@@ -1,0 +1,83 @@
+# Task Lifecycle
+
+Read this file only after `oo cloud-task run` returns a `taskID`.
+
+## Goal
+
+Make progress without recreating work: wait in bounded windows, inspect the
+latest result snapshot, and only materialize artifacts after success.
+
+## Wait with a bounded window first
+
+Canonical form:
+
+```bash
+oo cloud-task wait "<taskId>" --timeout "<window>"
+```
+
+Facts:
+
+- `oo cloud-task wait` does not support `--json`.
+- It polls every `3` seconds.
+- Default timeout is `6h`.
+- Minimum timeout is `10s`.
+- Maximum timeout is `24h`.
+- Supported timeout formats include `1m`, `4h`, `120s`, and `360`.
+- Success exits with code `0` and prints text output.
+- Failed tasks print a result snapshot and then exit non-zero.
+- Timeout also exits non-zero.
+- While the task is still running, the CLI prints periodic status snapshots.
+
+## Waiting policy
+
+- Prefer a short bounded wait window first instead of a single long wait.
+- Do not treat timeout as task failure.
+- Never re-create a task just because a wait window ended.
+- If wait output shows HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`, stop and send
+  the user to https://console.oomol.com/billing/recharge.
+
+## Inspect the latest result snapshot
+
+Canonical form:
+
+```bash
+oo cloud-task result "<taskId>" --json
+```
+
+Possible JSON shapes:
+
+```json
+{
+  "progress": 0.5,
+  "status": "queued"
+}
+```
+
+```json
+{
+  "resultData": {},
+  "resultURL": null,
+  "status": "success"
+}
+```
+
+```json
+{
+  "error": "message",
+  "status": "failed"
+}
+```
+
+## Interpret the latest state
+
+- In-progress statuses include `queued`, `scheduling`, `scheduled`, and
+  `running`. Treat any of them as non-terminal.
+- Use `oo cloud-task result` after a non-zero wait exit to distinguish timeout,
+  failure, and a late success.
+- If the result snapshot contains HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`,
+  treat it as a billing problem and stop instead of retrying.
+- If the task succeeded and `resultURL` is present, read
+  [file-transfer.md](file-transfer.md) before downloading the artifact.
+- If the task succeeded and `resultURL` is missing or `null`, do not invent a
+  download URL from `resultData` or logs. Report the success using the returned
+  structured result instead.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -265,9 +265,10 @@ Before running a command, `oo` silently synchronizes managed skills for every
 supported host directory that already exists.
 
 - Bundled skills: `oo` ensures `oo` and `oo-find-skills` are installed for
-  each detected Codex, Claude Code, and OpenClaw host. Existing oo-managed
-  bundled skill targets are refreshed to the current `oo` version, except that
-  `0.0.0-development` startup runs do not refresh existing bundled targets.
+  each detected Codex, Claude Code, OpenClaw, and QoderWork host. Existing
+  oo-managed bundled skill targets are refreshed to the current `oo` version,
+  except that `0.0.0-development` startup runs do not refresh existing bundled
+  targets.
 - Published skills: when a published skill already has a local canonical copy
   under `<config-dir>/skills/registry/<skill-id>`, `oo` publishes that copy to
   any newly detected supported host that is missing it.
@@ -280,16 +281,17 @@ supported host directory that already exists.
 List oo-managed skills from supported local skill directories.
 
 - Ownership rule: the command scans each existing supported local skill root:
-  `${CODEX_HOME:-~/.codex}/skills`, `~/.claude/skills`, and
-  `${OPENCLAW_HOME:-~/.openclaw}/skills`. It keeps only child directories whose
-  `.oo-metadata.json` can be parsed and contains a non-empty `version`.
+  `${CODEX_HOME:-~/.codex}/skills`, `~/.claude/skills`,
+  `${OPENCLAW_HOME:-~/.openclaw}/skills`, and `~/.qoderwork/skills`. It keeps
+  only child directories whose `.oo-metadata.json` can be parsed and contains a
+  non-empty `version`.
 - Output: text output prints a summary line and one block per unique visible
   skill identity. Identical `name`/source/version installs across multiple
   hosts are folded into one block.
 - Ordering: bundled skills are listed first when present, with `oo` before
   `oo-find-skills` before `oo-create-skill`; the remaining skills are ordered
   by skill name. Host names within a block follow `Codex`,
-  `Claude Code`, `OpenClaw` order.
+  `Claude Code`, `OpenClaw`, `QoderWork` order.
 - Output: each skill block shows the skill name, host, source package or
   bundled/local marker, and recorded version.
 - Notes: when a folded skill is installed in multiple supported hosts, the
@@ -300,7 +302,7 @@ List oo-managed skills from supported local skill directories.
 Check whether this environment has permission to edit local skills.
 
 - Options: `--agent <agent>` restricts the host check to one supported agent:
-  `codex`, `claude`, or `openclaw`.
+  `codex`, `claude`, `openclaw`, or `qoderwork`.
 - Host check: without `--agent`, at least one supported agent home directory
   must already exist. With `--agent`, that specific agent home directory must
   exist.
@@ -334,7 +336,8 @@ directory that already exists.
 - Target directories: the command publishes directory links to each existing
   supported agent skill directory:
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`, `~/.claude/skills/<skill-id>`,
-  and `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`.
+  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
+  `~/.qoderwork/skills/<skill-id>`.
 - Failure behavior: if no supported agent home exists, or if the canonical
   local directory or any target directory already exists, the command exits
   non-zero before writing the skill.
@@ -402,7 +405,7 @@ Install bundled or published skills into supported local skill directories.
 - Canonical directory: bundled skills are materialized under
   `<config-dir>/skills/bundled/<agent>/<skill-id>`, where `<config-dir>` is the
   directory that contains `settings.toml` and `<agent>` is `codex`, `claude`,
-  or `openclaw`.
+  `openclaw`, or `qoderwork`.
 - Canonical directory: published skills are materialized to
   `<config-dir>/skills/registry/<skill-id>`.
 - Migration: on first run after upgrading, `oo skills install` removes legacy
@@ -414,15 +417,16 @@ Install bundled or published skills into supported local skill directories.
 - Target directory: bundled and published skills are published to each existing
   supported host directory, currently
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`,
-  `~/.claude/skills/<skill-id>`, and
-  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`.
+  `~/.claude/skills/<skill-id>`,
+  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
+  `~/.qoderwork/skills/<skill-id>`.
 - Path rule: published skill names are accepted only when their resolved
   canonical and target directories remain under those local `skills` roots.
-- Installation mode: bundled and published Codex and Claude Code skills are
-  published to the target directory as a symlink to the canonical directory
-  when the current platform and environment allow it. When symlink creation
-  fails, `oo` falls back to copying the canonical files into the target skills
-  directory.
+- Installation mode: bundled and published Codex, Claude Code, and QoderWork
+  skills are published to the target directory as a symlink to the canonical
+  directory when the current platform and environment allow it. When symlink
+  creation fails, `oo` falls back to copying the canonical files into the
+  target skills directory.
 - Installation mode: bundled and published OpenClaw skills are copied into
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>` so the installed skill
   stays inside OpenClaw's managed skills root.
@@ -443,7 +447,7 @@ Install bundled or published skills into supported local skill directories.
 - Notes: in the interactive picker, conflicting skills are marked in the list;
   selecting one means it will be overwritten.
 - Notes: the command exits with an error when none of the supported Codex,
-  Claude Code, or OpenClaw home directories exists.
+  Claude Code, OpenClaw, or QoderWork home directories exists.
 - Notes: an existing bundled skill installation is considered managed by `oo`
   only when its `.oo-metadata.json` file can be parsed and contains a
   non-empty `version`. Otherwise `oo` treats it as a different skill and will
@@ -489,7 +493,8 @@ Remove oo-managed skills from supported local skill directories.
 - Target directory removed: bundled and published skills are removed from every
   existing supported host directory, currently
   `${CODEX_HOME:-~/.codex}/skills/<skill>`, `~/.claude/skills/<skill>`, and
-  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`.
+  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`, and
+  `~/.qoderwork/skills/<skill>`.
 - Path rule: `[skill]` must resolve to child directories under those local
   `skills` roots. Names that escape those roots are rejected.
 - Notes: when no supported target has a managed installation for the requested

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -233,8 +233,9 @@
 在执行具体命令前，`oo` 会为已经存在的受支持宿主目录静默同步受管理的
 skills。
 
-- 内置 skill：`oo` 会确保每个检测到的 Codex、Claude Code 和 OpenClaw 宿主
-  都安装了 `oo` 与 `oo-find-skills`。已经由 oo 管理的内置 skill 目标会刷新
+- 内置 skill：`oo` 会确保每个检测到的 Codex、Claude Code、OpenClaw 和
+  QoderWork 宿主都安装了 `oo` 与 `oo-find-skills`。已经由 oo 管理的内置
+  skill 目标会刷新
   到当前 `oo` 版本；但当启动中的当前版本为 `0.0.0-development` 时，不会刷新
   已存在的内置 skill 目标。
 - 已发布 skill：如果某个已发布 skill 已经有本地 canonical 副本
@@ -249,13 +250,14 @@ skills。
 
 - 所有权规则：命令会扫描每个已存在的受支持本地 skill 根目录：
   `${CODEX_HOME:-~/.codex}/skills`、`~/.claude/skills`，以及
-  `${OPENCLAW_HOME:-~/.openclaw}/skills`。只保留包含可解析
-  `.oo-metadata.json` 且其中包含非空 `version` 的子目录。
+  `${OPENCLAW_HOME:-~/.openclaw}/skills`、`~/.qoderwork/skills`。只保留包含
+  可解析 `.oo-metadata.json` 且其中包含非空 `version` 的子目录。
 - 输出：文本输出会先打印摘要行，再为每个唯一的可见 skill 身份打印一个块。
   如果多个宿主中的安装具有相同 `name`、来源和版本，则会折叠到同一个块中。
 - 排序：bundled skills 会排在最前面；其中 `oo` 优先，其次
-  `oo-find-skills`，再其次 `oo-create-skill`；其余 skill 按名称排序。每个块内的宿主名称按 `Codex`、
-  `Claude Code`、`OpenClaw` 顺序显示。
+  `oo-find-skills`，再其次 `oo-create-skill`；其余 skill 按名称排序。每个
+  块内的宿主名称按 `Codex`、`Claude Code`、`OpenClaw`、`QoderWork`
+  顺序显示。
 - 输出：每个 skill 块会显示 skill 名称、宿主、来源 package、内置或本地标记，以
   及记录的版本号。
 - 说明：如果折叠后的 skill 安装在多个受支持宿主中，`宿主` 字段会列出所有
@@ -266,7 +268,7 @@ skills。
 检查当前环境是否有权限编辑本地 skills。
 
 - 选项：`--agent <agent>` 将宿主检查限制为一个受支持 agent：`codex`、
-  `claude` 或 `openclaw`。
+  `claude`、`openclaw` 或 `qoderwork`。
 - 宿主检查：未提供 `--agent` 时，至少需要存在一个受支持 agent home 目录。
   提供 `--agent` 时，该指定 agent home 目录必须存在。
 - 存储检查：命令会在需要时创建 `<config-dir>/skills/local` 和每个已检查宿主
@@ -293,7 +295,8 @@ skills。
   其中 `<config-dir>` 是 oo settings 文件所在目录。
 - 目标目录：命令会向每个已存在的受支持 agent skill 目录发布目录链接：
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`、`~/.claude/skills/<skill-id>`，
-  以及 `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`。
+  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`，以及
+  `~/.qoderwork/skills/<skill-id>`。
 - 失败行为：如果没有受支持的 agent home，或 canonical 本地目录、任意目标目录
   已存在，命令会在写入 skill 前以非零状态退出。
 - 输出：文本输出会先打印 canonical 存储目录，然后为每个目标路径打印一行带实际发布
@@ -351,7 +354,8 @@ skills。
   如果用户取消这些勾选，命令完成时会移除对应已安装 skill。
 - canonical 目录：内置 skill 会先释放到
   `<config-dir>/skills/bundled/<agent>/<skill-id>`，其中 `<config-dir>` 是
-  `settings.toml` 所在目录，`<agent>` 为 `codex`、`claude` 或 `openclaw`。
+  `settings.toml` 所在目录，`<agent>` 为 `codex`、`claude`、`openclaw`
+  或 `qoderwork`。
 - canonical 目录：已发布 skill 会先释放到
   `<config-dir>/skills/registry/<skill-id>`。
 - 迁移：升级后首次运行 `oo skills install` 时，命令会清理历史遗留的 canonical
@@ -361,10 +365,11 @@ skills。
 - 目标目录：内置和已发布 skill 会发布到所有已存在的受支持宿主目录，目前包括
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>` 和
   `~/.claude/skills/<skill-id>`，以及
-  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`。
-- 安装方式：内置和已发布的 Codex / Claude Code skill 会优先把目标目录发布
-  为指向 canonical 目录的软连接。如果当前平台或环境下创建软连接失败，则会
-  回退为把 canonical 目录内容复制到目标 skills 目录。
+  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`、
+  `~/.qoderwork/skills/<skill-id>`。
+- 安装方式：内置和已发布的 Codex / Claude Code / QoderWork skill 会优先把
+  目标目录发布为指向 canonical 目录的软连接。如果当前平台或环境下创建软连接
+  失败，则会回退为把 canonical 目录内容复制到目标 skills 目录。
 - 安装方式：内置和已发布的 OpenClaw skill 会直接复制到
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`，以确保安装后的 skill
   保持在 OpenClaw 管理的 skills 根目录内。
@@ -383,8 +388,8 @@ skills。
   skill，命令不会覆盖它。
 - 说明：在交互选择页面中，存在重名冲突的 skill 会在列表中显示状态标记；
   只要用户仍然选择该项，就会执行覆盖。
-- 说明：当 Codex、Claude Code 和 OpenClaw 的受支持根目录都不存在时，命令
-  会直接报错退出。
+- 说明：当 Codex、Claude Code、OpenClaw 和 QoderWork 的受支持根目录都不
+  存在时，命令会直接报错退出。
 - 说明：只有当 bundled skill 的 `.oo-metadata.json` 可以被解析，且其中包
   含非空的 `version` 时，`oo` 才会认为这是自己管理的内置 skill；否则会视
   为其他 skill，并拒绝覆盖。
@@ -422,7 +427,8 @@ skills。
 - 会同时移除目标目录：内置和已发布 skill 会从所有已存在的受支持宿主目录中
   移除，目前包括 `${CODEX_HOME:-~/.codex}/skills/<skill>` 和
   `~/.claude/skills/<skill>`，以及
-  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`。
+  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`、
+  `~/.qoderwork/skills/<skill>`。
 - 路径规则：`[skill]` 解析后必须仍然落在这些本地 `skills` 根目录的子目录中。
   任何会逃出这些根目录的名称都会被拒绝。
 - 说明：如果请求的 skill 在任何受支持目标中都不存在受管理安装，或某个已存在

--- a/src/application/commands/skills/bundled-skill-observation.test.ts
+++ b/src/application/commands/skills/bundled-skill-observation.test.ts
@@ -162,4 +162,30 @@ describe("bundled skill observation", () => {
             await rm(rootDirectory, { force: true, recursive: true });
         }
     });
+
+    test("requires the resolved QoderWork home directory to exist", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const qoderWorkHomeDirectory = join(rootDirectory, ".qoderwork");
+        const env = {
+            HOME: rootDirectory,
+        };
+
+        try {
+            await expect(
+                requireBundledSkillHomeDirectory({ env }, "qoderwork"),
+            ).rejects.toMatchObject({
+                exitCode: 1,
+                key: "errors.skills.qoderworkNotInstalled",
+            });
+
+            await mkdir(qoderWorkHomeDirectory, { recursive: true });
+
+            expect(await requireBundledSkillHomeDirectory({ env }, "qoderwork")).toBe(
+                qoderWorkHomeDirectory,
+            );
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
 });

--- a/src/application/commands/skills/bundled-skill-observation.ts
+++ b/src/application/commands/skills/bundled-skill-observation.ts
@@ -11,6 +11,7 @@ import {
     resolveBundledSkillHomeDirectory,
     resolveBundledSkillMetadataFilePath,
 } from "./bundled-skill-paths.ts";
+import { resolveManagedSkillHostMissingErrorKey } from "./managed-skill-host-errors.ts";
 import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 export async function requireBundledSkillHomeDirectory(
@@ -23,7 +24,7 @@ export async function requireBundledSkillHomeDirectory(
     );
 
     if (!(await directoryExists(homeDirectory))) {
-        const missingHostErrorKey = resolveBundledSkillHostMissingErrorKey(agentName);
+        const missingHostErrorKey = resolveManagedSkillHostMissingErrorKey(agentName);
 
         throw new CliUserError(
             missingHostErrorKey,
@@ -41,19 +42,6 @@ export async function requireCodexHomeDirectory(
     context: Pick<{ env: Record<string, string | undefined> }, "env">,
 ): Promise<string> {
     return requireBundledSkillHomeDirectory(context, "codex");
-}
-
-function resolveBundledSkillHostMissingErrorKey(
-    agentName: BundledSkillAgentName,
-): "errors.skills.claudeNotInstalled" | "errors.skills.codexNotInstalled" | "errors.skills.openclawNotInstalled" {
-    switch (agentName) {
-        case "claude":
-            return "errors.skills.claudeNotInstalled";
-        case "codex":
-            return "errors.skills.codexNotInstalled";
-        case "openclaw":
-            return "errors.skills.openclawNotInstalled";
-    }
 }
 
 export async function directoryExists(path: string): Promise<boolean> {

--- a/src/application/commands/skills/bundled-skill-paths.ts
+++ b/src/application/commands/skills/bundled-skill-paths.ts
@@ -6,6 +6,7 @@ import { resolveHomeDirectory } from "../../path/home-directory.ts";
 const codexDirectoryName = ".codex";
 const claudeDirectoryName = ".claude";
 const openClawDirectoryName = ".openclaw";
+const qoderWorkDirectoryName = ".qoderwork";
 export const codexSkillsDirectoryName = "skills";
 export const canonicalBundledSkillsDirectoryName = "bundled";
 export const canonicalLocalSkillsDirectoryName = "local";
@@ -43,6 +44,12 @@ export function resolveOpenClawHomeDirectory(
     return join(resolveHomeDirectory(env), openClawDirectoryName);
 }
 
+export function resolveQoderWorkHomeDirectory(
+    env: Record<string, string | undefined>,
+): string {
+    return join(resolveHomeDirectory(env), qoderWorkDirectoryName);
+}
+
 export function resolveBundledSkillHomeDirectory(
     env: Record<string, string | undefined>,
     agentName: BundledSkillAgentName,
@@ -54,6 +61,8 @@ export function resolveBundledSkillHomeDirectory(
             return resolveCodexHomeDirectory(env);
         case "openclaw":
             return resolveOpenClawHomeDirectory(env);
+        case "qoderwork":
+            return resolveQoderWorkHomeDirectory(env);
     }
 }
 

--- a/src/application/commands/skills/check.test.ts
+++ b/src/application/commands/skills/check.test.ts
@@ -9,6 +9,7 @@ import { APP_NAME } from "../../config/app-config.ts";
 import {
     resolveClaudeHomeDirectory,
     resolveCodexHomeDirectory,
+    resolveQoderWorkHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { resolveLocalSkillCanonicalRootDirectoryPath } from "./managed-skill-paths.ts";
 
@@ -67,6 +68,40 @@ describe("skills preflight command", () => {
             expect(result.stderr).toBe(
                 `Codex is not installed. Expected the Codex home directory at ${codexHomeDirectory}.\n`,
             );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("checks QoderWork as a requested agent", async () => {
+        const sandbox = await createCliSandbox();
+        const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalRootDirectoryPath = resolveLocalSkillCanonicalRootDirectoryPath(
+            storePaths.settingsFilePath,
+        );
+
+        try {
+            await mkdir(qoderWorkHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "preflight",
+                "--agent",
+                "qoderwork",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Local skill editing is ready. Writable storage: ${canonicalRootDirectoryPath}. Supported hosts: 1.\n`,
+            );
+            expect(await readdir(canonicalRootDirectoryPath)).toEqual([]);
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/check.ts
+++ b/src/application/commands/skills/check.ts
@@ -13,6 +13,7 @@ import {
     resolveBundledSkillHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { availableBundledSkillAgentNames } from "./embedded-assets.ts";
+import { resolveManagedSkillHostMissingErrorKey } from "./managed-skill-host-errors.ts";
 import {
     createMissingManagedSkillHostError,
     resolveAvailableManagedSkillHosts,
@@ -120,19 +121,6 @@ function createMissingRequestedManagedSkillHostError(
             path: homeDirectory,
         },
     );
-}
-
-function resolveManagedSkillHostMissingErrorKey(
-    agentName: BundledSkillAgentName,
-): "errors.skills.claudeNotInstalled" | "errors.skills.codexNotInstalled" | "errors.skills.openclawNotInstalled" {
-    switch (agentName) {
-        case "claude":
-            return "errors.skills.claudeNotInstalled";
-        case "codex":
-            return "errors.skills.codexNotInstalled";
-        case "openclaw":
-            return "errors.skills.openclawNotInstalled";
-    }
 }
 
 async function verifyWritableDirectory(directoryPath: string): Promise<void> {

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -41,6 +41,15 @@ describe("embedded skill assets", () => {
             "references/file-transfer.md",
             "references/task-lifecycle.md",
         ]);
+        expect(getBundledSkillFiles("oo", "qoderwork").map(file => file.relativePath)).toEqual([
+            "SKILL.md",
+            "references/auth-and-billing.md",
+            "references/search-and-selection.md",
+            "references/package-execution.md",
+            "references/connector-execution.md",
+            "references/file-transfer.md",
+            "references/task-lifecycle.md",
+        ]);
         expect(
             getBundledSkillFiles("oo-find-skills", "codex").map(
                 file => file.relativePath,
@@ -60,6 +69,14 @@ describe("embedded skill assets", () => {
         ]);
         expect(
             getBundledSkillFiles("oo-find-skills", "openclaw").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+            "references/oo-cli-contract.md",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-find-skills", "qoderwork").map(
                 file => file.relativePath,
             ),
         ).toEqual([
@@ -88,10 +105,22 @@ describe("embedded skill assets", () => {
         ).toEqual([
             "SKILL.md",
         ]);
+        expect(
+            getBundledSkillFiles("oo-create-skill", "qoderwork").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
     });
 
     test("maps bundled skills to contrib/skills/<agent>/<skill> source directories", () => {
-        expect([...availableBundledSkillAgentNames]).toEqual(["codex", "claude", "openclaw"]);
+        expect([...availableBundledSkillAgentNames]).toEqual([
+            "codex",
+            "claude",
+            "openclaw",
+            "qoderwork",
+        ]);
 
         for (const skillName of availableBundledSkillNames) {
             for (const agentName of availableBundledSkillAgentNames) {
@@ -116,10 +145,12 @@ describe("embedded skill assets", () => {
                 file => file.relativePath === "SKILL.md",
             );
 
-            expect(skillFile).toBeDefined();
+            if (skillFile === undefined) {
+                throw new Error(`Missing ${agentName} oo-create-skill SKILL.md`);
+            }
 
             const content = normalizeLineEndingsForAssertion(
-                await Bun.file(skillFile!.sourcePath).text(),
+                await Bun.file(skillFile.sourcePath).text(),
             );
 
             expect(content).toContain("Also pass `--title` and `--icon`.");
@@ -138,6 +169,21 @@ describe("embedded skill assets", () => {
             );
             expect(content).not.toContain(
                 "do\nnot add it by deriving a title from the skill name",
+            );
+        }
+    });
+
+    test("keeps QoderWork skill frontmatter free of Claude allowed tools", async () => {
+        for (const skillName of availableBundledSkillNames) {
+            const skillFile = getBundledSkillFiles(skillName, "qoderwork")
+                .find(file => file.relativePath === "SKILL.md");
+
+            if (skillFile === undefined) {
+                throw new Error(`Missing QoderWork SKILL.md for ${skillName}`);
+            }
+
+            expect(await Bun.file(skillFile.sourcePath).text()).not.toContain(
+                "allowed-tools",
             );
         }
     });

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -31,8 +31,18 @@ import ooOpenClawPackageExecutionReferencePath from "../../../../contrib/skills/
 import ooOpenClawSearchAndSelectionReferencePath from "../../../../contrib/skills/openclaw/oo/references/search-and-selection.md" with { type: "file" };
 import ooOpenClawTaskLifecycleReferencePath from "../../../../contrib/skills/openclaw/oo/references/task-lifecycle.md" with { type: "file" };
 import ooOpenClawSkillPath from "../../../../contrib/skills/openclaw/oo/SKILL.md" with { type: "file" };
+import ooCreateSkillQoderWorkSkillPath from "../../../../contrib/skills/qoderwork/oo-create-skill/SKILL.md" with { type: "file" };
+import ooFindSkillsQoderWorkCliContractPath from "../../../../contrib/skills/qoderwork/oo-find-skills/references/oo-cli-contract.md" with { type: "file" };
+import ooFindSkillsQoderWorkSkillPath from "../../../../contrib/skills/qoderwork/oo-find-skills/SKILL.md" with { type: "file" };
+import ooQoderWorkAuthAndBillingReferencePath from "../../../../contrib/skills/qoderwork/oo/references/auth-and-billing.md" with { type: "file" };
+import ooQoderWorkConnectorExecutionReferencePath from "../../../../contrib/skills/qoderwork/oo/references/connector-execution.md" with { type: "file" };
+import ooQoderWorkFileTransferReferencePath from "../../../../contrib/skills/qoderwork/oo/references/file-transfer.md" with { type: "file" };
+import ooQoderWorkPackageExecutionReferencePath from "../../../../contrib/skills/qoderwork/oo/references/package-execution.md" with { type: "file" };
+import ooQoderWorkSearchAndSelectionReferencePath from "../../../../contrib/skills/qoderwork/oo/references/search-and-selection.md" with { type: "file" };
+import ooQoderWorkTaskLifecycleReferencePath from "../../../../contrib/skills/qoderwork/oo/references/task-lifecycle.md" with { type: "file" };
+import ooQoderWorkSkillPath from "../../../../contrib/skills/qoderwork/oo/SKILL.md" with { type: "file" };
 
-export const availableBundledSkillAgentNames = ["codex", "claude", "openclaw"] as const;
+export const availableBundledSkillAgentNames = ["codex", "claude", "openclaw", "qoderwork"] as const;
 export type BundledSkillAgentName = (typeof availableBundledSkillAgentNames)[number];
 
 export const availableBundledSkillNames = ["oo", "oo-find-skills", "oo-create-skill"] as const;
@@ -76,6 +86,14 @@ const ooOpenClawReferenceFiles = createOoReferenceFiles({
     searchAndSelection: ooOpenClawSearchAndSelectionReferencePath,
     taskLifecycle: ooOpenClawTaskLifecycleReferencePath,
 });
+const ooQoderWorkReferenceFiles = createOoReferenceFiles({
+    authAndBilling: ooQoderWorkAuthAndBillingReferencePath,
+    connectorExecution: ooQoderWorkConnectorExecutionReferencePath,
+    fileTransfer: ooQoderWorkFileTransferReferencePath,
+    packageExecution: ooQoderWorkPackageExecutionReferencePath,
+    searchAndSelection: ooQoderWorkSearchAndSelectionReferencePath,
+    taskLifecycle: ooQoderWorkTaskLifecycleReferencePath,
+});
 
 // Keep this registry aligned with contrib/skills/<agent>/<skill> so Bun embeds the files.
 const bundledSkillRegistry = {
@@ -109,6 +127,15 @@ const bundledSkillRegistry = {
                     sourcePath: ooOpenClawSkillPath,
                 },
                 ...ooOpenClawReferenceFiles,
+            ],
+        },
+        qoderwork: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooQoderWorkSkillPath,
+                },
+                ...ooQoderWorkReferenceFiles,
             ],
         },
     },
@@ -153,6 +180,18 @@ const bundledSkillRegistry = {
                 },
             ],
         },
+        qoderwork: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooFindSkillsQoderWorkSkillPath,
+                },
+                {
+                    relativePath: "references/oo-cli-contract.md",
+                    sourcePath: ooFindSkillsQoderWorkCliContractPath,
+                },
+            ],
+        },
     },
     "oo-create-skill": {
         codex: {
@@ -180,6 +219,14 @@ const bundledSkillRegistry = {
                 {
                     relativePath: "SKILL.md",
                     sourcePath: ooCreateSkillOpenClawSkillPath,
+                },
+            ],
+        },
+        qoderwork: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCreateSkillQoderWorkSkillPath,
                 },
             ],
         },

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -26,6 +26,7 @@ import {
     resolveClaudeHomeDirectory,
     resolveCodexHomeDirectory,
     resolveOpenClawHomeDirectory,
+    resolveQoderWorkHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import {
     availableBundledSkillAgentNames,
@@ -435,6 +436,63 @@ describe("skills commands", () => {
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: "9.9.9" }),
             );
+            await expect(
+                stat(join(skillDirectoryPath, "agents", "openai.yaml")),
+            ).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("installs bundled skills into QoderWork without Claude allowed tools", async () => {
+        const sandbox = await createCliSandbox();
+        const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(qoderWorkHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+            "qoderwork",
+        );
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const skillFilePath = join(skillDirectoryPath, "SKILL.md");
+        const qoderWorkSkillFile = getBundledSkillFiles("oo", "qoderwork")
+            .find(file => file.relativePath === "SKILL.md");
+
+        try {
+            if (qoderWorkSkillFile === undefined) {
+                throw new Error("Missing QoderWork oo SKILL.md fixture");
+            }
+
+            await mkdir(qoderWorkHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "install", "oo"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Installed skill oo to ${skillDirectoryPath}.\n`,
+            );
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson({ version: "9.9.9" }),
+            );
+            const installedSkillMarkdown = await readFile(skillFilePath, "utf8");
+
+            expect(installedSkillMarkdown).toBe(
+                await Bun.file(qoderWorkSkillFile.sourcePath).text(),
+            );
+            expect(installedSkillMarkdown).not.toContain("allowed-tools");
             await expect(
                 stat(join(skillDirectoryPath, "agents", "openai.yaml")),
             ).rejects.toMatchObject({
@@ -1069,9 +1127,11 @@ describe("skills commands", () => {
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
         const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
+        const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
         const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
         const claudeSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
         const openClawSkillDirectoryPath = join(openClawHomeDirectory, "skills", "chatgpt");
+        const qoderWorkSkillDirectoryPath = join(qoderWorkHomeDirectory, "skills", "chatgpt");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
@@ -1087,6 +1147,7 @@ describe("skills commands", () => {
                 mkdir(codexHomeDirectory, { recursive: true }),
                 mkdir(claudeHomeDirectory, { recursive: true }),
                 mkdir(openClawHomeDirectory, { recursive: true }),
+                mkdir(qoderWorkHomeDirectory, { recursive: true }),
             ]);
             await writeAuthFile(sandbox);
 
@@ -1128,6 +1189,7 @@ describe("skills commands", () => {
                     `Installed skill chatgpt to ${codexSkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${claudeSkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${openClawSkillDirectoryPath}.`,
+                    `Installed skill chatgpt to ${qoderWorkSkillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );
@@ -1140,11 +1202,15 @@ describe("skills commands", () => {
             expect(await realpath(openClawSkillDirectoryPath)).not.toBe(
                 await realpath(canonicalSkillDirectoryPath),
             );
+            expect(await realpath(qoderWorkSkillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
             expect((await lstat(openClawSkillDirectoryPath)).isSymbolicLink()).toBeFalse();
             for (const skillDirectoryPath of [
                 codexSkillDirectoryPath,
                 claudeSkillDirectoryPath,
                 openClawSkillDirectoryPath,
+                qoderWorkSkillDirectoryPath,
             ]) {
                 expect(await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8")).toContain(
                     "# ChatGPT",

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -9,6 +9,7 @@ import {
     resolveClaudeHomeDirectory,
     resolveCodexHomeDirectory,
     resolveOpenClawHomeDirectory,
+    resolveQoderWorkHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
@@ -109,6 +110,49 @@ describe("skills list CLI", () => {
                     "",
                     "oo-create-skill",
                     "  Host: OpenClaw",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                ].join("\n"),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("lists startup-synchronized QoderWork bundled installs when Codex is not installed", async () => {
+        const sandbox = await createCliSandbox();
+        const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(qoderWorkHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install", "oo"], {
+                version: "9.9.9",
+            });
+
+            const result = await sandbox.run(["skills", "list"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    "✓ Found 3 oo-managed skills.",
+                    "",
+                    "oo",
+                    "  Host: QoderWork",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-find-skills",
+                    "  Host: QoderWork",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-create-skill",
+                    "  Host: QoderWork",
                     "  Source: bundled",
                     "  Version: 9.9.9",
                     "",

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -30,6 +30,7 @@ const managedSkillHostOrder = {
     codex: 0,
     claude: 1,
     openclaw: 2,
+    qoderwork: 3,
 } as const satisfies Record<BundledSkillAgentName, number>;
 
 export interface ManagedSkillListItem {
@@ -324,6 +325,8 @@ function readManagedSkillHostLabel(
             return context.translator.t("skills.list.host.codex");
         case "openclaw":
             return context.translator.t("skills.list.host.openclaw");
+        case "qoderwork":
+            return context.translator.t("skills.list.host.qoderwork");
         default:
             return hostName satisfies never;
     }

--- a/src/application/commands/skills/managed-skill-host-errors.ts
+++ b/src/application/commands/skills/managed-skill-host-errors.ts
@@ -1,0 +1,22 @@
+import type { BundledSkillAgentName } from "./embedded-assets.ts";
+
+export type ManagedSkillHostMissingErrorKey
+    = | "errors.skills.claudeNotInstalled"
+        | "errors.skills.codexNotInstalled"
+        | "errors.skills.openclawNotInstalled"
+        | "errors.skills.qoderworkNotInstalled";
+
+export function resolveManagedSkillHostMissingErrorKey(
+    agentName: BundledSkillAgentName,
+): ManagedSkillHostMissingErrorKey {
+    switch (agentName) {
+        case "claude":
+            return "errors.skills.claudeNotInstalled";
+        case "codex":
+            return "errors.skills.codexNotInstalled";
+        case "openclaw":
+            return "errors.skills.openclawNotInstalled";
+        case "qoderwork":
+            return "errors.skills.qoderworkNotInstalled";
+    }
+}

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -361,6 +361,8 @@ export const enMessages = {
         "Claude Code is not installed. Expected the Claude home directory at {path}.",
     "errors.skills.openclawNotInstalled":
         "OpenClaw is not installed. Expected the OpenClaw home directory at {path}.",
+    "errors.skills.qoderworkNotInstalled":
+        "QoderWork is not installed. Expected the QoderWork home directory at {path}.",
     "errors.skills.noSupportedBundledSkillHosts":
         "No supported skill host is installed. Expected one of: {paths}.",
     "errors.skills.install.confirmationRequired":
@@ -547,6 +549,7 @@ export const enMessages = {
     "skills.list.host.claude": "Claude Code",
     "skills.list.host.codex": "Codex",
     "skills.list.host.openclaw": "OpenClaw",
+    "skills.list.host.qoderwork": "QoderWork",
     "skills.list.source": "Source",
     "skills.list.source.bundled": "bundled",
     "skills.list.source.local": "local",
@@ -1006,6 +1009,8 @@ export const zhMessages = {
         "未检测到 Claude Code 安装。期望的 Claude 根目录为 {path}。",
     "errors.skills.openclawNotInstalled":
         "未检测到 OpenClaw 安装。期望的 OpenClaw 根目录为 {path}。",
+    "errors.skills.qoderworkNotInstalled":
+        "未检测到 QoderWork 安装。期望的 QoderWork 根目录为 {path}。",
     "errors.skills.noSupportedBundledSkillHosts":
         "未检测到已安装的受支持 skill 宿主。期望其中之一位于：{paths}。",
     "errors.skills.install.confirmationRequired":
@@ -1186,6 +1191,7 @@ export const zhMessages = {
     "skills.list.host.claude": "Claude Code",
     "skills.list.host.codex": "Codex",
     "skills.list.host.openclaw": "OpenClaw",
+    "skills.list.host.qoderwork": "QoderWork",
     "skills.list.source": "来源",
     "skills.list.source.bundled": "内置",
     "skills.list.source.local": "本地",


### PR DESCRIPTION
Publish oo-managed skills into QoderWork's ~/.qoderwork/skills directory so users can reuse the bundled skill templates there.

The QoderWork templates mirror the Claude-compatible skills while omitting the allowed-tools frontmatter that QoderWork does not support.
