### PR TITLE
feat(skills): summarize install output by skill and agent

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -407,6 +407,9 @@ Install bundled or published skills into supported local skill directories.
 - Options: `-y, --yes` skips confirmation prompts. When a package publishes
   multiple skills and no explicit `--skill` is provided, `-y` installs all of
   them.
+- Output: successful non-interactive installs print a compact summary grouped by
+  installed skills and target AI agents. When exactly one target is written, the
+  summary includes that target path.
 - Notes: when a package publishes exactly one skill and no `--skill` is
   provided, the command installs that skill automatically.
 - Notes: when a package publishes multiple skills and no `--skill`, `--all`, or

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -230,17 +230,17 @@
 
 ## AI Agent Skill
 
-在执行具体命令前，`oo` 会为已经存在的受支持宿主目录静默同步受管理的
+在执行具体命令前，`oo` 会为已经存在的受支持 Agent 目录静默同步受管理的
 skills。
 
 - 内置 skill：`oo` 会确保每个检测到的 Codex、Claude Code、Hermes、
-  CodeBuddy、WorkBuddy、Trae、OpenClaw 和 QoderWork 宿主都安装了 `oo` 与
+  CodeBuddy、WorkBuddy、Trae、OpenClaw 和 QoderWork Agent 都安装了 `oo` 与
   `oo-find-skills`。已经由 oo 管理的内置 skill 目标会刷新到当前 `oo` 版本；
   但当启动中的当前版本为 `0.0.0-development` 时，不会刷新已存在的内置 skill
   目标。
 - 已发布 skill：如果某个已发布 skill 已经有本地 canonical 副本
   `<config-dir>/skills/registry/<skill-id>`，`oo` 会把该副本发布到任何新检测
-  到且尚未安装它的受支持宿主。
+  到且尚未安装它的受支持 Agent。
 - 安全规则：启动同步不会请求 registry，不要求登录，不会产生额外命令输出，也
   不会覆盖不由 `oo` 管理的同名目标。
 
@@ -255,34 +255,34 @@ skills。
   `${OPENCLAW_HOME:-~/.openclaw}/skills`、`~/.qoderwork/skills`。只保留包含
   可解析 `.oo-metadata.json` 且其中包含非空 `version` 的子目录。
 - 输出：文本输出会先打印摘要行，再为每个唯一的可见 skill 身份打印一个块。
-  如果多个宿主中的安装具有相同 `name`、来源和版本，则会折叠到同一个块中。
+  如果多个 Agent 中的安装具有相同 `name`、来源和版本，则会折叠到同一个块中。
 - 排序：bundled skills 会排在最前面；其中 `oo` 优先，其次
   `oo-find-skills`，再其次 `oo-create-skill`；其余 skill 按名称排序。每个
-  块内的宿主名称按 `Codex`、`Claude Code`、`Hermes`、`CodeBuddy`、
+  块内的 Agent 名称按 `Codex`、`Claude Code`、`Hermes`、`CodeBuddy`、
   `WorkBuddy`、`Trae`、`OpenClaw`、`QoderWork` 顺序显示。
-- 输出：每个 skill 块会显示 skill 名称、宿主、来源 package、内置或本地标记，以
+- 输出：每个 skill 块会显示 skill 名称、Agents、来源 package、内置或本地标记，以
   及记录的版本号。
-- 说明：如果折叠后的 skill 安装在多个受支持宿主中，`宿主` 字段会列出所有
-  匹配的宿主。
+- 说明：如果折叠后的 skill 安装在多个受支持 Agent 中，`Agents` 字段会列出所有
+  匹配的 Agent。
 
 ### `oo skills preflight`
 
 检查当前环境是否有权限编辑本地 skills。
 
-- 选项：`--agent <agent>` 将宿主检查限制为一个受支持 agent：`codex`、
+- 选项：`--agent <agent>` 将 Agent 检查限制为一个受支持 Agent：`codex`、
   `claude`、`hermes`、`codebuddy`、`workbuddy`、`trae`、`openclaw` 或
   `qoderwork`。
-- 宿主检查：未提供 `--agent` 时，至少需要存在一个受支持 agent home 目录。
-  提供 `--agent` 时，该指定 agent home 目录必须存在。
-- 存储检查：命令会在需要时创建 `<config-dir>/skills/local` 和每个已检查宿主
+- Agent 检查：未提供 `--agent` 时，至少需要存在一个受支持 Agent home 目录。
+  提供 `--agent` 时，该指定 Agent home 目录必须存在。
+- 存储检查：命令会在需要时创建 `<config-dir>/skills/local` 和每个已检查 Agent
   的发布根目录（如 `<agent-home>/skills`），并在每个已检查目录中写入再移除
   临时探针文件。
-- 输出：成功时，文本输出会打印可写存储路径和已检查的受支持宿主数量。失败时
+- 输出：成功时，文本输出会打印可写存储路径和已检查的受支持 Agent 数量。失败时
   命令以非零状态退出。
 
 ### `oo skills init <name>`
 
-初始化一个本地 skill，并发布到所有已存在的受支持 agent home 目录。
+初始化一个本地 skill，并发布到所有已存在的受支持 Agent home 目录。
 
 - 参数：`<name>` 会规范化为小写短横线格式，并用作 skill id、canonical 目录名、
   目标目录名以及 frontmatter `name`。
@@ -296,7 +296,7 @@ skills。
   frontmatter。未提供时不会生成 `metadata.title`。
 - canonical 目录：skill 创建在 `<config-dir>/skills/local/<skill-id>` 下，
   其中 `<config-dir>` 是 oo settings 文件所在目录。
-- 目标目录：命令会向每个已存在的受支持 agent skill 目录发布该 skill：
+- 目标目录：命令会向每个已存在的受支持 Agent skill 目录发布该 skill：
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`、`~/.claude/skills/<skill-id>`，
   `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`、
   `~/.codebuddy/skills/<skill-id>`、`~/.workbuddy/skills/<skill-id>`、
@@ -306,7 +306,7 @@ skills。
 - 发布方式：Codex、Claude Code、Trae 和 QoderWork 目标会在当前平台和环境允许时
   发布为指向 canonical 目录的软连接；Hermes、CodeBuddy、WorkBuddy 和 OpenClaw
   目标会复制。
-- 失败行为：如果没有受支持的 agent home，或 canonical 本地目录、任意目标目录
+- 失败行为：如果没有受支持的 Agent home，或 canonical 本地目录、任意目标目录
   已存在，命令会在写入 skill 前以非零状态退出。
 - 输出：文本输出会先打印 canonical 存储目录，然后为每个目标路径打印一行带实际发布
   方式（软链接或复制）的成功消息。
@@ -355,6 +355,8 @@ skills。
 - 选项：`--all` 是安装全部已发布 skill 的快捷方式，并跳过 skill 选择提示。
 - 选项：`-y, --yes` 用于跳过确认提示。当 package 下有多个 skill 且未显式
   提供 `--skill` 时，`-y` 会安装全部 skill。
+- 输出：非交互安装成功时，会按已安装 skill 和目标 AI Agent 聚合输出精简摘要；
+  当实际只写入一个目标时，摘要会包含该目标路径。
 - 说明：如果 package 只发布了一个 skill，且未提供 `--skill`，命令会自动
   安装这个唯一的 skill。
 - 说明：如果 package 发布了多个 skill，且未提供 `--skill`、`--all` 或
@@ -371,7 +373,7 @@ skills。
   目录（`claude-skills/`、`openclaw-skills/`，以及直接位于 `skills/` 下的旧
   Codex 内置 / 已发布 skill 目录）。内置 skill 会自动以新布局重建；之前安装
   的已发布 skill 需要通过 `oo skills install <packageName>` 重新安装。
-- 目标目录：内置和已发布 skill 会发布到所有已存在的受支持宿主目录，目前包括
+- 目标目录：内置和已发布 skill 会发布到所有已存在的受支持 Agent 目录，目前包括
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>` 和
   `~/.claude/skills/<skill-id>`，以及
   `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`、
@@ -380,7 +382,7 @@ skills。
   `~/.trae/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`、
   `~/.qoderwork/skills/<skill-id>`。
-- 目标目录：当已存在的受支持宿主缺少 `skills` 根目录时，命令会先创建该目录，
+- 目标目录：当已存在的受支持 Agent 缺少 `skills` 根目录时，命令会先创建该目录，
   再发布所选 skill。
 - 安装方式：内置和已发布的 Codex / Claude Code / Trae / QoderWork skill 会优
   先把目标目录发布为指向 canonical 目录的软连接。如果当前平台或环境下创建
@@ -422,10 +424,10 @@ skills。
 - 已发布 skill：registry skill 会从 `.oo-metadata.json` 读取所属包名，再通过
   不带显式版本的 package info 请求判断最新可用版本。
 - 更新顺序：命令会先刷新 canonical 目录
-  `<config-dir>/skills/registry/<skill-id>`，再同步到所有已存在的受支持宿主目录。
+  `<config-dir>/skills/registry/<skill-id>`，再同步到所有已存在的受支持 Agent 目录。
 - 交互式终端：会显示实时进度。
 - 非交互式终端：对每个已是最新或失败的 skill 输出一行状态信息；对每个已更新
-  的宿主目标路径输出一行成功信息。
+  的 Agent 目标路径输出一行成功信息。
 
 ### `oo skills uninstall [skill]`
 
@@ -433,12 +435,12 @@ skills。
 
 - 别名：`oo skills remove [skill]`。
 - 参数：省略 `[skill]` 时，命令会移除全部内置 skill。
-- 所有权规则：对内置 skill 来说，只有当某个受支持宿主中的安装目录包含可解
-  析且带有非空 `version` 的 `.oo-metadata.json` 时，才允许从该宿主移除。
+- 所有权规则：对内置 skill 来说，只有当某个受支持 Agent 中的安装目录包含可解
+  析且带有非空 `version` 的 `.oo-metadata.json` 时，才允许从该 Agent 移除。
 - 会同时移除 canonical 目录：内置 skill 会移除
-  `<config-dir>/skills/bundled/<agent>/<skill>`（每个已安装宿主各一份），
+  `<config-dir>/skills/bundled/<agent>/<skill>`（每个已安装 Agent 各一份），
   已发布 skill 会移除 `<config-dir>/skills/registry/<skill>`。
-- 会同时移除目标目录：内置和已发布 skill 会从所有已存在的受支持宿主目录中
+- 会同时移除目标目录：内置和已发布 skill 会从所有已存在的受支持 Agent 目录中
   移除，目前包括 `${CODEX_HOME:-~/.codex}/skills/<skill>` 和
   `~/.claude/skills/<skill>`，以及
   `${HERMES_HOME:-~/.hermes}/skills/<skill>`、

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -96,9 +96,8 @@ exports[`skills CLI writes explicit skills install and uninstall logs 1`] = `
     "exitCode": 0,
     "stderr": "",
     "stdout": 
-"Installed skill oo to <HOME>/.codex/skills/oo.
-Installed skill oo-find-skills to <HOME>/.codex/skills/oo-find-skills.
-Installed skill oo-create-skill to <HOME>/.codex/skills/oo-create-skill.
+"Installed 3 skills to Codex.
+Skills: oo, oo-find-skills, oo-create-skill
 "
 ,
   },

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -307,9 +307,6 @@ describe("skills CLI", () => {
     test("supports skills add as an alias for install", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-        const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
-        const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
-        const createSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-create-skill");
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -321,9 +318,8 @@ describe("skills CLI", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
                 [
-                    `Installed skill oo to ${ooSkillDirectoryPath}.`,
-                    `Installed skill oo-find-skills to ${findSkillsDirectoryPath}.`,
-                    `Installed skill oo-create-skill to ${createSkillDirectoryPath}.`,
+                    "Installed 3 skills to Codex.",
+                    "Skills: oo, oo-find-skills, oo-create-skill",
                     "",
                 ].join("\n"),
             );

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -91,9 +91,8 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
                 [
-                    `Installed skill oo to ${ooSkillDirectoryPath}.`,
-                    `Installed skill oo-find-skills to ${findSkillsDirectoryPath}.`,
-                    `Installed skill oo-create-skill to ${createSkillDirectoryPath}.`,
+                    "Installed 3 skills to Codex.",
+                    "Skills: oo, oo-find-skills, oo-create-skill",
                     "",
                 ].join("\n"),
             );
@@ -132,6 +131,33 @@ describe("skills commands", () => {
             expect(await readFile(createSkillMetadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: resultVersion }),
             );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("colors compact bundled install summaries when stdout supports colors", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "install"], {
+                stdout: {
+                    hasColors: true,
+                },
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(stripVTControlCharacters(result.stdout)).toBe(
+                "Installed 3 skills to Codex.\nSkills: oo, oo-find-skills, oo-create-skill\n",
+            );
+            expect(result.stdout).toContain("\u001B[32mInstalled\u001B[39m");
+            expect(result.stdout).toContain("\u001B[36mCodex\u001B[39m");
+            expect(result.stdout).toContain("\u001B[36moo\u001B[39m");
         }
         finally {
             await sandbox.cleanup();
@@ -326,11 +352,7 @@ describe("skills commands", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
-                [
-                    `Installed skill oo to ${codexOoSkillDirectoryPath}.`,
-                    `Installed skill oo to ${claudeOoSkillDirectoryPath}.`,
-                    "",
-                ].join("\n"),
+                "Installed skill oo to 2 agents: Codex, Claude Code.\n",
             );
             expect(await realpath(codexOoSkillDirectoryPath)).toBe(
                 await realpath(codexCanonicalSkillDirectoryPath),
@@ -1474,17 +1496,7 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
-                [
-                    `Installed skill chatgpt to ${codexSkillDirectoryPath}.`,
-                    `Installed skill chatgpt to ${claudeSkillDirectoryPath}.`,
-                    `Installed skill chatgpt to ${hermesSkillDirectoryPath}.`,
-                    `Installed skill chatgpt to ${codeBuddySkillDirectoryPath}.`,
-                    `Installed skill chatgpt to ${workBuddySkillDirectoryPath}.`,
-                    `Installed skill chatgpt to ${traeSkillDirectoryPath}.`,
-                    `Installed skill chatgpt to ${openClawSkillDirectoryPath}.`,
-                    `Installed skill chatgpt to ${qoderWorkSkillDirectoryPath}.`,
-                    "",
-                ].join("\n"),
+                "Installed skill chatgpt to 8 agents: Codex, Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae, OpenClaw, QoderWork.\n",
             );
             const canonicalSkillRealPath = await realpath(canonicalSkillDirectoryPath);
 

--- a/src/application/commands/skills/install-output.test.ts
+++ b/src/application/commands/skills/install-output.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+
+import { createTextBuffer } from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
+import { writeManagedSkillInstallSummary } from "./install-output.ts";
+
+describe("skills install output", () => {
+    test("renders agents before skills when both detail lines are present", () => {
+        const stdout = createTextBuffer();
+
+        writeManagedSkillInstallSummary(
+            {
+                stdout: stdout.writer,
+                translator: createTranslator("en"),
+            },
+            createMultiSkillMultiAgentSummaries(),
+        );
+
+        expect(stdout.read()).toBe(
+            [
+                "Installed 2 skills to 2 agents.",
+                "Agents: Codex, Claude Code",
+                "Skills: chatgpt, vision",
+                "",
+            ].join("\n"),
+        );
+    });
+
+    test("renders plural skills in Chinese multi-skill summaries", () => {
+        const stdout = createTextBuffer();
+
+        writeManagedSkillInstallSummary(
+            {
+                stdout: stdout.writer,
+                translator: createTranslator("zh"),
+            },
+            createMultiSkillMultiAgentSummaries(),
+        );
+
+        const firstLine = stdout.read().split("\n")[0]!;
+
+        expect(firstLine).toContain("skills");
+        expect(firstLine).not.toContain("skill ");
+    });
+});
+
+function createMultiSkillMultiAgentSummaries() {
+    return [
+        {
+            name: "chatgpt",
+            publications: [
+                {
+                    agentName: "codex",
+                    path: "/tmp/codex/skills/chatgpt",
+                },
+                {
+                    agentName: "claude",
+                    path: "/tmp/claude/skills/chatgpt",
+                },
+            ],
+        },
+        {
+            name: "vision",
+            publications: [
+                {
+                    agentName: "codex",
+                    path: "/tmp/codex/skills/vision",
+                },
+                {
+                    agentName: "claude",
+                    path: "/tmp/claude/skills/vision",
+                },
+            ],
+        },
+    ] as const;
+}

--- a/src/application/commands/skills/install-output.ts
+++ b/src/application/commands/skills/install-output.ts
@@ -1,0 +1,182 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+import type { TerminalColors } from "../../terminal-colors.ts";
+import type { BundledSkillAgentName } from "./embedded-assets.ts";
+
+import type { ManagedSkillHostTranslator } from "./managed-skill-host-labels.ts";
+import { createWriterColors } from "../../terminal-colors.ts";
+import { writeLine } from "../shared/output.ts";
+import {
+
+    readManagedSkillHostLabel,
+} from "./managed-skill-host-labels.ts";
+
+export interface ManagedSkillInstallPublication {
+    agentName: BundledSkillAgentName;
+    path: string;
+}
+
+export interface ManagedSkillInstallSummary {
+    name: string;
+    publications: readonly ManagedSkillInstallPublication[];
+}
+
+export function writeManagedSkillInstallSummary(
+    context: Pick<CliExecutionContext, "stdout" | "translator">,
+    summaries: readonly ManagedSkillInstallSummary[],
+): void {
+    const completedSummaries = summaries.filter(
+        summary => summary.publications.length > 0,
+    );
+
+    if (completedSummaries.length === 0) {
+        return;
+    }
+
+    const colors = createWriterColors(context.stdout);
+
+    if (
+        completedSummaries.length === 1
+        && completedSummaries[0]!.publications.length === 1
+    ) {
+        const summary = completedSummaries[0]!;
+        const publication = summary.publications[0]!;
+
+        writeLine(
+            context.stdout,
+            context.translator.t("skills.install.success", {
+                name: colors.cyan(summary.name),
+                path: colors.dim(publication.path),
+            }),
+        );
+        return;
+    }
+
+    const skillNames = completedSummaries.map(summary => summary.name);
+    const agentNames = readUniqueAgentNames(completedSummaries);
+    const installedLabel = colors.green(
+        context.translator.t("skills.install.summary.installed"),
+    );
+
+    if (skillNames.length === 1) {
+        writeLine(
+            context.stdout,
+            context.translator.t(
+                "skills.install.summary.singleSkillMultipleAgents",
+                {
+                    agentCount: colors.bold(agentNames.length),
+                    agentNames: formatAgentNames(
+                        agentNames,
+                        context.translator,
+                        colors,
+                    ),
+                    skillName: colors.cyan(skillNames[0]!),
+                    status: installedLabel,
+                },
+            ),
+        );
+        return;
+    }
+
+    if (agentNames.length === 1) {
+        writeLine(
+            context.stdout,
+            context.translator.t(
+                "skills.install.summary.multipleSkillsSingleAgent",
+                {
+                    agentName: formatAgentNames(
+                        agentNames,
+                        context.translator,
+                        colors,
+                    ),
+                    skillCount: colors.bold(skillNames.length),
+                    status: installedLabel,
+                },
+            ),
+        );
+        writeDetailLine(
+            context,
+            colors.bold(
+                context.translator.t("skills.install.summary.skillsLabel"),
+            ),
+            formatSkillNames(skillNames, colors),
+        );
+        return;
+    }
+
+    writeLine(
+        context.stdout,
+        context.translator.t(
+            "skills.install.summary.multipleSkillsMultipleAgents",
+            {
+                agentCount: colors.bold(agentNames.length),
+                skillCount: colors.bold(skillNames.length),
+                status: installedLabel,
+            },
+        ),
+    );
+    writeDetailLine(
+        context,
+        colors.bold(
+            context.translator.t("skills.install.summary.agentsLabel"),
+        ),
+        formatAgentNames(agentNames, context.translator, colors),
+    );
+    writeDetailLine(
+        context,
+        colors.bold(
+            context.translator.t("skills.install.summary.skillsLabel"),
+        ),
+        formatSkillNames(skillNames, colors),
+    );
+}
+
+function readUniqueAgentNames(
+    summaries: readonly ManagedSkillInstallSummary[],
+): BundledSkillAgentName[] {
+    const agentNames: BundledSkillAgentName[] = [];
+    const seenAgentNames = new Set<BundledSkillAgentName>();
+
+    for (const summary of summaries) {
+        for (const publication of summary.publications) {
+            if (seenAgentNames.has(publication.agentName)) {
+                continue;
+            }
+
+            seenAgentNames.add(publication.agentName);
+            agentNames.push(publication.agentName);
+        }
+    }
+
+    return agentNames;
+}
+
+function writeDetailLine(
+    context: Pick<CliExecutionContext, "stdout" | "translator">,
+    label: string,
+    values: string,
+): void {
+    writeLine(
+        context.stdout,
+        context.translator.t("skills.install.summary.detailLine", {
+            label,
+            values,
+        }),
+    );
+}
+
+function formatSkillNames(
+    skillNames: readonly string[],
+    colors: TerminalColors,
+): string {
+    return skillNames.map(skillName => colors.cyan(skillName)).join(", ");
+}
+
+function formatAgentNames(
+    agentNames: readonly BundledSkillAgentName[],
+    translator: ManagedSkillHostTranslator,
+    colors: TerminalColors,
+): string {
+    return agentNames.map(agentName =>
+        colors.cyan(readManagedSkillHostLabel(agentName, translator)),
+    ).join(", ");
+}

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -1,8 +1,10 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import type { BundledSkillName } from "./embedded-assets.ts";
 
+import type { ManagedSkillInstallSummary } from "./install-output.ts";
 import { z } from "zod";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
+import { writeManagedSkillInstallSummary } from "./install-output.ts";
 import { migrateLegacyCanonicalSkillLayout } from "./legacy-canonical-migration.ts";
 import { installRegistrySkills } from "./registry-skill-install.ts";
 import { installBundledSkill, isBundledSkillName } from "./shared.ts";
@@ -56,17 +58,23 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         await migrateLegacyCanonicalSkillLayout(context);
 
         if (input.packageName === undefined) {
+            const summaries: ManagedSkillInstallSummary[] = [];
+
             for (const skillName of availableBundledSkillNames) {
-                await installBundledSkill(skillName, context);
+                summaries.push(await installBundledSkill(skillName, context));
             }
+
+            writeManagedSkillInstallSummary(context, summaries);
             return;
         }
 
         if (isBundledSkillName(input.packageName)) {
-            await installBundledSkill(
+            const summary = await installBundledSkill(
                 input.packageName as BundledSkillName,
                 context,
             );
+
+            writeManagedSkillInstallSummary(context, [summary]);
             return;
         }
 

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -12,6 +12,9 @@ import { createWriterColors } from "../../terminal-colors.ts";
 import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
 import {
+    readManagedSkillHostLabels,
+} from "./managed-skill-host-labels.ts";
+import {
     resolveAvailableManagedSkillHosts,
 } from "./managed-skill-hosts.ts";
 import { parseManagedSkillMetadataContent } from "./managed-skill-metadata.ts";
@@ -243,7 +246,7 @@ function formatManagedSkillListItem(
         formatManagedSkillDetailLine(
             context.translator.t("skills.list.host"),
             colors.hex(managedSkillSourceColor)(
-                readManagedSkillHostLabels(skill.hostNames, context),
+                readManagedSkillHostLabels(skill.hostNames, context.translator),
             ),
             colors,
         ),
@@ -307,41 +310,6 @@ function readManagedSkillSourceIdentity(
     }
 
     return "unknown";
-}
-
-function readManagedSkillHostLabels(
-    hostNames: readonly BundledSkillAgentName[],
-    context: Pick<CliExecutionContext, "translator">,
-): string {
-    return hostNames.map(hostName =>
-        readManagedSkillHostLabel(hostName, context),
-    ).join(", ");
-}
-
-function readManagedSkillHostLabel(
-    hostName: BundledSkillAgentName,
-    context: Pick<CliExecutionContext, "translator">,
-): string {
-    switch (hostName) {
-        case "claude":
-            return context.translator.t("skills.list.host.claude");
-        case "codebuddy":
-            return context.translator.t("skills.list.host.codebuddy");
-        case "codex":
-            return context.translator.t("skills.list.host.codex");
-        case "hermes":
-            return context.translator.t("skills.list.host.hermes");
-        case "openclaw":
-            return context.translator.t("skills.list.host.openclaw");
-        case "qoderwork":
-            return context.translator.t("skills.list.host.qoderwork");
-        case "trae":
-            return context.translator.t("skills.list.host.trae");
-        case "workbuddy":
-            return context.translator.t("skills.list.host.workbuddy");
-        default:
-            return hostName satisfies never;
-    }
 }
 
 function hasSameManagedSkillIdentity(

--- a/src/application/commands/skills/managed-skill-host-labels.ts
+++ b/src/application/commands/skills/managed-skill-host-labels.ts
@@ -1,0 +1,39 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+import type { BundledSkillAgentName } from "./embedded-assets.ts";
+
+export type ManagedSkillHostTranslator = Pick<CliExecutionContext["translator"], "t">;
+
+export function readManagedSkillHostLabel(
+    agentName: BundledSkillAgentName,
+    translator: ManagedSkillHostTranslator,
+): string {
+    switch (agentName) {
+        case "claude":
+            return translator.t("skills.list.host.claude");
+        case "codebuddy":
+            return translator.t("skills.list.host.codebuddy");
+        case "codex":
+            return translator.t("skills.list.host.codex");
+        case "hermes":
+            return translator.t("skills.list.host.hermes");
+        case "openclaw":
+            return translator.t("skills.list.host.openclaw");
+        case "qoderwork":
+            return translator.t("skills.list.host.qoderwork");
+        case "trae":
+            return translator.t("skills.list.host.trae");
+        case "workbuddy":
+            return translator.t("skills.list.host.workbuddy");
+        default:
+            return agentName satisfies never;
+    }
+}
+
+export function readManagedSkillHostLabels(
+    agentNames: readonly BundledSkillAgentName[],
+    translator: ManagedSkillHostTranslator,
+): string {
+    return agentNames.map(agentName =>
+        readManagedSkillHostLabel(agentName, translator),
+    ).join(", ");
+}

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -1,14 +1,17 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
+import type {
+    ManagedSkillInstallPublication,
+    ManagedSkillInstallSummary,
+} from "./install-output.ts";
 import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
 import type { RegistryPackageSkillInfo, RegistrySkillSummary } from "./registry-skill-source.ts";
-
 import { CliUserError } from "../../contracts/cli.ts";
 import { withPackageIdentity } from "../../logging/log-fields.ts";
-
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { writeLine } from "../shared/output.ts";
 import { directoryExists } from "./bundled-skill-observation.ts";
+import { writeManagedSkillInstallSummary } from "./install-output.ts";
 import { SkillsInstallProgressReporter } from "./install-progress.ts";
 import {
     confirmInteractiveValue,
@@ -140,15 +143,18 @@ export async function installRegistrySkills(
             progressReporter?.startInstalling(installSkillNames);
 
             try {
-                await executeInstallActions(
+                const summaries = await executeInstallActions(
                     installActions,
                     packageInfo,
                     account,
                     availableHosts,
                     settingsFilePath,
-                    selectionActions.isInteractive,
                     context,
                 );
+
+                if (!selectionActions.isInteractive) {
+                    writeManagedSkillInstallSummary(context, summaries);
+                }
             }
             catch (error) {
                 progressReporter?.failInstalling();
@@ -188,9 +194,8 @@ async function executeInstallActions(
     account: AuthAccount,
     availableHosts: readonly ManagedSkillHost[],
     settingsFilePath: string,
-    isInteractive: boolean,
     context: CliExecutionContext,
-): Promise<void> {
+): Promise<ManagedSkillInstallSummary[]> {
     for (const { skillName } of installActions) {
         await validateRegistrySkillPublicationTargets({
             hostInstallations: resolveManagedSkillHostInstallations(
@@ -210,6 +215,8 @@ async function executeInstallActions(
     const extractedPackage = await extractRegistryPackageArchive(packageBytes);
 
     try {
+        const summaries: ManagedSkillInstallSummary[] = [];
+
         for (const { skillName } of installActions) {
             const skill = findPackageSkillOrThrow(packageInfo.skills, skillName, packageInfo.packageName);
             const hostInstallations = resolveManagedSkillHostInstallations(
@@ -228,17 +235,13 @@ async function executeInstallActions(
                 }),
             );
 
-            if (!isInteractive) {
-                for (const publication of publications) {
-                    writeLine(
-                        context.stdout,
-                        context.translator.t("skills.install.success", {
-                            name: skillName,
-                            path: publication.path,
-                        }),
-                    );
-                }
-            }
+            summaries.push({
+                name: skillName,
+                publications: publications.map(publication => ({
+                    agentName: publication.agentName,
+                    path: publication.path,
+                }) satisfies ManagedSkillInstallPublication),
+            });
 
             for (const publication of publications) {
                 context.logger.info(
@@ -256,6 +259,8 @@ async function executeInstallActions(
                 );
             }
         }
+
+        return summaries;
     }
     finally {
         await extractedPackage.cleanup();

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -5,6 +5,10 @@ import type {
     BundledSkillAgentName,
     BundledSkillName,
 } from "./embedded-assets.ts";
+import type {
+    ManagedSkillInstallPublication,
+    ManagedSkillInstallSummary,
+} from "./install-output.ts";
 import type { ManagedSkillHostInstallation } from "./managed-skill-hosts.ts";
 import {
     mkdir,
@@ -55,7 +59,7 @@ interface BundledSkillHostInstallation extends ManagedSkillHostInstallation {
 export async function installBundledSkill(
     skillName: BundledSkillName,
     context: CliExecutionContext,
-): Promise<void> {
+): Promise<ManagedSkillInstallSummary> {
     const installations = await resolveAvailableBundledSkillHostInstallations(
         context,
         skillName,
@@ -73,6 +77,8 @@ export async function installBundledSkill(
         );
     }
 
+    const publications: ManagedSkillInstallPublication[] = [];
+
     for (const installation of installations) {
         const publishedInstallation = await publishManagedBundledSkill({
             agentName: installation.agentName,
@@ -82,13 +88,10 @@ export async function installBundledSkill(
             version: context.version,
         });
 
-        writeLine(
-            context.stdout,
-            context.translator.t("skills.install.success", {
-                name: skillName,
-                path: publishedInstallation.path,
-            }),
-        );
+        publications.push({
+            agentName: installation.agentName,
+            path: publishedInstallation.path,
+        });
         context.logger.info(
             {
                 agentName: installation.agentName,
@@ -101,6 +104,11 @@ export async function installBundledSkill(
             "Bundled skill installed explicitly.",
         );
     }
+
+    return {
+        name: skillName,
+        publications,
+    };
 }
 
 export async function uninstallBundledSkill(

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -574,12 +574,20 @@ export const enMessages = {
     "skills.init.linked": "Linked skill {name} to {path}.",
     "skills.init.copied": "Copied skill {name} to {path}.",
     "skills.install.success": "Installed skill {name} to {path}.",
+    "skills.install.summary.agentsLabel": "Agents",
+    "skills.install.summary.detailLine": "{label}: {values}",
+    "skills.install.summary.installed": "Installed",
+    "skills.install.summary.multipleSkillsMultipleAgents":
+        "{status} {skillCount} skills to {agentCount} agents.",
+    "skills.install.summary.multipleSkillsSingleAgent":
+        "{status} {skillCount} skills to {agentName}.",
+    "skills.install.summary.singleSkillMultipleAgents":
+        "{status} skill {skillName} to {agentCount} agents: {agentNames}.",
+    "skills.install.summary.skillsLabel": "Skills",
     "skills.install.overwrite.invalid":
         "Invalid choice. Enter y/yes or n/no.",
     "skills.install.overwrite.prompt":
         "Skill {name} already exists. Overwrite? [y/N] ",
-    "skills.install.selection.invalid":
-        "Invalid selection. Use one or more comma-separated numbers, or press Enter to cancel.",
     "skills.install.selection.prompt":
         "Select skills to install or keep installed (space to toggle)",
     "skills.install.progress.installing.start": "Installing selected skills...",
@@ -1032,7 +1040,7 @@ export const zhMessages = {
     "errors.skills.workbuddyNotInstalled":
         "未检测到 WorkBuddy 安装。期望的 WorkBuddy 根目录为 {path}。",
     "errors.skills.noSupportedBundledSkillHosts":
-        "未检测到已安装的受支持 skill 宿主。期望其中之一位于：{paths}。",
+        "未检测到已安装的受支持 Agent。期望其中之一位于：{paths}。",
     "errors.skills.install.confirmationRequired":
         "Skill {name} 已存在，且需要在交互终端中确认覆盖。",
     "errors.skills.install.invalidArchive":
@@ -1058,7 +1066,7 @@ export const zhMessages = {
     "errors.skills.update.packageNameMissing":
         "无法在 {hostNames} 中更新由 oo 管理的 skill {name}，因为缺少 package 元数据。",
     "errors.skills.update.notManaged":
-        "host {hostName} 中的 skill {name} 不是由 oo 管理的 skill，无法更新。",
+        "Agent {hostName} 中的 skill {name} 不是由 oo 管理的 skill，无法更新。",
     "errors.skills.nameConflict":
         "Skill 名称 {name} 已被 {path} 中的非 OOMOL skill 占用。",
     "errors.skills.storageConflict":
@@ -1152,7 +1160,7 @@ export const zhMessages = {
     "options.onlyPackageId": "仅返回 package id",
     "options.all":
         "安装全部已发布 skill，并跳过 skill 选择提示",
-    "options.agent": "检查一个受支持的 skill 宿主",
+    "options.agent": "检查一个受支持的 Agent",
     "options.nextToken": "指定下一页分页令牌",
     "options.packageId": "按 package id 过滤",
     "options.packageName": "--package-id 的别名",
@@ -1204,10 +1212,10 @@ export const zhMessages = {
     "skills.install.allSelected":
         "将安装全部 {count} 个 skill。",
     "skills.check.success":
-        "本地 skill 编辑环境可用。可写存储：{path}。受支持宿主数：{count}。",
+        "本地 skill 编辑环境可用。可写存储：{path}。受支持 Agents：{count}。",
     "skills.list.noResults":
         "未找到由 oo 管理的 skill。",
-    "skills.list.host": "宿主",
+    "skills.list.host": "Agents",
     "skills.list.host.claude": "Claude Code",
     "skills.list.host.codebuddy": "CodeBuddy",
     "skills.list.host.codex": "Codex",
@@ -1228,12 +1236,20 @@ export const zhMessages = {
     "skills.init.linked": "已将 skill {name} 软链接到 {path}。",
     "skills.init.copied": "已将 skill {name} 复制到 {path}。",
     "skills.install.success": "已将 skill {name} 安装到 {path}。",
+    "skills.install.summary.agentsLabel": "Agents",
+    "skills.install.summary.detailLine": "{label}：{values}",
+    "skills.install.summary.installed": "已安装",
+    "skills.install.summary.multipleSkillsMultipleAgents":
+        "{status} {skillCount} 个 skills 到 {agentCount} 个 Agents。",
+    "skills.install.summary.multipleSkillsSingleAgent":
+        "{status} {skillCount} 个 skills 到 {agentName}。",
+    "skills.install.summary.singleSkillMultipleAgents":
+        "{status} skill {skillName} 到 {agentCount} 个 Agents：{agentNames}。",
+    "skills.install.summary.skillsLabel": "Skills",
     "skills.install.overwrite.invalid":
         "输入无效。请输入 y/yes 或 n/no。",
     "skills.install.overwrite.prompt":
         "Skill {name} 已存在，是否覆盖？[y/N] ",
-    "skills.install.selection.invalid":
-        "选择无效。请输入一个或多个逗号分隔的序号，或直接回车取消。",
     "skills.install.selection.prompt":
         "选择要安装或保留的 skill（空格切换）",
     "skills.install.progress.installing.start": "正在安装所选 skill...",
@@ -1259,7 +1275,7 @@ export const zhMessages = {
     "skills.update.progress.header": "正在更新已安装的 skill",
     "skills.update.progress.checking": "检查更新中",
     "skills.update.progress.preparing": "更新 canonical 文件中",
-    "skills.update.progress.publishing": "同步到受支持宿主中",
+    "skills.update.progress.publishing": "同步到受支持 Agents 中",
     "skills.update.progress.current": "已是最新",
     "skills.update.progress.updated": "已更新",
     "skills.update.progress.failed": "失败",


### PR DESCRIPTION
Previously each managed skill publication printed its own line, which produced a wall of near-identical output when installing several skills across multiple agents. The new compact summary aggregates publications and renders one of four shapes depending on whether a single or multiple skills were installed across one or multiple agents, with optional ANSI colors when stdout supports them.

Also extract the agent label lookup into managed-skill-host-labels so both the list and install commands share a single source of truth, and update the docs and snapshots to reflect the new output shape.