### PR TITLE
fix(skills): create missing host skills roots

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -423,6 +423,8 @@ Install bundled or published skills into supported local skill directories.
   `~/.codebuddy/skills/<skill-id>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
   `~/.qoderwork/skills/<skill-id>`.
+- Target directory: if an existing supported host is missing its `skills` root,
+  the command creates that root before publishing the selected skill.
 - Path rule: published skill names are accepted only when their resolved
   canonical and target directories remain under those local `skills` roots.
 - Installation mode: bundled and published Codex, Claude Code, CodeBuddy, and

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -369,6 +369,8 @@ skills。
   `~/.codebuddy/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`、
   `~/.qoderwork/skills/<skill-id>`。
+- 目标目录：当已存在的受支持宿主缺少 `skills` 根目录时，命令会先创建该目录，
+  再发布所选 skill。
 - 安装方式：内置和已发布的 Codex / Claude Code / CodeBuddy / QoderWork
   skill 会优先把目标目录发布为指向 canonical 目录的软连接。如果当前平台或环境
   下创建软连接失败，则会回退为把 canonical 目录内容复制到目标 skills 目录。

--- a/src/application/commands/skills/bundled-skill-filesystem.ts
+++ b/src/application/commands/skills/bundled-skill-filesystem.ts
@@ -76,6 +76,8 @@ export async function publishBundledSkillInstallation(
 ): Promise<BundledSkillPublicationResult> {
     const publicationMode = options.publicationMode ?? "symlink-or-copy";
 
+    await mkdir(dirname(options.installedSkillDirectoryPath), { recursive: true });
+
     if (publicationMode === "symlink-or-copy") {
         const createDirectoryLink
             = dependencies.createDirectorySymlink ?? createBundledSkillDirectorySymlink;
@@ -251,7 +253,6 @@ async function copyBundledSkillDirectory(
     destinationPath: string,
 ): Promise<void> {
     await removePath(destinationPath);
-    await mkdir(dirname(destinationPath), { recursive: true });
     await cp(sourcePath, destinationPath, {
         dereference: true,
         force: true,

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -451,6 +451,7 @@ describe("skills commands", () => {
     test("installs bundled skills into QoderWork without Claude allowed tools", async () => {
         const sandbox = await createCliSandbox();
         const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
+        const qoderWorkSkillsDirectoryPath = join(qoderWorkHomeDirectory, "skills");
         const skillDirectoryPath = join(qoderWorkHomeDirectory, "skills", "oo");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
@@ -473,6 +474,9 @@ describe("skills commands", () => {
             }
 
             await mkdir(qoderWorkHomeDirectory, { recursive: true });
+            await expect(stat(qoderWorkSkillsDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
 
             const result = await sandbox.run(["skills", "install", "oo"], {
                 version: "9.9.9",
@@ -482,6 +486,7 @@ describe("skills commands", () => {
             expect(result.stdout).toBe(
                 `Installed skill oo to ${skillDirectoryPath}.\n`,
             );
+            expect((await stat(qoderWorkSkillsDirectoryPath)).isDirectory()).toBeTrue();
             expect(await realpath(skillDirectoryPath)).toBe(
                 await realpath(canonicalSkillDirectoryPath),
             );


### PR DESCRIPTION
QoderWork can have an existing home directory without a skills root, so publishing a managed skill must not assume that parent directory already exists. Creating the target root at the publication boundary keeps symlink and copy installs consistent across supported hosts.

Document the behavior and cover the QoderWork case where the host home exists but its skills directory is created during install.