### PR TITLE
ci: notify Feishu on release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -190,3 +190,32 @@ jobs:
     with:
       tag: ${{ needs.compute-version.outputs.tag_name }}
     secrets: inherit
+
+  notify-feishu-release:
+    needs:
+      - compute-version
+      - publish
+      - upload-release-binaries-to-oss
+      - deploy-install-worker
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      RELEASE_VERSION: ${{ needs.compute-version.outputs.version }}
+      RELEASE_TAG: ${{ needs.compute-version.outputs.tag_name }}
+      FEISHU_RELEASE_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
+      FEISHU_RELEASE_SECRET: ${{ secrets.FEISHU_RELEASE_SECRET }}
+
+    steps:
+      - name: Checkout
+        if: env.FEISHU_RELEASE_WEBHOOK != ''
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Bun
+        if: env.FEISHU_RELEASE_WEBHOOK != ''
+        uses: oven-sh/setup-bun@v2.2.0
+        with:
+          bun-version-file: .bun-version
+
+      - name: Notify Feishu release group
+        if: env.FEISHU_RELEASE_WEBHOOK != ''
+        run: bun run contrib/ci/release-workflow.ts notify-feishu-release

--- a/contrib/ci/release-steps.ts
+++ b/contrib/ci/release-steps.ts
@@ -48,3 +48,44 @@ export function buildCreateReleaseCommand(input: {
     command.push("--latest");
     return command;
 }
+
+export function buildFeishuReleaseNotification(input: {
+    releaseVersion: string;
+    releaseTag: string;
+    repository: string;
+    serverUrl: string;
+    runId: string;
+    timestamp?: string;
+    sign?: string;
+}): string {
+    if (input.releaseVersion === "") {
+        throw new Error("RELEASE_VERSION is required.");
+    }
+
+    if (input.releaseTag === "") {
+        throw new Error("RELEASE_TAG is required.");
+    }
+
+    const releaseUrl = `${input.serverUrl}/${input.repository}/releases/tag/${input.releaseTag}`;
+    const runUrl = `${input.serverUrl}/${input.repository}/actions/runs/${input.runId}`;
+    const payload: Record<string, unknown> = {
+        msg_type: "text",
+        content: {
+            text: [
+                `oo-cli ${input.releaseTag} 已发布`,
+                "",
+                `版本：${input.releaseVersion}`,
+                `npm：https://www.npmjs.com/package/@oomol-lab/oo-cli/v/${input.releaseVersion}`,
+                `Release：${releaseUrl}`,
+                `Workflow：${runUrl}`,
+            ].join("\n"),
+        },
+    };
+
+    if (input.timestamp !== undefined && input.sign !== undefined) {
+        payload.timestamp = input.timestamp;
+        payload.sign = input.sign;
+    }
+
+    return JSON.stringify(payload);
+}

--- a/contrib/ci/release-steps.ts
+++ b/contrib/ci/release-steps.ts
@@ -58,24 +58,26 @@ export function buildFeishuReleaseNotification(input: {
     timestamp?: string;
     sign?: string;
 }): string {
-    if (input.releaseVersion === "") {
+    const releaseVersion = input.releaseVersion.trim();
+    if (releaseVersion === "") {
         throw new Error("RELEASE_VERSION is required.");
     }
 
-    if (input.releaseTag === "") {
+    const releaseTag = input.releaseTag.trim();
+    if (releaseTag === "") {
         throw new Error("RELEASE_TAG is required.");
     }
 
-    const releaseUrl = `${input.serverUrl}/${input.repository}/releases/tag/${input.releaseTag}`;
+    const releaseUrl = `${input.serverUrl}/${input.repository}/releases/tag/${releaseTag}`;
     const runUrl = `${input.serverUrl}/${input.repository}/actions/runs/${input.runId}`;
     const payload: Record<string, unknown> = {
         msg_type: "text",
         content: {
             text: [
-                `oo-cli ${input.releaseTag} 已发布`,
+                `oo-cli ${releaseTag} 已发布`,
                 "",
-                `版本：${input.releaseVersion}`,
-                `npm：https://www.npmjs.com/package/@oomol-lab/oo-cli/v/${input.releaseVersion}`,
+                `版本：${releaseVersion}`,
+                `npm：https://www.npmjs.com/package/@oomol-lab/oo-cli/v/${releaseVersion}`,
                 `Release：${releaseUrl}`,
                 `Workflow：${runUrl}`,
             ].join("\n"),

--- a/contrib/ci/release-workflow.test.ts
+++ b/contrib/ci/release-workflow.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
     buildCreateReleaseCommand,
+    buildFeishuReleaseNotification,
     preparePackageManifest,
 } from "./release-steps.ts";
 
@@ -102,5 +103,55 @@ describe("release-workflow", () => {
                 assets: [],
             }),
         ).toThrow("At least one release asset is required.");
+    });
+
+    test("builds the Feishu release notification payload", () => {
+        expect(JSON.parse(buildFeishuReleaseNotification({
+            releaseVersion: "1.2.3",
+            releaseTag: "v1.2.3",
+            repository: "oomol-lab/oo-cli",
+            serverUrl: "https://github.com",
+            runId: "123456789",
+        }))).toEqual({
+            msg_type: "text",
+            content: {
+                text: [
+                    "oo-cli v1.2.3 已发布",
+                    "",
+                    "版本：1.2.3",
+                    "npm：https://www.npmjs.com/package/@oomol-lab/oo-cli/v/1.2.3",
+                    "Release：https://github.com/oomol-lab/oo-cli/releases/tag/v1.2.3",
+                    "Workflow：https://github.com/oomol-lab/oo-cli/actions/runs/123456789",
+                ].join("\n"),
+            },
+        });
+    });
+
+    test("builds the signed Feishu release notification payload", () => {
+        expect(JSON.parse(buildFeishuReleaseNotification({
+            releaseVersion: "1.2.3",
+            releaseTag: "v1.2.3",
+            repository: "oomol-lab/oo-cli",
+            serverUrl: "https://github.com",
+            runId: "123456789",
+            timestamp: "1710000000",
+            sign: "signature",
+        }))).toMatchObject({
+            timestamp: "1710000000",
+            sign: "signature",
+            msg_type: "text",
+        });
+    });
+
+    test("rejects Feishu notifications without a release tag", () => {
+        expect(() =>
+            buildFeishuReleaseNotification({
+                releaseVersion: "1.2.3",
+                releaseTag: "",
+                repository: "oomol-lab/oo-cli",
+                serverUrl: "https://github.com",
+                runId: "123456789",
+            }),
+        ).toThrow("RELEASE_TAG is required.");
     });
 });

--- a/contrib/ci/release-workflow.test.ts
+++ b/contrib/ci/release-workflow.test.ts
@@ -106,13 +106,7 @@ describe("release-workflow", () => {
     });
 
     test("builds the Feishu release notification payload", () => {
-        expect(JSON.parse(buildFeishuReleaseNotification({
-            releaseVersion: "1.2.3",
-            releaseTag: "v1.2.3",
-            repository: "oomol-lab/oo-cli",
-            serverUrl: "https://github.com",
-            runId: "123456789",
-        }))).toEqual({
+        expect(JSON.parse(buildFeishuReleaseNotification(createFeishuInput()))).toEqual({
             msg_type: "text",
             content: {
                 text: [
@@ -128,15 +122,10 @@ describe("release-workflow", () => {
     });
 
     test("builds the signed Feishu release notification payload", () => {
-        expect(JSON.parse(buildFeishuReleaseNotification({
-            releaseVersion: "1.2.3",
-            releaseTag: "v1.2.3",
-            repository: "oomol-lab/oo-cli",
-            serverUrl: "https://github.com",
-            runId: "123456789",
+        expect(JSON.parse(buildFeishuReleaseNotification(createFeishuInput({
             timestamp: "1710000000",
             sign: "signature",
-        }))).toMatchObject({
+        })))).toMatchObject({
             timestamp: "1710000000",
             sign: "signature",
             msg_type: "text",
@@ -145,13 +134,18 @@ describe("release-workflow", () => {
 
     test("rejects Feishu notifications without a release tag", () => {
         expect(() =>
-            buildFeishuReleaseNotification({
-                releaseVersion: "1.2.3",
-                releaseTag: "",
-                repository: "oomol-lab/oo-cli",
-                serverUrl: "https://github.com",
-                runId: "123456789",
-            }),
+            buildFeishuReleaseNotification(createFeishuInput({ releaseTag: "" })),
         ).toThrow("RELEASE_TAG is required.");
     });
 });
+
+function createFeishuInput(overrides: Partial<Parameters<typeof buildFeishuReleaseNotification>[0]> = {}): Parameters<typeof buildFeishuReleaseNotification>[0] {
+    return {
+        releaseVersion: "1.2.3",
+        releaseTag: "v1.2.3",
+        repository: "oomol-lab/oo-cli",
+        serverUrl: "https://github.com",
+        runId: "123456789",
+        ...overrides,
+    };
+}

--- a/contrib/ci/release-workflow.ts
+++ b/contrib/ci/release-workflow.ts
@@ -1,10 +1,15 @@
+import { createHmac } from "node:crypto";
 import process from "node:process";
 
 import {
     assembleReleaseArtifacts,
     parseBuildTargetIds,
 } from "./npm-packages.ts";
-import { buildCreateReleaseCommand, preparePackageManifest } from "./release-steps.ts";
+import {
+    buildCreateReleaseCommand,
+    buildFeishuReleaseNotification,
+    preparePackageManifest,
+} from "./release-steps.ts";
 
 async function runPrepareManifest(): Promise<void> {
     const releaseVersion = readRequiredEnv("RELEASE_VERSION");
@@ -33,6 +38,49 @@ async function runCreateGitHubRelease(assets: readonly string[]): Promise<void> 
     if (exitCode !== 0) {
         process.exit(exitCode);
     }
+}
+
+async function runNotifyFeishuRelease(): Promise<void> {
+    const webhookUrl = readRequiredEnv("FEISHU_RELEASE_WEBHOOK");
+    const feishuSignature = createFeishuSignature(process.env.FEISHU_RELEASE_SECRET ?? "");
+    const payload = buildFeishuReleaseNotification({
+        releaseVersion: readRequiredEnv("RELEASE_VERSION"),
+        releaseTag: readRequiredEnv("RELEASE_TAG"),
+        repository: readRequiredEnv("GITHUB_REPOSITORY"),
+        serverUrl: readRequiredEnv("GITHUB_SERVER_URL"),
+        runId: readRequiredEnv("GITHUB_RUN_ID"),
+        timestamp: feishuSignature?.timestamp,
+        sign: feishuSignature?.sign,
+    });
+
+    const response = await fetch(webhookUrl, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+        },
+        body: payload,
+    });
+    const responseText = await response.text();
+
+    if (!response.ok) {
+        throw new Error(`Failed to notify Feishu release group: ${response.status} ${response.statusText}`);
+    }
+
+    const responseBody = JSON.parse(responseText) as Record<string, unknown>;
+    const errorCode = responseBody.code ?? responseBody.StatusCode;
+    if (errorCode !== 0) {
+        throw new Error(`Failed to notify Feishu release group: ${responseText}`);
+    }
+}
+
+function createFeishuSignature(secret: string): { timestamp: string; sign: string } | undefined {
+    if (secret === "") {
+        return undefined;
+    }
+
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const sign = createHmac("sha256", `${timestamp}\n${secret}`).digest("base64");
+    return { timestamp, sign };
 }
 
 async function runAssembleReleaseArtifacts(): Promise<void> {
@@ -68,6 +116,9 @@ export async function main(args: readonly string[]): Promise<void> {
             return;
         case "create-github-release":
             await runCreateGitHubRelease(commandArgs);
+            return;
+        case "notify-feishu-release":
+            await runNotifyFeishuRelease();
             return;
         default:
             throw new Error(`Unsupported command: ${command ?? ""}`);

--- a/contrib/ci/release-workflow.ts
+++ b/contrib/ci/release-workflow.ts
@@ -59,6 +59,7 @@ async function runNotifyFeishuRelease(): Promise<void> {
             "content-type": "application/json",
         },
         body: payload,
+        signal: AbortSignal.timeout(15_000),
     });
     const responseText = await response.text();
 


### PR DESCRIPTION
## Summary
- add a best-effort Feishu release notification job after publish, OSS upload, and install worker deployment
- support optional Feishu webhook signing via FEISHU_RELEASE_SECRET
- include release notification payload tests

## Validation
- bun run lint:fix
- bun run ts-check
- bun run test