### PR TITLE
style(skills): collapse multiline descriptions to single-line strings

### DIFF
--- a/contrib/skills/codebuddy/oo-create-skill/SKILL.md
+++ b/contrib/skills/codebuddy/oo-create-skill/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: oo-create-skill
-description: >-
-  Create or update a local agent skill for a known OOMOL package workflow. Use
-  when the user already knows which oo package or block should power the
-  workflow and wants reusable skill instructions.
+description: "Create or update a local agent skill for a known OOMOL package workflow. Use when the user already knows which oo package or block should power the workflow and wants reusable skill instructions."
 ---
 
 # oo Create Skill

--- a/contrib/skills/codebuddy/oo-find-skills/SKILL.md
+++ b/contrib/skills/codebuddy/oo-find-skills/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: oo-find-skills
-description: >-
-  Find, compare, and install published OOMOL/oo skills. Use when the user asks
-  to find, search for, discover, recommend, compare, choose, or install an
-  existing skill for a task; asks whether there is a skill that can do
-  something; or explicitly mentions the OOMOL/oo skill catalog. Do not use for
-  creating or editing local skills, generic skill design, or non-OOMOL skill
-  catalogs.
+description: "Find, compare, and install published OOMOL/oo skills. Use when the user asks to find, search for, discover, recommend, compare, choose, or install an existing skill for a task; asks whether there is a skill that can do something; or explicitly mentions the OOMOL/oo skill catalog. Do not use for creating or editing local skills, generic skill design, or non-OOMOL skill catalogs."
 ---
 
 # oo Find Skills

--- a/contrib/skills/codebuddy/oo/SKILL.md
+++ b/contrib/skills/codebuddy/oo/SKILL.md
@@ -1,16 +1,6 @@
 ---
 name: oo
-description: >-
-  First-choice router for tasks whose outcome lives outside this
-  workspace — a connected third-party account (email, calendar, drive,
-  chat, notes, issue tracker, code host, CRM, storage, etc.), an external
-  API, or a managed AI pipeline (OCR, translation, transcription,
-  TTS, text-to-image, subtitles, long-document understanding) — as long
-  as the user is not asking for a local implementation. Concrete
-  capabilities are discovered at runtime, so no package or action names
-  are listed here. Match intent across languages. SKIP only for pure
-  local coding, shell glue, edits to this repo, text-only work an LLM
-  can do alone, or an explicit "do it locally" request.
+description: "First-choice router for tasks whose outcome lives outside this workspace — a connected third-party account (email, calendar, drive, chat, notes, issue tracker, code host, CRM, storage, etc.), an external API, or a managed AI pipeline (OCR, translation, transcription, TTS, text-to-image, subtitles, long-document understanding) — as long as the user is not asking for a local implementation. Concrete capabilities are discovered at runtime, so no package or action names are listed here. Match intent across languages. SKIP only for pure local coding, shell glue, edits to this repo, text-only work an LLM can do alone, or an explicit \"do it locally\" request."
 ---
 
 # oo


### PR DESCRIPTION
The YAML frontmatter descriptions used block scalar (>-) syntax which split text across many lines. Collapse them into single-line quoted strings for consistency and easier reading.