### PR TITLE
feat(skills): add WorkBuddy skill host

### DIFF
--- a/README-ZH_CN.md
+++ b/README-ZH_CN.md
@@ -58,8 +58,16 @@ skills：
   `${CODEX_HOME:-~/.codex}/skills/oo-find-skills`
 - Claude Code：`~/.claude/skills/oo` 和
   `~/.claude/skills/oo-find-skills`
+- CodeBuddy：`~/.codebuddy/skills/oo` 和
+  `~/.codebuddy/skills/oo-find-skills`
+- WorkBuddy：`~/.workbuddy/skills/oo` 和
+  `~/.workbuddy/skills/oo-find-skills`
+- OpenClaw：`${OPENCLAW_HOME:-~/.openclaw}/skills/oo` 和
+  `${OPENCLAW_HOME:-~/.openclaw}/skills/oo-find-skills`
+- QoderWork：`~/.qoderwork/skills/oo` 和
+  `~/.qoderwork/skills/oo-find-skills`
 
-之后你就可以在 Codex 或 Claude Code 中使用它们。比如在 Codex 中：
+之后你就可以在任一受支持宿主中使用它们。比如在 Codex 中：
 
 ```text
 $oo 帮我生成 OOMOL 字符串的二维码

--- a/README.md
+++ b/README.md
@@ -59,8 +59,16 @@ supported local host that already exists:
 - Codex: `${CODEX_HOME:-~/.codex}/skills/oo` and
   `${CODEX_HOME:-~/.codex}/skills/oo-find-skills`
 - Claude Code: `~/.claude/skills/oo` and `~/.claude/skills/oo-find-skills`
+- CodeBuddy: `~/.codebuddy/skills/oo` and
+  `~/.codebuddy/skills/oo-find-skills`
+- WorkBuddy: `~/.workbuddy/skills/oo` and
+  `~/.workbuddy/skills/oo-find-skills`
+- OpenClaw: `${OPENCLAW_HOME:-~/.openclaw}/skills/oo` and
+  `${OPENCLAW_HOME:-~/.openclaw}/skills/oo-find-skills`
+- QoderWork: `~/.qoderwork/skills/oo` and
+  `~/.qoderwork/skills/oo-find-skills`
 
-Then you can use them in Codex or Claude Code. For example, in Codex:
+Then you can use them in any supported host. For example, in Codex:
 
 ```text
 $oo generate a QR code for the string OOMOL

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -265,7 +265,8 @@ Before running a command, `oo` silently synchronizes managed skills for every
 supported host directory that already exists.
 
 - Bundled skills: `oo` ensures `oo` and `oo-find-skills` are installed for
-  each detected Codex, Claude Code, CodeBuddy, OpenClaw, and QoderWork host.
+  each detected Codex, Claude Code, CodeBuddy, WorkBuddy, OpenClaw, and
+  QoderWork host.
   Existing oo-managed bundled skill targets are refreshed to the current `oo`
   version, except that `0.0.0-development` startup runs do not refresh
   existing bundled targets.
@@ -282,8 +283,8 @@ List oo-managed skills from supported local skill directories.
 
 - Ownership rule: the command scans each existing supported local skill root:
   `${CODEX_HOME:-~/.codex}/skills`, `~/.claude/skills`,
-  `~/.codebuddy/skills`, `${OPENCLAW_HOME:-~/.openclaw}/skills`, and
-  `~/.qoderwork/skills`. It keeps
+  `~/.codebuddy/skills`, `~/.workbuddy/skills`,
+  `${OPENCLAW_HOME:-~/.openclaw}/skills`, and `~/.qoderwork/skills`. It keeps
   only child directories whose `.oo-metadata.json` can be parsed and contains a
   non-empty `version`.
 - Output: text output prints a summary line and one block per unique visible
@@ -292,7 +293,7 @@ List oo-managed skills from supported local skill directories.
 - Ordering: bundled skills are listed first when present, with `oo` before
   `oo-find-skills` before `oo-create-skill`; the remaining skills are ordered
   by skill name. Host names within a block follow `Codex`,
-  `Claude Code`, `CodeBuddy`, `OpenClaw`, `QoderWork` order.
+  `Claude Code`, `CodeBuddy`, `WorkBuddy`, `OpenClaw`, `QoderWork` order.
 - Output: each skill block shows the skill name, host, source package or
   bundled/local marker, and recorded version.
 - Notes: when a folded skill is installed in multiple supported hosts, the
@@ -303,7 +304,7 @@ List oo-managed skills from supported local skill directories.
 Check whether this environment has permission to edit local skills.
 
 - Options: `--agent <agent>` restricts the host check to one supported agent:
-  `codex`, `claude`, `codebuddy`, `openclaw`, or `qoderwork`.
+  `codex`, `claude`, `codebuddy`, `workbuddy`, `openclaw`, or `qoderwork`.
 - Host check: without `--agent`, at least one supported agent home directory
   must already exist. With `--agent`, that specific agent home directory must
   exist.
@@ -338,6 +339,7 @@ directory that already exists.
   supported agent skill directory:
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`, `~/.claude/skills/<skill-id>`,
   `~/.codebuddy/skills/<skill-id>`,
+  `~/.workbuddy/skills/<skill-id>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
   `~/.qoderwork/skills/<skill-id>`.
 - Failure behavior: if no supported agent home exists, or if the canonical
@@ -407,7 +409,7 @@ Install bundled or published skills into supported local skill directories.
 - Canonical directory: bundled skills are materialized under
   `<config-dir>/skills/bundled/<agent>/<skill-id>`, where `<config-dir>` is the
   directory that contains `settings.toml` and `<agent>` is `codex`, `claude`,
-  `codebuddy`, `openclaw`, or `qoderwork`.
+  `codebuddy`, `workbuddy`, `openclaw`, or `qoderwork`.
 - Canonical directory: published skills are materialized to
   `<config-dir>/skills/registry/<skill-id>`.
 - Migration: on first run after upgrading, `oo skills install` removes legacy
@@ -421,17 +423,18 @@ Install bundled or published skills into supported local skill directories.
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`,
   `~/.claude/skills/<skill-id>`,
   `~/.codebuddy/skills/<skill-id>`,
+  `~/.workbuddy/skills/<skill-id>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
   `~/.qoderwork/skills/<skill-id>`.
 - Target directory: if an existing supported host is missing its `skills` root,
   the command creates that root before publishing the selected skill.
 - Path rule: published skill names are accepted only when their resolved
   canonical and target directories remain under those local `skills` roots.
-- Installation mode: bundled and published Codex, Claude Code, CodeBuddy, and
-  QoderWork skills are published to the target directory as a symlink to the
-  canonical directory when the current platform and environment allow it. When
-  symlink creation fails, `oo` falls back to copying the canonical files into
-  the target skills directory.
+- Installation mode: bundled and published Codex, Claude Code, CodeBuddy,
+  WorkBuddy, and QoderWork skills are published to the target directory as a
+  symlink to the canonical directory when the current platform and environment
+  allow it. When symlink creation fails, `oo` falls back to copying the
+  canonical files into the target skills directory.
 - Installation mode: bundled and published OpenClaw skills are copied into
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>` so the installed skill
   stays inside OpenClaw's managed skills root.
@@ -452,7 +455,8 @@ Install bundled or published skills into supported local skill directories.
 - Notes: in the interactive picker, conflicting skills are marked in the list;
   selecting one means it will be overwritten.
 - Notes: the command exits with an error when none of the supported Codex,
-  Claude Code, CodeBuddy, OpenClaw, or QoderWork home directories exists.
+  Claude Code, CodeBuddy, WorkBuddy, OpenClaw, or QoderWork home directories
+  exists.
 - Notes: an existing bundled skill installation is considered managed by `oo`
   only when its `.oo-metadata.json` file can be parsed and contains a
   non-empty `version`. Otherwise `oo` treats it as a different skill and will
@@ -499,6 +503,7 @@ Remove oo-managed skills from supported local skill directories.
   existing supported host directory, currently
   `${CODEX_HOME:-~/.codex}/skills/<skill>`, `~/.claude/skills/<skill>`,
   `~/.codebuddy/skills/<skill>`,
+  `~/.workbuddy/skills/<skill>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`, and
   `~/.qoderwork/skills/<skill>`.
 - Path rule: `[skill]` must resolve to child directories under those local

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -234,7 +234,7 @@
 skills。
 
 - 内置 skill：`oo` 会确保每个检测到的 Codex、Claude Code、CodeBuddy、
-  OpenClaw 和 QoderWork 宿主都安装了 `oo` 与 `oo-find-skills`。已经由 oo
+  WorkBuddy、OpenClaw 和 QoderWork 宿主都安装了 `oo` 与 `oo-find-skills`。已经由 oo
   管理的内置 skill 目标会刷新到当前 `oo` 版本；但当启动中的当前版本为
   `0.0.0-development` 时，不会刷新已存在的内置 skill 目标。
 - 已发布 skill：如果某个已发布 skill 已经有本地 canonical 副本
@@ -249,15 +249,15 @@ skills。
 
 - 所有权规则：命令会扫描每个已存在的受支持本地 skill 根目录：
   `${CODEX_HOME:-~/.codex}/skills`、`~/.claude/skills`，以及
-  `~/.codebuddy/skills`、`${OPENCLAW_HOME:-~/.openclaw}/skills`、
-  `~/.qoderwork/skills`。只保留包含
+  `~/.codebuddy/skills`、`~/.workbuddy/skills`、
+  `${OPENCLAW_HOME:-~/.openclaw}/skills`、`~/.qoderwork/skills`。只保留包含
   可解析 `.oo-metadata.json` 且其中包含非空 `version` 的子目录。
 - 输出：文本输出会先打印摘要行，再为每个唯一的可见 skill 身份打印一个块。
   如果多个宿主中的安装具有相同 `name`、来源和版本，则会折叠到同一个块中。
 - 排序：bundled skills 会排在最前面；其中 `oo` 优先，其次
   `oo-find-skills`，再其次 `oo-create-skill`；其余 skill 按名称排序。每个
-  块内的宿主名称按 `Codex`、`Claude Code`、`CodeBuddy`、`OpenClaw`、
-  `QoderWork` 顺序显示。
+  块内的宿主名称按 `Codex`、`Claude Code`、`CodeBuddy`、`WorkBuddy`、
+  `OpenClaw`、`QoderWork` 顺序显示。
 - 输出：每个 skill 块会显示 skill 名称、宿主、来源 package、内置或本地标记，以
   及记录的版本号。
 - 说明：如果折叠后的 skill 安装在多个受支持宿主中，`宿主` 字段会列出所有
@@ -268,7 +268,7 @@ skills。
 检查当前环境是否有权限编辑本地 skills。
 
 - 选项：`--agent <agent>` 将宿主检查限制为一个受支持 agent：`codex`、
-  `claude`、`codebuddy`、`openclaw` 或 `qoderwork`。
+  `claude`、`codebuddy`、`workbuddy`、`openclaw` 或 `qoderwork`。
 - 宿主检查：未提供 `--agent` 时，至少需要存在一个受支持 agent home 目录。
   提供 `--agent` 时，该指定 agent home 目录必须存在。
 - 存储检查：命令会在需要时创建 `<config-dir>/skills/local` 和每个已检查宿主
@@ -296,6 +296,7 @@ skills。
 - 目标目录：命令会向每个已存在的受支持 agent skill 目录发布目录链接：
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`、`~/.claude/skills/<skill-id>`，
   `~/.codebuddy/skills/<skill-id>`、
+  `~/.workbuddy/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`，以及
   `~/.qoderwork/skills/<skill-id>`。
 - 失败行为：如果没有受支持的 agent home，或 canonical 本地目录、任意目标目录
@@ -356,7 +357,7 @@ skills。
 - canonical 目录：内置 skill 会先释放到
   `<config-dir>/skills/bundled/<agent>/<skill-id>`，其中 `<config-dir>` 是
   `settings.toml` 所在目录，`<agent>` 为 `codex`、`claude`、`codebuddy`、
-  `openclaw` 或 `qoderwork`。
+  `workbuddy`、`openclaw` 或 `qoderwork`。
 - canonical 目录：已发布 skill 会先释放到
   `<config-dir>/skills/registry/<skill-id>`。
 - 迁移：升级后首次运行 `oo skills install` 时，命令会清理历史遗留的 canonical
@@ -367,13 +368,14 @@ skills。
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>` 和
   `~/.claude/skills/<skill-id>`，以及
   `~/.codebuddy/skills/<skill-id>`、
+  `~/.workbuddy/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`、
   `~/.qoderwork/skills/<skill-id>`。
 - 目标目录：当已存在的受支持宿主缺少 `skills` 根目录时，命令会先创建该目录，
   再发布所选 skill。
-- 安装方式：内置和已发布的 Codex / Claude Code / CodeBuddy / QoderWork
-  skill 会优先把目标目录发布为指向 canonical 目录的软连接。如果当前平台或环境
-  下创建软连接失败，则会回退为把 canonical 目录内容复制到目标 skills 目录。
+- 安装方式：内置和已发布的 Codex / Claude Code / CodeBuddy / WorkBuddy /
+  QoderWork skill 会优先把目标目录发布为指向 canonical 目录的软连接。如果当前平台
+  或环境下创建软连接失败，则会回退为把 canonical 目录内容复制到目标 skills 目录。
 - 安装方式：内置和已发布的 OpenClaw skill 会直接复制到
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`，以确保安装后的 skill
   保持在 OpenClaw 管理的 skills 根目录内。
@@ -392,8 +394,8 @@ skills。
   skill，命令不会覆盖它。
 - 说明：在交互选择页面中，存在重名冲突的 skill 会在列表中显示状态标记；
   只要用户仍然选择该项，就会执行覆盖。
-- 说明：当 Codex、Claude Code、CodeBuddy、OpenClaw 和 QoderWork 的受支持根
-  目录都不存在时，命令会直接报错退出。
+- 说明：当 Codex、Claude Code、CodeBuddy、WorkBuddy、OpenClaw 和 QoderWork
+  的受支持根目录都不存在时，命令会直接报错退出。
 - 说明：只有当 bundled skill 的 `.oo-metadata.json` 可以被解析，且其中包
   含非空的 `version` 时，`oo` 才会认为这是自己管理的内置 skill；否则会视
   为其他 skill，并拒绝覆盖。
@@ -432,6 +434,7 @@ skills。
   移除，目前包括 `${CODEX_HOME:-~/.codex}/skills/<skill>` 和
   `~/.claude/skills/<skill>`，以及
   `~/.codebuddy/skills/<skill>`、
+  `~/.workbuddy/skills/<skill>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`、
   `~/.qoderwork/skills/<skill>`。
 - 路径规则：`[skill]` 解析后必须仍然落在这些本地 `skills` 根目录的子目录中。

--- a/src/application/commands/skills/bundled-skill-observation.test.ts
+++ b/src/application/commands/skills/bundled-skill-observation.test.ts
@@ -163,6 +163,32 @@ describe("bundled skill observation", () => {
         }
     });
 
+    test("requires the resolved WorkBuddy home directory to exist", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const workBuddyHomeDirectory = join(rootDirectory, ".workbuddy");
+        const env = {
+            HOME: rootDirectory,
+        };
+
+        try {
+            await expect(
+                requireBundledSkillHomeDirectory({ env }, "workbuddy"),
+            ).rejects.toMatchObject({
+                exitCode: 1,
+                key: "errors.skills.workbuddyNotInstalled",
+            });
+
+            await mkdir(workBuddyHomeDirectory, { recursive: true });
+
+            expect(await requireBundledSkillHomeDirectory({ env }, "workbuddy")).toBe(
+                workBuddyHomeDirectory,
+            );
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
     test("requires the resolved OpenClaw home directory to exist", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
         const openClawHomeDirectory = join(rootDirectory, ".openclaw");

--- a/src/application/commands/skills/bundled-skill-paths.ts
+++ b/src/application/commands/skills/bundled-skill-paths.ts
@@ -8,6 +8,7 @@ const claudeDirectoryName = ".claude";
 const codeBuddyDirectoryName = ".codebuddy";
 const openClawDirectoryName = ".openclaw";
 const qoderWorkDirectoryName = ".qoderwork";
+const workBuddyDirectoryName = ".workbuddy";
 export const codexSkillsDirectoryName = "skills";
 export const canonicalBundledSkillsDirectoryName = "bundled";
 export const canonicalLocalSkillsDirectoryName = "local";
@@ -57,6 +58,12 @@ export function resolveQoderWorkHomeDirectory(
     return join(resolveHomeDirectory(env), qoderWorkDirectoryName);
 }
 
+export function resolveWorkBuddyHomeDirectory(
+    env: Record<string, string | undefined>,
+): string {
+    return join(resolveHomeDirectory(env), workBuddyDirectoryName);
+}
+
 export function resolveBundledSkillHomeDirectory(
     env: Record<string, string | undefined>,
     agentName: BundledSkillAgentName,
@@ -72,6 +79,8 @@ export function resolveBundledSkillHomeDirectory(
             return resolveOpenClawHomeDirectory(env);
         case "qoderwork":
             return resolveQoderWorkHomeDirectory(env);
+        case "workbuddy":
+            return resolveWorkBuddyHomeDirectory(env);
     }
 }
 

--- a/src/application/commands/skills/check.test.ts
+++ b/src/application/commands/skills/check.test.ts
@@ -11,6 +11,7 @@ import {
     resolveCodeBuddyHomeDirectory,
     resolveCodexHomeDirectory,
     resolveQoderWorkHomeDirectory,
+    resolveWorkBuddyHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { resolveLocalSkillCanonicalRootDirectoryPath } from "./managed-skill-paths.ts";
 
@@ -129,6 +130,40 @@ describe("skills preflight command", () => {
                 "preflight",
                 "--agent",
                 "codebuddy",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Local skill editing is ready. Writable storage: ${canonicalRootDirectoryPath}. Supported hosts: 1.\n`,
+            );
+            expect(await readdir(canonicalRootDirectoryPath)).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("checks WorkBuddy as a requested agent", async () => {
+        const sandbox = await createCliSandbox();
+        const workBuddyHomeDirectory = resolveWorkBuddyHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalRootDirectoryPath = resolveLocalSkillCanonicalRootDirectoryPath(
+            storePaths.settingsFilePath,
+        );
+
+        try {
+            await mkdir(workBuddyHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "preflight",
+                "--agent",
+                "workbuddy",
             ]);
 
             expect(result.exitCode).toBe(0);

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -41,6 +41,15 @@ describe("embedded skill assets", () => {
             "references/file-transfer.md",
             "references/task-lifecycle.md",
         ]);
+        expect(getBundledSkillFiles("oo", "workbuddy").map(file => file.relativePath)).toEqual([
+            "SKILL.md",
+            "references/auth-and-billing.md",
+            "references/search-and-selection.md",
+            "references/package-execution.md",
+            "references/connector-execution.md",
+            "references/file-transfer.md",
+            "references/task-lifecycle.md",
+        ]);
         expect(getBundledSkillFiles("oo", "openclaw").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "references/auth-and-billing.md",
@@ -78,6 +87,14 @@ describe("embedded skill assets", () => {
         ]);
         expect(
             getBundledSkillFiles("oo-find-skills", "codebuddy").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+            "references/oo-cli-contract.md",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-find-skills", "workbuddy").map(
                 file => file.relativePath,
             ),
         ).toEqual([
@@ -123,6 +140,13 @@ describe("embedded skill assets", () => {
             "SKILL.md",
         ]);
         expect(
+            getBundledSkillFiles("oo-create-skill", "workbuddy").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
             getBundledSkillFiles("oo-create-skill", "openclaw").map(
                 file => file.relativePath,
             ),
@@ -143,13 +167,17 @@ describe("embedded skill assets", () => {
             "codex",
             "claude",
             "codebuddy",
+            "workbuddy",
             "openclaw",
             "qoderwork",
         ]);
 
         for (const skillName of availableBundledSkillNames) {
             for (const agentName of availableBundledSkillAgentNames) {
-                const sourceDirectory = `contrib/skills/${agentName}/${skillName}`;
+                const sourceAgentName = agentName === "workbuddy"
+                    ? "codebuddy"
+                    : agentName;
+                const sourceDirectory = `contrib/skills/${sourceAgentName}/${skillName}`;
                 const skillFiles = getBundledSkillFiles(skillName, agentName);
 
                 expect(skillFiles.every(file => file.agentName === agentName)).toBeTrue();
@@ -198,18 +226,20 @@ describe("embedded skill assets", () => {
         }
     });
 
-    test("keeps QoderWork skill frontmatter free of Claude allowed tools", async () => {
-        for (const skillName of availableBundledSkillNames) {
-            const skillFile = getBundledSkillFiles(skillName, "qoderwork")
-                .find(file => file.relativePath === "SKILL.md");
+    test("keeps Claude-compatible skill frontmatter free of Claude allowed tools", async () => {
+        for (const agentName of ["qoderwork", "workbuddy"] as const) {
+            for (const skillName of availableBundledSkillNames) {
+                const skillFile = getBundledSkillFiles(skillName, agentName)
+                    .find(file => file.relativePath === "SKILL.md");
 
-            if (skillFile === undefined) {
-                throw new Error(`Missing QoderWork SKILL.md for ${skillName}`);
+                if (skillFile === undefined) {
+                    throw new Error(`Missing ${agentName} SKILL.md for ${skillName}`);
+                }
+
+                expect(await Bun.file(skillFile.sourcePath).text()).not.toContain(
+                    "allowed-tools",
+                );
             }
-
-            expect(await Bun.file(skillFile.sourcePath).text()).not.toContain(
-                "allowed-tools",
-            );
         }
     });
 });

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -52,7 +52,7 @@ import ooQoderWorkSearchAndSelectionReferencePath from "../../../../contrib/skil
 import ooQoderWorkTaskLifecycleReferencePath from "../../../../contrib/skills/qoderwork/oo/references/task-lifecycle.md" with { type: "file" };
 import ooQoderWorkSkillPath from "../../../../contrib/skills/qoderwork/oo/SKILL.md" with { type: "file" };
 
-export const availableBundledSkillAgentNames = ["codex", "claude", "codebuddy", "openclaw", "qoderwork"] as const;
+export const availableBundledSkillAgentNames = ["codex", "claude", "codebuddy", "workbuddy", "openclaw", "qoderwork"] as const;
 export type BundledSkillAgentName = (typeof availableBundledSkillAgentNames)[number];
 
 export const availableBundledSkillNames = ["oo", "oo-find-skills", "oo-create-skill"] as const;
@@ -147,6 +147,15 @@ const bundledSkillRegistry = {
                 ...ooCodeBuddyReferenceFiles,
             ],
         },
+        workbuddy: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCodeBuddySkillPath,
+                },
+                ...ooCodeBuddyReferenceFiles,
+            ],
+        },
         openclaw: {
             files: [
                 {
@@ -207,6 +216,18 @@ const bundledSkillRegistry = {
                 },
             ],
         },
+        workbuddy: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooFindSkillsCodeBuddySkillPath,
+                },
+                {
+                    relativePath: "references/oo-cli-contract.md",
+                    sourcePath: ooFindSkillsCodeBuddyCliContractPath,
+                },
+            ],
+        },
         openclaw: {
             files: [
                 {
@@ -254,6 +275,14 @@ const bundledSkillRegistry = {
             ],
         },
         codebuddy: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCreateSkillCodeBuddySkillPath,
+                },
+            ],
+        },
+        workbuddy: {
             files: [
                 {
                     relativePath: "SKILL.md",

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -28,6 +28,7 @@ import {
     resolveCodexHomeDirectory,
     resolveOpenClawHomeDirectory,
     resolveQoderWorkHomeDirectory,
+    resolveWorkBuddyHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import {
     availableBundledSkillAgentNames,
@@ -564,6 +565,60 @@ describe("skills commands", () => {
         }
     });
 
+    test("installs bundled skills into WorkBuddy", async () => {
+        const sandbox = await createCliSandbox();
+        const workBuddyHomeDirectory = resolveWorkBuddyHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(workBuddyHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+            "workbuddy",
+        );
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const skillFilePath = join(skillDirectoryPath, "SKILL.md");
+        const workBuddySkillFile = getBundledSkillFiles("oo", "workbuddy")
+            .find(file => file.relativePath === "SKILL.md");
+
+        try {
+            if (workBuddySkillFile === undefined) {
+                throw new Error("Missing WorkBuddy oo SKILL.md fixture");
+            }
+
+            await mkdir(workBuddyHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "install", "oo"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Installed skill oo to ${skillDirectoryPath}.\n`,
+            );
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson({ version: "9.9.9" }),
+            );
+            expect(await readFile(skillFilePath, "utf8")).toBe(
+                await Bun.file(workBuddySkillFile.sourcePath).text(),
+            );
+            await expect(
+                stat(join(skillDirectoryPath, "agents", "openai.yaml")),
+            ).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("refuses to overwrite an existing non-OOMOL skill with the same name", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -713,8 +768,16 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
+        const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
+        const workBuddyHomeDirectory = resolveWorkBuddyHomeDirectory(sandbox.env);
+        const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
+        const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
         const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
         const claudeSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
+        const codeBuddySkillDirectoryPath = join(codeBuddyHomeDirectory, "skills", "chatgpt");
+        const workBuddySkillDirectoryPath = join(workBuddyHomeDirectory, "skills", "chatgpt");
+        const openClawSkillDirectoryPath = join(openClawHomeDirectory, "skills", "chatgpt");
+        const qoderWorkSkillDirectoryPath = join(qoderWorkHomeDirectory, "skills", "chatgpt");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
@@ -726,14 +789,26 @@ describe("skills commands", () => {
         );
 
         try {
-            await mkdir(join(codexSkillDirectoryPath, "agents"), { recursive: true });
-            await mkdir(join(claudeSkillDirectoryPath, "agents"), { recursive: true });
+            for (const skillDirectoryPath of [
+                codexSkillDirectoryPath,
+                claudeSkillDirectoryPath,
+                codeBuddySkillDirectoryPath,
+                workBuddySkillDirectoryPath,
+                openClawSkillDirectoryPath,
+                qoderWorkSkillDirectoryPath,
+            ]) {
+                await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            }
             await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
                 recursive: true,
             });
             for (const skillDirectoryPath of [
                 codexSkillDirectoryPath,
                 claudeSkillDirectoryPath,
+                codeBuddySkillDirectoryPath,
+                workBuddySkillDirectoryPath,
+                openClawSkillDirectoryPath,
+                qoderWorkSkillDirectoryPath,
             ]) {
                 await Bun.write(
                     resolveManagedSkillMetadataFilePath(skillDirectoryPath),
@@ -750,16 +825,26 @@ describe("skills commands", () => {
                 [
                     `Removed skill chatgpt from ${codexSkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${claudeSkillDirectoryPath}.`,
+                    `Removed skill chatgpt from ${codeBuddySkillDirectoryPath}.`,
+                    `Removed skill chatgpt from ${workBuddySkillDirectoryPath}.`,
+                    `Removed skill chatgpt from ${openClawSkillDirectoryPath}.`,
+                    `Removed skill chatgpt from ${qoderWorkSkillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );
             expect(result.stderr).toBe("");
-            await expect(stat(codexSkillDirectoryPath)).rejects.toMatchObject({
-                code: "ENOENT",
-            });
-            await expect(stat(claudeSkillDirectoryPath)).rejects.toMatchObject({
-                code: "ENOENT",
-            });
+            for (const skillDirectoryPath of [
+                codexSkillDirectoryPath,
+                claudeSkillDirectoryPath,
+                codeBuddySkillDirectoryPath,
+                workBuddySkillDirectoryPath,
+                openClawSkillDirectoryPath,
+                qoderWorkSkillDirectoryPath,
+            ]) {
+                await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
+                    code: "ENOENT",
+                });
+            }
             await expect(stat(canonicalSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
@@ -1187,11 +1272,13 @@ describe("skills commands", () => {
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
         const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
+        const workBuddyHomeDirectory = resolveWorkBuddyHomeDirectory(sandbox.env);
         const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
         const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
         const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
         const claudeSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
         const codeBuddySkillDirectoryPath = join(codeBuddyHomeDirectory, "skills", "chatgpt");
+        const workBuddySkillDirectoryPath = join(workBuddyHomeDirectory, "skills", "chatgpt");
         const openClawSkillDirectoryPath = join(openClawHomeDirectory, "skills", "chatgpt");
         const qoderWorkSkillDirectoryPath = join(qoderWorkHomeDirectory, "skills", "chatgpt");
         const storePaths = resolveStorePaths({
@@ -1209,6 +1296,7 @@ describe("skills commands", () => {
                 mkdir(codexHomeDirectory, { recursive: true }),
                 mkdir(claudeHomeDirectory, { recursive: true }),
                 mkdir(codeBuddyHomeDirectory, { recursive: true }),
+                mkdir(workBuddyHomeDirectory, { recursive: true }),
                 mkdir(openClawHomeDirectory, { recursive: true }),
                 mkdir(qoderWorkHomeDirectory, { recursive: true }),
             ]);
@@ -1252,6 +1340,7 @@ describe("skills commands", () => {
                     `Installed skill chatgpt to ${codexSkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${claudeSkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${codeBuddySkillDirectoryPath}.`,
+                    `Installed skill chatgpt to ${workBuddySkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${openClawSkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${qoderWorkSkillDirectoryPath}.`,
                     "",
@@ -1266,6 +1355,9 @@ describe("skills commands", () => {
             expect(await realpath(codeBuddySkillDirectoryPath)).toBe(
                 await realpath(canonicalSkillDirectoryPath),
             );
+            expect(await realpath(workBuddySkillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
             expect(await realpath(openClawSkillDirectoryPath)).not.toBe(
                 await realpath(canonicalSkillDirectoryPath),
             );
@@ -1277,6 +1369,7 @@ describe("skills commands", () => {
                 codexSkillDirectoryPath,
                 claudeSkillDirectoryPath,
                 codeBuddySkillDirectoryPath,
+                workBuddySkillDirectoryPath,
                 openClawSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
             ]) {

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -11,6 +11,7 @@ import {
     resolveCodexHomeDirectory,
     resolveOpenClawHomeDirectory,
     resolveQoderWorkHomeDirectory,
+    resolveWorkBuddyHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
@@ -197,6 +198,49 @@ describe("skills list CLI", () => {
                     "",
                     "oo-create-skill",
                     "  Host: CodeBuddy",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                ].join("\n"),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("lists startup-synchronized WorkBuddy bundled installs when Codex is not installed", async () => {
+        const sandbox = await createCliSandbox();
+        const workBuddyHomeDirectory = resolveWorkBuddyHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(workBuddyHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install", "oo"], {
+                version: "9.9.9",
+            });
+
+            const result = await sandbox.run(["skills", "list"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    "✓ Found 3 oo-managed skills.",
+                    "",
+                    "oo",
+                    "  Host: WorkBuddy",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-find-skills",
+                    "  Host: WorkBuddy",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-create-skill",
+                    "  Host: WorkBuddy",
                     "  Source: bundled",
                     "  Version: 9.9.9",
                     "",

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -30,8 +30,9 @@ const managedSkillHostOrder = {
     codex: 0,
     claude: 1,
     codebuddy: 2,
-    openclaw: 3,
-    qoderwork: 4,
+    workbuddy: 3,
+    openclaw: 4,
+    qoderwork: 5,
 } as const satisfies Record<BundledSkillAgentName, number>;
 
 export interface ManagedSkillListItem {
@@ -330,6 +331,8 @@ function readManagedSkillHostLabel(
             return context.translator.t("skills.list.host.openclaw");
         case "qoderwork":
             return context.translator.t("skills.list.host.qoderwork");
+        case "workbuddy":
+            return context.translator.t("skills.list.host.workbuddy");
         default:
             return hostName satisfies never;
     }

--- a/src/application/commands/skills/managed-skill-host-errors.ts
+++ b/src/application/commands/skills/managed-skill-host-errors.ts
@@ -5,7 +5,8 @@ export type ManagedSkillHostMissingErrorKey
         | "errors.skills.codebuddyNotInstalled"
         | "errors.skills.codexNotInstalled"
         | "errors.skills.openclawNotInstalled"
-        | "errors.skills.qoderworkNotInstalled";
+        | "errors.skills.qoderworkNotInstalled"
+        | "errors.skills.workbuddyNotInstalled";
 
 export function resolveManagedSkillHostMissingErrorKey(
     agentName: BundledSkillAgentName,
@@ -21,5 +22,7 @@ export function resolveManagedSkillHostMissingErrorKey(
             return "errors.skills.openclawNotInstalled";
         case "qoderwork":
             return "errors.skills.qoderworkNotInstalled";
+        case "workbuddy":
+            return "errors.skills.workbuddyNotInstalled";
     }
 }

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -365,6 +365,8 @@ export const enMessages = {
         "OpenClaw is not installed. Expected the OpenClaw home directory at {path}.",
     "errors.skills.qoderworkNotInstalled":
         "QoderWork is not installed. Expected the QoderWork home directory at {path}.",
+    "errors.skills.workbuddyNotInstalled":
+        "WorkBuddy is not installed. Expected the WorkBuddy home directory at {path}.",
     "errors.skills.noSupportedBundledSkillHosts":
         "No supported skill host is installed. Expected one of: {paths}.",
     "errors.skills.install.confirmationRequired":
@@ -553,6 +555,7 @@ export const enMessages = {
     "skills.list.host.codex": "Codex",
     "skills.list.host.openclaw": "OpenClaw",
     "skills.list.host.qoderwork": "QoderWork",
+    "skills.list.host.workbuddy": "WorkBuddy",
     "skills.list.source": "Source",
     "skills.list.source.bundled": "bundled",
     "skills.list.source.local": "local",
@@ -1016,6 +1019,8 @@ export const zhMessages = {
         "未检测到 OpenClaw 安装。期望的 OpenClaw 根目录为 {path}。",
     "errors.skills.qoderworkNotInstalled":
         "未检测到 QoderWork 安装。期望的 QoderWork 根目录为 {path}。",
+    "errors.skills.workbuddyNotInstalled":
+        "未检测到 WorkBuddy 安装。期望的 WorkBuddy 根目录为 {path}。",
     "errors.skills.noSupportedBundledSkillHosts":
         "未检测到已安装的受支持 skill 宿主。期望其中之一位于：{paths}。",
     "errors.skills.install.confirmationRequired":
@@ -1198,6 +1203,7 @@ export const zhMessages = {
     "skills.list.host.codex": "Codex",
     "skills.list.host.openclaw": "OpenClaw",
     "skills.list.host.qoderwork": "QoderWork",
+    "skills.list.host.workbuddy": "WorkBuddy",
     "skills.list.source": "来源",
     "skills.list.source.bundled": "内置",
     "skills.list.source.local": "本地",


### PR DESCRIPTION
Register WorkBuddy (~/.workbuddy) as a supported skill host, reusing CodeBuddy skill assets. This adds home directory resolution, bundled skill registration, host ordering, i18n labels, error messages, and tests for install, list, check, and remove flows.