### PR TITLE
feat(skills): add Trae skill host

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -265,8 +265,8 @@ Before running a command, `oo` silently synchronizes managed skills for every
 supported host directory that already exists.
 
 - Bundled skills: `oo` ensures `oo` and `oo-find-skills` are installed for
-  each detected Codex, Claude Code, Hermes, CodeBuddy, WorkBuddy, OpenClaw,
-  and QoderWork host.
+  each detected Codex, Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae,
+  OpenClaw, and QoderWork host.
   Existing oo-managed bundled skill targets are refreshed to the current `oo`
   version, except that `0.0.0-development` startup runs do not refresh
   existing bundled targets.
@@ -284,8 +284,9 @@ List oo-managed skills from supported local skill directories.
 - Ownership rule: the command scans each existing supported local skill root:
   `${CODEX_HOME:-~/.codex}/skills`, `~/.claude/skills`,
   `${HERMES_HOME:-~/.hermes}/skills`, `~/.codebuddy/skills`,
-  `~/.workbuddy/skills`, `${OPENCLAW_HOME:-~/.openclaw}/skills`, and
-  `~/.qoderwork/skills`. It keeps only child directories whose
+  `~/.workbuddy/skills`, `~/.trae/skills`,
+  `${OPENCLAW_HOME:-~/.openclaw}/skills`, and `~/.qoderwork/skills`. It keeps
+  only child directories whose
   `.oo-metadata.json` can be parsed and contains a non-empty `version`.
 - Output: text output prints a summary line and one block per unique visible
   skill identity. Identical `name`/source/version installs across multiple
@@ -293,8 +294,8 @@ List oo-managed skills from supported local skill directories.
 - Ordering: bundled skills are listed first when present, with `oo` before
   `oo-find-skills` before `oo-create-skill`; the remaining skills are ordered
   by skill name. Host names within a block follow `Codex`,
-  `Claude Code`, `Hermes`, `CodeBuddy`, `WorkBuddy`, `OpenClaw`, `QoderWork`
-  order.
+  `Claude Code`, `Hermes`, `CodeBuddy`, `WorkBuddy`, `Trae`, `OpenClaw`,
+  `QoderWork` order.
 - Output: each skill block shows the skill name, host, source package or
   bundled/local marker, and recorded version.
 - Notes: when a folded skill is installed in multiple supported hosts, the
@@ -305,8 +306,8 @@ List oo-managed skills from supported local skill directories.
 Check whether this environment has permission to edit local skills.
 
 - Options: `--agent <agent>` restricts the host check to one supported agent:
-  `codex`, `claude`, `hermes`, `codebuddy`, `workbuddy`, `openclaw`, or
-  `qoderwork`.
+  `codex`, `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`,
+  or `qoderwork`.
 - Host check: without `--agent`, at least one supported agent home directory
   must already exist. With `--agent`, that specific agent home directory must
   exist.
@@ -342,11 +343,13 @@ directory that already exists.
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`, `~/.claude/skills/<skill-id>`,
   `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`,
   `~/.codebuddy/skills/<skill-id>`, `~/.workbuddy/skills/<skill-id>`,
+  `~/.trae/skills/<skill-id>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
   `~/.qoderwork/skills/<skill-id>`.
-- Publication mode: Codex, Claude Code, and QoderWork targets are published as
-  symlinks to the canonical directory when the current platform and environment
-  allow it. Hermes, CodeBuddy, WorkBuddy, and OpenClaw targets are copied.
+- Publication mode: Codex, Claude Code, Trae, and QoderWork targets are
+  published as symlinks to the canonical directory when the current platform
+  and environment allow it. Hermes, CodeBuddy, WorkBuddy, and OpenClaw targets
+  are copied.
 - Failure behavior: if no supported agent home exists, or if the canonical
   local directory or any target directory already exists, the command exits
   non-zero before writing the skill.
@@ -414,7 +417,7 @@ Install bundled or published skills into supported local skill directories.
 - Canonical directory: bundled skills are materialized under
   `<config-dir>/skills/bundled/<agent>/<skill-id>`, where `<config-dir>` is the
   directory that contains `settings.toml` and `<agent>` is `codex`, `claude`,
-  `hermes`, `codebuddy`, `workbuddy`, `openclaw`, or `qoderwork`.
+  `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`, or `qoderwork`.
 - Canonical directory: published skills are materialized to
   `<config-dir>/skills/registry/<skill-id>`.
 - Migration: on first run after upgrading, `oo skills install` removes legacy
@@ -430,17 +433,18 @@ Install bundled or published skills into supported local skill directories.
   `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`,
   `~/.codebuddy/skills/<skill-id>`,
   `~/.workbuddy/skills/<skill-id>`,
+  `~/.trae/skills/<skill-id>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
   `~/.qoderwork/skills/<skill-id>`.
 - Target directory: if an existing supported host is missing its `skills` root,
   the command creates that root before publishing the selected skill.
 - Path rule: published skill names are accepted only when their resolved
   canonical and target directories remain under those local `skills` roots.
-- Installation mode: bundled and published Codex, Claude Code, and QoderWork
-  skills are published to the target directory as a symlink to the canonical
-  directory when the current platform and environment allow it. When symlink
-  creation fails, `oo` falls back to copying the canonical files into the target
-  skills directory.
+- Installation mode: bundled and published Codex, Claude Code, Trae, and
+  QoderWork skills are published to the target directory as a symlink to the
+  canonical directory when the current platform and environment allow it. When
+  symlink creation fails, `oo` falls back to copying the canonical files into
+  the target skills directory.
 - Installation mode: bundled and published Hermes, CodeBuddy, WorkBuddy, and
   OpenClaw skills are copied into the target skills directory.
 - Metadata: bundled skills write a hidden `.oo-metadata.json` file whose
@@ -460,7 +464,7 @@ Install bundled or published skills into supported local skill directories.
 - Notes: in the interactive picker, conflicting skills are marked in the list;
   selecting one means it will be overwritten.
 - Notes: the command exits with an error when none of the supported Codex,
-  Claude Code, Hermes, CodeBuddy, WorkBuddy, OpenClaw, or QoderWork home
+  Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae, OpenClaw, or QoderWork home
   directories exists.
 - Notes: an existing bundled skill installation is considered managed by `oo`
   only when its `.oo-metadata.json` file can be parsed and contains a
@@ -509,6 +513,7 @@ Remove oo-managed skills from supported local skill directories.
   `${CODEX_HOME:-~/.codex}/skills/<skill>`, `~/.claude/skills/<skill>`,
   `${HERMES_HOME:-~/.hermes}/skills/<skill>`,
   `~/.codebuddy/skills/<skill>`, `~/.workbuddy/skills/<skill>`,
+  `~/.trae/skills/<skill>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`, and
   `~/.qoderwork/skills/<skill>`.
 - Path rule: `[skill]` must resolve to child directories under those local

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -234,9 +234,10 @@
 skills。
 
 - 内置 skill：`oo` 会确保每个检测到的 Codex、Claude Code、Hermes、
-  CodeBuddy、WorkBuddy、OpenClaw 和 QoderWork 宿主都安装了 `oo` 与 `oo-find-skills`。已经由 oo
-  管理的内置 skill 目标会刷新到当前 `oo` 版本；但当启动中的当前版本为
-  `0.0.0-development` 时，不会刷新已存在的内置 skill 目标。
+  CodeBuddy、WorkBuddy、Trae、OpenClaw 和 QoderWork 宿主都安装了 `oo` 与
+  `oo-find-skills`。已经由 oo 管理的内置 skill 目标会刷新到当前 `oo` 版本；
+  但当启动中的当前版本为 `0.0.0-development` 时，不会刷新已存在的内置 skill
+  目标。
 - 已发布 skill：如果某个已发布 skill 已经有本地 canonical 副本
   `<config-dir>/skills/registry/<skill-id>`，`oo` 会把该副本发布到任何新检测
   到且尚未安装它的受支持宿主。
@@ -250,15 +251,15 @@ skills。
 - 所有权规则：命令会扫描每个已存在的受支持本地 skill 根目录：
   `${CODEX_HOME:-~/.codex}/skills`、`~/.claude/skills`，以及
   `${HERMES_HOME:-~/.hermes}/skills`、`~/.codebuddy/skills`、
-  `~/.workbuddy/skills`、`${OPENCLAW_HOME:-~/.openclaw}/skills`、
-  `~/.qoderwork/skills`。只保留包含可解析 `.oo-metadata.json` 且其中包含非空
-  `version` 的子目录。
+  `~/.workbuddy/skills`、`~/.trae/skills`、
+  `${OPENCLAW_HOME:-~/.openclaw}/skills`、`~/.qoderwork/skills`。只保留包含
+  可解析 `.oo-metadata.json` 且其中包含非空 `version` 的子目录。
 - 输出：文本输出会先打印摘要行，再为每个唯一的可见 skill 身份打印一个块。
   如果多个宿主中的安装具有相同 `name`、来源和版本，则会折叠到同一个块中。
 - 排序：bundled skills 会排在最前面；其中 `oo` 优先，其次
   `oo-find-skills`，再其次 `oo-create-skill`；其余 skill 按名称排序。每个
   块内的宿主名称按 `Codex`、`Claude Code`、`Hermes`、`CodeBuddy`、
-  `WorkBuddy`、`OpenClaw`、`QoderWork` 顺序显示。
+  `WorkBuddy`、`Trae`、`OpenClaw`、`QoderWork` 顺序显示。
 - 输出：每个 skill 块会显示 skill 名称、宿主、来源 package、内置或本地标记，以
   及记录的版本号。
 - 说明：如果折叠后的 skill 安装在多个受支持宿主中，`宿主` 字段会列出所有
@@ -269,7 +270,8 @@ skills。
 检查当前环境是否有权限编辑本地 skills。
 
 - 选项：`--agent <agent>` 将宿主检查限制为一个受支持 agent：`codex`、
-  `claude`、`hermes`、`codebuddy`、`workbuddy`、`openclaw` 或 `qoderwork`。
+  `claude`、`hermes`、`codebuddy`、`workbuddy`、`trae`、`openclaw` 或
+  `qoderwork`。
 - 宿主检查：未提供 `--agent` 时，至少需要存在一个受支持 agent home 目录。
   提供 `--agent` 时，该指定 agent home 目录必须存在。
 - 存储检查：命令会在需要时创建 `<config-dir>/skills/local` 和每个已检查宿主
@@ -298,10 +300,12 @@ skills。
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`、`~/.claude/skills/<skill-id>`，
   `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`、
   `~/.codebuddy/skills/<skill-id>`、`~/.workbuddy/skills/<skill-id>`、
+  `~/.trae/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`，以及
   `~/.qoderwork/skills/<skill-id>`。
-- 发布方式：Codex、Claude Code 和 QoderWork 目标会在当前平台和环境允许时发布为
-  指向 canonical 目录的软连接；Hermes、CodeBuddy、WorkBuddy 和 OpenClaw 目标会复制。
+- 发布方式：Codex、Claude Code、Trae 和 QoderWork 目标会在当前平台和环境允许时
+  发布为指向 canonical 目录的软连接；Hermes、CodeBuddy、WorkBuddy 和 OpenClaw
+  目标会复制。
 - 失败行为：如果没有受支持的 agent home，或 canonical 本地目录、任意目标目录
   已存在，命令会在写入 skill 前以非零状态退出。
 - 输出：文本输出会先打印 canonical 存储目录，然后为每个目标路径打印一行带实际发布
@@ -360,7 +364,7 @@ skills。
 - canonical 目录：内置 skill 会先释放到
   `<config-dir>/skills/bundled/<agent>/<skill-id>`，其中 `<config-dir>` 是
   `settings.toml` 所在目录，`<agent>` 为 `codex`、`claude`、`hermes`、
-  `codebuddy`、`workbuddy`、`openclaw` 或 `qoderwork`。
+  `codebuddy`、`workbuddy`、`trae`、`openclaw` 或 `qoderwork`。
 - canonical 目录：已发布 skill 会先释放到
   `<config-dir>/skills/registry/<skill-id>`。
 - 迁移：升级后首次运行 `oo skills install` 时，命令会清理历史遗留的 canonical
@@ -373,13 +377,14 @@ skills。
   `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`、
   `~/.codebuddy/skills/<skill-id>`、
   `~/.workbuddy/skills/<skill-id>`、
+  `~/.trae/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`、
   `~/.qoderwork/skills/<skill-id>`。
 - 目标目录：当已存在的受支持宿主缺少 `skills` 根目录时，命令会先创建该目录，
   再发布所选 skill。
-- 安装方式：内置和已发布的 Codex / Claude Code / QoderWork skill 会优先把
-  目标目录发布为指向 canonical 目录的软连接。如果当前平台或环境下创建软连接失败，则
-  会回退为把 canonical 目录内容复制到目标 skills 目录。
+- 安装方式：内置和已发布的 Codex / Claude Code / Trae / QoderWork skill 会优
+  先把目标目录发布为指向 canonical 目录的软连接。如果当前平台或环境下创建
+  软连接失败，则会回退为把 canonical 目录内容复制到目标 skills 目录。
 - 安装方式：内置和已发布的 Hermes / CodeBuddy / WorkBuddy / OpenClaw skill
   会直接复制到目标 skills 目录。
 - 元数据：内置 skill 会写入一个隐藏的 `.oo-metadata.json` 文件，其中
@@ -397,8 +402,8 @@ skills。
   skill，命令不会覆盖它。
 - 说明：在交互选择页面中，存在重名冲突的 skill 会在列表中显示状态标记；
   只要用户仍然选择该项，就会执行覆盖。
-- 说明：当 Codex、Claude Code、Hermes、CodeBuddy、WorkBuddy、OpenClaw 和
-  QoderWork 的受支持根目录都不存在时，命令会直接报错退出。
+- 说明：当 Codex、Claude Code、Hermes、CodeBuddy、WorkBuddy、Trae、OpenClaw
+  和 QoderWork 的受支持根目录都不存在时，命令会直接报错退出。
 - 说明：只有当 bundled skill 的 `.oo-metadata.json` 可以被解析，且其中包
   含非空的 `version` 时，`oo` 才会认为这是自己管理的内置 skill；否则会视
   为其他 skill，并拒绝覆盖。
@@ -439,6 +444,7 @@ skills。
   `${HERMES_HOME:-~/.hermes}/skills/<skill>`、
   `~/.codebuddy/skills/<skill>`、
   `~/.workbuddy/skills/<skill>`、
+  `~/.trae/skills/<skill>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`、
   `~/.qoderwork/skills/<skill>`。
 - 路径规则：`[skill]` 解析后必须仍然落在这些本地 `skills` 根目录的子目录中。

--- a/src/application/commands/skills/bundled-skill-observation.test.ts
+++ b/src/application/commands/skills/bundled-skill-observation.test.ts
@@ -13,6 +13,7 @@ import {
     requireCodexHomeDirectory,
     writeInstalledBundledSkillMetadata,
 } from "./bundled-skill-observation.ts";
+import { resolveTraeHomeDirectory } from "./bundled-skill-paths.ts";
 
 describe("bundled skill observation", () => {
     test("reports directory and file existence from stat-backed wrappers", async () => {
@@ -262,6 +263,33 @@ describe("bundled skill observation", () => {
             expect(await requireBundledSkillHomeDirectory({ env }, "qoderwork")).toBe(
                 qoderWorkHomeDirectory,
             );
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("requires the resolved Trae home directory to exist", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const traeHomeDirectory = join(rootDirectory, ".trae");
+        const env = {
+            HOME: rootDirectory,
+        };
+
+        try {
+            await expect(
+                requireBundledSkillHomeDirectory({ env }, "trae"),
+            ).rejects.toMatchObject({
+                exitCode: 1,
+                key: "errors.skills.traeNotInstalled",
+            });
+
+            await mkdir(traeHomeDirectory, { recursive: true });
+
+            expect(await requireBundledSkillHomeDirectory({ env }, "trae")).toBe(
+                traeHomeDirectory,
+            );
+            expect(resolveTraeHomeDirectory(env)).toBe(traeHomeDirectory);
         }
         finally {
             await rm(rootDirectory, { force: true, recursive: true });

--- a/src/application/commands/skills/bundled-skill-paths.ts
+++ b/src/application/commands/skills/bundled-skill-paths.ts
@@ -9,6 +9,7 @@ const codeBuddyDirectoryName = ".codebuddy";
 const hermesDirectoryName = ".hermes";
 const openClawDirectoryName = ".openclaw";
 const qoderWorkDirectoryName = ".qoderwork";
+const traeDirectoryName = ".trae";
 const workBuddyDirectoryName = ".workbuddy";
 export const codexSkillsDirectoryName = "skills";
 export const canonicalBundledSkillsDirectoryName = "bundled";
@@ -71,6 +72,12 @@ export function resolveQoderWorkHomeDirectory(
     return join(resolveHomeDirectory(env), qoderWorkDirectoryName);
 }
 
+export function resolveTraeHomeDirectory(
+    env: Record<string, string | undefined>,
+): string {
+    return join(resolveHomeDirectory(env), traeDirectoryName);
+}
+
 export function resolveWorkBuddyHomeDirectory(
     env: Record<string, string | undefined>,
 ): string {
@@ -94,6 +101,8 @@ export function resolveBundledSkillHomeDirectory(
             return resolveOpenClawHomeDirectory(env);
         case "qoderwork":
             return resolveQoderWorkHomeDirectory(env);
+        case "trae":
+            return resolveTraeHomeDirectory(env);
         case "workbuddy":
             return resolveWorkBuddyHomeDirectory(env);
     }

--- a/src/application/commands/skills/check.test.ts
+++ b/src/application/commands/skills/check.test.ts
@@ -12,6 +12,7 @@ import {
     resolveCodexHomeDirectory,
     resolveHermesHomeDirectory,
     resolveQoderWorkHomeDirectory,
+    resolveTraeHomeDirectory,
     resolveWorkBuddyHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { resolveLocalSkillCanonicalRootDirectoryPath } from "./managed-skill-paths.ts";
@@ -199,6 +200,40 @@ describe("skills preflight command", () => {
                 "preflight",
                 "--agent",
                 "workbuddy",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Local skill editing is ready. Writable storage: ${canonicalRootDirectoryPath}. Supported hosts: 1.\n`,
+            );
+            expect(await readdir(canonicalRootDirectoryPath)).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("checks Trae as a requested agent", async () => {
+        const sandbox = await createCliSandbox();
+        const traeHomeDirectory = resolveTraeHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalRootDirectoryPath = resolveLocalSkillCanonicalRootDirectoryPath(
+            storePaths.settingsFilePath,
+        );
+
+        try {
+            await mkdir(traeHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "preflight",
+                "--agent",
+                "trae",
             ]);
 
             expect(result.exitCode).toBe(0);

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -59,6 +59,15 @@ describe("embedded skill assets", () => {
             "references/file-transfer.md",
             "references/task-lifecycle.md",
         ]);
+        expect(getBundledSkillFiles("oo", "trae").map(file => file.relativePath)).toEqual([
+            "SKILL.md",
+            "references/auth-and-billing.md",
+            "references/search-and-selection.md",
+            "references/package-execution.md",
+            "references/connector-execution.md",
+            "references/file-transfer.md",
+            "references/task-lifecycle.md",
+        ]);
         expect(getBundledSkillFiles("oo", "openclaw").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "references/auth-and-billing.md",
@@ -119,6 +128,14 @@ describe("embedded skill assets", () => {
             "references/oo-cli-contract.md",
         ]);
         expect(
+            getBundledSkillFiles("oo-find-skills", "trae").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+            "references/oo-cli-contract.md",
+        ]);
+        expect(
             getBundledSkillFiles("oo-find-skills", "openclaw").map(
                 file => file.relativePath,
             ),
@@ -171,6 +188,13 @@ describe("embedded skill assets", () => {
             "SKILL.md",
         ]);
         expect(
+            getBundledSkillFiles("oo-create-skill", "trae").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
             getBundledSkillFiles("oo-create-skill", "openclaw").map(
                 file => file.relativePath,
             ),
@@ -193,6 +217,7 @@ describe("embedded skill assets", () => {
             "hermes",
             "codebuddy",
             "workbuddy",
+            "trae",
             "openclaw",
             "qoderwork",
         ]);
@@ -249,8 +274,8 @@ describe("embedded skill assets", () => {
         }
     });
 
-    test("keeps Claude-compatible skill frontmatter free of Claude allowed tools", async () => {
-        for (const agentName of ["qoderwork", "workbuddy"] as const) {
+    test("keeps non-Claude skill frontmatter free of Claude allowed tools", async () => {
+        for (const agentName of ["qoderwork", "trae", "workbuddy"] as const) {
             for (const skillName of availableBundledSkillNames) {
                 const skillFile = getBundledSkillFiles(skillName, agentName)
                     .find(file => file.relativePath === "SKILL.md");
@@ -281,6 +306,7 @@ function readBundledSkillSourceAgentName(
     switch (agentName) {
         case "hermes":
             return "claude";
+        case "trae":
         case "workbuddy":
             return "codebuddy";
         default:

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -52,7 +52,7 @@ import ooQoderWorkSearchAndSelectionReferencePath from "../../../../contrib/skil
 import ooQoderWorkTaskLifecycleReferencePath from "../../../../contrib/skills/qoderwork/oo/references/task-lifecycle.md" with { type: "file" };
 import ooQoderWorkSkillPath from "../../../../contrib/skills/qoderwork/oo/SKILL.md" with { type: "file" };
 
-export const availableBundledSkillAgentNames = ["codex", "claude", "hermes", "codebuddy", "workbuddy", "openclaw", "qoderwork"] as const;
+export const availableBundledSkillAgentNames = ["codex", "claude", "hermes", "codebuddy", "workbuddy", "trae", "openclaw", "qoderwork"] as const;
 export type BundledSkillAgentName = (typeof availableBundledSkillAgentNames)[number];
 
 export const availableBundledSkillNames = ["oo", "oo-find-skills", "oo-create-skill"] as const;
@@ -165,6 +165,15 @@ const bundledSkillRegistry = {
                 ...ooCodeBuddyReferenceFiles,
             ],
         },
+        trae: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCodeBuddySkillPath,
+                },
+                ...ooCodeBuddyReferenceFiles,
+            ],
+        },
         openclaw: {
             files: [
                 {
@@ -249,6 +258,18 @@ const bundledSkillRegistry = {
                 },
             ],
         },
+        trae: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooFindSkillsCodeBuddySkillPath,
+                },
+                {
+                    relativePath: "references/oo-cli-contract.md",
+                    sourcePath: ooFindSkillsCodeBuddyCliContractPath,
+                },
+            ],
+        },
         openclaw: {
             files: [
                 {
@@ -312,6 +333,14 @@ const bundledSkillRegistry = {
             ],
         },
         workbuddy: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCreateSkillCodeBuddySkillPath,
+                },
+            ],
+        },
+        trae: {
             files: [
                 {
                     relativePath: "SKILL.md",

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -29,6 +29,7 @@ import {
     resolveHermesHomeDirectory,
     resolveOpenClawHomeDirectory,
     resolveQoderWorkHomeDirectory,
+    resolveTraeHomeDirectory,
     resolveWorkBuddyHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import {
@@ -679,6 +680,65 @@ describe("skills commands", () => {
         }
     });
 
+    test("installs bundled skills into Trae using the CodeBuddy skill template", async () => {
+        const sandbox = await createCliSandbox();
+        const traeHomeDirectory = resolveTraeHomeDirectory(sandbox.env);
+        const traeSkillsDirectoryPath = join(traeHomeDirectory, "skills");
+        const skillDirectoryPath = join(traeHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+            "trae",
+        );
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const skillFilePath = join(skillDirectoryPath, "SKILL.md");
+        const traeSkillFile = getBundledSkillFiles("oo", "trae")
+            .find(file => file.relativePath === "SKILL.md");
+
+        try {
+            if (traeSkillFile === undefined) {
+                throw new Error("Missing Trae oo SKILL.md fixture");
+            }
+
+            await mkdir(traeHomeDirectory, { recursive: true });
+            await expect(stat(traeSkillsDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+
+            const result = await sandbox.run(["skills", "install", "oo"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Installed skill oo to ${skillDirectoryPath}.\n`,
+            );
+            expect((await stat(traeSkillsDirectoryPath)).isDirectory()).toBeTrue();
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson({ version: "9.9.9" }),
+            );
+            expect(await readFile(skillFilePath, "utf8")).toBe(
+                await Bun.file(traeSkillFile.sourcePath).text(),
+            );
+            await expect(
+                stat(join(skillDirectoryPath, "agents", "openai.yaml")),
+            ).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("refuses to overwrite an existing non-OOMOL skill with the same name", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -831,6 +891,7 @@ describe("skills commands", () => {
         const hermesHomeDirectory = resolveHermesHomeDirectory(sandbox.env);
         const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
         const workBuddyHomeDirectory = resolveWorkBuddyHomeDirectory(sandbox.env);
+        const traeHomeDirectory = resolveTraeHomeDirectory(sandbox.env);
         const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
         const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
         const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
@@ -838,6 +899,7 @@ describe("skills commands", () => {
         const hermesSkillDirectoryPath = join(hermesHomeDirectory, "skills", "chatgpt");
         const codeBuddySkillDirectoryPath = join(codeBuddyHomeDirectory, "skills", "chatgpt");
         const workBuddySkillDirectoryPath = join(workBuddyHomeDirectory, "skills", "chatgpt");
+        const traeSkillDirectoryPath = join(traeHomeDirectory, "skills", "chatgpt");
         const openClawSkillDirectoryPath = join(openClawHomeDirectory, "skills", "chatgpt");
         const qoderWorkSkillDirectoryPath = join(qoderWorkHomeDirectory, "skills", "chatgpt");
         const storePaths = resolveStorePaths({
@@ -857,6 +919,7 @@ describe("skills commands", () => {
                 hermesSkillDirectoryPath,
                 codeBuddySkillDirectoryPath,
                 workBuddySkillDirectoryPath,
+                traeSkillDirectoryPath,
                 openClawSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
             ]) {
@@ -871,6 +934,7 @@ describe("skills commands", () => {
                 hermesSkillDirectoryPath,
                 codeBuddySkillDirectoryPath,
                 workBuddySkillDirectoryPath,
+                traeSkillDirectoryPath,
                 openClawSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
             ]) {
@@ -892,6 +956,7 @@ describe("skills commands", () => {
                     `Removed skill chatgpt from ${hermesSkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${codeBuddySkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${workBuddySkillDirectoryPath}.`,
+                    `Removed skill chatgpt from ${traeSkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${openClawSkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${qoderWorkSkillDirectoryPath}.`,
                     "",
@@ -904,6 +969,7 @@ describe("skills commands", () => {
                 hermesSkillDirectoryPath,
                 codeBuddySkillDirectoryPath,
                 workBuddySkillDirectoryPath,
+                traeSkillDirectoryPath,
                 openClawSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
             ]) {
@@ -1340,6 +1406,7 @@ describe("skills commands", () => {
         const hermesHomeDirectory = resolveHermesHomeDirectory(sandbox.env);
         const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
         const workBuddyHomeDirectory = resolveWorkBuddyHomeDirectory(sandbox.env);
+        const traeHomeDirectory = resolveTraeHomeDirectory(sandbox.env);
         const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
         const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
         const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
@@ -1347,6 +1414,7 @@ describe("skills commands", () => {
         const hermesSkillDirectoryPath = join(hermesHomeDirectory, "skills", "chatgpt");
         const codeBuddySkillDirectoryPath = join(codeBuddyHomeDirectory, "skills", "chatgpt");
         const workBuddySkillDirectoryPath = join(workBuddyHomeDirectory, "skills", "chatgpt");
+        const traeSkillDirectoryPath = join(traeHomeDirectory, "skills", "chatgpt");
         const openClawSkillDirectoryPath = join(openClawHomeDirectory, "skills", "chatgpt");
         const qoderWorkSkillDirectoryPath = join(qoderWorkHomeDirectory, "skills", "chatgpt");
         const storePaths = resolveStorePaths({
@@ -1366,6 +1434,7 @@ describe("skills commands", () => {
                 mkdir(hermesHomeDirectory, { recursive: true }),
                 mkdir(codeBuddyHomeDirectory, { recursive: true }),
                 mkdir(workBuddyHomeDirectory, { recursive: true }),
+                mkdir(traeHomeDirectory, { recursive: true }),
                 mkdir(openClawHomeDirectory, { recursive: true }),
                 mkdir(qoderWorkHomeDirectory, { recursive: true }),
             ]);
@@ -1411,6 +1480,7 @@ describe("skills commands", () => {
                     `Installed skill chatgpt to ${hermesSkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${codeBuddySkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${workBuddySkillDirectoryPath}.`,
+                    `Installed skill chatgpt to ${traeSkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${openClawSkillDirectoryPath}.`,
                     `Installed skill chatgpt to ${qoderWorkSkillDirectoryPath}.`,
                     "",
@@ -1421,6 +1491,7 @@ describe("skills commands", () => {
             for (const linkedSkillDirectoryPath of [
                 codexSkillDirectoryPath,
                 claudeSkillDirectoryPath,
+                traeSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
             ]) {
                 expect(await realpath(linkedSkillDirectoryPath)).toBe(
@@ -1445,6 +1516,7 @@ describe("skills commands", () => {
                 hermesSkillDirectoryPath,
                 codeBuddySkillDirectoryPath,
                 workBuddySkillDirectoryPath,
+                traeSkillDirectoryPath,
                 openClawSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
             ]) {

--- a/src/application/commands/skills/init.test.ts
+++ b/src/application/commands/skills/init.test.ts
@@ -10,6 +10,7 @@ import {
     resolveClaudeHomeDirectory,
     resolveCodeBuddyHomeDirectory,
     resolveCodexHomeDirectory,
+    resolveTraeHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { resolveLocalSkillCanonicalDirectoryPath } from "./managed-skill-paths.ts";
 import {
@@ -173,6 +174,48 @@ describe("skills init command", () => {
                 await realpath(canonicalSkillDirectoryPath),
             );
             expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("initializes a local skill by linking for Trae", async () => {
+        const sandbox = await createCliSandbox();
+        const traeHomeDirectory = resolveTraeHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(traeHomeDirectory, "skills", "trae-skill");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "trae-skill",
+        );
+
+        try {
+            await mkdir(traeHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "init",
+                "trae-skill",
+                "--description",
+                "Use a known package workflow.",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                [
+                    `Initialized skill trae-skill in canonical storage at ${canonicalSkillDirectoryPath}.`,
+                    `Linked skill trae-skill to ${skillDirectoryPath}.`,
+                    "",
+                ].join("\n"),
+            );
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -12,6 +12,7 @@ import {
     resolveHermesHomeDirectory,
     resolveOpenClawHomeDirectory,
     resolveQoderWorkHomeDirectory,
+    resolveTraeHomeDirectory,
     resolveWorkBuddyHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { renderSkillMetadataJson } from "./skill-metadata.ts";
@@ -242,6 +243,49 @@ describe("skills list CLI", () => {
                     "",
                     "oo-create-skill",
                     "  Host: WorkBuddy",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                ].join("\n"),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("lists startup-synchronized Trae bundled installs when Codex is not installed", async () => {
+        const sandbox = await createCliSandbox();
+        const traeHomeDirectory = resolveTraeHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(traeHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install", "oo"], {
+                version: "9.9.9",
+            });
+
+            const result = await sandbox.run(["skills", "list"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    "✓ Found 3 oo-managed skills.",
+                    "",
+                    "oo",
+                    "  Host: Trae",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-find-skills",
+                    "  Host: Trae",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-create-skill",
+                    "  Host: Trae",
                     "  Source: bundled",
                     "  Version: 9.9.9",
                     "",

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -32,8 +32,9 @@ const managedSkillHostOrder = {
     hermes: 2,
     codebuddy: 3,
     workbuddy: 4,
-    openclaw: 5,
-    qoderwork: 6,
+    trae: 5,
+    openclaw: 6,
+    qoderwork: 7,
 } as const satisfies Record<BundledSkillAgentName, number>;
 
 export interface ManagedSkillListItem {
@@ -334,6 +335,8 @@ function readManagedSkillHostLabel(
             return context.translator.t("skills.list.host.openclaw");
         case "qoderwork":
             return context.translator.t("skills.list.host.qoderwork");
+        case "trae":
+            return context.translator.t("skills.list.host.trae");
         case "workbuddy":
             return context.translator.t("skills.list.host.workbuddy");
         default:

--- a/src/application/commands/skills/managed-skill-host-errors.ts
+++ b/src/application/commands/skills/managed-skill-host-errors.ts
@@ -7,6 +7,7 @@ export type ManagedSkillHostMissingErrorKey
         | "errors.skills.hermesNotInstalled"
         | "errors.skills.openclawNotInstalled"
         | "errors.skills.qoderworkNotInstalled"
+        | "errors.skills.traeNotInstalled"
         | "errors.skills.workbuddyNotInstalled";
 
 export function resolveManagedSkillHostMissingErrorKey(
@@ -25,6 +26,8 @@ export function resolveManagedSkillHostMissingErrorKey(
             return "errors.skills.openclawNotInstalled";
         case "qoderwork":
             return "errors.skills.qoderworkNotInstalled";
+        case "trae":
+            return "errors.skills.traeNotInstalled";
         case "workbuddy":
             return "errors.skills.workbuddyNotInstalled";
     }

--- a/src/application/commands/skills/managed-skill-publication.test.ts
+++ b/src/application/commands/skills/managed-skill-publication.test.ts
@@ -19,6 +19,7 @@ describe("managed skill publication policy", () => {
             hermes: "copy",
             openclaw: "copy",
             qoderwork: "symlink-or-copy",
+            trae: "symlink-or-copy",
             workbuddy: "copy",
         });
     });

--- a/src/application/commands/skills/managed-skill-publication.ts
+++ b/src/application/commands/skills/managed-skill-publication.ts
@@ -5,6 +5,7 @@ const symlinkCapableManagedSkillAgentNames: ReadonlySet<BundledSkillAgentName> =
     "claude",
     "codex",
     "qoderwork",
+    "trae",
 ]);
 
 export function resolveManagedSkillPublicationMode(

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -367,6 +367,8 @@ export const enMessages = {
         "OpenClaw is not installed. Expected the OpenClaw home directory at {path}.",
     "errors.skills.qoderworkNotInstalled":
         "QoderWork is not installed. Expected the QoderWork home directory at {path}.",
+    "errors.skills.traeNotInstalled":
+        "Trae is not installed. Expected the Trae home directory at {path}.",
     "errors.skills.workbuddyNotInstalled":
         "WorkBuddy is not installed. Expected the WorkBuddy home directory at {path}.",
     "errors.skills.noSupportedBundledSkillHosts":
@@ -558,6 +560,7 @@ export const enMessages = {
     "skills.list.host.hermes": "Hermes",
     "skills.list.host.openclaw": "OpenClaw",
     "skills.list.host.qoderwork": "QoderWork",
+    "skills.list.host.trae": "Trae",
     "skills.list.host.workbuddy": "WorkBuddy",
     "skills.list.source": "Source",
     "skills.list.source.bundled": "bundled",
@@ -1024,6 +1027,8 @@ export const zhMessages = {
         "未检测到 OpenClaw 安装。期望的 OpenClaw 根目录为 {path}。",
     "errors.skills.qoderworkNotInstalled":
         "未检测到 QoderWork 安装。期望的 QoderWork 根目录为 {path}。",
+    "errors.skills.traeNotInstalled":
+        "未检测到 Trae 安装。期望的 Trae 根目录为 {path}。",
     "errors.skills.workbuddyNotInstalled":
         "未检测到 WorkBuddy 安装。期望的 WorkBuddy 根目录为 {path}。",
     "errors.skills.noSupportedBundledSkillHosts":
@@ -1209,6 +1214,7 @@ export const zhMessages = {
     "skills.list.host.hermes": "Hermes",
     "skills.list.host.openclaw": "OpenClaw",
     "skills.list.host.qoderwork": "QoderWork",
+    "skills.list.host.trae": "Trae",
     "skills.list.host.workbuddy": "WorkBuddy",
     "skills.list.source": "来源",
     "skills.list.source.bundled": "内置",


### PR DESCRIPTION
Trae uses the same skill contract as CodeBuddy, so reuse those bundled templates instead of maintaining another copy. Publish Trae targets through symlinks to keep local and registry skills in sync with canonical storage while preserving copy fallback behavior.