### PR TITLE
fix(skills): copy skills for non-symlink agents

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -337,13 +337,16 @@ directory that already exists.
 - Canonical directory: the skill is created under
   `<config-dir>/skills/local/<skill-id>`, where `<config-dir>` is the directory
   containing the oo settings file.
-- Target directories: the command publishes directory links to each existing
+- Target directories: the command publishes the skill to each existing
   supported agent skill directory:
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`, `~/.claude/skills/<skill-id>`,
   `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`,
   `~/.codebuddy/skills/<skill-id>`, `~/.workbuddy/skills/<skill-id>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
   `~/.qoderwork/skills/<skill-id>`.
+- Publication mode: Codex, Claude Code, and QoderWork targets are published as
+  symlinks to the canonical directory when the current platform and environment
+  allow it. Hermes, CodeBuddy, WorkBuddy, and OpenClaw targets are copied.
 - Failure behavior: if no supported agent home exists, or if the canonical
   local directory or any target directory already exists, the command exits
   non-zero before writing the skill.
@@ -433,14 +436,13 @@ Install bundled or published skills into supported local skill directories.
   the command creates that root before publishing the selected skill.
 - Path rule: published skill names are accepted only when their resolved
   canonical and target directories remain under those local `skills` roots.
-- Installation mode: bundled and published Codex, Claude Code, Hermes,
-  CodeBuddy, WorkBuddy, and QoderWork skills are published to the target
-  directory as a symlink to the canonical directory when the current platform
-  and environment allow it. When symlink creation fails, `oo` falls back to
-  copying the canonical files into the target skills directory.
-- Installation mode: bundled and published OpenClaw skills are copied into
-  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>` so the installed skill
-  stays inside OpenClaw's managed skills root.
+- Installation mode: bundled and published Codex, Claude Code, and QoderWork
+  skills are published to the target directory as a symlink to the canonical
+  directory when the current platform and environment allow it. When symlink
+  creation fails, `oo` falls back to copying the canonical files into the target
+  skills directory.
+- Installation mode: bundled and published Hermes, CodeBuddy, WorkBuddy, and
+  OpenClaw skills are copied into the target skills directory.
 - Metadata: bundled skills write a hidden `.oo-metadata.json` file whose
   `version` field matches the current `oo` version.
 - Metadata: published skills write a hidden `.oo-metadata.json` file whose

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -294,12 +294,14 @@ skills。
   frontmatter。未提供时不会生成 `metadata.title`。
 - canonical 目录：skill 创建在 `<config-dir>/skills/local/<skill-id>` 下，
   其中 `<config-dir>` 是 oo settings 文件所在目录。
-- 目标目录：命令会向每个已存在的受支持 agent skill 目录发布目录链接：
+- 目标目录：命令会向每个已存在的受支持 agent skill 目录发布该 skill：
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`、`~/.claude/skills/<skill-id>`，
   `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`、
   `~/.codebuddy/skills/<skill-id>`、`~/.workbuddy/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`，以及
   `~/.qoderwork/skills/<skill-id>`。
+- 发布方式：Codex、Claude Code 和 QoderWork 目标会在当前平台和环境允许时发布为
+  指向 canonical 目录的软连接；Hermes、CodeBuddy、WorkBuddy 和 OpenClaw 目标会复制。
 - 失败行为：如果没有受支持的 agent home，或 canonical 本地目录、任意目标目录
   已存在，命令会在写入 skill 前以非零状态退出。
 - 输出：文本输出会先打印 canonical 存储目录，然后为每个目标路径打印一行带实际发布
@@ -375,12 +377,11 @@ skills。
   `~/.qoderwork/skills/<skill-id>`。
 - 目标目录：当已存在的受支持宿主缺少 `skills` 根目录时，命令会先创建该目录，
   再发布所选 skill。
-- 安装方式：内置和已发布的 Codex / Claude Code / Hermes / CodeBuddy /
-  WorkBuddy / QoderWork skill 会优先把目标目录发布为指向 canonical 目录的软连接。如果当前平台
-  或环境下创建软连接失败，则会回退为把 canonical 目录内容复制到目标 skills 目录。
-- 安装方式：内置和已发布的 OpenClaw skill 会直接复制到
-  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`，以确保安装后的 skill
-  保持在 OpenClaw 管理的 skills 根目录内。
+- 安装方式：内置和已发布的 Codex / Claude Code / QoderWork skill 会优先把
+  目标目录发布为指向 canonical 目录的软连接。如果当前平台或环境下创建软连接失败，则
+  会回退为把 canonical 目录内容复制到目标 skills 目录。
+- 安装方式：内置和已发布的 Hermes / CodeBuddy / WorkBuddy / OpenClaw skill
+  会直接复制到目标 skills 目录。
 - 元数据：内置 skill 会写入一个隐藏的 `.oo-metadata.json` 文件，其中
   `version` 字段记录当前 `oo` 版本。
 - 元数据：已发布 skill 也会写入一个隐藏的 `.oo-metadata.json` 文件，

--- a/src/application/commands/skills/auto-sync.ts
+++ b/src/application/commands/skills/auto-sync.ts
@@ -39,6 +39,7 @@ import {
     isManagedSkillPathContained,
     resolveManagedSkillCanonicalRootDirectoryPath,
 } from "./managed-skill-paths.ts";
+import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
 import { publishManagedBundledSkill } from "./shared.ts";
 
 interface ManagedSkillTargetState<Metadata> {
@@ -310,9 +311,9 @@ async function synchronizeRegistrySkill(
         const publication = await publishBundledSkillInstallation({
             canonicalSkillDirectoryPath: skill.path,
             installedSkillDirectoryPath: installation.installedSkillDirectoryPath,
-            publicationMode: installation.agentName === "openclaw"
-                ? "copy"
-                : "symlink-or-copy",
+            publicationMode: resolveManagedSkillPublicationMode(
+                installation.agentName,
+            ),
         });
 
         context.logger.info(

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -439,9 +439,10 @@ describe("skills commands", () => {
             expect(result.stdout).toBe(
                 `Installed skill oo to ${skillDirectoryPath}.\n`,
             );
-            expect(await realpath(skillDirectoryPath)).toBe(
+            expect(await realpath(skillDirectoryPath)).not.toBe(
                 await realpath(canonicalSkillDirectoryPath),
             );
+            expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: "9.9.9" }),
             );
@@ -602,9 +603,10 @@ describe("skills commands", () => {
             expect(result.stdout).toBe(
                 `Installed skill oo to ${skillDirectoryPath}.\n`,
             );
-            expect(await realpath(skillDirectoryPath)).toBe(
+            expect(await realpath(skillDirectoryPath)).not.toBe(
                 await realpath(canonicalSkillDirectoryPath),
             );
+            expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: "9.9.9" }),
             );
@@ -656,9 +658,10 @@ describe("skills commands", () => {
             expect(result.stdout).toBe(
                 `Installed skill oo to ${skillDirectoryPath}.\n`,
             );
-            expect(await realpath(skillDirectoryPath)).toBe(
+            expect(await realpath(skillDirectoryPath)).not.toBe(
                 await realpath(canonicalSkillDirectoryPath),
             );
+            expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: "9.9.9" }),
             );
@@ -1413,28 +1416,29 @@ describe("skills commands", () => {
                     "",
                 ].join("\n"),
             );
-            expect(await realpath(codexSkillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
-            );
-            expect(await realpath(claudeSkillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
-            );
-            expect(await realpath(hermesSkillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
-            );
-            expect(await realpath(codeBuddySkillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
-            );
-            expect(await realpath(workBuddySkillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
-            );
-            expect(await realpath(openClawSkillDirectoryPath)).not.toBe(
-                await realpath(canonicalSkillDirectoryPath),
-            );
-            expect(await realpath(qoderWorkSkillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
-            );
-            expect((await lstat(openClawSkillDirectoryPath)).isSymbolicLink()).toBeFalse();
+            const canonicalSkillRealPath = await realpath(canonicalSkillDirectoryPath);
+
+            for (const linkedSkillDirectoryPath of [
+                codexSkillDirectoryPath,
+                claudeSkillDirectoryPath,
+                qoderWorkSkillDirectoryPath,
+            ]) {
+                expect(await realpath(linkedSkillDirectoryPath)).toBe(
+                    canonicalSkillRealPath,
+                );
+            }
+
+            for (const copiedSkillDirectoryPath of [
+                hermesSkillDirectoryPath,
+                codeBuddySkillDirectoryPath,
+                workBuddySkillDirectoryPath,
+                openClawSkillDirectoryPath,
+            ]) {
+                expect(await realpath(copiedSkillDirectoryPath)).not.toBe(
+                    canonicalSkillRealPath,
+                );
+                expect((await lstat(copiedSkillDirectoryPath)).isSymbolicLink()).toBeFalse();
+            }
             for (const skillDirectoryPath of [
                 codexSkillDirectoryPath,
                 claudeSkillDirectoryPath,

--- a/src/application/commands/skills/init.test.ts
+++ b/src/application/commands/skills/init.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, realpath, stat } from "node:fs/promises";
+import { lstat, mkdir, readFile, realpath, stat } from "node:fs/promises";
 import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
@@ -8,6 +8,7 @@ import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import {
     resolveClaudeHomeDirectory,
+    resolveCodeBuddyHomeDirectory,
     resolveCodexHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { resolveLocalSkillCanonicalDirectoryPath } from "./managed-skill-paths.ts";
@@ -129,6 +130,49 @@ describe("skills init command", () => {
                 "TODO: Describe the workflow this skill should follow.",
                 "",
             ].join("\n"));
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("initializes a local skill by copying for non-symlink hosts", async () => {
+        const sandbox = await createCliSandbox();
+        const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codeBuddyHomeDirectory, "skills", "copy-skill");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "copy-skill",
+        );
+
+        try {
+            await mkdir(codeBuddyHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "init",
+                "copy-skill",
+                "--description",
+                "Use a known package workflow.",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                [
+                    `Initialized skill copy-skill in canonical storage at ${canonicalSkillDirectoryPath}.`,
+                    `Copied skill copy-skill to ${skillDirectoryPath}.`,
+                    "",
+                ].join("\n"),
+            );
+            expect(await realpath(skillDirectoryPath)).not.toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/init.ts
+++ b/src/application/commands/skills/init.ts
@@ -24,6 +24,7 @@ import {
     isLocalSkillPathContained,
     resolveLocalSkillCanonicalDirectoryPath,
 } from "./managed-skill-paths.ts";
+import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
 import {
     installedRegistrySkillCompatibility,
     renderOoPackageExecutionGuidance,
@@ -175,7 +176,9 @@ async function initializeLocalSkill(
             const published = await publishBundledSkillInstallation({
                 canonicalSkillDirectoryPath,
                 installedSkillDirectoryPath: target.installedSkillDirectoryPath,
-                publicationMode: "symlink-or-copy",
+                publicationMode: resolveManagedSkillPublicationMode(
+                    target.agentName,
+                ),
             });
 
             publishedTargets.push(target);

--- a/src/application/commands/skills/managed-skill-publication.test.ts
+++ b/src/application/commands/skills/managed-skill-publication.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { availableBundledSkillAgentNames } from "./embedded-assets.ts";
+import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
+
+describe("managed skill publication policy", () => {
+    test("allows symlink publication only for explicitly supported agents", () => {
+        const modes = Object.fromEntries(
+            availableBundledSkillAgentNames.map(agentName => [
+                agentName,
+                resolveManagedSkillPublicationMode(agentName),
+            ]),
+        );
+
+        expect(modes).toEqual({
+            claude: "symlink-or-copy",
+            codebuddy: "copy",
+            codex: "symlink-or-copy",
+            hermes: "copy",
+            openclaw: "copy",
+            qoderwork: "symlink-or-copy",
+            workbuddy: "copy",
+        });
+    });
+});

--- a/src/application/commands/skills/managed-skill-publication.ts
+++ b/src/application/commands/skills/managed-skill-publication.ts
@@ -1,0 +1,16 @@
+import type { BundledSkillPublicationMode } from "./bundled-skill-filesystem.ts";
+import type { BundledSkillAgentName } from "./embedded-assets.ts";
+
+const symlinkCapableManagedSkillAgentNames: ReadonlySet<BundledSkillAgentName> = new Set([
+    "claude",
+    "codex",
+    "qoderwork",
+]);
+
+export function resolveManagedSkillPublicationMode(
+    agentName: BundledSkillAgentName,
+): BundledSkillPublicationMode {
+    return symlinkCapableManagedSkillAgentNames.has(agentName)
+        ? "symlink-or-copy"
+        : "copy";
+}

--- a/src/application/commands/skills/registry-skill-publication.ts
+++ b/src/application/commands/skills/registry-skill-publication.ts
@@ -19,6 +19,7 @@ import {
 import {
     resolveManagedSkillCanonicalDirectoryPath,
 } from "./managed-skill-paths.ts";
+import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
 import { requireExtractedRegistrySkillDirectory } from "./registry-skill-archive.ts";
 import { rewriteInstalledRegistrySkillMarkdown } from "./registry-skill-markdown.ts";
 
@@ -93,9 +94,9 @@ export async function publishPreparedRegistrySkillPublication(
             const publication = await publishBundledSkillInstallation({
                 canonicalSkillDirectoryPath: preparedPublication.canonicalSkillDirectoryPath,
                 installedSkillDirectoryPath: installation.installedSkillDirectoryPath,
-                publicationMode: installation.agentName === "openclaw"
-                    ? "copy"
-                    : "symlink-or-copy",
+                publicationMode: resolveManagedSkillPublicationMode(
+                    installation.agentName,
+                ),
             });
 
             return {

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -41,11 +41,12 @@ import {
     resolveManagedSkillHostInstallations,
 } from "./managed-skill-hosts.ts";
 import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
-
 import {
     isManagedSkillPathContained,
     resolveManagedSkillCanonicalDirectoryPath,
 } from "./managed-skill-paths.ts";
+
+import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
 
 interface BundledSkillHostInstallation extends ManagedSkillHostInstallation {
     canonicalSkillDirectoryPath: string;
@@ -220,7 +221,7 @@ export async function publishManagedBundledSkill(options: {
 
     return publishBundledSkillInstallation({
         ...installationPaths,
-        publicationMode: options.agentName === "openclaw" ? "copy" : "symlink-or-copy",
+        publicationMode: resolveManagedSkillPublicationMode(options.agentName),
     });
 }
 

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, realpath } from "node:fs/promises";
 import { join } from "node:path";
 import { stripVTControlCharacters } from "node:util";
 
@@ -19,6 +19,7 @@ import { APP_NAME } from "../../config/app-config.ts";
 import {
     resolveClaudeHomeDirectory,
     resolveCodexHomeDirectory,
+    resolveHermesHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import {
     resolveManagedSkillCanonicalDirectoryPath,
@@ -240,6 +241,84 @@ describe("skills update command", () => {
                 "utf8",
             )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }));
             expect(await readFile(join(claudeInstalledSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
+                "# ChatGPT fresh",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("updates a published managed skill by copying for non-symlink hosts", async () => {
+        const sandbox = await createCliSandbox();
+        const hermesHomeDirectory = resolveHermesHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const installedSkillDirectoryPath = join(hermesHomeDirectory, "skills", "chatgpt");
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+
+        try {
+            await mkdir(hermesHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+            await writeManagedRegistrySkillInstallation({
+                canonicalSkillDirectoryPath,
+                installedSkillDirectoryPath,
+                packageName: "openai",
+                skillMarkdown: "# ChatGPT stale\n",
+                version: "0.0.3",
+            });
+
+            const result = await sandbox.run(
+                ["skills", "update", "chatgpt"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.4",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/openai/-/meta/openai-0.0.4.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT fresh\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Updated skill chatgpt to ${installedSkillDirectoryPath}.\n`,
+            );
+            expect(await realpath(installedSkillDirectoryPath)).not.toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect((await lstat(installedSkillDirectoryPath)).isSymbolicLink()).toBeFalse();
+            expect(await readFile(
+                resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
+                "utf8",
+            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }));
+            expect(await readFile(join(installedSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
                 "# ChatGPT fresh",
             );
         }


### PR DESCRIPTION
Some supported agents ignore skills when the installed target is a symlink. Centralizing the publication policy keeps bundled, registry, update, startup sync, and local init paths aligned while retaining symlinks only for agents known to support them.