### PR TITLE
feat(skills): enhance skill publishing with agent support

### DIFF
--- a/contrib/skills/claude/oo-create-skill/SKILL.md
+++ b/contrib/skills/claude/oo-create-skill/SKILL.md
@@ -1,16 +1,25 @@
 ---
 name: oo-create-skill
 description: >-
-  Create or update a local agent skill for a known OOMOL package workflow. Use
-  when the user already knows which oo package or block should power the
-  workflow and wants reusable skill instructions.
+  Author, generate, scaffold, or update a local AI agent skill that turns an
+  OOMOL/oo package, block, or selected workflow into reusable instructions. Use
+  when the user asks to create a skill, write a skill, make a Codex/Claude/agent
+  skill, or refine an existing local skill for an oo-powered workflow, even if
+  package discovery is needed first. Do not use for finding/installing published
+  skills or publishing skills.
 allowed-tools: ["Bash(oo *)"]
 ---
 
 # oo Create Skill
 
-Use this skill when the user wants to create or update a local skill around an
-OOMOL package workflow.
+Use this skill when the user wants to create, generate, scaffold, author, or
+update a local skill around an OOMOL/oo package workflow. This includes requests
+to turn a specific package or block into reusable agent instructions, or to
+create the skill after the right package is discovered.
+
+If the user only wants to discover or install existing published skills, use
+`oo-find-skills`. If the user wants to publish a finished skill, use
+`oo-publish-skill`.
 
 ## Workflow
 

--- a/contrib/skills/claude/oo-create-skill/SKILL.md
+++ b/contrib/skills/claude/oo-create-skill/SKILL.md
@@ -33,6 +33,7 @@ Ask for missing authoring inputs only when they are needed:
 - stable block names, when the user knows them
 - user inputs the skill should collect
 - workflow ordering and expected outputs
+- likely user requests that should trigger the generated skill
 - optional display title and icon preference
 
 If the user does not provide a display title or icon preference, choose them
@@ -72,12 +73,24 @@ initialization. If initialization fails because the local canonical directory or
 an agent target directory already exists, ask the user for a different skill
 name instead of overwriting.
 
+Make `--description` trigger-oriented because it becomes the generated skill's
+frontmatter. Cover the real user requests that should invoke the skill: include
+likely verbs, task nouns, domain terms, inputs, outputs, and the package or
+block-backed capability. Add a concise "Do not use" boundary for nearby skills
+or workflows that should not trigger it.
+
 ### 4. Author the workflow instructions
 
 Write the generated skill in domain terms: when to use it, what to ask the
 user, which workflow steps to follow, and what outputs to report. Reference
 packages with `oo::packageName` and stable blocks with
 `oo::packageName::blockName`.
+
+Review the generated frontmatter `description` before finishing. It must be
+specific enough for future agents to trigger the skill in the target scenario:
+name the task outcome, common user phrasing, important inputs and outputs, and
+the concrete package or block capability. Avoid generic descriptions such as
+"use an OOMOL package workflow" that do not mention the user's domain.
 
 Preserve the generated frontmatter `metadata.title` field when it exists. If
 you change the skill's displayed title or first heading, update

--- a/contrib/skills/claude/oo-publish-skill/SKILL.md
+++ b/contrib/skills/claude/oo-publish-skill/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: oo-publish-skill
-description: >-
-  Publish, release, upload, submit, or share an existing AI agent skill
-  directory with SKILL.md to the OOMOL registry by running oo skills publish.
-  Use when the user asks to publish a skill, make a skill available in the
-  OOMOL skill catalog, release a registry skill package, or publish from a
-  local, agent-installed, registry-installed, or path-based skill source. Do
-  not use for finding, installing, creating, or editing skills unless the final
-  goal is publication.
+description: Publish, release, upload, submit, or share an existing AI agent skill to the OOMOL registry by running oo skills publish. Use when the user asks to publish a skill, make a skill available in the OOMOL hub, release a registry skill package.
 allowed-tools: ["Bash(oo *)"]
 ---
 

--- a/contrib/skills/claude/oo-publish-skill/SKILL.md
+++ b/contrib/skills/claude/oo-publish-skill/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: oo-publish-skill
+description: >-
+  Publish, release, upload, submit, or share an existing AI agent skill
+  directory with SKILL.md to the OOMOL registry by running oo skills publish.
+  Use when the user asks to publish a skill, make a skill available in the
+  OOMOL skill catalog, release a registry skill package, or publish from a
+  local, agent-installed, registry-installed, or path-based skill source. Do
+  not use for finding, installing, creating, or editing skills unless the final
+  goal is publication.
+allowed-tools: ["Bash(oo *)"]
+---
+
+# oo Publish Skill
+
+Use this skill when the user wants to publish an existing agent skill to the
+OOMOL registry or skill catalog. The source can be any valid agent skill
+directory with a `SKILL.md`; it does not need to be an oo-specific skill.
+
+## Workflow
+
+### 1. Identify the publish source
+
+Ask for the missing skill id or skill directory path only when needed:
+
+- skill id or path to a skill directory
+
+Choose the command shape from the source:
+
+```bash
+oo skills publish <skill-id> --agent <agent>
+oo skills publish <path-to-skill-directory>
+```
+
+When publishing by skill id, include `--agent <agent>`. Choose `<agent>`
+yourself from the supported ids according to the current host: `codex`,
+`claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`, or
+`qoderwork`. Do not ask the user just to choose this source agent. When
+publishing by filesystem path, pass the path directly and omit `--agent`.
+
+The publish command performs its own environment, authentication, and account
+checks, so run it directly.
+
+Use the default private visibility unless the user explicitly asks for a public
+package. Add `--visibility public` only for that explicit public request.
+
+Do not ask whether to publish to the current account. `oo skills publish`
+resolves the account and asks any necessary ownership questions itself.
+
+### 2. Publish through oo
+
+Run the publish command directly:
+
+```bash
+oo skills publish my-skill --agent claude
+oo skills publish ./my-skill
+oo skills publish my-skill --agent claude --visibility public
+```
+
+If this shared skill file is running in Hermes, CodeBuddy, WorkBuddy, Trae,
+OpenClaw, QoderWork, or Codex instead of Claude Code, replace `claude` with that
+host id from the supported list.
+
+If the command prompts about adopting a path or agent-installed skill, publishing
+a registry-installed skill under the active account, or overwriting an existing
+remote package, let that prompt drive the next user confirmation. Do not ask
+those questions in advance.
+
+Do not package manually, do not use `npm publish`, and do not copy files into an
+arbitrary fallback directory.
+
+### 3. Report the result
+
+Report the published package name, version, visibility, and hub URL from the
+command output. Also mention any local adoption or metadata writeback that
+occurred. If publish fails, do not retry blindly; summarize the failing command,
+the user-facing error, and the smallest next fix.

--- a/contrib/skills/codebuddy/oo-create-skill/SKILL.md
+++ b/contrib/skills/codebuddy/oo-create-skill/SKILL.md
@@ -32,6 +32,7 @@ Ask for missing authoring inputs only when they are needed:
 - stable block names, when the user knows them
 - user inputs the skill should collect
 - workflow ordering and expected outputs
+- likely user requests that should trigger the generated skill
 - optional display title and icon preference
 
 If the user does not provide a display title or icon preference, choose them
@@ -71,12 +72,24 @@ initialization. If initialization fails because the local canonical directory or
 an agent target directory already exists, ask the user for a different skill
 name instead of overwriting.
 
+Make `--description` trigger-oriented because it becomes the generated skill's
+frontmatter. Cover the real user requests that should invoke the skill: include
+likely verbs, task nouns, domain terms, inputs, outputs, and the package or
+block-backed capability. Add a concise "Do not use" boundary for nearby skills
+or workflows that should not trigger it.
+
 ### 4. Author the workflow instructions
 
 Write the generated skill in domain terms: when to use it, what to ask the
 user, which workflow steps to follow, and what outputs to report. Reference
 packages with `oo::packageName` and stable blocks with
 `oo::packageName::blockName`.
+
+Review the generated frontmatter `description` before finishing. It must be
+specific enough for future agents to trigger the skill in the target scenario:
+name the task outcome, common user phrasing, important inputs and outputs, and
+the concrete package or block capability. Avoid generic descriptions such as
+"use an OOMOL package workflow" that do not mention the user's domain.
 
 Preserve the generated frontmatter `metadata.title` field when it exists. If
 you change the skill's displayed title or first heading, update

--- a/contrib/skills/codebuddy/oo-create-skill/SKILL.md
+++ b/contrib/skills/codebuddy/oo-create-skill/SKILL.md
@@ -1,12 +1,24 @@
 ---
 name: oo-create-skill
-description: "Create or update a local agent skill for a known OOMOL package workflow. Use when the user already knows which oo package or block should power the workflow and wants reusable skill instructions."
+description: >-
+  Author, generate, scaffold, or update a local AI agent skill that turns an
+  OOMOL/oo package, block, or selected workflow into reusable instructions. Use
+  when the user asks to create a skill, write a skill, make a Codex/Claude/agent
+  skill, or refine an existing local skill for an oo-powered workflow, even if
+  package discovery is needed first. Do not use for finding/installing published
+  skills or publishing skills.
 ---
 
 # oo Create Skill
 
-Use this skill when the user wants to create or update a local skill around an
-OOMOL package workflow.
+Use this skill when the user wants to create, generate, scaffold, author, or
+update a local skill around an OOMOL/oo package workflow. This includes requests
+to turn a specific package or block into reusable agent instructions, or to
+create the skill after the right package is discovered.
+
+If the user only wants to discover or install existing published skills, use
+`oo-find-skills`. If the user wants to publish a finished skill, use
+`oo-publish-skill`.
 
 ## Workflow
 

--- a/contrib/skills/codebuddy/oo-publish-skill/SKILL.md
+++ b/contrib/skills/codebuddy/oo-publish-skill/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: oo-publish-skill
+description: "Publish, release, upload, submit, or share an existing AI agent skill directory with SKILL.md to the OOMOL registry by running oo skills publish. Use when the user asks to publish a skill, make a skill available in the OOMOL skill catalog, release a registry skill package, or publish from a local, agent-installed, registry-installed, or path-based skill source. Do not use for finding, installing, creating, or editing skills unless the final goal is publication."
+---
+
+# oo Publish Skill
+
+Use this skill when the user wants to publish an existing agent skill to the
+OOMOL registry or skill catalog. The source can be any valid agent skill
+directory with a `SKILL.md`; it does not need to be an oo-specific skill.
+
+## Workflow
+
+### 1. Identify the publish source
+
+Ask for the missing skill id or skill directory path only when needed:
+
+- skill id or path to a skill directory
+
+Choose the command shape from the source:
+
+```bash
+oo skills publish <skill-id> --agent <agent>
+oo skills publish <path-to-skill-directory>
+```
+
+When publishing by skill id, include `--agent <agent>`. Choose `<agent>`
+yourself from the supported ids according to the current host: `codex`,
+`claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`, or
+`qoderwork`. Do not ask the user just to choose this source agent. When
+publishing by filesystem path, pass the path directly and omit `--agent`.
+
+The publish command performs its own environment, authentication, and account
+checks, so run it directly.
+
+Use the default private visibility unless the user explicitly asks for a public
+package. Add `--visibility public` only for that explicit public request.
+
+Do not ask whether to publish to the current account. `oo skills publish`
+resolves the account and asks any necessary ownership questions itself.
+
+### 2. Publish through oo
+
+Run the publish command directly:
+
+```bash
+oo skills publish my-skill --agent codebuddy
+oo skills publish ./my-skill
+oo skills publish my-skill --agent codebuddy --visibility public
+```
+
+If this shared skill file is running in WorkBuddy or Trae, replace `codebuddy`
+with `workbuddy` or `trae`. If it is running in another supported host, choose
+that host id from the supported list.
+
+If the command prompts about adopting a path or agent-installed skill, publishing
+a registry-installed skill under the active account, or overwriting an existing
+remote package, let that prompt drive the next user confirmation. Do not ask
+those questions in advance.
+
+Do not package manually, do not use `npm publish`, and do not copy files into an
+arbitrary fallback directory.
+
+### 3. Report the result
+
+Report the published package name, version, visibility, and hub URL from the
+command output. Also mention any local adoption or metadata writeback that
+occurred. If publish fails, do not retry blindly; summarize the failing command,
+the user-facing error, and the smallest next fix.

--- a/contrib/skills/codex/oo-create-skill/SKILL.md
+++ b/contrib/skills/codex/oo-create-skill/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: oo-create-skill
 description: >-
-  Create or update a local agent skill for a known OOMOL package workflow. Use
-  when the user already knows which oo package or block should power the
-  workflow and wants reusable skill instructions.
+  Author, generate, scaffold, or update a local AI agent skill that turns an
+  OOMOL/oo package, block, or selected workflow into reusable instructions. Use
+  when the user asks to create a skill, write a skill, make a Codex/Claude/agent
+  skill, or refine an existing local skill for an oo-powered workflow, even if
+  package discovery is needed first. Do not use for finding/installing published
+  skills or publishing skills.
 ---
 
 # oo Create Skill
 
-Use this skill when the user wants to create or update a local skill around an
-OOMOL package workflow.
+Use this skill when the user wants to create, generate, scaffold, author, or
+update a local skill around an OOMOL/oo package workflow. This includes requests
+to turn a specific package or block into reusable agent instructions, or to
+create the skill after the right package is discovered.
+
+If the user only wants to discover or install existing published skills, use
+`oo-find-skills`. If the user wants to publish a finished skill, use
+`oo-publish-skill`.
 
 ## Workflow
 

--- a/contrib/skills/codex/oo-create-skill/SKILL.md
+++ b/contrib/skills/codex/oo-create-skill/SKILL.md
@@ -79,6 +79,7 @@ Ask for missing authoring inputs only when they are needed:
 - stable block names, when the user knows them
 - user inputs the skill should collect
 - workflow ordering and expected outputs
+- likely user requests that should trigger the generated skill
 - optional display title and icon preference
 
 If the user does not provide a display title or icon preference, choose them
@@ -118,6 +119,12 @@ initialization. If initialization fails because the local canonical directory or
 an agent target directory already exists, ask the user for a different skill
 name instead of overwriting.
 
+Make `--description` trigger-oriented because it becomes the generated skill's
+frontmatter. Cover the real user requests that should invoke the skill: include
+likely verbs, task nouns, domain terms, inputs, outputs, and the package or
+block-backed capability. Add a concise "Do not use" boundary for nearby skills
+or workflows that should not trigger it.
+
 Do not substitute manual file creation for this step. The initialized skill
 directory must come from a successful `oo skills init` invocation before you
 edit its workflow instructions or run validation.
@@ -128,6 +135,12 @@ Write the generated skill in domain terms: when to use it, what to ask the
 user, which workflow steps to follow, and what outputs to report. Reference
 packages with `oo::packageName` and stable blocks with
 `oo::packageName::blockName`.
+
+Review the generated frontmatter `description` before finishing. It must be
+specific enough for future agents to trigger the skill in the target scenario:
+name the task outcome, common user phrasing, important inputs and outputs, and
+the concrete package or block capability. Avoid generic descriptions such as
+"use an OOMOL package workflow" that do not mention the user's domain.
 
 Preserve the generated frontmatter `metadata.title` field when it exists. If
 you change the skill's displayed title or first heading, update

--- a/contrib/skills/codex/oo-create-skill/agents/openai.yaml
+++ b/contrib/skills/codex/oo-create-skill/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: oo Create Skill
-  short_description: Create local OOMOL package workflow skills
-  default_prompt: Use $oo-create-skill when the user wants to create or update a local agent skill for a known OOMOL/oo package workflow and already knows the package or block references. Do not use it for discovering unknown packages or finding published skills.
+  short_description: Create local OOMOL workflow skills
+  default_prompt: "Use $oo-create-skill when the user asks to author, scaffold, generate, or update a local AI agent skill for an OOMOL/oo package, block, or workflow, even when package discovery is needed before authoring; do not use it for finding/installing published skills or publishing finished skills."
 
 policy:
   allow_implicit_invocation: true

--- a/contrib/skills/codex/oo-publish-skill/SKILL.md
+++ b/contrib/skills/codex/oo-publish-skill/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: oo-publish-skill
+description: >-
+  Publish, release, upload, submit, or share an existing AI agent skill
+  directory with SKILL.md to the OOMOL registry by running oo skills publish.
+  Use when the user asks to publish a skill, make a skill available in the
+  OOMOL skill catalog, release a registry skill package, or publish from a
+  local, agent-installed, registry-installed, or path-based skill source. Do
+  not use for finding, installing, creating, or editing skills unless the final
+  goal is publication.
+---
+
+# oo Publish Skill
+
+Use this skill when the user wants to publish an existing agent skill to the
+OOMOL registry or skill catalog. The source can be any valid agent skill
+directory with a `SKILL.md`; it does not need to be an oo-specific skill.
+
+## Workflow
+
+### 1. Identify the publish source
+
+Ask for the missing skill id or skill directory path only when needed:
+
+- skill id or path to a skill directory
+
+Choose the command shape from the source:
+
+```bash
+oo skills publish <skill-id> --agent codex
+oo skills publish <path-to-skill-directory>
+```
+
+When publishing by skill id from Codex, include `--agent codex`. When publishing
+by filesystem path, pass the path directly and omit `--agent`.
+
+The publish command performs its own environment, authentication, and account
+checks, so run it directly.
+
+Use the default private visibility unless the user explicitly asks for a public
+package. Add `--visibility public` only for that explicit public request.
+
+Do not ask whether to publish to the current account. `oo skills publish`
+resolves the account and asks any necessary ownership questions itself.
+
+### 2. Publish through oo
+
+Run the publish command directly:
+
+```bash
+oo skills publish my-skill --agent codex
+oo skills publish ./my-skill
+oo skills publish my-skill --agent codex --visibility public
+```
+
+If the command prompts about adopting a path or agent-installed skill, publishing
+a registry-installed skill under the active account, or overwriting an existing
+remote package, let that prompt drive the next user confirmation. Do not ask
+those questions in advance.
+
+Do not package manually, do not use `npm publish`, and do not copy files into an
+arbitrary fallback directory.
+
+### 3. Report the result
+
+Report the published package name, version, visibility, and hub URL from the
+command output. Also mention any local adoption or metadata writeback that
+occurred. If publish fails, do not retry blindly; summarize the failing command,
+the user-facing error, and the smallest next fix.

--- a/contrib/skills/codex/oo-publish-skill/SKILL.md
+++ b/contrib/skills/codex/oo-publish-skill/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: oo-publish-skill
-description: >-
-  Publish, release, upload, submit, or share an existing AI agent skill
-  directory with SKILL.md to the OOMOL registry by running oo skills publish.
-  Use when the user asks to publish a skill, make a skill available in the
-  OOMOL skill catalog, release a registry skill package, or publish from a
-  local, agent-installed, registry-installed, or path-based skill source. Do
-  not use for finding, installing, creating, or editing skills unless the final
-  goal is publication.
+description: Publish, release, upload, submit, or share an existing AI agent skill to the OOMOL registry by running oo skills publish. Use when the user asks to publish a skill, make a skill available in the OOMOL hub, release a registry skill package.
 ---
 
 # oo Publish Skill

--- a/contrib/skills/codex/oo-publish-skill/agents/openai.yaml
+++ b/contrib/skills/codex/oo-publish-skill/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: oo Publish Skill
+  short_description: Publish agent skills to OOMOL registry
+  default_prompt: Use $oo-publish-skill when the user asks to publish, release, upload, submit, or share an existing AI agent skill directory with SKILL.md to the OOMOL registry or skill catalog, asks to run oo skills publish, make a skill available as a registry package, or resolve publish visibility, version, adoption, package-name, or overwrite prompts. Do not use it for finding, installing, creating, or editing skills unless the final goal is publication.
+
+policy:
+  allow_implicit_invocation: true

--- a/contrib/skills/openclaw/oo-create-skill/SKILL.md
+++ b/contrib/skills/openclaw/oo-create-skill/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: oo-create-skill
 description: >-
-  Create or update a local agent skill for a known OOMOL package workflow. Use
-  when the user already knows which oo package or block should power the
-  workflow and wants reusable skill instructions.
+  Author, generate, scaffold, or update a local AI agent skill that turns an
+  OOMOL/oo package, block, or selected workflow into reusable instructions. Use
+  when the user asks to create a skill, write a skill, make a Codex/Claude/agent
+  skill, or refine an existing local skill for an oo-powered workflow, even if
+  package discovery is needed first. Do not use for finding/installing published
+  skills or publishing skills.
 ---
 
 # oo Create Skill
 
-Use this skill when the user wants to create or update a local skill around an
-OOMOL package workflow.
+Use this skill when the user wants to create, generate, scaffold, author, or
+update a local skill around an OOMOL/oo package workflow. This includes requests
+to turn a specific package or block into reusable agent instructions, or to
+create the skill after the right package is discovered.
+
+If the user only wants to discover or install existing published skills, use
+`oo-find-skills`. If the user wants to publish a finished skill, use
+`oo-publish-skill`.
 
 ## Workflow
 

--- a/contrib/skills/openclaw/oo-create-skill/SKILL.md
+++ b/contrib/skills/openclaw/oo-create-skill/SKILL.md
@@ -32,6 +32,7 @@ Ask for missing authoring inputs only when they are needed:
 - stable block names, when the user knows them
 - user inputs the skill should collect
 - workflow ordering and expected outputs
+- likely user requests that should trigger the generated skill
 - optional display title and icon preference
 
 If the user does not provide a display title or icon preference, choose them
@@ -71,12 +72,24 @@ initialization. If initialization fails because the local canonical directory or
 an agent target directory already exists, ask the user for a different skill
 name instead of overwriting.
 
+Make `--description` trigger-oriented because it becomes the generated skill's
+frontmatter. Cover the real user requests that should invoke the skill: include
+likely verbs, task nouns, domain terms, inputs, outputs, and the package or
+block-backed capability. Add a concise "Do not use" boundary for nearby skills
+or workflows that should not trigger it.
+
 ### 4. Author the workflow instructions
 
 Write the generated skill in domain terms: when to use it, what to ask the
 user, which workflow steps to follow, and what outputs to report. Reference
 packages with `oo::packageName` and stable blocks with
 `oo::packageName::blockName`.
+
+Review the generated frontmatter `description` before finishing. It must be
+specific enough for future agents to trigger the skill in the target scenario:
+name the task outcome, common user phrasing, important inputs and outputs, and
+the concrete package or block capability. Avoid generic descriptions such as
+"use an OOMOL package workflow" that do not mention the user's domain.
 
 Preserve the generated frontmatter `metadata.title` field when it exists. If
 you change the skill's displayed title or first heading, update

--- a/contrib/skills/openclaw/oo-publish-skill/SKILL.md
+++ b/contrib/skills/openclaw/oo-publish-skill/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: oo-publish-skill
-description: >-
-  Publish, release, upload, submit, or share an existing AI agent skill
-  directory with SKILL.md to the OOMOL registry by running oo skills publish.
-  Use when the user asks to publish a skill, make a skill available in the
-  OOMOL skill catalog, release a registry skill package, or publish from a
-  local, agent-installed, registry-installed, or path-based skill source. Do
-  not use for finding, installing, creating, or editing skills unless the final
-  goal is publication.
+description: Publish, release, upload, submit, or share an existing AI agent skill to the OOMOL registry by running oo skills publish. Use when the user asks to publish a skill, make a skill available in the OOMOL hub, release a registry skill package.
 ---
 
 # oo Publish Skill

--- a/contrib/skills/openclaw/oo-publish-skill/SKILL.md
+++ b/contrib/skills/openclaw/oo-publish-skill/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: oo-publish-skill
+description: >-
+  Publish, release, upload, submit, or share an existing AI agent skill
+  directory with SKILL.md to the OOMOL registry by running oo skills publish.
+  Use when the user asks to publish a skill, make a skill available in the
+  OOMOL skill catalog, release a registry skill package, or publish from a
+  local, agent-installed, registry-installed, or path-based skill source. Do
+  not use for finding, installing, creating, or editing skills unless the final
+  goal is publication.
+---
+
+# oo Publish Skill
+
+Use this skill when the user wants to publish an existing agent skill to the
+OOMOL registry or skill catalog. The source can be any valid agent skill
+directory with a `SKILL.md`; it does not need to be an oo-specific skill.
+
+## Workflow
+
+### 1. Identify the publish source
+
+Ask for the missing skill id or skill directory path only when needed:
+
+- skill id or path to a skill directory
+
+Choose the command shape from the source:
+
+```bash
+oo skills publish <skill-id> --agent <agent>
+oo skills publish <path-to-skill-directory>
+```
+
+When publishing by skill id, include `--agent <agent>`. Choose `<agent>`
+yourself from the supported ids according to the current host: `codex`,
+`claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`, or
+`qoderwork`. Do not ask the user just to choose this source agent. When
+publishing by filesystem path, pass the path directly and omit `--agent`.
+
+The publish command performs its own environment, authentication, and account
+checks, so run it directly.
+
+Use the default private visibility unless the user explicitly asks for a public
+package. Add `--visibility public` only for that explicit public request.
+
+Do not ask whether to publish to the current account. `oo skills publish`
+resolves the account and asks any necessary ownership questions itself.
+
+### 2. Publish through oo
+
+Run the publish command directly:
+
+```bash
+oo skills publish my-skill --agent openclaw
+oo skills publish ./my-skill
+oo skills publish my-skill --agent openclaw --visibility public
+```
+
+If this shared skill file is running in another supported host, replace
+`openclaw` with that host id from the supported list.
+
+If the command prompts about adopting a path or agent-installed skill, publishing
+a registry-installed skill under the active account, or overwriting an existing
+remote package, let that prompt drive the next user confirmation. Do not ask
+those questions in advance.
+
+Do not package manually, do not use `npm publish`, and do not copy files into an
+arbitrary fallback directory.
+
+### 3. Report the result
+
+Report the published package name, version, visibility, and hub URL from the
+command output. Also mention any local adoption or metadata writeback that
+occurred. If publish fails, do not retry blindly; summarize the failing command,
+the user-facing error, and the smallest next fix.

--- a/contrib/skills/qoderwork/oo-create-skill/SKILL.md
+++ b/contrib/skills/qoderwork/oo-create-skill/SKILL.md
@@ -1,15 +1,24 @@
 ---
 name: oo-create-skill
 description: >-
-  Create or update a local agent skill for a known OOMOL package workflow. Use
-  when the user already knows which oo package or block should power the
-  workflow and wants reusable skill instructions.
+  Author, generate, scaffold, or update a local AI agent skill that turns an
+  OOMOL/oo package, block, or selected workflow into reusable instructions. Use
+  when the user asks to create a skill, write a skill, make a Codex/Claude/agent
+  skill, or refine an existing local skill for an oo-powered workflow, even if
+  package discovery is needed first. Do not use for finding/installing published
+  skills or publishing skills.
 ---
 
 # oo Create Skill
 
-Use this skill when the user wants to create or update a local skill around an
-OOMOL package workflow.
+Use this skill when the user wants to create, generate, scaffold, author, or
+update a local skill around an OOMOL/oo package workflow. This includes requests
+to turn a specific package or block into reusable agent instructions, or to
+create the skill after the right package is discovered.
+
+If the user only wants to discover or install existing published skills, use
+`oo-find-skills`. If the user wants to publish a finished skill, use
+`oo-publish-skill`.
 
 ## Workflow
 

--- a/contrib/skills/qoderwork/oo-create-skill/SKILL.md
+++ b/contrib/skills/qoderwork/oo-create-skill/SKILL.md
@@ -32,6 +32,7 @@ Ask for missing authoring inputs only when they are needed:
 - stable block names, when the user knows them
 - user inputs the skill should collect
 - workflow ordering and expected outputs
+- likely user requests that should trigger the generated skill
 - optional display title and icon preference
 
 If the user does not provide a display title or icon preference, choose them
@@ -71,12 +72,24 @@ initialization. If initialization fails because the local canonical directory or
 an agent target directory already exists, ask the user for a different skill
 name instead of overwriting.
 
+Make `--description` trigger-oriented because it becomes the generated skill's
+frontmatter. Cover the real user requests that should invoke the skill: include
+likely verbs, task nouns, domain terms, inputs, outputs, and the package or
+block-backed capability. Add a concise "Do not use" boundary for nearby skills
+or workflows that should not trigger it.
+
 ### 4. Author the workflow instructions
 
 Write the generated skill in domain terms: when to use it, what to ask the
 user, which workflow steps to follow, and what outputs to report. Reference
 packages with `oo::packageName` and stable blocks with
 `oo::packageName::blockName`.
+
+Review the generated frontmatter `description` before finishing. It must be
+specific enough for future agents to trigger the skill in the target scenario:
+name the task outcome, common user phrasing, important inputs and outputs, and
+the concrete package or block capability. Avoid generic descriptions such as
+"use an OOMOL package workflow" that do not mention the user's domain.
 
 Preserve the generated frontmatter `metadata.title` field when it exists. If
 you change the skill's displayed title or first heading, update

--- a/contrib/skills/qoderwork/oo-publish-skill/SKILL.md
+++ b/contrib/skills/qoderwork/oo-publish-skill/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: oo-publish-skill
-description: >-
-  Publish, release, upload, submit, or share an existing AI agent skill
-  directory with SKILL.md to the OOMOL registry by running oo skills publish.
-  Use when the user asks to publish a skill, make a skill available in the
-  OOMOL skill catalog, release a registry skill package, or publish from a
-  local, agent-installed, registry-installed, or path-based skill source. Do
-  not use for finding, installing, creating, or editing skills unless the final
-  goal is publication.
+description: Publish, release, upload, submit, or share an existing AI agent skill to the OOMOL registry by running oo skills publish. Use when the user asks to publish a skill, make a skill available in the OOMOL hub, release a registry skill package.
 ---
 
 # oo Publish Skill

--- a/contrib/skills/qoderwork/oo-publish-skill/SKILL.md
+++ b/contrib/skills/qoderwork/oo-publish-skill/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: oo-publish-skill
+description: >-
+  Publish, release, upload, submit, or share an existing AI agent skill
+  directory with SKILL.md to the OOMOL registry by running oo skills publish.
+  Use when the user asks to publish a skill, make a skill available in the
+  OOMOL skill catalog, release a registry skill package, or publish from a
+  local, agent-installed, registry-installed, or path-based skill source. Do
+  not use for finding, installing, creating, or editing skills unless the final
+  goal is publication.
+---
+
+# oo Publish Skill
+
+Use this skill when the user wants to publish an existing agent skill to the
+OOMOL registry or skill catalog. The source can be any valid agent skill
+directory with a `SKILL.md`; it does not need to be an oo-specific skill.
+
+## Workflow
+
+### 1. Identify the publish source
+
+Ask for the missing skill id or skill directory path only when needed:
+
+- skill id or path to a skill directory
+
+Choose the command shape from the source:
+
+```bash
+oo skills publish <skill-id> --agent <agent>
+oo skills publish <path-to-skill-directory>
+```
+
+When publishing by skill id, include `--agent <agent>`. Choose `<agent>`
+yourself from the supported ids according to the current host: `codex`,
+`claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`, or
+`qoderwork`. Do not ask the user just to choose this source agent. When
+publishing by filesystem path, pass the path directly and omit `--agent`.
+
+The publish command performs its own environment, authentication, and account
+checks, so run it directly.
+
+Use the default private visibility unless the user explicitly asks for a public
+package. Add `--visibility public` only for that explicit public request.
+
+Do not ask whether to publish to the current account. `oo skills publish`
+resolves the account and asks any necessary ownership questions itself.
+
+### 2. Publish through oo
+
+Run the publish command directly:
+
+```bash
+oo skills publish my-skill --agent qoderwork
+oo skills publish ./my-skill
+oo skills publish my-skill --agent qoderwork --visibility public
+```
+
+If this shared skill file is running in another supported host, replace
+`qoderwork` with that host id from the supported list.
+
+If the command prompts about adopting a path or agent-installed skill, publishing
+a registry-installed skill under the active account, or overwriting an existing
+remote package, let that prompt drive the next user confirmation. Do not ask
+those questions in advance.
+
+Do not package manually, do not use `npm publish`, and do not copy files into an
+arbitrary fallback directory.
+
+### 3. Report the result
+
+Report the published package name, version, visibility, and hub URL from the
+command output. Also mention any local adoption or metadata writeback that
+occurred. If publish fails, do not retry blindly; summarize the failing command,
+the user-facing error, and the smallest next fix.

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -1,2 +1,3 @@
 words:
+  - OOMOL
   - wopjs

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -264,9 +264,9 @@ Search packages and connector actions with one free-form query.
 Before running a command, `oo` silently synchronizes managed skills for every
 supported host directory that already exists.
 
-- Bundled skills: `oo` ensures `oo` and `oo-find-skills` are installed for
-  each detected Codex, Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae,
-  OpenClaw, and QoderWork host.
+- Bundled skills: `oo` ensures `oo`, `oo-find-skills`, `oo-create-skill`, and
+  `oo-publish-skill` are installed for each detected Codex, Claude Code,
+  Hermes, CodeBuddy, WorkBuddy, Trae, OpenClaw, and QoderWork host.
   Existing oo-managed bundled skill targets are refreshed to the current `oo`
   version, except that `0.0.0-development` startup runs do not refresh
   existing bundled targets.
@@ -292,10 +292,10 @@ List oo-managed skills from supported local skill directories.
   skill identity. Identical `name`/source/version installs across multiple
   hosts are folded into one block.
 - Ordering: bundled skills are listed first when present, with `oo` before
-  `oo-find-skills` before `oo-create-skill`; the remaining skills are ordered
-  by skill name. Host names within a block follow `Codex`,
-  `Claude Code`, `Hermes`, `CodeBuddy`, `WorkBuddy`, `Trae`, `OpenClaw`,
-  `QoderWork` order.
+  `oo-find-skills` before `oo-create-skill` before `oo-publish-skill`; the
+  remaining skills are ordered by skill name. Host names within a block follow
+  `Codex`, `Claude Code`, `Hermes`, `CodeBuddy`, `WorkBuddy`, `Trae`,
+  `OpenClaw`, `QoderWork` order.
 - Output: each skill block shows the skill name, host, source package or
   bundled/local marker, and recorded version.
 - Notes: when a folded skill is installed in multiple supported hosts, the
@@ -374,14 +374,38 @@ Validate a local skill directory against the generic skill contract.
 
 ### `oo skills publish <skill-id>`
 
-Convert one canonical local skill into an OOMOL package and run the publish
-step.
+Convert one skill into an OOMOL package and run the publish step.
 
-- Arguments: `<skill-id>` is the canonical local skill id. The source directory
-  is `<config-dir>/skills/local/<skill-id>`, where `<config-dir>` is the
-  directory containing the oo settings file.
+- Arguments: `<skill-id>` is normally a skill id. When no managed skill matches,
+  it may also be a path to a skill directory containing `SKILL.md`. Relative
+  paths resolve from the current working directory.
 - Options: `--visibility <visibility>` sets the registry package visibility.
   Accepted values are `private` and `public`. The default is `private`.
+- Options: `--agent <agent>` is a source hint used only when the skill is not
+  found in local, bundled, or registry storage. Accepted values are `codex`,
+  `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`, and
+  `qoderwork`.
+- Source resolution: the command first checks
+  `<config-dir>/skills/local/<skill-id>`. If present, that local skill is
+  published.
+- Source resolution: bundled skills are rejected because they are managed by the
+  oo CLI release.
+- Source resolution: registry skills under
+  `<config-dir>/skills/registry/<skill-id>` can be published. If their installed
+  metadata package name differs from the target package name, an interactive
+  `[y/N]` confirmation is required before publishing them under the current
+  account scope.
+- Source resolution: when `--agent` is provided and no managed source matched,
+  the command checks that agent's `<agent-home>/skills/<skill-id>` directory.
+  A matching skill is adopted into local canonical storage before publishing.
+- Source resolution: when no managed source matched, `<skill-id>` is resolved as
+  a filesystem path. A matching skill directory is adopted into local canonical
+  storage before publishing.
+- Adoption: adopting a skill moves it to `<config-dir>/skills/local/<skill-id>`,
+  imports any managed `.oo-metadata.json` fields into `SKILL.md` frontmatter,
+  removes `.oo-metadata.json`, and publishes the local canonical copy to
+  supported agent skill directories. Adoption requires an interactive `[y/N]`
+  confirmation.
 - Authentication: the command requires the current OOMOL account. The package
   name is always `@<lowercase-account.name>/<lowercase-skill-id>`.
 - Validation: the source directory must contain `SKILL.md` with frontmatter
@@ -433,8 +457,9 @@ Install bundled or published skills into supported local skill directories.
 - Alias: `oo skills add [packageName]`.
 - Arguments: `[packageName]` is optional.
 - Arguments: when omitted, the command installs all bundled skills.
-- Arguments: when `[packageName]` is `oo`, `oo-find-skills`, or
-  `oo-create-skill`, the command installs the corresponding bundled skill.
+- Arguments: when `[packageName]` is `oo`, `oo-find-skills`,
+  `oo-create-skill`, or `oo-publish-skill`, the command installs the
+  corresponding bundled skill.
 - Arguments: when `[packageName]` is a published package name, the command
   installs skills from that package.
 - Options: `-s, --skill <skills...>` installs one or more named published
@@ -520,8 +545,9 @@ Update installed oo-managed published skills.
   published skill.
 - Arguments: when one or more skill names are provided, only those named skills
   are checked and updated.
-- Bundled skills: bundled skills such as `oo` and `oo-find-skills` are
-  excluded from this command. Refresh them with `oo skills add`, or let a
+- Bundled skills: bundled skills such as `oo`, `oo-find-skills`,
+  `oo-create-skill`, and `oo-publish-skill` are excluded from this command.
+  Refresh them with `oo skills add`, or let a
   successful `oo install` or `oo update` refresh them automatically.
 - Ownership rule: a skill is considered managed for update only when its
   `.oo-metadata.json` file can be parsed and contains a non-empty `version`;

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -405,7 +405,7 @@ Convert one skill into an OOMOL package and run the publish step.
   imports any managed `.oo-metadata.json` fields into `SKILL.md` frontmatter,
   removes `.oo-metadata.json`, and publishes the local canonical copy to
   supported agent skill directories. Adoption requires an interactive `[y/N]`
-  confirmation.
+  confirmation. Adopted source directories must not contain symbolic links.
 - Authentication: the command requires the current OOMOL account. The package
   name is always `@<lowercase-account.name>/<lowercase-skill-id>`.
 - Validation: the source directory must contain `SKILL.md` with frontmatter

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -234,8 +234,9 @@
 skills。
 
 - 内置 skill：`oo` 会确保每个检测到的 Codex、Claude Code、Hermes、
-  CodeBuddy、WorkBuddy、Trae、OpenClaw 和 QoderWork Agent 都安装了 `oo` 与
-  `oo-find-skills`。已经由 oo 管理的内置 skill 目标会刷新到当前 `oo` 版本；
+  CodeBuddy、WorkBuddy、Trae、OpenClaw 和 QoderWork Agent 都安装了 `oo`、
+  `oo-find-skills`、`oo-create-skill` 与 `oo-publish-skill`。已经由 oo 管理的
+  内置 skill 目标会刷新到当前 `oo` 版本；
   但当启动中的当前版本为 `0.0.0-development` 时，不会刷新已存在的内置 skill
   目标。
 - 已发布 skill：如果某个已发布 skill 已经有本地 canonical 副本
@@ -257,9 +258,9 @@ skills。
 - 输出：文本输出会先打印摘要行，再为每个唯一的可见 skill 身份打印一个块。
   如果多个 Agent 中的安装具有相同 `name`、来源和版本，则会折叠到同一个块中。
 - 排序：bundled skills 会排在最前面；其中 `oo` 优先，其次
-  `oo-find-skills`，再其次 `oo-create-skill`；其余 skill 按名称排序。每个
-  块内的 Agent 名称按 `Codex`、`Claude Code`、`Hermes`、`CodeBuddy`、
-  `WorkBuddy`、`Trae`、`OpenClaw`、`QoderWork` 顺序显示。
+  `oo-find-skills`，再其次 `oo-create-skill`，再其次 `oo-publish-skill`；其余
+  skill 按名称排序。每个块内的 Agent 名称按 `Codex`、`Claude Code`、
+  `Hermes`、`CodeBuddy`、`WorkBuddy`、`Trae`、`OpenClaw`、`QoderWork` 顺序显示。
 - 输出：每个 skill 块会显示 skill 名称、Agents、来源 package、内置或本地标记，以
   及记录的版本号。
 - 说明：如果折叠后的 skill 安装在多个受支持 Agent 中，`Agents` 字段会列出所有
@@ -325,13 +326,30 @@ skills。
 
 ### `oo skills publish <skill-id>`
 
-将一个 canonical 本地 skill 转换为 OOMOL 包，并执行发布步骤。
+将一个 skill 转换为 OOMOL 包，并执行发布步骤。
 
-- 参数：`<skill-id>` 是 canonical 本地 skill id。源目录为
-  `<config-dir>/skills/local/<skill-id>`，其中 `<config-dir>` 是 oo
-  settings 文件所在目录。
+- 参数：`<skill-id>` 通常是 skill id。当没有匹配到由 oo 管理的 skill 时，也可以
+  是包含 `SKILL.md` 的 skill 目录路径。相对路径会从当前工作目录解析。
 - 选项：`--visibility <visibility>` 设置 registry 包可见性。可选值为
   `private` 和 `public`，默认值为 `private`。
+- 选项：`--agent <agent>` 仅在 local、bundled 和 registry 存储中都没有匹配时
+  作为来源提示。可选值为 `codex`、`claude`、`hermes`、`codebuddy`、
+  `workbuddy`、`trae`、`openclaw` 和 `qoderwork`。
+- 来源解析：命令会先检查 `<config-dir>/skills/local/<skill-id>`。如果存在，则发布
+  这个本地 skill。
+- 来源解析：内置 skill 会被拒绝发布，因为它们由 oo CLI 版本管理。
+- 来源解析：可以发布 `<config-dir>/skills/registry/<skill-id>` 下的 registry
+  skill。如果已安装元数据中的包名和目标包名不同，命令会使用交互式 `[y/N]`
+  确认，再将它发布到当前账号 scope 下。
+- 来源解析：如果传入了 `--agent` 且前面的来源都没有匹配，命令会检查该 Agent 的
+  `<agent-home>/skills/<skill-id>` 目录。匹配到的 skill 会先被接管到本地 canonical
+  存储，再继续发布。
+- 来源解析：如果仍未匹配，`<skill-id>` 会按文件系统路径解析。匹配到的 skill
+  目录会先被接管到本地 canonical 存储，再继续发布。
+- 接管：接管会把 skill 移动到 `<config-dir>/skills/local/<skill-id>`，将已有
+  `.oo-metadata.json` 字段导入 `SKILL.md` frontmatter，删除 `.oo-metadata.json`，
+  并把本地 canonical 副本发布到受支持的 Agent skill 目录。接管需要交互式 `[y/N]`
+  确认。
 - 认证：命令要求存在当前 OOMOL 账号。包名始终为
   `@<小写 account.name>/<小写 skill-id>`。
 - 校验：源目录必须包含 `SKILL.md`，其 frontmatter `name` 必须匹配
@@ -377,8 +395,8 @@ skills。
 - 别名：`oo skills add [packageName]`。
 - 参数：`[packageName]` 可选。
 - 参数：未提供时，该命令会安装全部内置 skill。
-- 参数：当 `[packageName]` 为 `oo`、`oo-find-skills` 或 `oo-create-skill` 时，
-  命令安装对应的内置 skill。
+- 参数：当 `[packageName]` 为 `oo`、`oo-find-skills`、`oo-create-skill` 或
+  `oo-publish-skill` 时，命令安装对应的内置 skill。
 - 参数：当 `[packageName]` 为已发布 package 名称时，命令从该 package 中
   安装 skill。
 - 选项：`-s, --skill <skills...>` 用于安装 package 中一个或多个指定的
@@ -448,9 +466,9 @@ skills。
 
 - 参数：省略时，会检查所有已安装且由 oo 管理的已发布 skill。
 - 参数：提供一个或多个 skill 名称时，只会检查并更新这些指定 skill。
-- 内置 skill：bundled `oo`、`oo-find-skills` 等内置 skill 不在此命令处理
-  范围内。请使用 `oo skills add` 刷新，或让成功的 `oo install` / `oo update`
-  自动刷新它们。
+- 内置 skill：bundled `oo`、`oo-find-skills`、`oo-create-skill`、
+  `oo-publish-skill` 等内置 skill 不在此命令处理范围内。请使用
+  `oo skills add` 刷新，或让成功的 `oo install` / `oo update` 自动刷新它们。
 - 所有权规则：只有当 skill 的 `.oo-metadata.json` 可以被解析，且包含非空
   `version` 时，update 才会认为它由 oo 管理；否则会把现有目标视为非托管。
 - 已发布 skill：registry skill 会从 `.oo-metadata.json` 读取所属包名，再通过

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -349,7 +349,7 @@ skills。
 - 接管：接管会把 skill 移动到 `<config-dir>/skills/local/<skill-id>`，将已有
   `.oo-metadata.json` 字段导入 `SKILL.md` frontmatter，删除 `.oo-metadata.json`，
   并把本地 canonical 副本发布到受支持的 Agent skill 目录。接管需要交互式 `[y/N]`
-  确认。
+  确认。被接管的源目录不能包含符号链接。
 - 认证：命令要求存在当前 OOMOL 账号。包名始终为
   `@<小写 account.name>/<小写 skill-id>`。
 - 校验：源目录必须包含 `SKILL.md`，其 frontmatter `name` 必须匹配

--- a/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/index.cli.test.ts.snap
@@ -96,8 +96,8 @@ exports[`skills CLI writes explicit skills install and uninstall logs 1`] = `
     "exitCode": 0,
     "stderr": "",
     "stdout": 
-"Installed 3 skills to Codex.
-Skills: oo, oo-find-skills, oo-create-skill
+"Installed 4 skills to Codex.
+Skills: oo, oo-find-skills, oo-create-skill, oo-publish-skill
 "
 ,
   },
@@ -108,6 +108,7 @@ Skills: oo, oo-find-skills, oo-create-skill
 "Removed skill oo from <HOME>/.codex/skills/oo.
 Removed skill oo-find-skills from <HOME>/.codex/skills/oo-find-skills.
 Removed skill oo-create-skill from <HOME>/.codex/skills/oo-create-skill.
+Removed skill oo-publish-skill from <HOME>/.codex/skills/oo-publish-skill.
 "
 ,
   },

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -12,6 +12,7 @@ describe("embedded skill assets", () => {
             "oo",
             "oo-find-skills",
             "oo-create-skill",
+            "oo-publish-skill",
         ]);
         expect(getBundledSkillFiles("oo", "codex").map(file => file.relativePath)).toEqual([
             "SKILL.md",
@@ -208,6 +209,63 @@ describe("embedded skill assets", () => {
         ).toEqual([
             "SKILL.md",
         ]);
+        expect(
+            getBundledSkillFiles("oo-publish-skill", "codex").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+            "agents/openai.yaml",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-publish-skill", "claude").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-publish-skill", "hermes").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-publish-skill", "codebuddy").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-publish-skill", "workbuddy").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-publish-skill", "trae").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-publish-skill", "openclaw").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-publish-skill", "qoderwork").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
     });
 
     test("maps bundled skills to contrib/skills/<agent>/<skill> source directories", () => {
@@ -271,6 +329,80 @@ describe("embedded skill assets", () => {
             expect(content).not.toContain(
                 "do\nnot add it by deriving a title from the skill name",
             );
+        }
+    });
+
+    test("guides oo-create-skill trigger descriptions toward local skill authoring", async () => {
+        for (const agentName of availableBundledSkillAgentNames) {
+            const skillFile = getBundledSkillFiles("oo-create-skill", agentName).find(
+                file => file.relativePath === "SKILL.md",
+            );
+
+            if (skillFile === undefined) {
+                throw new Error(`Missing ${agentName} oo-create-skill SKILL.md`);
+            }
+
+            const content = normalizeLineEndingsForAssertion(
+                await Bun.file(skillFile.sourcePath).text(),
+            );
+
+            expect(content).toContain("Author, generate, scaffold, or update");
+            expect(content).toContain("create a skill, write a skill, make a Codex/Claude/agent");
+            expect(content).toContain("package discovery is needed first");
+            expect(content).toContain("discover or install existing published skills");
+            expect(content).toContain("publish a finished skill");
+            expect(content).not.toContain("already knows which oo package or block");
+        }
+
+        const openAiAgentFile = getBundledSkillFiles("oo-create-skill", "codex").find(
+            file => file.relativePath === "agents/openai.yaml",
+        );
+
+        if (openAiAgentFile === undefined) {
+            throw new Error("Missing codex oo-create-skill agents/openai.yaml");
+        }
+
+        const openAiAgentContent = await Bun.file(openAiAgentFile.sourcePath).text();
+
+        expect(openAiAgentContent).toContain("$oo-create-skill");
+        expect(openAiAgentContent).toContain("author, scaffold, generate, or update");
+        expect(openAiAgentContent).toContain("package discovery is needed before authoring");
+        expect(openAiAgentContent).toContain(
+            "finding/installing published skills or publishing finished skills",
+        );
+    });
+
+    test("guides oo-publish-skill agents to publish agent skills", async () => {
+        for (const agentName of availableBundledSkillAgentNames) {
+            const skillFile = getBundledSkillFiles("oo-publish-skill", agentName).find(
+                file => file.relativePath === "SKILL.md",
+            );
+
+            if (skillFile === undefined) {
+                throw new Error(`Missing ${agentName} oo-publish-skill SKILL.md`);
+            }
+
+            const content = normalizeLineEndingsForAssertion(
+                await Bun.file(skillFile.sourcePath).text(),
+            );
+
+            expect(content).toContain(
+                "Publish, release, upload, submit, or share",
+            );
+            expect(content).toContain("existing AI agent skill");
+            expect(content).toContain("it does not need to be an oo-specific skill");
+            expect(content).toContain("oo skills publish");
+            expect(content).toContain("When publishing by skill id");
+            expect(content).toContain("include `--agent");
+            expect(content).toContain("Add `--visibility public` only");
+            expect(content).toContain("The publish command performs its own");
+            expect(content).toContain("Do not ask whether to publish to the current account");
+            expect(content).toContain("Do not package manually");
+            expect(content).toContain("Report the published package name");
+            expect(content).not.toContain("OOMOL/oo skill");
+            expect(content).not.toContain("oo skills preflight");
+            expect(content).not.toContain("oo auth status");
+            expect(content).not.toContain("Use `--agent` only as a source hint");
         }
     });
 

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -1,6 +1,7 @@
 import ooCreateSkillClaudeSkillPath from "../../../../contrib/skills/claude/oo-create-skill/SKILL.md" with { type: "file" };
 import ooFindSkillsClaudeCliContractPath from "../../../../contrib/skills/claude/oo-find-skills/references/oo-cli-contract.md" with { type: "file" };
 import ooFindSkillsClaudeSkillPath from "../../../../contrib/skills/claude/oo-find-skills/SKILL.md" with { type: "file" };
+import ooPublishSkillClaudeSkillPath from "../../../../contrib/skills/claude/oo-publish-skill/SKILL.md" with { type: "file" };
 import ooClaudeAuthAndBillingReferencePath from "../../../../contrib/skills/claude/oo/references/auth-and-billing.md" with { type: "file" };
 import ooClaudeConnectorExecutionReferencePath from "../../../../contrib/skills/claude/oo/references/connector-execution.md" with { type: "file" };
 import ooClaudeFileTransferReferencePath from "../../../../contrib/skills/claude/oo/references/file-transfer.md" with { type: "file" };
@@ -11,6 +12,7 @@ import ooClaudeSkillPath from "../../../../contrib/skills/claude/oo/SKILL.md" wi
 import ooCreateSkillCodeBuddySkillPath from "../../../../contrib/skills/codebuddy/oo-create-skill/SKILL.md" with { type: "file" };
 import ooFindSkillsCodeBuddyCliContractPath from "../../../../contrib/skills/codebuddy/oo-find-skills/references/oo-cli-contract.md" with { type: "file" };
 import ooFindSkillsCodeBuddySkillPath from "../../../../contrib/skills/codebuddy/oo-find-skills/SKILL.md" with { type: "file" };
+import ooPublishSkillCodeBuddySkillPath from "../../../../contrib/skills/codebuddy/oo-publish-skill/SKILL.md" with { type: "file" };
 import ooCodeBuddyAuthAndBillingReferencePath from "../../../../contrib/skills/codebuddy/oo/references/auth-and-billing.md" with { type: "file" };
 import ooCodeBuddyConnectorExecutionReferencePath from "../../../../contrib/skills/codebuddy/oo/references/connector-execution.md" with { type: "file" };
 import ooCodeBuddyFileTransferReferencePath from "../../../../contrib/skills/codebuddy/oo/references/file-transfer.md" with { type: "file" };
@@ -23,6 +25,8 @@ import ooCreateSkillPath from "../../../../contrib/skills/codex/oo-create-skill/
 import ooFindSkillsOpenAIAgentPath from "../../../../contrib/skills/codex/oo-find-skills/agents/openai.yaml" with { type: "file" };
 import ooFindSkillsCliContractPath from "../../../../contrib/skills/codex/oo-find-skills/references/oo-cli-contract.md" with { type: "file" };
 import ooFindSkillsSkillPath from "../../../../contrib/skills/codex/oo-find-skills/SKILL.md" with { type: "file" };
+import ooPublishSkillOpenAIAgentPath from "../../../../contrib/skills/codex/oo-publish-skill/agents/openai.yaml" with { type: "file" };
+import ooPublishSkillPath from "../../../../contrib/skills/codex/oo-publish-skill/SKILL.md" with { type: "file" };
 import ooOpenAIAgentPath from "../../../../contrib/skills/codex/oo/agents/openai.yaml" with { type: "file" };
 import ooAuthAndBillingReferencePath from "../../../../contrib/skills/codex/oo/references/auth-and-billing.md" with { type: "file" };
 import ooConnectorExecutionReferencePath from "../../../../contrib/skills/codex/oo/references/connector-execution.md" with { type: "file" };
@@ -34,6 +38,7 @@ import ooSkillPath from "../../../../contrib/skills/codex/oo/SKILL.md" with { ty
 import ooCreateSkillOpenClawSkillPath from "../../../../contrib/skills/openclaw/oo-create-skill/SKILL.md" with { type: "file" };
 import ooFindSkillsOpenClawCliContractPath from "../../../../contrib/skills/openclaw/oo-find-skills/references/oo-cli-contract.md" with { type: "file" };
 import ooFindSkillsOpenClawSkillPath from "../../../../contrib/skills/openclaw/oo-find-skills/SKILL.md" with { type: "file" };
+import ooPublishSkillOpenClawSkillPath from "../../../../contrib/skills/openclaw/oo-publish-skill/SKILL.md" with { type: "file" };
 import ooOpenClawAuthAndBillingReferencePath from "../../../../contrib/skills/openclaw/oo/references/auth-and-billing.md" with { type: "file" };
 import ooOpenClawConnectorExecutionReferencePath from "../../../../contrib/skills/openclaw/oo/references/connector-execution.md" with { type: "file" };
 import ooOpenClawFileTransferReferencePath from "../../../../contrib/skills/openclaw/oo/references/file-transfer.md" with { type: "file" };
@@ -44,6 +49,7 @@ import ooOpenClawSkillPath from "../../../../contrib/skills/openclaw/oo/SKILL.md
 import ooCreateSkillQoderWorkSkillPath from "../../../../contrib/skills/qoderwork/oo-create-skill/SKILL.md" with { type: "file" };
 import ooFindSkillsQoderWorkCliContractPath from "../../../../contrib/skills/qoderwork/oo-find-skills/references/oo-cli-contract.md" with { type: "file" };
 import ooFindSkillsQoderWorkSkillPath from "../../../../contrib/skills/qoderwork/oo-find-skills/SKILL.md" with { type: "file" };
+import ooPublishSkillQoderWorkSkillPath from "../../../../contrib/skills/qoderwork/oo-publish-skill/SKILL.md" with { type: "file" };
 import ooQoderWorkAuthAndBillingReferencePath from "../../../../contrib/skills/qoderwork/oo/references/auth-and-billing.md" with { type: "file" };
 import ooQoderWorkConnectorExecutionReferencePath from "../../../../contrib/skills/qoderwork/oo/references/connector-execution.md" with { type: "file" };
 import ooQoderWorkFileTransferReferencePath from "../../../../contrib/skills/qoderwork/oo/references/file-transfer.md" with { type: "file" };
@@ -55,7 +61,7 @@ import ooQoderWorkSkillPath from "../../../../contrib/skills/qoderwork/oo/SKILL.
 export const availableBundledSkillAgentNames = ["codex", "claude", "hermes", "codebuddy", "workbuddy", "trae", "openclaw", "qoderwork"] as const;
 export type BundledSkillAgentName = (typeof availableBundledSkillAgentNames)[number];
 
-export const availableBundledSkillNames = ["oo", "oo-find-skills", "oo-create-skill"] as const;
+export const availableBundledSkillNames = ["oo", "oo-find-skills", "oo-create-skill", "oo-publish-skill"] as const;
 export type BundledSkillName = (typeof availableBundledSkillNames)[number];
 
 interface BundledSkillSourceFile {
@@ -361,6 +367,76 @@ const bundledSkillRegistry = {
                 {
                     relativePath: "SKILL.md",
                     sourcePath: ooCreateSkillQoderWorkSkillPath,
+                },
+            ],
+        },
+    },
+    "oo-publish-skill": {
+        codex: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooPublishSkillPath,
+                },
+                {
+                    relativePath: "agents/openai.yaml",
+                    sourcePath: ooPublishSkillOpenAIAgentPath,
+                },
+            ],
+        },
+        claude: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooPublishSkillClaudeSkillPath,
+                },
+            ],
+        },
+        hermes: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooPublishSkillClaudeSkillPath,
+                },
+            ],
+        },
+        codebuddy: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooPublishSkillCodeBuddySkillPath,
+                },
+            ],
+        },
+        workbuddy: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooPublishSkillCodeBuddySkillPath,
+                },
+            ],
+        },
+        trae: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooPublishSkillCodeBuddySkillPath,
+                },
+            ],
+        },
+        openclaw: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooPublishSkillOpenClawSkillPath,
+                },
+            ],
+        },
+        qoderwork: {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooPublishSkillQoderWorkSkillPath,
                 },
             ],
         },

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -279,6 +279,7 @@ describe("skills CLI", () => {
         const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
         const createSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-create-skill");
+        const publishSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-publish-skill");
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -294,6 +295,7 @@ describe("skills CLI", () => {
                     `Removed skill oo from ${ooSkillDirectoryPath}.`,
                     `Removed skill oo-find-skills from ${findSkillsDirectoryPath}.`,
                     `Removed skill oo-create-skill from ${createSkillDirectoryPath}.`,
+                    `Removed skill oo-publish-skill from ${publishSkillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );
@@ -318,8 +320,8 @@ describe("skills CLI", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
                 [
-                    "Installed 3 skills to Codex.",
-                    "Skills: oo, oo-find-skills, oo-create-skill",
+                    "Installed 4 skills to Codex.",
+                    "Skills: oo, oo-find-skills, oo-create-skill, oo-publish-skill",
                     "",
                 ].join("\n"),
             );
@@ -335,8 +337,10 @@ describe("skills CLI", () => {
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
+        const publishSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-publish-skill");
         const serializedOoSkillDirectoryPath = JSON.stringify(ooSkillDirectoryPath);
         const serializedFindSkillsDirectoryPath = JSON.stringify(findSkillsDirectoryPath);
+        const serializedPublishSkillDirectoryPath = JSON.stringify(publishSkillDirectoryPath);
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -357,8 +361,10 @@ describe("skills CLI", () => {
             );
             expect(installContent).toContain(`"skillName":"oo"`);
             expect(installContent).toContain(`"skillName":"oo-find-skills"`);
+            expect(installContent).toContain(`"skillName":"oo-publish-skill"`);
             expect(installContent).toContain(`"path":${serializedOoSkillDirectoryPath}`);
             expect(installContent).toContain(`"path":${serializedFindSkillsDirectoryPath}`);
+            expect(installContent).toContain(`"path":${serializedPublishSkillDirectoryPath}`);
             expect(installContent).toContain(`"version":"9.9.9"`);
 
             expect(uninstallContent).toContain(

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -55,6 +55,7 @@ describe("skills commands", () => {
         const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
         const createSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-create-skill");
+        const publishSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-publish-skill");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
@@ -72,8 +73,15 @@ describe("skills commands", () => {
             storePaths.settingsFilePath,
             "oo-create-skill",
         );
+        const publishSkillCanonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo-publish-skill",
+        );
         const createSkillMetadataFilePath = resolveBundledSkillMetadataFilePath(
             createSkillDirectoryPath,
+        );
+        const publishSkillMetadataFilePath = resolveBundledSkillMetadataFilePath(
+            publishSkillDirectoryPath,
         );
         const ooMetadataFilePath = resolveBundledSkillMetadataFilePath(ooSkillDirectoryPath);
         const findSkillsMetadataFilePath = resolveBundledSkillMetadataFilePath(
@@ -91,8 +99,8 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
                 [
-                    "Installed 3 skills to Codex.",
-                    "Skills: oo, oo-find-skills, oo-create-skill",
+                    "Installed 4 skills to Codex.",
+                    "Skills: oo, oo-find-skills, oo-create-skill, oo-publish-skill",
                     "",
                 ].join("\n"),
             );
@@ -105,6 +113,9 @@ describe("skills commands", () => {
             );
             expect(await realpath(createSkillDirectoryPath)).toBe(
                 await realpath(createSkillCanonicalSkillDirectoryPath),
+            );
+            expect(await realpath(publishSkillDirectoryPath)).toBe(
+                await realpath(publishSkillCanonicalSkillDirectoryPath),
             );
 
             for (const file of getBundledSkillFiles("oo")) {
@@ -122,6 +133,11 @@ describe("skills commands", () => {
                     await readFile(join(createSkillDirectoryPath, file.relativePath), "utf8"),
                 ).toBe(await Bun.file(file.sourcePath).text());
             }
+            for (const file of getBundledSkillFiles("oo-publish-skill")) {
+                expect(
+                    await readFile(join(publishSkillDirectoryPath, file.relativePath), "utf8"),
+                ).toBe(await Bun.file(file.sourcePath).text());
+            }
             expect(await readFile(ooMetadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: resultVersion }),
             );
@@ -129,6 +145,9 @@ describe("skills commands", () => {
                 renderSkillMetadataJson({ version: resultVersion }),
             );
             expect(await readFile(createSkillMetadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson({ version: resultVersion }),
+            );
+            expect(await readFile(publishSkillMetadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: resultVersion }),
             );
         }
@@ -153,7 +172,7 @@ describe("skills commands", () => {
 
             expect(result.exitCode).toBe(0);
             expect(stripVTControlCharacters(result.stdout)).toBe(
-                "Installed 3 skills to Codex.\nSkills: oo, oo-find-skills, oo-create-skill\n",
+                "Installed 4 skills to Codex.\nSkills: oo, oo-find-skills, oo-create-skill, oo-publish-skill\n",
             );
             expect(result.stdout).toContain("\u001B[32mInstalled\u001B[39m");
             expect(result.stdout).toContain("\u001B[36mCodex\u001B[39m");
@@ -284,6 +303,46 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
                 `Installed skill oo-find-skills to ${skillDirectoryPath}.\n`,
+            );
+            expect(result.stderr).toBe("");
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson({ version: resultVersion }),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("installs the oo-publish-skill bundled skill by explicit name", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo-publish-skill");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo-publish-skill",
+        );
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const resultVersion = "9.9.9";
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "install", "oo-publish-skill"], {
+                version: resultVersion,
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Installed skill oo-publish-skill to ${skillDirectoryPath}.\n`,
             );
             expect(result.stderr).toBe("");
             expect(await realpath(skillDirectoryPath)).toBe(
@@ -846,6 +905,7 @@ describe("skills commands", () => {
         const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
         const createSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-create-skill");
+        const publishSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-publish-skill");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
@@ -863,6 +923,10 @@ describe("skills commands", () => {
             storePaths.settingsFilePath,
             "oo-create-skill",
         );
+        const publishSkillCanonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo-publish-skill",
+        );
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -878,6 +942,7 @@ describe("skills commands", () => {
                     `Removed skill oo from ${ooSkillDirectoryPath}.`,
                     `Removed skill oo-find-skills from ${findSkillsDirectoryPath}.`,
                     `Removed skill oo-create-skill from ${createSkillDirectoryPath}.`,
+                    `Removed skill oo-publish-skill from ${publishSkillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );
@@ -891,6 +956,9 @@ describe("skills commands", () => {
             await expect(stat(createSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
+            await expect(stat(publishSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
             await expect(stat(ooCanonicalSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
@@ -898,6 +966,9 @@ describe("skills commands", () => {
                 code: "ENOENT",
             });
             await expect(stat(createSkillCanonicalSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(publishSkillCanonicalSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
         }
@@ -1069,6 +1140,7 @@ describe("skills commands", () => {
         const ooSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const findSkillsDirectoryPath = join(codexHomeDirectory, "skills", "oo-find-skills");
         const createSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-create-skill");
+        const publishSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo-publish-skill");
 
         try {
             await mkdir(codexHomeDirectory, { recursive: true });
@@ -1084,6 +1156,7 @@ describe("skills commands", () => {
                     `Removed skill oo from ${ooSkillDirectoryPath}.`,
                     `Removed skill oo-find-skills from ${findSkillsDirectoryPath}.`,
                     `Removed skill oo-create-skill from ${createSkillDirectoryPath}.`,
+                    `Removed skill oo-publish-skill from ${publishSkillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );
@@ -1095,6 +1168,9 @@ describe("skills commands", () => {
                 code: "ENOENT",
             });
             await expect(stat(createSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(publishSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
         }

--- a/src/application/commands/skills/init.ts
+++ b/src/application/commands/skills/init.ts
@@ -38,13 +38,13 @@ interface SkillsInitInput {
     title?: string;
 }
 
-interface LocalSkillHostPublicationTarget {
+export interface LocalSkillHostPublicationTarget {
     agentName: BundledSkillAgentName;
     homeDirectory: string;
     installedSkillDirectoryPath: string;
 }
 
-interface LocalSkillHostPublicationResult {
+export interface LocalSkillHostPublicationResult {
     mode: "copy" | "symlink";
     path: string;
 }
@@ -227,7 +227,7 @@ async function initializeLocalSkill(
     }
 }
 
-function resolveSkillInitPublicationMessageKey(
+export function resolveSkillInitPublicationMessageKey(
     mode: LocalSkillHostPublicationResult["mode"],
 ): "skills.init.linked" | "skills.init.copied" {
     switch (mode) {
@@ -238,7 +238,7 @@ function resolveSkillInitPublicationMessageKey(
     }
 }
 
-async function resolveLocalSkillPublicationTargets(
+export async function resolveLocalSkillPublicationTargets(
     env: Record<string, string | undefined>,
     skillName: string,
 ): Promise<LocalSkillHostPublicationTarget[]> {

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -52,7 +52,7 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 4 oo-managed skills.",
+                    "✓ Found 5 oo-managed skills.",
                     "",
                     "oo",
                     "  Host: Codex",
@@ -65,6 +65,11 @@ describe("skills list CLI", () => {
                     "  Version: 9.9.9",
                     "",
                     "oo-create-skill",
+                    "  Host: Codex",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-publish-skill",
                     "  Host: Codex",
                     "  Source: bundled",
                     "  Version: 9.9.9",
@@ -100,7 +105,7 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 3 oo-managed skills.",
+                    "✓ Found 4 oo-managed skills.",
                     "",
                     "oo",
                     "  Host: OpenClaw",
@@ -113,6 +118,11 @@ describe("skills list CLI", () => {
                     "  Version: 9.9.9",
                     "",
                     "oo-create-skill",
+                    "  Host: OpenClaw",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-publish-skill",
                     "  Host: OpenClaw",
                     "  Source: bundled",
                     "  Version: 9.9.9",
@@ -143,7 +153,7 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 3 oo-managed skills.",
+                    "✓ Found 4 oo-managed skills.",
                     "",
                     "oo",
                     "  Host: QoderWork",
@@ -156,6 +166,11 @@ describe("skills list CLI", () => {
                     "  Version: 9.9.9",
                     "",
                     "oo-create-skill",
+                    "  Host: QoderWork",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-publish-skill",
                     "  Host: QoderWork",
                     "  Source: bundled",
                     "  Version: 9.9.9",
@@ -186,7 +201,7 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 3 oo-managed skills.",
+                    "✓ Found 4 oo-managed skills.",
                     "",
                     "oo",
                     "  Host: CodeBuddy",
@@ -199,6 +214,11 @@ describe("skills list CLI", () => {
                     "  Version: 9.9.9",
                     "",
                     "oo-create-skill",
+                    "  Host: CodeBuddy",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-publish-skill",
                     "  Host: CodeBuddy",
                     "  Source: bundled",
                     "  Version: 9.9.9",
@@ -229,7 +249,7 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 3 oo-managed skills.",
+                    "✓ Found 4 oo-managed skills.",
                     "",
                     "oo",
                     "  Host: WorkBuddy",
@@ -242,6 +262,11 @@ describe("skills list CLI", () => {
                     "  Version: 9.9.9",
                     "",
                     "oo-create-skill",
+                    "  Host: WorkBuddy",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-publish-skill",
                     "  Host: WorkBuddy",
                     "  Source: bundled",
                     "  Version: 9.9.9",
@@ -272,7 +297,7 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 3 oo-managed skills.",
+                    "✓ Found 4 oo-managed skills.",
                     "",
                     "oo",
                     "  Host: Trae",
@@ -285,6 +310,11 @@ describe("skills list CLI", () => {
                     "  Version: 9.9.9",
                     "",
                     "oo-create-skill",
+                    "  Host: Trae",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-publish-skill",
                     "  Host: Trae",
                     "  Source: bundled",
                     "  Version: 9.9.9",
@@ -315,7 +345,7 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 3 oo-managed skills.",
+                    "✓ Found 4 oo-managed skills.",
                     "",
                     "oo",
                     "  Host: Hermes",
@@ -328,6 +358,11 @@ describe("skills list CLI", () => {
                     "  Version: 9.9.9",
                     "",
                     "oo-create-skill",
+                    "  Host: Hermes",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-publish-skill",
                     "  Host: Hermes",
                     "  Source: bundled",
                     "  Version: 9.9.9",
@@ -360,7 +395,7 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 3 oo-managed skills.",
+                    "✓ Found 4 oo-managed skills.",
                     "",
                     "oo",
                     "  Host: Codex, Claude Code",
@@ -373,6 +408,11 @@ describe("skills list CLI", () => {
                     "  Version: 9.9.9",
                     "",
                     "oo-create-skill",
+                    "  Host: Codex, Claude Code",
+                    "  Source: bundled",
+                    "  Version: 9.9.9",
+                    "",
+                    "oo-publish-skill",
                     "  Host: Codex, Claude Code",
                     "  Source: bundled",
                     "  Version: 9.9.9",

--- a/src/application/commands/skills/package-conversion.ts
+++ b/src/application/commands/skills/package-conversion.ts
@@ -51,6 +51,12 @@ export interface PublishConvertedSkillPackageOptions {
     visibility: SkillPublishVisibility;
 }
 
+export interface SkillFrontmatterMetadataUpdate {
+    icon?: string;
+    packageName?: string;
+    version?: string;
+}
+
 interface PackageMetadataFile {
     description: string;
     displayName: string;
@@ -259,17 +265,22 @@ export async function writePublishedSkillMetadata(
         version: string;
     },
 ): Promise<void> {
-    if (!isNonBlankString(options.packageName)) {
-        throw new CliUserError("errors.skills.publish.invalidPackageMetadata", 1, {
-            message: "Package name must be a non-empty string.",
-        });
-    }
+    await writeSkillFrontmatterMetadata({
+        metadata: {
+            packageName: options.packageName,
+            version: options.version,
+        },
+        skillDirectoryPath: options.skillDirectoryPath,
+    });
+}
 
-    if (!isSemver(options.version)) {
-        throw new CliUserError("errors.skills.publish.invalidPackageMetadata", 1, {
-            message: "Package version must be a valid semver string.",
-        });
-    }
+export async function writeSkillFrontmatterMetadata(
+    options: {
+        metadata: SkillFrontmatterMetadataUpdate;
+        skillDirectoryPath: string;
+    },
+): Promise<void> {
+    validateSkillFrontmatterMetadataUpdate(options.metadata);
 
     const skillFilePath = join(options.skillDirectoryPath, "SKILL.md");
     const parsed = await readSkillMarkdownMatter(skillFilePath);
@@ -286,8 +297,7 @@ export async function writePublishedSkillMetadata(
         ...parsed.data,
         metadata: {
             ...(metadata ?? {}),
-            packageName: options.packageName,
-            version: options.version,
+            ...createDefinedSkillFrontmatterMetadata(options.metadata),
         },
     };
 
@@ -295,6 +305,38 @@ export async function writePublishedSkillMetadata(
         skillFilePath,
         matter.stringify(parsed.content, nextFrontmatter),
     );
+}
+
+function validateSkillFrontmatterMetadataUpdate(
+    metadata: SkillFrontmatterMetadataUpdate,
+): void {
+    if (metadata.icon !== undefined && !isNonBlankString(metadata.icon)) {
+        throw new CliUserError("errors.skills.publish.invalidPackageMetadata", 1, {
+            message: "Skill icon must be a non-empty string.",
+        });
+    }
+
+    if (metadata.packageName !== undefined && !isNonBlankString(metadata.packageName)) {
+        throw new CliUserError("errors.skills.publish.invalidPackageMetadata", 1, {
+            message: "Package name must be a non-empty string.",
+        });
+    }
+
+    if (metadata.version !== undefined && !isSemver(metadata.version)) {
+        throw new CliUserError("errors.skills.publish.invalidPackageMetadata", 1, {
+            message: "Package version must be a valid semver string.",
+        });
+    }
+}
+
+function createDefinedSkillFrontmatterMetadata(
+    metadata: SkillFrontmatterMetadataUpdate,
+): SkillFrontmatterMetadataUpdate {
+    return {
+        ...(metadata.icon === undefined ? {} : { icon: metadata.icon }),
+        ...(metadata.packageName === undefined ? {} : { packageName: metadata.packageName }),
+        ...(metadata.version === undefined ? {} : { version: metadata.version }),
+    };
 }
 
 export async function publishConvertedSkillPackage(

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -602,6 +602,31 @@ describe("skills publish command", () => {
         }
     });
 
+    test("rejects publishing bundled skills by installed target path", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = resolveManagedSkillDirectoryPath(
+            codexHomeDirectory,
+            "oo",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            const installResult = await sandbox.run(["skills", "install", "oo"]);
+            expect(installResult.exitCode).toBe(0);
+
+            const result = await sandbox.run(["skills", "publish", skillDirectoryPath]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toBe(
+                "Bundled skill oo cannot be published directly because it is managed by the oo CLI release. Create or adopt a local copy before publishing.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("rejects an unsupported publish agent", async () => {
         const sandbox = await createCliSandbox();
 

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -1,6 +1,6 @@
 import type { CliCatalog, CliExecutionContext, Fetcher } from "../../contracts/cli.ts";
 
-import { mkdir, readFile, stat } from "node:fs/promises";
+import { lstat, mkdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
@@ -25,9 +25,18 @@ import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import { defaultSettings } from "../../schemas/settings.ts";
-import { resolveCodexHomeDirectory } from "./bundled-skill-paths.ts";
-import { resolveLocalSkillCanonicalDirectoryPath } from "./managed-skill-paths.ts";
-import { publishLocalSkillPackage } from "./publish.ts";
+import {
+    resolveClaudeHomeDirectory,
+    resolveCodexHomeDirectory,
+} from "./bundled-skill-paths.ts";
+import {
+    resolveLocalSkillCanonicalDirectoryPath,
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillDirectoryPath,
+    resolveManagedSkillMetadataFilePath,
+} from "./managed-skill-paths.ts";
+import { publishLocalSkillPackage, publishSkillPackage } from "./publish.ts";
+import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 const emptyCatalog: CliCatalog = {
     name: "oo",
@@ -150,6 +159,465 @@ describe("skills publish command", () => {
             await expect(requests[1]!.json()).resolves.toMatchObject({
                 access: "public",
             });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("publishes a registry skill when the installed package matches the target package", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const skillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "registry-skill",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+            await writeSkillFile(skillDirectoryPath, [
+                "---",
+                "name: registry-skill",
+                "description: Use a registry package workflow.",
+                "metadata:",
+                "  version: '0.2.0'",
+                "---",
+                "",
+            ].join("\n"));
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+                renderSkillMetadataJson({
+                    packageName: "@alice/registry-skill",
+                    version: "0.1.0",
+                }),
+            );
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["skills", "publish", "registry-skill"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.url.includes("/-/oomol/package-info/")) {
+                            return new Response("not found", { status: 404 });
+                        }
+
+                        return new Response("", { status: 201 });
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                "Published skill registry-skill as private package @alice/registry-skill@0.2.0. View it at https://hub.oomol.com/package/@alice/registry-skill.\n",
+            );
+            expect(requests.map(request => `${request.method} ${request.url}`)).toEqual([
+                "GET https://registry.oomol.com/-/oomol/package-info/%40alice%2Fregistry-skill/latest?lang=en",
+                "PUT https://registry.oomol.com/@alice%2fregistry-skill",
+            ]);
+
+            const parsed = matter(
+                await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8"),
+            );
+
+            expect(parsed.data.metadata).toMatchObject({
+                packageName: "@alice/registry-skill",
+                version: "0.2.0",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("confirms before publishing a registry skill from a different package", async () => {
+        const configRootDirectoryPath = await createTemporaryDirectory("publish-registry-mismatch-config");
+        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
+        const stdin = createInteractiveInput();
+        const promptOutput = createTextBuffer();
+        const context = createPublishContext(settingsFilePath, {
+            stdin,
+            stdout: promptOutput.writer,
+        });
+        const skillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            settingsFilePath,
+            "forked-skill",
+        );
+
+        cleanup.track(configRootDirectoryPath);
+
+        await writeSkillFile(skillDirectoryPath, [
+            "---",
+            "name: forked-skill",
+            "description: Use a registry package workflow.",
+            "---",
+            "",
+        ].join("\n"));
+        await Bun.write(
+            resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+            renderSkillMetadataJson({
+                packageName: "@bob/forked-skill",
+                version: "0.1.0",
+            }),
+        );
+
+        stdin.feed("yes\n");
+
+        const result = await publishSkillPackage(
+            "forked-skill",
+            context,
+            "private",
+            {},
+            {
+                checkAuthoringEnvironment: () => Promise.resolve({
+                    canonicalRootDirectoryPath: "",
+                    hostCount: 1,
+                }),
+                publishConvertedSkillPackage: () => Promise.resolve(),
+                resolveFinalPublishVersion: request => Promise.resolve(request.requestedVersion),
+            },
+        );
+
+        expect(result.packageName).toBe("@alice/forked-skill");
+        expect(promptOutput.read()).toBe(
+            "Skill forked-skill is installed from @bob/forked-skill. Publish it as @alice/forked-skill? [y/N] ",
+        );
+    });
+
+    test("adopts an agent skill before publishing it", async () => {
+        const sandbox = await createCliSandbox();
+        const stdin = createInteractiveInput();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const agentSkillDirectoryPath = resolveManagedSkillDirectoryPath(
+            codexHomeDirectory,
+            "agent-skill",
+        );
+        const localSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "agent-skill",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+            await writeSkillFile(agentSkillDirectoryPath, [
+                "---",
+                "name: agent-skill",
+                "description: Use an agent-local workflow.",
+                "---",
+                "",
+            ].join("\n"));
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(agentSkillDirectoryPath),
+                renderSkillMetadataJson({
+                    icon: ":sparkles:",
+                    packageName: "@bob/agent-skill",
+                    version: "0.3.0",
+                }),
+            );
+
+            stdin.feed("yes\n");
+
+            const result = await sandbox.run(
+                ["skills", "publish", "agent-skill", "--agent", "codex"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/-/oomol/package-info/")) {
+                            return new Response("not found", { status: 404 });
+                        }
+
+                        return new Response("", { status: 201 });
+                    },
+                    stdin,
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                `Adopted skill agent-skill into local canonical storage at ${localSkillDirectoryPath}.\n`,
+            );
+            expect(result.stdout).toContain(
+                "Published skill agent-skill as private package @alice/agent-skill@0.3.0.",
+            );
+            await expect(stat(resolveManagedSkillMetadataFilePath(localSkillDirectoryPath)))
+                .rejects
+                .toMatchObject({ code: "ENOENT" });
+
+            const parsed = matter(
+                await readFile(join(localSkillDirectoryPath, "SKILL.md"), "utf8"),
+            );
+
+            expect(parsed.data.metadata).toMatchObject({
+                icon: ":sparkles:",
+                packageName: "@alice/agent-skill",
+                version: "0.3.0",
+            });
+            expect((await lstat(agentSkillDirectoryPath)).isSymbolicLink()).toBeTrue();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("adopts a skill from a relative path before publishing it", async () => {
+        const configRootDirectoryPath = await createTemporaryDirectory("publish-path-config");
+        const cwd = await createTemporaryDirectory("publish-path-cwd");
+        const codexHomeDirectory = await createTemporaryDirectory("publish-path-codex");
+        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
+        const stdin = createInteractiveInput();
+        const context = createPublishContext(settingsFilePath, { stdin });
+        const sourceSkillDirectoryPath = join(cwd, "path-skill");
+        const localSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            settingsFilePath,
+            "path-skill",
+        );
+
+        cleanup.track(configRootDirectoryPath);
+        cleanup.track(cwd);
+        cleanup.track(codexHomeDirectory);
+
+        context.cwd = cwd;
+        context.env = {
+            CODEX_HOME: codexHomeDirectory,
+            HOME: configRootDirectoryPath,
+            USERPROFILE: configRootDirectoryPath,
+        };
+
+        await writeSkillFile(sourceSkillDirectoryPath, [
+            "---",
+            "name: path-skill",
+            "description: Use a path-local workflow.",
+            "---",
+            "",
+        ].join("\n"));
+
+        stdin.feed("yes\n");
+
+        const result = await publishSkillPackage(
+            "./path-skill",
+            context,
+            "private",
+            {},
+            {
+                checkAuthoringEnvironment: () => Promise.resolve({
+                    canonicalRootDirectoryPath: "",
+                    hostCount: 1,
+                }),
+                publishConvertedSkillPackage: () => Promise.resolve(),
+                resolveFinalPublishVersion: request => Promise.resolve(request.requestedVersion),
+            },
+        );
+
+        expect(result).toMatchObject({
+            packageName: "@alice/path-skill",
+            skillDirectoryPath: localSkillDirectoryPath,
+            skillId: "path-skill",
+            version: "0.0.1",
+        });
+        await expect(stat(sourceSkillDirectoryPath)).rejects.toMatchObject({
+            code: "ENOENT",
+        });
+        await expect(stat(join(codexHomeDirectory, "skills", "path-skill")))
+            .resolves
+            .toMatchObject({
+                isDirectory: expect.any(Function),
+            });
+    });
+
+    test("does not move an invalid path skill into local storage", async () => {
+        const configRootDirectoryPath = await createTemporaryDirectory("publish-invalid-path-config");
+        const cwd = await createTemporaryDirectory("publish-invalid-path-cwd");
+        const codexHomeDirectory = await createTemporaryDirectory("publish-invalid-path-codex");
+        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
+        const stdin = createInteractiveInput();
+        const context = createPublishContext(settingsFilePath, { stdin });
+        const sourceSkillDirectoryPath = join(cwd, "invalid-path-skill");
+        const localSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            settingsFilePath,
+            "invalid-path-skill",
+        );
+
+        cleanup.track(configRootDirectoryPath);
+        cleanup.track(cwd);
+        cleanup.track(codexHomeDirectory);
+
+        context.cwd = cwd;
+        context.env = {
+            CODEX_HOME: codexHomeDirectory,
+            HOME: configRootDirectoryPath,
+            USERPROFILE: configRootDirectoryPath,
+        };
+
+        await writeSkillFile(sourceSkillDirectoryPath, [
+            "---",
+            "name: other-skill",
+            "description: Use a path-local workflow.",
+            "---",
+            "",
+        ].join("\n"));
+
+        stdin.feed("yes\n");
+
+        await expect(publishSkillPackage(
+            "./invalid-path-skill",
+            context,
+            "private",
+            {},
+            {
+                checkAuthoringEnvironment: () => Promise.resolve({
+                    canonicalRootDirectoryPath: "",
+                    hostCount: 1,
+                }),
+                convertSkillDirectoryToPackage: () => {
+                    throw new Error("Conversion should not run.");
+                },
+                publishConvertedSkillPackage: () => Promise.resolve(),
+            },
+        )).rejects.toMatchObject({
+            key: "errors.skills.publish.invalidSkillFile",
+        });
+
+        await expect(stat(sourceSkillDirectoryPath)).resolves.toMatchObject({
+            isDirectory: expect.any(Function),
+        });
+        await expect(stat(localSkillDirectoryPath)).rejects.toMatchObject({
+            code: "ENOENT",
+        });
+    });
+
+    test("does not adopt an agent skill when another host target conflicts", async () => {
+        const configRootDirectoryPath = await createTemporaryDirectory("publish-agent-conflict-config");
+        const codexHomeDirectory = await createTemporaryDirectory("publish-agent-conflict-codex");
+        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
+        const stdin = createInteractiveInput();
+        const context = createPublishContext(settingsFilePath, { stdin });
+        const claudeHomeDirectory = resolveClaudeHomeDirectory({
+            HOME: configRootDirectoryPath,
+            USERPROFILE: configRootDirectoryPath,
+        });
+        const sourceSkillDirectoryPath = resolveManagedSkillDirectoryPath(
+            codexHomeDirectory,
+            "conflict-skill",
+        );
+        const conflictingSkillDirectoryPath = resolveManagedSkillDirectoryPath(
+            claudeHomeDirectory,
+            "conflict-skill",
+        );
+        const localSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            settingsFilePath,
+            "conflict-skill",
+        );
+
+        cleanup.track(configRootDirectoryPath);
+        cleanup.track(codexHomeDirectory);
+
+        context.env = {
+            CODEX_HOME: codexHomeDirectory,
+            HOME: configRootDirectoryPath,
+            USERPROFILE: configRootDirectoryPath,
+        };
+
+        await mkdir(claudeHomeDirectory, { recursive: true });
+        await writeSkillFile(sourceSkillDirectoryPath, [
+            "---",
+            "name: conflict-skill",
+            "description: Use an agent-local workflow.",
+            "---",
+            "",
+        ].join("\n"));
+        await writeSkillFile(conflictingSkillDirectoryPath, [
+            "---",
+            "name: conflict-skill",
+            "description: Existing unmanaged skill.",
+            "---",
+            "",
+        ].join("\n"));
+
+        stdin.feed("yes\n");
+
+        await expect(publishSkillPackage(
+            "conflict-skill",
+            context,
+            "private",
+            { agentName: "codex" },
+            {
+                checkAuthoringEnvironment: () => Promise.resolve({
+                    canonicalRootDirectoryPath: "",
+                    hostCount: 2,
+                }),
+                convertSkillDirectoryToPackage: () => {
+                    throw new Error("Conversion should not run.");
+                },
+                publishConvertedSkillPackage: () => Promise.resolve(),
+            },
+        )).rejects.toMatchObject({
+            key: "errors.skills.nameConflict",
+            params: {
+                name: "conflict-skill",
+                path: conflictingSkillDirectoryPath,
+            },
+        });
+
+        await expect(stat(sourceSkillDirectoryPath)).resolves.toMatchObject({
+            isDirectory: expect.any(Function),
+        });
+        await expect(stat(localSkillDirectoryPath)).rejects.toMatchObject({
+            code: "ENOENT",
+        });
+    });
+
+    test("rejects publishing bundled skills directly", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["skills", "publish", "oo"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toBe(
+                "Bundled skill oo cannot be published directly because it is managed by the oo CLI release. Create or adopt a local copy before publishing.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects an unsupported publish agent", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "publish",
+                "demo-skill",
+                "--agent",
+                "unknown",
+            ]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toBe(
+                "Unsupported skill agent: unknown. Use codex, claude, hermes, codebuddy, workbuddy, trae, openclaw, or qoderwork.\n",
+            );
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -1,6 +1,6 @@
 import type { CliCatalog, CliExecutionContext, Fetcher } from "../../contracts/cli.ts";
 
-import { lstat, mkdir, readFile, stat } from "node:fs/promises";
+import { lstat, mkdir, readFile, stat, symlink } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
@@ -438,6 +438,110 @@ describe("skills publish command", () => {
             .toMatchObject({
                 isDirectory: expect.any(Function),
             });
+    });
+
+    test("rejects adopting a skill directory that contains symlinks", async () => {
+        const cases = [
+            {
+                createLinkedPath: async (targetPath: string, linkPath: string) => {
+                    await Bun.write(targetPath, "secret\n");
+                    await symlink(targetPath, linkPath);
+                },
+                linkPath: join("nested", "linked-secret.txt"),
+                name: "file",
+            },
+            {
+                createLinkedPath: async (targetPath: string, linkPath: string) => {
+                    await mkdir(targetPath, { recursive: true });
+                    await Bun.write(join(targetPath, "secret.txt"), "secret\n");
+                    await symlink(targetPath, linkPath, "dir");
+                },
+                linkPath: join("nested", "linked-secret"),
+                name: "directory",
+            },
+        ] as const;
+
+        for (const testCase of cases) {
+            const configRootDirectoryPath = await createTemporaryDirectory(
+                `publish-adopt-symlink-${testCase.name}-config`,
+            );
+            const cwd = await createTemporaryDirectory(
+                `publish-adopt-symlink-${testCase.name}-cwd`,
+            );
+            const codexHomeDirectory = await createTemporaryDirectory(
+                `publish-adopt-symlink-${testCase.name}-codex`,
+            );
+            const externalPath = await createTemporaryDirectory(
+                `publish-adopt-symlink-${testCase.name}-external`,
+            );
+            const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
+            const stdin = createInteractiveInput();
+            const context = createPublishContext(settingsFilePath, { stdin });
+            const skillId = `symlink-${testCase.name}-skill`;
+            const sourceSkillDirectoryPath = join(cwd, skillId);
+            const localSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+                settingsFilePath,
+                skillId,
+            );
+
+            cleanup.track(configRootDirectoryPath);
+            cleanup.track(cwd);
+            cleanup.track(codexHomeDirectory);
+            cleanup.track(externalPath);
+
+            context.cwd = cwd;
+            context.env = {
+                CODEX_HOME: codexHomeDirectory,
+                HOME: configRootDirectoryPath,
+                USERPROFILE: configRootDirectoryPath,
+            };
+
+            await writeSkillFile(sourceSkillDirectoryPath, [
+                "---",
+                `name: ${skillId}`,
+                "description: Use a path-local workflow.",
+                "---",
+                "",
+            ].join("\n"));
+            await mkdir(join(sourceSkillDirectoryPath, "nested"), { recursive: true });
+            await testCase.createLinkedPath(
+                join(externalPath, "secret"),
+                join(sourceSkillDirectoryPath, testCase.linkPath),
+            );
+
+            stdin.feed("yes\n");
+
+            await expect(publishSkillPackage(
+                `./${skillId}`,
+                context,
+                "private",
+                {},
+                {
+                    checkAuthoringEnvironment: () => Promise.resolve({
+                        canonicalRootDirectoryPath: "",
+                        hostCount: 1,
+                    }),
+                    convertSkillDirectoryToPackage: () => {
+                        throw new Error("Conversion should not run.");
+                    },
+                    publishConvertedSkillPackage: () => Promise.resolve(),
+                },
+            )).rejects.toMatchObject({
+                key: "errors.skills.publish.invalidSkillFile",
+                params: {
+                    message: `Skill entries must not be symbolic links: ${testCase.linkPath}.`,
+                    path: sourceSkillDirectoryPath,
+                },
+            });
+
+            expect(
+                (await lstat(join(sourceSkillDirectoryPath, testCase.linkPath)))
+                    .isSymbolicLink(),
+            ).toBeTrue();
+            await expect(stat(localSkillDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
     });
 
     test("does not move an invalid path skill into local storage", async () => {

--- a/src/application/commands/skills/publish.ts
+++ b/src/application/commands/skills/publish.ts
@@ -548,6 +548,10 @@ async function resolvePathSkillPublishSource(
         };
     }
 
+    if (isBundledSkillName(skillId)) {
+        throw createBundledSkillPublishError(skillId);
+    }
+
     const bundledSkillDirectoryPath = await findExistingBundledSkillDirectoryPath(
         settingsFilePath,
         skillId,

--- a/src/application/commands/skills/publish.ts
+++ b/src/application/commands/skills/publish.ts
@@ -4,9 +4,9 @@ import type { BundledSkillAgentName } from "./embedded-assets.ts";
 import type { LocalSkillHostPublicationTarget } from "./init.ts";
 
 import type { SkillPublishVisibility } from "./package-conversion.ts";
-import { cp, lstat, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { cp, lstat, mkdir, mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { z } from "zod";
 import { resolveRequestLanguage } from "../../../i18n/locale.ts";
 import { CliUserError } from "../../contracts/cli.ts";
@@ -809,10 +809,11 @@ async function copySkillDirectoryToLocalStorage(
         });
     }
 
+    await assertSkillDirectoryHasNoSymbolicLinks(sourceDirectoryPath);
     await mkdir(dirname(localSkillDirectoryPath), { recursive: true });
 
     await cp(sourceDirectoryPath, localSkillDirectoryPath, {
-        dereference: true,
+        dereference: false,
         errorOnExist: true,
         force: false,
         recursive: true,
@@ -926,12 +927,51 @@ async function restoreSourceSkillDirectoryFromLocalStorage(
     localSkillDirectoryPath: string,
     sourceDirectoryPath: string,
 ): Promise<void> {
+    await assertSkillDirectoryHasNoSymbolicLinks(localSkillDirectoryPath);
     await mkdir(dirname(sourceDirectoryPath), { recursive: true });
     await cp(localSkillDirectoryPath, sourceDirectoryPath, {
-        dereference: true,
+        dereference: false,
         errorOnExist: true,
         force: false,
         recursive: true,
+    });
+}
+
+async function assertSkillDirectoryHasNoSymbolicLinks(
+    skillDirectoryPath: string,
+    path: string = skillDirectoryPath,
+): Promise<void> {
+    const metadata = await lstat(path);
+
+    if (metadata.isSymbolicLink()) {
+        throw createSymbolicLinkSkillEntryError(skillDirectoryPath, path);
+    }
+
+    if (!metadata.isDirectory()) {
+        return;
+    }
+
+    const entries = await readdir(path, { withFileTypes: true });
+
+    await Promise.all(entries.map(entry =>
+        assertSkillDirectoryHasNoSymbolicLinks(
+            skillDirectoryPath,
+            join(path, entry.name),
+        ),
+    ));
+}
+
+function createSymbolicLinkSkillEntryError(
+    skillDirectoryPath: string,
+    symbolicLinkPath: string,
+): CliUserError {
+    const entryPath = relative(skillDirectoryPath, symbolicLinkPath);
+
+    return new CliUserError("errors.skills.publish.invalidSkillFile", 1, {
+        message: `Skill entries must not be symbolic links: ${
+            entryPath === "" ? symbolicLinkPath : entryPath
+        }.`,
+        path: skillDirectoryPath,
     });
 }
 

--- a/src/application/commands/skills/publish.ts
+++ b/src/application/commands/skills/publish.ts
@@ -1,10 +1,12 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
-import type { SkillPublishVisibility } from "./package-conversion.ts";
+import type { BundledSkillAgentName } from "./embedded-assets.ts";
+import type { LocalSkillHostPublicationTarget } from "./init.ts";
 
-import { mkdtemp, rm } from "node:fs/promises";
+import type { SkillPublishVisibility } from "./package-conversion.ts";
+import { cp, lstat, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { z } from "zod";
 import { resolveRequestLanguage } from "../../../i18n/locale.ts";
 import { CliUserError } from "../../contracts/cli.ts";
@@ -13,10 +15,39 @@ import { loadPackageInfo, parsePackageSpecifier } from "../package/shared.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { parseEnumOption } from "../shared/input-parsing.ts";
 import { writeLine } from "../shared/output.ts";
+import {
+    isNodeNotFoundError,
+    publishBundledSkillInstallation,
+    removePath,
+} from "./bundled-skill-filesystem.ts";
 import { directoryExists } from "./bundled-skill-observation.ts";
+import {
+    resolveBundledSkillCanonicalRootDirectoryPath,
+    resolveBundledSkillHomeDirectory,
+} from "./bundled-skill-paths.ts";
 import { checkLocalSkillAuthoringEnvironment } from "./check.ts";
+import {
+    availableBundledSkillAgentNames,
+    availableBundledSkillNames,
+} from "./embedded-assets.ts";
+import {
+    resolveLocalSkillPublicationTargets,
+    resolveSkillInitPublicationMessageKey,
+} from "./init.ts";
 import { confirmInteractiveValue } from "./interactive-prompts.ts";
-import { resolveLocalSkillCanonicalDirectoryPath } from "./managed-skill-paths.ts";
+import { createMissingManagedSkillHostError } from "./managed-skill-hosts.ts";
+import {
+    parseManagedSkillMetadataContent,
+    readManagedSkillMetadata,
+} from "./managed-skill-metadata.ts";
+import {
+    isLocalSkillPathContained,
+    resolveLocalSkillCanonicalDirectoryPath,
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillDirectoryPath,
+    resolveManagedSkillMetadataFilePath,
+} from "./managed-skill-paths.ts";
+import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
 import {
     convertSkillDirectoryToPackage,
     defaultSkillPublishVisibility,
@@ -24,9 +55,11 @@ import {
     readLocalSkillPackageMetadata,
     skillPublishVisibilityValues,
     writePublishedSkillMetadata,
+    writeSkillFrontmatterMetadata,
 } from "./package-conversion.ts";
 
 interface SkillsPublishInput {
+    agent?: string;
     skill: string;
     visibility?: string;
 }
@@ -38,6 +71,34 @@ interface PublishLocalSkillPackageResult {
     skillId: string;
     version: string;
 }
+
+interface PublishSkillPackageOptions {
+    agentName?: BundledSkillAgentName;
+}
+
+interface LocalSkillPublishSource {
+    kind: "local";
+    skillDirectoryPath: string;
+    skillId: string;
+}
+
+interface RegistrySkillPublishSource {
+    kind: "registry";
+    packageName: string;
+    skillDirectoryPath: string;
+    skillId: string;
+}
+
+interface AdoptableSkillPublishSource {
+    kind: "adoptable";
+    skillDirectoryPath: string;
+    skillId: string;
+}
+
+type SkillPublishSource
+    = | AdoptableSkillPublishSource
+        | LocalSkillPublishSource
+        | RegistrySkillPublishSource;
 
 interface ResolveSkillPublishVersionRequest {
     account: AuthAccount;
@@ -76,6 +137,12 @@ export const skillsPublishCommand: CliCommandDefinition<SkillsPublishInput> = {
     ],
     options: [
         {
+            name: "agent",
+            longFlag: "--agent",
+            valueName: "agent",
+            descriptionKey: "options.agent",
+        },
+        {
             name: "visibility",
             longFlag: "--visibility",
             valueName: "visibility",
@@ -83,16 +150,19 @@ export const skillsPublishCommand: CliCommandDefinition<SkillsPublishInput> = {
         },
     ],
     inputSchema: z.object({
+        agent: z.string().optional(),
         skill: z.string(),
         visibility: z.string().optional(),
     }),
     handler: async (input, context) => {
+        const agentName = parseSkillPublishAgent(input.agent);
         const visibility = parseSkillPublishVisibility(input.visibility)
             ?? defaultSkillPublishVisibility;
-        const result = await publishLocalSkillPackage(
+        const result = await publishSkillPackage(
             input.skill,
             context,
             visibility,
+            { agentName },
         );
 
         writeLine(
@@ -119,18 +189,6 @@ export async function publishLocalSkillPackage(
     const checkAuthoringEnvironment
         = dependencies.checkAuthoringEnvironment ?? checkLocalSkillAuthoringEnvironment;
     const requireAccount = dependencies.requireCurrentAccount ?? requireCurrentAccount;
-    const resolveFinalPublishVersion = dependencies.resolveFinalPublishVersion
-        ?? resolveRequestedSkillPublishVersion;
-    const createTemporaryPackageRoot = dependencies.createTemporaryPackageRoot
-        ?? createDefaultTemporaryPackageRoot;
-    const removeTemporaryPackageRoot = dependencies.removeTemporaryPackageRoot
-        ?? removeDefaultTemporaryPackageRoot;
-    const convertDirectory = dependencies.convertSkillDirectoryToPackage
-        ?? convertSkillDirectoryToPackage;
-    const publishPackage = dependencies.publishConvertedSkillPackage
-        ?? publishConvertedSkillPackage;
-    const writeMetadata = dependencies.writePublishedSkillMetadata
-        ?? writePublishedSkillMetadata;
 
     await checkAuthoringEnvironment(context);
 
@@ -148,17 +206,96 @@ export async function publishLocalSkillPackage(
 
     const account = await requireAccount(context);
     const packageName = resolveCanonicalSkillPackageName(account.name, skillId);
-    const hubUrl = createSkillPackageHubUrl(account.endpoint, packageName);
+
+    return await publishResolvedSkillPackage(
+        {
+            account,
+            packageName,
+            skillDirectoryPath,
+            skillId,
+        },
+        context,
+        visibility,
+        dependencies,
+    );
+}
+
+export async function publishSkillPackage(
+    skillReference: string,
+    context: CliExecutionContext,
+    visibility: SkillPublishVisibility = defaultSkillPublishVisibility,
+    options: PublishSkillPackageOptions = {},
+    dependencies: PublishLocalSkillPackageDependencies = {},
+): Promise<PublishLocalSkillPackageResult> {
+    const source = await resolveSkillPublishSource(skillReference, context, {
+        agentName: options.agentName,
+    });
+    const checkAuthoringEnvironment
+        = dependencies.checkAuthoringEnvironment ?? checkLocalSkillAuthoringEnvironment;
+    const requireAccount = dependencies.requireCurrentAccount ?? requireCurrentAccount;
+
+    await checkAuthoringEnvironment(context);
+
+    const account = await requireAccount(context);
+    const packageName = resolveCanonicalSkillPackageName(account.name, source.skillId);
+    const publishSource = await confirmAndPrepareSkillPublishSource(
+        {
+            packageName,
+            source,
+        },
+        context,
+    );
+
+    return await publishResolvedSkillPackage(
+        {
+            account,
+            packageName,
+            skillDirectoryPath: publishSource.skillDirectoryPath,
+            skillId: publishSource.skillId,
+        },
+        context,
+        visibility,
+        dependencies,
+    );
+}
+
+async function publishResolvedSkillPackage(
+    request: {
+        account: AuthAccount;
+        packageName: string;
+        skillDirectoryPath: string;
+        skillId: string;
+    },
+    context: CliExecutionContext,
+    visibility: SkillPublishVisibility,
+    dependencies: PublishLocalSkillPackageDependencies,
+): Promise<PublishLocalSkillPackageResult> {
+    const resolveFinalPublishVersion = dependencies.resolveFinalPublishVersion
+        ?? resolveRequestedSkillPublishVersion;
+    const createTemporaryPackageRoot = dependencies.createTemporaryPackageRoot
+        ?? createDefaultTemporaryPackageRoot;
+    const removeTemporaryPackageRoot = dependencies.removeTemporaryPackageRoot
+        ?? removeDefaultTemporaryPackageRoot;
+    const convertDirectory = dependencies.convertSkillDirectoryToPackage
+        ?? convertSkillDirectoryToPackage;
+    const publishPackage = dependencies.publishConvertedSkillPackage
+        ?? publishConvertedSkillPackage;
+    const writeMetadata = dependencies.writePublishedSkillMetadata
+        ?? writePublishedSkillMetadata;
+    const hubUrl = createSkillPackageHubUrl(
+        request.account.endpoint,
+        request.packageName,
+    );
     const skillMetadata = await readLocalSkillPackageMetadata({
-        skillDirectoryPath,
-        skillId,
+        skillDirectoryPath: request.skillDirectoryPath,
+        skillId: request.skillId,
     });
     const version = await resolveFinalPublishVersion({
-        account,
+        account: request.account,
         context,
-        packageName,
+        packageName: request.packageName,
         requestedVersion: skillMetadata.requestedVersion,
-        skillId,
+        skillId: request.skillId,
     });
     let packageRootDirectoryPath: string | undefined;
 
@@ -166,21 +303,21 @@ export async function publishLocalSkillPackage(
         packageRootDirectoryPath = await createTemporaryPackageRoot();
 
         await convertDirectory({
-            packageName,
+            packageName: request.packageName,
             packageRootDirectoryPath,
-            skillDirectoryPath,
-            skillId,
+            skillDirectoryPath: request.skillDirectoryPath,
+            skillId: request.skillId,
             version,
         });
         await publishPackage({
-            account,
+            account: request.account,
             context,
             packageRootDirectoryPath,
             visibility,
         });
         await writeMetadata({
-            packageName,
-            skillDirectoryPath,
+            packageName: request.packageName,
+            skillDirectoryPath: request.skillDirectoryPath,
             version,
         });
     }
@@ -192,11 +329,21 @@ export async function publishLocalSkillPackage(
 
     return {
         hubUrl,
-        packageName,
-        skillDirectoryPath,
-        skillId,
+        packageName: request.packageName,
+        skillDirectoryPath: request.skillDirectoryPath,
+        skillId: request.skillId,
         version,
     };
+}
+
+function parseSkillPublishAgent(
+    value: string | undefined,
+): BundledSkillAgentName | undefined {
+    return parseEnumOption(
+        value,
+        availableBundledSkillAgentNames,
+        "errors.skills.publish.invalidAgent",
+    );
 }
 
 function parseSkillPublishVisibility(
@@ -207,6 +354,714 @@ function parseSkillPublishVisibility(
         skillPublishVisibilityValues,
         "errors.skills.publish.invalidVisibility",
     );
+}
+
+async function resolveSkillPublishSource(
+    skillReference: string,
+    context: Pick<CliExecutionContext, "cwd" | "env" | "settingsStore">,
+    options: PublishSkillPackageOptions,
+): Promise<SkillPublishSource> {
+    const normalizedReference = skillReference.trim();
+
+    if (normalizedReference === "") {
+        throw createSkillPublishSourceMissingError(skillReference);
+    }
+
+    const settingsFilePath = context.settingsStore.getFilePath();
+
+    if (isSkillIdReference(normalizedReference)) {
+        const localSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            settingsFilePath,
+            normalizedReference,
+        );
+
+        if (await directoryExists(localSkillDirectoryPath)) {
+            return {
+                kind: "local",
+                skillDirectoryPath: localSkillDirectoryPath,
+                skillId: normalizedReference,
+            };
+        }
+
+        await rejectBundledSkillPublishIfMatched(
+            settingsFilePath,
+            normalizedReference,
+        );
+
+        const registrySkillSource = await resolveRegistrySkillPublishSource(
+            settingsFilePath,
+            normalizedReference,
+        );
+
+        if (registrySkillSource !== undefined) {
+            return registrySkillSource;
+        }
+
+        if (options.agentName !== undefined) {
+            const agentSkillSource = await resolveAgentSkillPublishSource(
+                context.env,
+                normalizedReference,
+                options.agentName,
+            );
+
+            if (agentSkillSource !== undefined) {
+                return agentSkillSource;
+            }
+        }
+    }
+
+    const pathSkillSource = await resolvePathSkillPublishSource(
+        normalizedReference,
+        context.cwd,
+        settingsFilePath,
+    );
+
+    if (pathSkillSource !== undefined) {
+        return pathSkillSource;
+    }
+
+    throw createSkillPublishSourceMissingError(skillReference);
+}
+
+async function rejectBundledSkillPublishIfMatched(
+    settingsFilePath: string,
+    skillId: string,
+): Promise<void> {
+    if (isBundledSkillName(skillId)) {
+        throw createBundledSkillPublishError(skillId);
+    }
+
+    const bundledSkillDirectoryPath = await findExistingBundledSkillDirectoryPath(
+        settingsFilePath,
+        skillId,
+    );
+
+    if (bundledSkillDirectoryPath !== undefined) {
+        throw createBundledSkillPublishError(skillId);
+    }
+}
+
+async function findExistingBundledSkillDirectoryPath(
+    settingsFilePath: string,
+    skillId: string,
+): Promise<string | undefined> {
+    const bundledSkillDirectoryPaths = availableBundledSkillAgentNames.map(
+        agentName => join(
+            resolveBundledSkillCanonicalRootDirectoryPath(
+                settingsFilePath,
+                agentName,
+            ),
+            skillId,
+        ),
+    );
+
+    for (const bundledSkillDirectoryPath of bundledSkillDirectoryPaths) {
+        if (await directoryExists(bundledSkillDirectoryPath)) {
+            return bundledSkillDirectoryPath;
+        }
+    }
+
+    return undefined;
+}
+
+async function resolveRegistrySkillPublishSource(
+    settingsFilePath: string,
+    skillId: string,
+): Promise<RegistrySkillPublishSource | undefined> {
+    const skillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+        settingsFilePath,
+        skillId,
+    );
+
+    if (!(await directoryExists(skillDirectoryPath))) {
+        return undefined;
+    }
+
+    const metadata = await readManagedSkillMetadata(skillDirectoryPath);
+
+    if (metadata?.packageName === undefined) {
+        throw new CliUserError("errors.skills.publish.registryMetadataMissing", 1, {
+            name: skillId,
+            path: resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+        });
+    }
+
+    return {
+        kind: "registry",
+        packageName: metadata.packageName,
+        skillDirectoryPath,
+        skillId,
+    };
+}
+
+async function resolveAgentSkillPublishSource(
+    env: Record<string, string | undefined>,
+    skillId: string,
+    agentName: BundledSkillAgentName,
+): Promise<AdoptableSkillPublishSource | undefined> {
+    const homeDirectory = resolveBundledSkillHomeDirectory(env, agentName);
+    const skillDirectoryPath = resolveManagedSkillDirectoryPath(
+        homeDirectory,
+        skillId,
+    );
+
+    if (!(await isSkillDirectoryWithSkillFile(skillDirectoryPath))) {
+        return undefined;
+    }
+
+    return {
+        kind: "adoptable",
+        skillDirectoryPath,
+        skillId,
+    };
+}
+
+async function resolvePathSkillPublishSource(
+    skillReference: string,
+    cwd: string,
+    settingsFilePath: string,
+): Promise<SkillPublishSource | undefined> {
+    const skillDirectoryPath = isAbsolute(skillReference)
+        ? resolve(skillReference)
+        : resolve(cwd, skillReference);
+
+    if (!(await isSkillDirectoryWithSkillFile(skillDirectoryPath))) {
+        return undefined;
+    }
+
+    const skillId = basename(skillDirectoryPath);
+
+    if (!isSkillIdReference(skillId)) {
+        return undefined;
+    }
+
+    const localSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+        settingsFilePath,
+        skillId,
+    );
+
+    if (resolve(localSkillDirectoryPath) === skillDirectoryPath) {
+        return {
+            kind: "local",
+            skillDirectoryPath,
+            skillId,
+        };
+    }
+
+    const bundledSkillDirectoryPath = await findExistingBundledSkillDirectoryPath(
+        settingsFilePath,
+        skillId,
+    );
+
+    if (
+        bundledSkillDirectoryPath !== undefined
+        && resolve(bundledSkillDirectoryPath) === skillDirectoryPath
+    ) {
+        throw createBundledSkillPublishError(skillId);
+    }
+
+    const registrySkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+        settingsFilePath,
+        skillId,
+    );
+
+    if (resolve(registrySkillDirectoryPath) === skillDirectoryPath) {
+        return await resolveRegistrySkillPublishSource(settingsFilePath, skillId);
+    }
+
+    return {
+        kind: "adoptable",
+        skillDirectoryPath,
+        skillId,
+    };
+}
+
+async function confirmAndPrepareSkillPublishSource(
+    options: {
+        packageName: string;
+        source: SkillPublishSource;
+    },
+    context: Pick<CliExecutionContext, "env" | "settingsStore" | "stdin" | "stdout" | "translator">,
+): Promise<LocalSkillPublishSource | RegistrySkillPublishSource> {
+    switch (options.source.kind) {
+        case "local":
+            return options.source;
+        case "registry": {
+            if (
+                normalizePackageNameForComparison(options.source.packageName)
+                === normalizePackageNameForComparison(options.packageName)
+            ) {
+                return options.source;
+            }
+
+            await confirmRegistrySkillPackagePublish(
+                options.source,
+                options.packageName,
+                context,
+            );
+
+            return options.source;
+        }
+        case "adoptable": {
+            const localSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+                context.settingsStore.getFilePath(),
+                options.source.skillId,
+            );
+            const publicationTargets = await resolveAdoptedLocalSkillPublicationTargets({
+                context,
+                source: options.source,
+            });
+
+            await validateAdoptableSkillPublishSource(options.source);
+
+            await confirmAdoptableSkillPublish(
+                {
+                    localSkillDirectoryPath,
+                    packageName: options.packageName,
+                    source: options.source,
+                },
+                context,
+            );
+
+            await adoptSkillPublishSource({
+                context,
+                localSkillDirectoryPath,
+                publicationTargets,
+                source: options.source,
+            });
+
+            return {
+                kind: "local",
+                skillDirectoryPath: localSkillDirectoryPath,
+                skillId: options.source.skillId,
+            };
+        }
+    }
+}
+
+async function confirmRegistrySkillPackagePublish(
+    source: RegistrySkillPublishSource,
+    targetPackageName: string,
+    context: Pick<CliExecutionContext, "stdin" | "stdout" | "translator">,
+): Promise<void> {
+    const params = {
+        name: source.skillId,
+        packageName: source.packageName,
+        targetPackageName,
+    };
+
+    if (context.stdin.isTTY !== true) {
+        throw new CliUserError(
+            "errors.skills.publish.registryPackageConfirmationRequired",
+            1,
+            params,
+        );
+    }
+
+    const confirmed = await confirmInteractiveValue(
+        context,
+        {
+            invalidMessage: context.translator.t(
+                "skills.publish.confirm.invalid",
+            ),
+            prompt: context.translator.t(
+                "skills.publish.registryPackage.prompt",
+                params,
+            ),
+        },
+    );
+
+    if (!confirmed) {
+        throw new CliUserError(
+            "errors.skills.publish.registryPackageMismatch",
+            1,
+            params,
+        );
+    }
+}
+
+async function confirmAdoptableSkillPublish(
+    options: {
+        localSkillDirectoryPath: string;
+        packageName: string;
+        source: AdoptableSkillPublishSource;
+    },
+    context: Pick<CliExecutionContext, "stdin" | "stdout" | "translator">,
+): Promise<void> {
+    const params = {
+        localPath: options.localSkillDirectoryPath,
+        name: options.source.skillId,
+        packageName: options.packageName,
+        path: options.source.skillDirectoryPath,
+    };
+
+    if (context.stdin.isTTY !== true) {
+        throw new CliUserError(
+            "errors.skills.publish.adoptionConfirmationRequired",
+            1,
+            params,
+        );
+    }
+
+    const confirmed = await confirmInteractiveValue(
+        context,
+        {
+            invalidMessage: context.translator.t(
+                "skills.publish.confirm.invalid",
+            ),
+            prompt: context.translator.t(
+                "skills.publish.adoption.prompt",
+                params,
+            ),
+        },
+    );
+
+    if (!confirmed) {
+        throw new CliUserError("errors.skills.publish.adoptionCancelled", 1, params);
+    }
+}
+
+async function adoptSkillPublishSource(
+    options: {
+        context: Pick<CliExecutionContext, "env" | "settingsStore" | "stdout" | "translator">;
+        localSkillDirectoryPath: string;
+        publicationTargets: readonly LocalSkillHostPublicationTarget[];
+        source: AdoptableSkillPublishSource;
+    },
+): Promise<void> {
+    const publishedTargets: LocalSkillHostPublicationTarget[] = [];
+    let activePublicationTarget: LocalSkillHostPublicationTarget | undefined;
+
+    try {
+        await copySkillDirectoryToLocalStorage(
+            options.source.skillDirectoryPath,
+            options.localSkillDirectoryPath,
+            options.source.skillId,
+        );
+        await importManagedMetadataToSkillFrontmatter(options.localSkillDirectoryPath);
+        await validateAdoptedLocalSkill(options.localSkillDirectoryPath, options.source.skillId);
+
+        writeLine(
+            options.context.stdout,
+            options.context.translator.t("skills.publish.adopted", {
+                name: options.source.skillId,
+                path: options.localSkillDirectoryPath,
+            }),
+        );
+
+        for (const target of orderAdoptedLocalSkillPublicationTargets(
+            options.publicationTargets,
+            options.source.skillDirectoryPath,
+        )) {
+            activePublicationTarget = target;
+            const published = await publishBundledSkillInstallation({
+                canonicalSkillDirectoryPath: options.localSkillDirectoryPath,
+                installedSkillDirectoryPath: target.installedSkillDirectoryPath,
+                publicationMode: resolveManagedSkillPublicationMode(target.agentName),
+            });
+
+            publishedTargets.push(target);
+            activePublicationTarget = undefined;
+
+            writeLine(
+                options.context.stdout,
+                options.context.translator.t(
+                    resolveSkillInitPublicationMessageKey(published.mode),
+                    {
+                        name: options.source.skillId,
+                        path: published.path,
+                    },
+                ),
+            );
+        }
+
+        if (!hasSourcePublicationTarget(
+            options.publicationTargets,
+            options.source.skillDirectoryPath,
+        )) {
+            await removePath(options.source.skillDirectoryPath);
+        }
+    }
+    catch (error) {
+        await rollbackAdoptedSkillPublishSource({
+            localSkillDirectoryPath: options.localSkillDirectoryPath,
+            publishedTargets,
+            source: options.source,
+            targetBeingPublished: activePublicationTarget,
+        });
+        throw error;
+    }
+}
+
+async function copySkillDirectoryToLocalStorage(
+    sourceDirectoryPath: string,
+    localSkillDirectoryPath: string,
+    skillId: string,
+): Promise<void> {
+    if (await pathExists(localSkillDirectoryPath)) {
+        throw new CliUserError("errors.skills.storageConflict", 1, {
+            name: skillId,
+            path: localSkillDirectoryPath,
+        });
+    }
+
+    await mkdir(dirname(localSkillDirectoryPath), { recursive: true });
+
+    await cp(sourceDirectoryPath, localSkillDirectoryPath, {
+        dereference: true,
+        errorOnExist: true,
+        force: false,
+        recursive: true,
+    });
+}
+
+async function importManagedMetadataToSkillFrontmatter(
+    skillDirectoryPath: string,
+): Promise<void> {
+    const metadataFilePath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
+    let content: string;
+
+    try {
+        content = await readFile(metadataFilePath, "utf8");
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return;
+        }
+
+        throw error;
+    }
+
+    const metadata = parseManagedSkillMetadataContent(content);
+
+    if (metadata !== undefined) {
+        await writeSkillFrontmatterMetadata({
+            metadata: {
+                icon: metadata.icon,
+                packageName: metadata.packageName,
+                version: metadata.version,
+            },
+            skillDirectoryPath,
+        });
+    }
+
+    await rm(metadataFilePath, { force: true });
+}
+
+async function resolveAdoptedLocalSkillPublicationTargets(
+    options: {
+        context: Pick<CliExecutionContext, "env" | "settingsStore">;
+        source: AdoptableSkillPublishSource;
+    },
+): Promise<LocalSkillHostPublicationTarget[]> {
+    const targets = await resolveLocalSkillPublicationTargets(
+        options.context.env,
+        options.source.skillId,
+    );
+
+    if (targets.length === 0) {
+        throw createMissingManagedSkillHostError(options.context.env);
+    }
+
+    const settingsFilePath = options.context.settingsStore.getFilePath();
+
+    if (targets.some(target =>
+        !isLocalSkillPathContained(
+            target.homeDirectory,
+            settingsFilePath,
+            options.source.skillId,
+        ),
+    )) {
+        throw new CliUserError("errors.skills.invalidPath", 1, {
+            name: options.source.skillId,
+        });
+    }
+
+    const conflictingTarget = await findExistingLocalSkillPublicationTarget(
+        targets,
+        options.source.skillDirectoryPath,
+    );
+
+    if (conflictingTarget !== undefined) {
+        throw new CliUserError("errors.skills.nameConflict", 1, {
+            name: options.source.skillId,
+            path: conflictingTarget.installedSkillDirectoryPath,
+        });
+    }
+
+    return targets;
+}
+
+async function rollbackAdoptedSkillPublishSource(
+    options: {
+        localSkillDirectoryPath: string;
+        publishedTargets: readonly LocalSkillHostPublicationTarget[];
+        source: AdoptableSkillPublishSource;
+        targetBeingPublished?: LocalSkillHostPublicationTarget;
+    },
+): Promise<void> {
+    const targetsToRemove = options.targetBeingPublished === undefined
+        ? [...options.publishedTargets]
+        : [...options.publishedTargets, options.targetBeingPublished];
+
+    await Promise.all(targetsToRemove.map(target =>
+        removePath(target.installedSkillDirectoryPath),
+    ));
+
+    if (!(await pathExists(options.source.skillDirectoryPath))) {
+        await restoreSourceSkillDirectoryFromLocalStorage(
+            options.localSkillDirectoryPath,
+            options.source.skillDirectoryPath,
+        );
+    }
+
+    await removePath(options.localSkillDirectoryPath);
+}
+
+async function restoreSourceSkillDirectoryFromLocalStorage(
+    localSkillDirectoryPath: string,
+    sourceDirectoryPath: string,
+): Promise<void> {
+    await mkdir(dirname(sourceDirectoryPath), { recursive: true });
+    await cp(localSkillDirectoryPath, sourceDirectoryPath, {
+        dereference: true,
+        errorOnExist: true,
+        force: false,
+        recursive: true,
+    });
+}
+
+async function findExistingLocalSkillPublicationTarget(
+    targets: readonly LocalSkillHostPublicationTarget[],
+    sourceDirectoryPath: string,
+): Promise<LocalSkillHostPublicationTarget | undefined> {
+    for (const target of targets) {
+        if (
+            await pathExists(target.installedSkillDirectoryPath)
+            && !isSameResolvedPath(target.installedSkillDirectoryPath, sourceDirectoryPath)
+        ) {
+            return target;
+        }
+    }
+
+    return undefined;
+}
+
+function orderAdoptedLocalSkillPublicationTargets(
+    targets: readonly LocalSkillHostPublicationTarget[],
+    sourceDirectoryPath: string,
+): LocalSkillHostPublicationTarget[] {
+    const nonSourceTargets: LocalSkillHostPublicationTarget[] = [];
+    const sourceTargets: LocalSkillHostPublicationTarget[] = [];
+
+    for (const target of targets) {
+        if (isSourcePublicationTarget(target, sourceDirectoryPath)) {
+            sourceTargets.push(target);
+            continue;
+        }
+
+        nonSourceTargets.push(target);
+    }
+
+    return [...nonSourceTargets, ...sourceTargets];
+}
+
+function hasSourcePublicationTarget(
+    targets: readonly LocalSkillHostPublicationTarget[],
+    sourceDirectoryPath: string,
+): boolean {
+    return targets.some(target => isSourcePublicationTarget(target, sourceDirectoryPath));
+}
+
+function isSourcePublicationTarget(
+    target: LocalSkillHostPublicationTarget,
+    sourceDirectoryPath: string,
+): boolean {
+    return isSameResolvedPath(target.installedSkillDirectoryPath, sourceDirectoryPath);
+}
+
+function isSameResolvedPath(leftPath: string, rightPath: string): boolean {
+    return resolve(leftPath) === resolve(rightPath);
+}
+
+async function validateAdoptableSkillPublishSource(
+    source: AdoptableSkillPublishSource,
+): Promise<void> {
+    await validateAdoptedLocalSkill(source.skillDirectoryPath, source.skillId);
+}
+
+async function validateAdoptedLocalSkill(
+    skillDirectoryPath: string,
+    skillId: string,
+): Promise<void> {
+    await readLocalSkillPackageMetadata({
+        skillDirectoryPath,
+        skillId,
+    });
+}
+
+async function isSkillDirectoryWithSkillFile(
+    directoryPath: string,
+): Promise<boolean> {
+    if (!(await directoryExists(directoryPath))) {
+        return false;
+    }
+
+    try {
+        const skillFileStats = await lstat(join(directoryPath, "SKILL.md"));
+
+        return skillFileStats.isFile();
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+    try {
+        await lstat(path);
+        return true;
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+function isSkillIdReference(value: string): boolean {
+    const trimmedValue = value.trim();
+
+    return trimmedValue !== ""
+        && trimmedValue !== "."
+        && trimmedValue !== ".."
+        && basename(trimmedValue) === trimmedValue;
+}
+
+function normalizePackageNameForComparison(packageName: string): string {
+    return packageName.trim().toLowerCase();
+}
+
+function isBundledSkillName(value: string): boolean {
+    return (availableBundledSkillNames as readonly string[]).includes(value);
+}
+
+function createBundledSkillPublishError(skillId: string): CliUserError {
+    return new CliUserError("errors.skills.publish.bundledSkill", 1, {
+        name: skillId,
+    });
+}
+
+function createSkillPublishSourceMissingError(skillReference: string): CliUserError {
+    return new CliUserError("errors.skills.publish.skillNotFound", 1, {
+        name: skillReference,
+    });
 }
 
 async function resolveRequestedSkillPublishVersion(

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -139,8 +139,8 @@ export const enMessages = {
         "Validate a local skill directory against the generic skill contract.",
     "commands.skills.validate.summary": "Validate a skill directory",
     "commands.skills.publish.description":
-        "Convert one local skill into an OOMOL package and publish it.",
-    "commands.skills.publish.summary": "Publish a local skill",
+        "Convert one skill into an OOMOL package and publish it.",
+    "commands.skills.publish.summary": "Publish a skill",
     "commands.skills.install.description":
         "Install bundled or published skills into supported local skill directories.",
     "commands.skills.install.summary": "Install skills",
@@ -308,12 +308,26 @@ export const enMessages = {
         "Invalid skill name: {value}. Use a name that can be normalized to lowercase hyphen-case.",
     "errors.skills.publish.invalidPackageMetadata":
         "Invalid skill package metadata: {message}",
+    "errors.skills.publish.invalidAgent":
+        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, openclaw, or qoderwork.",
     "errors.skills.publish.invalidSkillFile":
         "Cannot publish the skill at {path}: {message}",
     "errors.skills.publish.invalidVisibility":
         "Invalid skill publish visibility: {value}. Use private or public.",
+    "errors.skills.publish.adoptionCancelled":
+        "Publishing skill {name} was cancelled before moving {path} into local storage.",
+    "errors.skills.publish.adoptionConfirmationRequired":
+        "Skill {name} was found at {path}. Run in an interactive terminal to confirm moving it into local storage at {localPath}.",
+    "errors.skills.publish.bundledSkill":
+        "Bundled skill {name} cannot be published directly because it is managed by the oo CLI release. Create or adopt a local copy before publishing.",
     "errors.skills.publish.localSkillMissing":
         "Local skill {name} does not exist at {path}.",
+    "errors.skills.publish.registryMetadataMissing":
+        "Registry skill {name} cannot be published because its metadata file at {path} does not identify a packageName.",
+    "errors.skills.publish.registryPackageConfirmationRequired":
+        "Skill {name} is installed from {packageName}. Run in an interactive terminal to confirm publishing it as {targetPackageName}.",
+    "errors.skills.publish.registryPackageMismatch":
+        "Publishing skill {name} as {targetPackageName} was cancelled because it is installed from {packageName}.",
     "errors.skills.publish.remotePackageHasBlocks":
         "Publishing skill {name} as {packageName} was cancelled because remote package {packageName}@{version} contains blocks.",
     "errors.skills.publish.remotePackageHasBlocksConfirmationRequired":
@@ -324,6 +338,8 @@ export const enMessages = {
         "The skill package publish request failed: {message}",
     "errors.skills.publish.requestFailed":
         "The skill package publish request returned HTTP {status}: {message}",
+    "errors.skills.publish.skillNotFound":
+        "Cannot find skill {name} in local, bundled, registry, requested agent, or path sources.",
     "errors.fileDownload.downloadFailed":
         "Failed to download the file at {path}: {message}",
     "errors.fileDownload.invalidExt":
@@ -598,8 +614,16 @@ export const enMessages = {
     "skills.init.copied": "Copied skill {name} to {path}.",
     "skills.publish.success":
         "Published skill {name} as {visibility} package {packageName}@{version}. View it at {hubUrl}.",
+    "skills.publish.adopted":
+        "Adopted skill {name} into local canonical storage at {path}.",
+    "skills.publish.adoption.prompt":
+        "Skill {name} was found at {path}. Move it into local storage at {localPath} and publish it as {packageName}? [y/N] ",
+    "skills.publish.confirm.invalid":
+        "Invalid choice. Enter y/yes or n/no.",
     "skills.publish.visibility.private": "private",
     "skills.publish.visibility.public": "public",
+    "skills.publish.registryPackage.prompt":
+        "Skill {name} is installed from {packageName}. Publish it as {targetPackageName}? [y/N] ",
     "skills.publish.remoteBlocks.invalid":
         "Invalid choice. Enter y/yes or n/no.",
     "skills.publish.remoteBlocks.prompt":
@@ -850,8 +874,8 @@ export const zhMessages = {
         "按照通用 skill 契约校验本地 skill 目录。",
     "commands.skills.validate.summary": "校验 skill 目录",
     "commands.skills.publish.description":
-        "将一个本地 skill 转换为 OOMOL 包并发布。",
-    "commands.skills.publish.summary": "发布本地 skill",
+        "将一个 skill 转换为 OOMOL 包并发布。",
+    "commands.skills.publish.summary": "发布 skill",
     "commands.skills.install.description":
         "将内置或已发布 skill 安装到受支持的本地 skill 目录。",
     "commands.skills.install.summary": "安装 skill",
@@ -1007,12 +1031,26 @@ export const zhMessages = {
         "无效的 skill 名称：{value}。请使用可规范化为小写短横线格式的名称。",
     "errors.skills.publish.invalidPackageMetadata":
         "skill 包元数据无效：{message}",
+    "errors.skills.publish.invalidAgent":
+        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、openclaw 或 qoderwork。",
     "errors.skills.publish.invalidSkillFile":
         "无法发布 {path} 中的 skill：{message}",
     "errors.skills.publish.invalidVisibility":
         "无效的 skill 发布可见性：{value}。请使用 private 或 public。",
+    "errors.skills.publish.adoptionCancelled":
+        "已在将 {path} 移入本地存储前取消发布 skill {name}。",
+    "errors.skills.publish.adoptionConfirmationRequired":
+        "在 {path} 找到 skill {name}。请在交互式终端中确认是否将它移入本地存储 {localPath}。",
+    "errors.skills.publish.bundledSkill":
+        "不能直接发布内置 skill {name}，因为它由 oo CLI 版本管理。请先创建或接管一个本地副本再发布。",
     "errors.skills.publish.localSkillMissing":
         "本地 skill {name} 不存在于 {path}。",
+    "errors.skills.publish.registryMetadataMissing":
+        "无法发布 registry skill {name}，因为它位于 {path} 的元数据文件没有标识 packageName。",
+    "errors.skills.publish.registryPackageConfirmationRequired":
+        "skill {name} 安装自 {packageName}。请在交互式终端中确认是否将它发布为 {targetPackageName}。",
+    "errors.skills.publish.registryPackageMismatch":
+        "已取消将 skill {name} 发布为 {targetPackageName}：它安装自 {packageName}。",
     "errors.skills.publish.remotePackageHasBlocks":
         "已取消将 skill {name} 发布为 {packageName}：远端包 {packageName}@{version} 中存在区块。",
     "errors.skills.publish.remotePackageHasBlocksConfirmationRequired":
@@ -1023,6 +1061,8 @@ export const zhMessages = {
         "skill 包发布请求失败：{message}",
     "errors.skills.publish.requestFailed":
         "skill 包发布请求返回了 HTTP {status}：{message}",
+    "errors.skills.publish.skillNotFound":
+        "无法在 local、bundled、registry、指定 Agent 或路径来源中找到 skill {name}。",
     "errors.fileDownload.downloadFailed":
         "下载文件到 {path} 失败：{message}",
     "errors.fileDownload.invalidExt":
@@ -1291,8 +1331,16 @@ export const zhMessages = {
     "skills.init.copied": "已将 skill {name} 复制到 {path}。",
     "skills.publish.success":
         "已将 skill {name} 以{visibility}发布为 {packageName}@{version}。可在 {hubUrl} 查看。",
+    "skills.publish.adopted":
+        "已将 skill {name} 接管到本地 canonical 存储 {path}。",
+    "skills.publish.adoption.prompt":
+        "在 {path} 找到 skill {name}。是否将它移入本地存储 {localPath} 并发布为 {packageName}？[y/N] ",
+    "skills.publish.confirm.invalid":
+        "输入无效。请输入 y/yes 或 n/no。",
     "skills.publish.visibility.private": "私有包",
     "skills.publish.visibility.public": "公开包",
+    "skills.publish.registryPackage.prompt":
+        "skill {name} 安装自 {packageName}。是否发布为 {targetPackageName}？[y/N] ",
     "skills.publish.remoteBlocks.invalid":
         "输入无效。请输入 y/yes 或 n/no。",
     "skills.publish.remoteBlocks.prompt":


### PR DESCRIPTION
- Added support for specifying a skill agent during the publishing process.
- Refactored the skill publishing logic to handle different skill sources (local, registry, adoptable).
- Introduced new error messages for invalid agents, adoption cancellations, and missing skills.
- Updated i18n catalog for new messages related to skill publishing and adoption.
- Improved the confirmation prompts for adopting and publishing skills.