### PR TITLE
feat(skills): add Hermes skill host

### DIFF
--- a/README-ZH_CN.md
+++ b/README-ZH_CN.md
@@ -58,6 +58,8 @@ skills：
   `${CODEX_HOME:-~/.codex}/skills/oo-find-skills`
 - Claude Code：`~/.claude/skills/oo` 和
   `~/.claude/skills/oo-find-skills`
+- Hermes：`${HERMES_HOME:-~/.hermes}/skills/oo` 和
+  `${HERMES_HOME:-~/.hermes}/skills/oo-find-skills`
 - CodeBuddy：`~/.codebuddy/skills/oo` 和
   `~/.codebuddy/skills/oo-find-skills`
 - WorkBuddy：`~/.workbuddy/skills/oo` 和

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ supported local host that already exists:
 - Codex: `${CODEX_HOME:-~/.codex}/skills/oo` and
   `${CODEX_HOME:-~/.codex}/skills/oo-find-skills`
 - Claude Code: `~/.claude/skills/oo` and `~/.claude/skills/oo-find-skills`
+- Hermes: `${HERMES_HOME:-~/.hermes}/skills/oo` and
+  `${HERMES_HOME:-~/.hermes}/skills/oo-find-skills`
 - CodeBuddy: `~/.codebuddy/skills/oo` and
   `~/.codebuddy/skills/oo-find-skills`
 - WorkBuddy: `~/.workbuddy/skills/oo` and

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -265,8 +265,8 @@ Before running a command, `oo` silently synchronizes managed skills for every
 supported host directory that already exists.
 
 - Bundled skills: `oo` ensures `oo` and `oo-find-skills` are installed for
-  each detected Codex, Claude Code, CodeBuddy, WorkBuddy, OpenClaw, and
-  QoderWork host.
+  each detected Codex, Claude Code, Hermes, CodeBuddy, WorkBuddy, OpenClaw,
+  and QoderWork host.
   Existing oo-managed bundled skill targets are refreshed to the current `oo`
   version, except that `0.0.0-development` startup runs do not refresh
   existing bundled targets.
@@ -283,17 +283,18 @@ List oo-managed skills from supported local skill directories.
 
 - Ownership rule: the command scans each existing supported local skill root:
   `${CODEX_HOME:-~/.codex}/skills`, `~/.claude/skills`,
-  `~/.codebuddy/skills`, `~/.workbuddy/skills`,
-  `${OPENCLAW_HOME:-~/.openclaw}/skills`, and `~/.qoderwork/skills`. It keeps
-  only child directories whose `.oo-metadata.json` can be parsed and contains a
-  non-empty `version`.
+  `${HERMES_HOME:-~/.hermes}/skills`, `~/.codebuddy/skills`,
+  `~/.workbuddy/skills`, `${OPENCLAW_HOME:-~/.openclaw}/skills`, and
+  `~/.qoderwork/skills`. It keeps only child directories whose
+  `.oo-metadata.json` can be parsed and contains a non-empty `version`.
 - Output: text output prints a summary line and one block per unique visible
   skill identity. Identical `name`/source/version installs across multiple
   hosts are folded into one block.
 - Ordering: bundled skills are listed first when present, with `oo` before
   `oo-find-skills` before `oo-create-skill`; the remaining skills are ordered
   by skill name. Host names within a block follow `Codex`,
-  `Claude Code`, `CodeBuddy`, `WorkBuddy`, `OpenClaw`, `QoderWork` order.
+  `Claude Code`, `Hermes`, `CodeBuddy`, `WorkBuddy`, `OpenClaw`, `QoderWork`
+  order.
 - Output: each skill block shows the skill name, host, source package or
   bundled/local marker, and recorded version.
 - Notes: when a folded skill is installed in multiple supported hosts, the
@@ -304,7 +305,8 @@ List oo-managed skills from supported local skill directories.
 Check whether this environment has permission to edit local skills.
 
 - Options: `--agent <agent>` restricts the host check to one supported agent:
-  `codex`, `claude`, `codebuddy`, `workbuddy`, `openclaw`, or `qoderwork`.
+  `codex`, `claude`, `hermes`, `codebuddy`, `workbuddy`, `openclaw`, or
+  `qoderwork`.
 - Host check: without `--agent`, at least one supported agent home directory
   must already exist. With `--agent`, that specific agent home directory must
   exist.
@@ -338,8 +340,8 @@ directory that already exists.
 - Target directories: the command publishes directory links to each existing
   supported agent skill directory:
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`, `~/.claude/skills/<skill-id>`,
-  `~/.codebuddy/skills/<skill-id>`,
-  `~/.workbuddy/skills/<skill-id>`,
+  `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`,
+  `~/.codebuddy/skills/<skill-id>`, `~/.workbuddy/skills/<skill-id>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
   `~/.qoderwork/skills/<skill-id>`.
 - Failure behavior: if no supported agent home exists, or if the canonical
@@ -409,7 +411,7 @@ Install bundled or published skills into supported local skill directories.
 - Canonical directory: bundled skills are materialized under
   `<config-dir>/skills/bundled/<agent>/<skill-id>`, where `<config-dir>` is the
   directory that contains `settings.toml` and `<agent>` is `codex`, `claude`,
-  `codebuddy`, `workbuddy`, `openclaw`, or `qoderwork`.
+  `hermes`, `codebuddy`, `workbuddy`, `openclaw`, or `qoderwork`.
 - Canonical directory: published skills are materialized to
   `<config-dir>/skills/registry/<skill-id>`.
 - Migration: on first run after upgrading, `oo skills install` removes legacy
@@ -422,6 +424,7 @@ Install bundled or published skills into supported local skill directories.
   supported host directory, currently
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`,
   `~/.claude/skills/<skill-id>`,
+  `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`,
   `~/.codebuddy/skills/<skill-id>`,
   `~/.workbuddy/skills/<skill-id>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
@@ -430,11 +433,11 @@ Install bundled or published skills into supported local skill directories.
   the command creates that root before publishing the selected skill.
 - Path rule: published skill names are accepted only when their resolved
   canonical and target directories remain under those local `skills` roots.
-- Installation mode: bundled and published Codex, Claude Code, CodeBuddy,
-  WorkBuddy, and QoderWork skills are published to the target directory as a
-  symlink to the canonical directory when the current platform and environment
-  allow it. When symlink creation fails, `oo` falls back to copying the
-  canonical files into the target skills directory.
+- Installation mode: bundled and published Codex, Claude Code, Hermes,
+  CodeBuddy, WorkBuddy, and QoderWork skills are published to the target
+  directory as a symlink to the canonical directory when the current platform
+  and environment allow it. When symlink creation fails, `oo` falls back to
+  copying the canonical files into the target skills directory.
 - Installation mode: bundled and published OpenClaw skills are copied into
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>` so the installed skill
   stays inside OpenClaw's managed skills root.
@@ -455,8 +458,8 @@ Install bundled or published skills into supported local skill directories.
 - Notes: in the interactive picker, conflicting skills are marked in the list;
   selecting one means it will be overwritten.
 - Notes: the command exits with an error when none of the supported Codex,
-  Claude Code, CodeBuddy, WorkBuddy, OpenClaw, or QoderWork home directories
-  exists.
+  Claude Code, Hermes, CodeBuddy, WorkBuddy, OpenClaw, or QoderWork home
+  directories exists.
 - Notes: an existing bundled skill installation is considered managed by `oo`
   only when its `.oo-metadata.json` file can be parsed and contains a
   non-empty `version`. Otherwise `oo` treats it as a different skill and will
@@ -502,8 +505,8 @@ Remove oo-managed skills from supported local skill directories.
 - Target directory removed: bundled and published skills are removed from every
   existing supported host directory, currently
   `${CODEX_HOME:-~/.codex}/skills/<skill>`, `~/.claude/skills/<skill>`,
-  `~/.codebuddy/skills/<skill>`,
-  `~/.workbuddy/skills/<skill>`,
+  `${HERMES_HOME:-~/.hermes}/skills/<skill>`,
+  `~/.codebuddy/skills/<skill>`, `~/.workbuddy/skills/<skill>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`, and
   `~/.qoderwork/skills/<skill>`.
 - Path rule: `[skill]` must resolve to child directories under those local

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -233,8 +233,8 @@
 在执行具体命令前，`oo` 会为已经存在的受支持宿主目录静默同步受管理的
 skills。
 
-- 内置 skill：`oo` 会确保每个检测到的 Codex、Claude Code、CodeBuddy、
-  WorkBuddy、OpenClaw 和 QoderWork 宿主都安装了 `oo` 与 `oo-find-skills`。已经由 oo
+- 内置 skill：`oo` 会确保每个检测到的 Codex、Claude Code、Hermes、
+  CodeBuddy、WorkBuddy、OpenClaw 和 QoderWork 宿主都安装了 `oo` 与 `oo-find-skills`。已经由 oo
   管理的内置 skill 目标会刷新到当前 `oo` 版本；但当启动中的当前版本为
   `0.0.0-development` 时，不会刷新已存在的内置 skill 目标。
 - 已发布 skill：如果某个已发布 skill 已经有本地 canonical 副本
@@ -249,15 +249,16 @@ skills。
 
 - 所有权规则：命令会扫描每个已存在的受支持本地 skill 根目录：
   `${CODEX_HOME:-~/.codex}/skills`、`~/.claude/skills`，以及
-  `~/.codebuddy/skills`、`~/.workbuddy/skills`、
-  `${OPENCLAW_HOME:-~/.openclaw}/skills`、`~/.qoderwork/skills`。只保留包含
-  可解析 `.oo-metadata.json` 且其中包含非空 `version` 的子目录。
+  `${HERMES_HOME:-~/.hermes}/skills`、`~/.codebuddy/skills`、
+  `~/.workbuddy/skills`、`${OPENCLAW_HOME:-~/.openclaw}/skills`、
+  `~/.qoderwork/skills`。只保留包含可解析 `.oo-metadata.json` 且其中包含非空
+  `version` 的子目录。
 - 输出：文本输出会先打印摘要行，再为每个唯一的可见 skill 身份打印一个块。
   如果多个宿主中的安装具有相同 `name`、来源和版本，则会折叠到同一个块中。
 - 排序：bundled skills 会排在最前面；其中 `oo` 优先，其次
   `oo-find-skills`，再其次 `oo-create-skill`；其余 skill 按名称排序。每个
-  块内的宿主名称按 `Codex`、`Claude Code`、`CodeBuddy`、`WorkBuddy`、
-  `OpenClaw`、`QoderWork` 顺序显示。
+  块内的宿主名称按 `Codex`、`Claude Code`、`Hermes`、`CodeBuddy`、
+  `WorkBuddy`、`OpenClaw`、`QoderWork` 顺序显示。
 - 输出：每个 skill 块会显示 skill 名称、宿主、来源 package、内置或本地标记，以
   及记录的版本号。
 - 说明：如果折叠后的 skill 安装在多个受支持宿主中，`宿主` 字段会列出所有
@@ -268,7 +269,7 @@ skills。
 检查当前环境是否有权限编辑本地 skills。
 
 - 选项：`--agent <agent>` 将宿主检查限制为一个受支持 agent：`codex`、
-  `claude`、`codebuddy`、`workbuddy`、`openclaw` 或 `qoderwork`。
+  `claude`、`hermes`、`codebuddy`、`workbuddy`、`openclaw` 或 `qoderwork`。
 - 宿主检查：未提供 `--agent` 时，至少需要存在一个受支持 agent home 目录。
   提供 `--agent` 时，该指定 agent home 目录必须存在。
 - 存储检查：命令会在需要时创建 `<config-dir>/skills/local` 和每个已检查宿主
@@ -295,8 +296,8 @@ skills。
   其中 `<config-dir>` 是 oo settings 文件所在目录。
 - 目标目录：命令会向每个已存在的受支持 agent skill 目录发布目录链接：
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`、`~/.claude/skills/<skill-id>`，
-  `~/.codebuddy/skills/<skill-id>`、
-  `~/.workbuddy/skills/<skill-id>`、
+  `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`、
+  `~/.codebuddy/skills/<skill-id>`、`~/.workbuddy/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`，以及
   `~/.qoderwork/skills/<skill-id>`。
 - 失败行为：如果没有受支持的 agent home，或 canonical 本地目录、任意目标目录
@@ -356,8 +357,8 @@ skills。
   如果用户取消这些勾选，命令完成时会移除对应已安装 skill。
 - canonical 目录：内置 skill 会先释放到
   `<config-dir>/skills/bundled/<agent>/<skill-id>`，其中 `<config-dir>` 是
-  `settings.toml` 所在目录，`<agent>` 为 `codex`、`claude`、`codebuddy`、
-  `workbuddy`、`openclaw` 或 `qoderwork`。
+  `settings.toml` 所在目录，`<agent>` 为 `codex`、`claude`、`hermes`、
+  `codebuddy`、`workbuddy`、`openclaw` 或 `qoderwork`。
 - canonical 目录：已发布 skill 会先释放到
   `<config-dir>/skills/registry/<skill-id>`。
 - 迁移：升级后首次运行 `oo skills install` 时，命令会清理历史遗留的 canonical
@@ -367,14 +368,15 @@ skills。
 - 目标目录：内置和已发布 skill 会发布到所有已存在的受支持宿主目录，目前包括
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>` 和
   `~/.claude/skills/<skill-id>`，以及
+  `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`、
   `~/.codebuddy/skills/<skill-id>`、
   `~/.workbuddy/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`、
   `~/.qoderwork/skills/<skill-id>`。
 - 目标目录：当已存在的受支持宿主缺少 `skills` 根目录时，命令会先创建该目录，
   再发布所选 skill。
-- 安装方式：内置和已发布的 Codex / Claude Code / CodeBuddy / WorkBuddy /
-  QoderWork skill 会优先把目标目录发布为指向 canonical 目录的软连接。如果当前平台
+- 安装方式：内置和已发布的 Codex / Claude Code / Hermes / CodeBuddy /
+  WorkBuddy / QoderWork skill 会优先把目标目录发布为指向 canonical 目录的软连接。如果当前平台
   或环境下创建软连接失败，则会回退为把 canonical 目录内容复制到目标 skills 目录。
 - 安装方式：内置和已发布的 OpenClaw skill 会直接复制到
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`，以确保安装后的 skill
@@ -394,8 +396,8 @@ skills。
   skill，命令不会覆盖它。
 - 说明：在交互选择页面中，存在重名冲突的 skill 会在列表中显示状态标记；
   只要用户仍然选择该项，就会执行覆盖。
-- 说明：当 Codex、Claude Code、CodeBuddy、WorkBuddy、OpenClaw 和 QoderWork
-  的受支持根目录都不存在时，命令会直接报错退出。
+- 说明：当 Codex、Claude Code、Hermes、CodeBuddy、WorkBuddy、OpenClaw 和
+  QoderWork 的受支持根目录都不存在时，命令会直接报错退出。
 - 说明：只有当 bundled skill 的 `.oo-metadata.json` 可以被解析，且其中包
   含非空的 `version` 时，`oo` 才会认为这是自己管理的内置 skill；否则会视
   为其他 skill，并拒绝覆盖。
@@ -433,6 +435,7 @@ skills。
 - 会同时移除目标目录：内置和已发布 skill 会从所有已存在的受支持宿主目录中
   移除，目前包括 `${CODEX_HOME:-~/.codex}/skills/<skill>` 和
   `~/.claude/skills/<skill>`，以及
+  `${HERMES_HOME:-~/.hermes}/skills/<skill>`、
   `~/.codebuddy/skills/<skill>`、
   `~/.workbuddy/skills/<skill>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`、

--- a/src/application/commands/skills/bundled-skill-observation.test.ts
+++ b/src/application/commands/skills/bundled-skill-observation.test.ts
@@ -137,6 +137,33 @@ describe("bundled skill observation", () => {
         }
     });
 
+    test("requires the resolved Hermes home directory to exist", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const hermesHomeDirectory = join(rootDirectory, "custom-hermes-home");
+        const env = {
+            HERMES_HOME: hermesHomeDirectory,
+            HOME: rootDirectory,
+        };
+
+        try {
+            await expect(
+                requireBundledSkillHomeDirectory({ env }, "hermes"),
+            ).rejects.toMatchObject({
+                exitCode: 1,
+                key: "errors.skills.hermesNotInstalled",
+            });
+
+            await mkdir(hermesHomeDirectory, { recursive: true });
+
+            expect(await requireBundledSkillHomeDirectory({ env }, "hermes")).toBe(
+                hermesHomeDirectory,
+            );
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
     test("requires the resolved CodeBuddy home directory to exist", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
         const codeBuddyHomeDirectory = join(rootDirectory, ".codebuddy");

--- a/src/application/commands/skills/bundled-skill-paths.ts
+++ b/src/application/commands/skills/bundled-skill-paths.ts
@@ -6,6 +6,7 @@ import { resolveHomeDirectory } from "../../path/home-directory.ts";
 const codexDirectoryName = ".codex";
 const claudeDirectoryName = ".claude";
 const codeBuddyDirectoryName = ".codebuddy";
+const hermesDirectoryName = ".hermes";
 const openClawDirectoryName = ".openclaw";
 const qoderWorkDirectoryName = ".qoderwork";
 const workBuddyDirectoryName = ".workbuddy";
@@ -38,6 +39,18 @@ export function resolveCodeBuddyHomeDirectory(
     env: Record<string, string | undefined>,
 ): string {
     return join(resolveHomeDirectory(env), codeBuddyDirectoryName);
+}
+
+export function resolveHermesHomeDirectory(
+    env: Record<string, string | undefined>,
+): string {
+    const explicitHermesHome = env.HERMES_HOME?.trim();
+
+    if (explicitHermesHome) {
+        return explicitHermesHome;
+    }
+
+    return join(resolveHomeDirectory(env), hermesDirectoryName);
 }
 
 export function resolveOpenClawHomeDirectory(
@@ -75,6 +88,8 @@ export function resolveBundledSkillHomeDirectory(
             return resolveCodeBuddyHomeDirectory(env);
         case "codex":
             return resolveCodexHomeDirectory(env);
+        case "hermes":
+            return resolveHermesHomeDirectory(env);
         case "openclaw":
             return resolveOpenClawHomeDirectory(env);
         case "qoderwork":

--- a/src/application/commands/skills/check.test.ts
+++ b/src/application/commands/skills/check.test.ts
@@ -10,6 +10,7 @@ import {
     resolveClaudeHomeDirectory,
     resolveCodeBuddyHomeDirectory,
     resolveCodexHomeDirectory,
+    resolveHermesHomeDirectory,
     resolveQoderWorkHomeDirectory,
     resolveWorkBuddyHomeDirectory,
 } from "./bundled-skill-paths.ts";
@@ -96,6 +97,40 @@ describe("skills preflight command", () => {
                 "preflight",
                 "--agent",
                 "qoderwork",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Local skill editing is ready. Writable storage: ${canonicalRootDirectoryPath}. Supported hosts: 1.\n`,
+            );
+            expect(await readdir(canonicalRootDirectoryPath)).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("checks Hermes as a requested agent", async () => {
+        const sandbox = await createCliSandbox();
+        const hermesHomeDirectory = resolveHermesHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalRootDirectoryPath = resolveLocalSkillCanonicalRootDirectoryPath(
+            storePaths.settingsFilePath,
+        );
+
+        try {
+            await mkdir(hermesHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "preflight",
+                "--agent",
+                "hermes",
             ]);
 
             expect(result.exitCode).toBe(0);

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -32,6 +32,15 @@ describe("embedded skill assets", () => {
             "references/file-transfer.md",
             "references/task-lifecycle.md",
         ]);
+        expect(getBundledSkillFiles("oo", "hermes").map(file => file.relativePath)).toEqual([
+            "SKILL.md",
+            "references/auth-and-billing.md",
+            "references/search-and-selection.md",
+            "references/package-execution.md",
+            "references/connector-execution.md",
+            "references/file-transfer.md",
+            "references/task-lifecycle.md",
+        ]);
         expect(getBundledSkillFiles("oo", "codebuddy").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "references/auth-and-billing.md",
@@ -86,6 +95,14 @@ describe("embedded skill assets", () => {
             "references/oo-cli-contract.md",
         ]);
         expect(
+            getBundledSkillFiles("oo-find-skills", "hermes").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+            "references/oo-cli-contract.md",
+        ]);
+        expect(
             getBundledSkillFiles("oo-find-skills", "codebuddy").map(
                 file => file.relativePath,
             ),
@@ -133,6 +150,13 @@ describe("embedded skill assets", () => {
             "SKILL.md",
         ]);
         expect(
+            getBundledSkillFiles("oo-create-skill", "hermes").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
             getBundledSkillFiles("oo-create-skill", "codebuddy").map(
                 file => file.relativePath,
             ),
@@ -166,6 +190,7 @@ describe("embedded skill assets", () => {
         expect([...availableBundledSkillAgentNames]).toEqual([
             "codex",
             "claude",
+            "hermes",
             "codebuddy",
             "workbuddy",
             "openclaw",
@@ -174,9 +199,7 @@ describe("embedded skill assets", () => {
 
         for (const skillName of availableBundledSkillNames) {
             for (const agentName of availableBundledSkillAgentNames) {
-                const sourceAgentName = agentName === "workbuddy"
-                    ? "codebuddy"
-                    : agentName;
+                const sourceAgentName = readBundledSkillSourceAgentName(agentName);
                 const sourceDirectory = `contrib/skills/${sourceAgentName}/${skillName}`;
                 const skillFiles = getBundledSkillFiles(skillName, agentName);
 
@@ -250,4 +273,17 @@ function normalizePathForAssertion(path: string): string {
 
 function normalizeLineEndingsForAssertion(text: string): string {
     return text.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
+}
+
+function readBundledSkillSourceAgentName(
+    agentName: (typeof availableBundledSkillAgentNames)[number],
+): string {
+    switch (agentName) {
+        case "hermes":
+            return "claude";
+        case "workbuddy":
+            return "codebuddy";
+        default:
+            return agentName;
+    }
 }

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -52,7 +52,7 @@ import ooQoderWorkSearchAndSelectionReferencePath from "../../../../contrib/skil
 import ooQoderWorkTaskLifecycleReferencePath from "../../../../contrib/skills/qoderwork/oo/references/task-lifecycle.md" with { type: "file" };
 import ooQoderWorkSkillPath from "../../../../contrib/skills/qoderwork/oo/SKILL.md" with { type: "file" };
 
-export const availableBundledSkillAgentNames = ["codex", "claude", "codebuddy", "workbuddy", "openclaw", "qoderwork"] as const;
+export const availableBundledSkillAgentNames = ["codex", "claude", "hermes", "codebuddy", "workbuddy", "openclaw", "qoderwork"] as const;
 export type BundledSkillAgentName = (typeof availableBundledSkillAgentNames)[number];
 
 export const availableBundledSkillNames = ["oo", "oo-find-skills", "oo-create-skill"] as const;
@@ -113,7 +113,7 @@ const ooQoderWorkReferenceFiles = createOoReferenceFiles({
     taskLifecycle: ooQoderWorkTaskLifecycleReferencePath,
 });
 
-// Keep this registry aligned with contrib/skills/<agent>/<skill> so Bun embeds the files.
+// Keep this registry aligned with contrib/skills/<agent>/<skill> or its compatible source so Bun embeds the files.
 const bundledSkillRegistry = {
     "oo": {
         codex: {
@@ -130,6 +130,15 @@ const bundledSkillRegistry = {
             ],
         },
         claude: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooClaudeSkillPath,
+                },
+                ...ooClaudeCompatibleReferenceFiles,
+            ],
+        },
+        hermes: {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -204,6 +213,18 @@ const bundledSkillRegistry = {
                 },
             ],
         },
+        hermes: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooFindSkillsClaudeSkillPath,
+                },
+                {
+                    relativePath: "references/oo-cli-contract.md",
+                    sourcePath: ooFindSkillsClaudeCliContractPath,
+                },
+            ],
+        },
         codebuddy: {
             files: [
                 {
@@ -267,6 +288,14 @@ const bundledSkillRegistry = {
             ],
         },
         claude: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCreateSkillClaudeSkillPath,
+                },
+            ],
+        },
+        hermes: {
             files: [
                 {
                     relativePath: "SKILL.md",

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -26,6 +26,7 @@ import {
     resolveClaudeHomeDirectory,
     resolveCodeBuddyHomeDirectory,
     resolveCodexHomeDirectory,
+    resolveHermesHomeDirectory,
     resolveOpenClawHomeDirectory,
     resolveQoderWorkHomeDirectory,
     resolveWorkBuddyHomeDirectory,
@@ -404,6 +405,62 @@ describe("skills commands", () => {
         }
     });
 
+    test("installs bundled skills into Hermes using the Claude skill template", async () => {
+        const sandbox = await createCliSandbox();
+        const hermesHomeDirectory = resolveHermesHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(hermesHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+            "hermes",
+        );
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const skillFilePath = join(skillDirectoryPath, "SKILL.md");
+        const hermesSkillFile = getBundledSkillFiles("oo", "hermes")
+            .find(file => file.relativePath === "SKILL.md");
+
+        try {
+            if (hermesSkillFile === undefined) {
+                throw new Error("Missing Hermes oo SKILL.md fixture");
+            }
+
+            await mkdir(hermesHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "install", "oo"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Installed skill oo to ${skillDirectoryPath}.\n`,
+            );
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson({ version: "9.9.9" }),
+            );
+            const installedSkillMarkdown = await readFile(skillFilePath, "utf8");
+
+            expect(installedSkillMarkdown).toBe(
+                await Bun.file(hermesSkillFile.sourcePath).text(),
+            );
+            await expect(
+                stat(join(skillDirectoryPath, "agents", "openai.yaml")),
+            ).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("installs bundled skills into OpenClaw when only OpenClaw is installed", async () => {
         const sandbox = await createCliSandbox();
         const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
@@ -768,12 +825,14 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
+        const hermesHomeDirectory = resolveHermesHomeDirectory(sandbox.env);
         const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
         const workBuddyHomeDirectory = resolveWorkBuddyHomeDirectory(sandbox.env);
         const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
         const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
         const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
         const claudeSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
+        const hermesSkillDirectoryPath = join(hermesHomeDirectory, "skills", "chatgpt");
         const codeBuddySkillDirectoryPath = join(codeBuddyHomeDirectory, "skills", "chatgpt");
         const workBuddySkillDirectoryPath = join(workBuddyHomeDirectory, "skills", "chatgpt");
         const openClawSkillDirectoryPath = join(openClawHomeDirectory, "skills", "chatgpt");
@@ -792,6 +851,7 @@ describe("skills commands", () => {
             for (const skillDirectoryPath of [
                 codexSkillDirectoryPath,
                 claudeSkillDirectoryPath,
+                hermesSkillDirectoryPath,
                 codeBuddySkillDirectoryPath,
                 workBuddySkillDirectoryPath,
                 openClawSkillDirectoryPath,
@@ -805,6 +865,7 @@ describe("skills commands", () => {
             for (const skillDirectoryPath of [
                 codexSkillDirectoryPath,
                 claudeSkillDirectoryPath,
+                hermesSkillDirectoryPath,
                 codeBuddySkillDirectoryPath,
                 workBuddySkillDirectoryPath,
                 openClawSkillDirectoryPath,
@@ -825,6 +886,7 @@ describe("skills commands", () => {
                 [
                     `Removed skill chatgpt from ${codexSkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${claudeSkillDirectoryPath}.`,
+                    `Removed skill chatgpt from ${hermesSkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${codeBuddySkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${workBuddySkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${openClawSkillDirectoryPath}.`,
@@ -836,6 +898,7 @@ describe("skills commands", () => {
             for (const skillDirectoryPath of [
                 codexSkillDirectoryPath,
                 claudeSkillDirectoryPath,
+                hermesSkillDirectoryPath,
                 codeBuddySkillDirectoryPath,
                 workBuddySkillDirectoryPath,
                 openClawSkillDirectoryPath,
@@ -1271,12 +1334,14 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
+        const hermesHomeDirectory = resolveHermesHomeDirectory(sandbox.env);
         const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
         const workBuddyHomeDirectory = resolveWorkBuddyHomeDirectory(sandbox.env);
         const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
         const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
         const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
         const claudeSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
+        const hermesSkillDirectoryPath = join(hermesHomeDirectory, "skills", "chatgpt");
         const codeBuddySkillDirectoryPath = join(codeBuddyHomeDirectory, "skills", "chatgpt");
         const workBuddySkillDirectoryPath = join(workBuddyHomeDirectory, "skills", "chatgpt");
         const openClawSkillDirectoryPath = join(openClawHomeDirectory, "skills", "chatgpt");
@@ -1295,6 +1360,7 @@ describe("skills commands", () => {
             await Promise.all([
                 mkdir(codexHomeDirectory, { recursive: true }),
                 mkdir(claudeHomeDirectory, { recursive: true }),
+                mkdir(hermesHomeDirectory, { recursive: true }),
                 mkdir(codeBuddyHomeDirectory, { recursive: true }),
                 mkdir(workBuddyHomeDirectory, { recursive: true }),
                 mkdir(openClawHomeDirectory, { recursive: true }),
@@ -1339,6 +1405,7 @@ describe("skills commands", () => {
                 [
                     `Installed skill chatgpt to ${codexSkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${claudeSkillDirectoryPath}.`,
+                    `Installed skill chatgpt to ${hermesSkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${codeBuddySkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${workBuddySkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${openClawSkillDirectoryPath}.`,
@@ -1350,6 +1417,9 @@ describe("skills commands", () => {
                 await realpath(canonicalSkillDirectoryPath),
             );
             expect(await realpath(claudeSkillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect(await realpath(hermesSkillDirectoryPath)).toBe(
                 await realpath(canonicalSkillDirectoryPath),
             );
             expect(await realpath(codeBuddySkillDirectoryPath)).toBe(
@@ -1368,6 +1438,7 @@ describe("skills commands", () => {
             for (const skillDirectoryPath of [
                 codexSkillDirectoryPath,
                 claudeSkillDirectoryPath,
+                hermesSkillDirectoryPath,
                 codeBuddySkillDirectoryPath,
                 workBuddySkillDirectoryPath,
                 openClawSkillDirectoryPath,

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -9,6 +9,7 @@ import {
     resolveClaudeHomeDirectory,
     resolveCodeBuddyHomeDirectory,
     resolveCodexHomeDirectory,
+    resolveHermesHomeDirectory,
     resolveOpenClawHomeDirectory,
     resolveQoderWorkHomeDirectory,
     resolveWorkBuddyHomeDirectory,
@@ -241,6 +242,49 @@ describe("skills list CLI", () => {
                     "",
                     "oo-create-skill",
                     "  Host: WorkBuddy",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                ].join("\n"),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("lists startup-synchronized Hermes bundled installs when Codex is not installed", async () => {
+        const sandbox = await createCliSandbox();
+        const hermesHomeDirectory = resolveHermesHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(hermesHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install", "oo"], {
+                version: "9.9.9",
+            });
+
+            const result = await sandbox.run(["skills", "list"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    "✓ Found 3 oo-managed skills.",
+                    "",
+                    "oo",
+                    "  Host: Hermes",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-find-skills",
+                    "  Host: Hermes",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-create-skill",
+                    "  Host: Hermes",
                     "  Source: bundled",
                     "  Version: 9.9.9",
                     "",

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -29,10 +29,11 @@ const managedSkillVersionColor = "#7DD3FC";
 const managedSkillHostOrder = {
     codex: 0,
     claude: 1,
-    codebuddy: 2,
-    workbuddy: 3,
-    openclaw: 4,
-    qoderwork: 5,
+    hermes: 2,
+    codebuddy: 3,
+    workbuddy: 4,
+    openclaw: 5,
+    qoderwork: 6,
 } as const satisfies Record<BundledSkillAgentName, number>;
 
 export interface ManagedSkillListItem {
@@ -327,6 +328,8 @@ function readManagedSkillHostLabel(
             return context.translator.t("skills.list.host.codebuddy");
         case "codex":
             return context.translator.t("skills.list.host.codex");
+        case "hermes":
+            return context.translator.t("skills.list.host.hermes");
         case "openclaw":
             return context.translator.t("skills.list.host.openclaw");
         case "qoderwork":

--- a/src/application/commands/skills/managed-skill-host-errors.ts
+++ b/src/application/commands/skills/managed-skill-host-errors.ts
@@ -4,6 +4,7 @@ export type ManagedSkillHostMissingErrorKey
     = | "errors.skills.claudeNotInstalled"
         | "errors.skills.codebuddyNotInstalled"
         | "errors.skills.codexNotInstalled"
+        | "errors.skills.hermesNotInstalled"
         | "errors.skills.openclawNotInstalled"
         | "errors.skills.qoderworkNotInstalled"
         | "errors.skills.workbuddyNotInstalled";
@@ -18,6 +19,8 @@ export function resolveManagedSkillHostMissingErrorKey(
             return "errors.skills.codebuddyNotInstalled";
         case "codex":
             return "errors.skills.codexNotInstalled";
+        case "hermes":
+            return "errors.skills.hermesNotInstalled";
         case "openclaw":
             return "errors.skills.openclawNotInstalled";
         case "qoderwork":

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -361,6 +361,8 @@ export const enMessages = {
         "Claude Code is not installed. Expected the Claude home directory at {path}.",
     "errors.skills.codebuddyNotInstalled":
         "CodeBuddy is not installed. Expected the CodeBuddy home directory at {path}.",
+    "errors.skills.hermesNotInstalled":
+        "Hermes is not installed. Expected the Hermes home directory at {path}.",
     "errors.skills.openclawNotInstalled":
         "OpenClaw is not installed. Expected the OpenClaw home directory at {path}.",
     "errors.skills.qoderworkNotInstalled":
@@ -553,6 +555,7 @@ export const enMessages = {
     "skills.list.host.claude": "Claude Code",
     "skills.list.host.codebuddy": "CodeBuddy",
     "skills.list.host.codex": "Codex",
+    "skills.list.host.hermes": "Hermes",
     "skills.list.host.openclaw": "OpenClaw",
     "skills.list.host.qoderwork": "QoderWork",
     "skills.list.host.workbuddy": "WorkBuddy",
@@ -1015,6 +1018,8 @@ export const zhMessages = {
         "未检测到 Claude Code 安装。期望的 Claude 根目录为 {path}。",
     "errors.skills.codebuddyNotInstalled":
         "未检测到 CodeBuddy 安装。期望的 CodeBuddy 根目录为 {path}。",
+    "errors.skills.hermesNotInstalled":
+        "未检测到 Hermes 安装。期望的 Hermes 根目录为 {path}。",
     "errors.skills.openclawNotInstalled":
         "未检测到 OpenClaw 安装。期望的 OpenClaw 根目录为 {path}。",
     "errors.skills.qoderworkNotInstalled":
@@ -1201,6 +1206,7 @@ export const zhMessages = {
     "skills.list.host.claude": "Claude Code",
     "skills.list.host.codebuddy": "CodeBuddy",
     "skills.list.host.codex": "Codex",
+    "skills.list.host.hermes": "Hermes",
     "skills.list.host.openclaw": "OpenClaw",
     "skills.list.host.qoderwork": "QoderWork",
     "skills.list.host.workbuddy": "WorkBuddy",


### PR DESCRIPTION
Hermes reuses the Claude Code skill template and is integrated into all skill lifecycle commands (install, list, preflight, remove). Its home directory defaults to ~/.hermes and can be overridden via the HERMES_HOME environment variable.