### PR TITLE
refactor(self-update): store managed versions as directories

### DIFF
--- a/src/application/commands/self-update.cli.test.ts
+++ b/src/application/commands/self-update.cli.test.ts
@@ -4,7 +4,7 @@ import type {
     CliSnapshotContext,
 } from "../../../__tests__/helpers.ts";
 import { mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import process from "node:process";
 import { describe, expect, test } from "bun:test";
 import {
@@ -14,7 +14,8 @@ import {
 } from "../../../__tests__/helpers.ts";
 import {
     resolveSelfUpdatePaths,
-    resolveSelfUpdateVersionFilePath,
+    resolveSelfUpdateVersionDirectoryPath,
+    resolveSelfUpdateVersionExecutablePath,
 } from "../self-update/paths.ts";
 import { detectSelfUpdateReleasePlatform } from "../self-update/platform.ts";
 
@@ -240,7 +241,7 @@ describe("self-update commands", () => {
             env: sandbox.env,
             platform: process.platform,
         });
-        const targetVersionPath = resolveSelfUpdateVersionFilePath(
+        const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
             paths,
             "2.0.0",
         );
@@ -385,7 +386,7 @@ describe("self-update commands", () => {
             env: sandbox.env,
             platform: process.platform,
         });
-        const targetVersionPath = resolveSelfUpdateVersionFilePath(
+        const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
             paths,
             "2.0.0",
         );
@@ -572,7 +573,7 @@ describe("self-update commands", () => {
             env: sandbox.env,
             platform: process.platform,
         });
-        const currentVersionPath = resolveSelfUpdateVersionFilePath(
+        const currentVersionPath = resolveSelfUpdateVersionExecutablePath(
             paths,
             "1.2.3",
         );
@@ -581,8 +582,7 @@ describe("self-update commands", () => {
         const selfUpdateRuntime = createCapturedSelfUpdateRuntime();
 
         try {
-            await mkdir(paths.versionsDirectory, { recursive: true });
-            await Bun.write(currentVersionPath, "existing-binary");
+            await writeManagedVersion(currentVersionPath, "existing-binary");
 
             const result = await sandbox.run(["update"], {
                 fetcher: async (input, init) => {
@@ -614,6 +614,74 @@ describe("self-update commands", () => {
             });
             expect(latestRequestCount).toBe(1);
             expect(binaryRequestCount).toBe(0);
+            expect(selfUpdateRuntime.commands).toEqual([
+                {
+                    commandArguments: ["skills", "add"],
+                    commandPath: currentVersionPath,
+                    timeoutMs: 10_000,
+                },
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("update repairs a same-version native install that still uses the legacy version file layout", async () => {
+        const sandbox = await createCliSandbox();
+        const releasePlatform = await detectSelfUpdateReleasePlatform({
+            arch: process.arch,
+            platform: process.platform,
+        });
+        const paths = resolveSelfUpdatePaths({
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const legacyVersionPath = resolveSelfUpdateVersionDirectoryPath(
+            paths,
+            "1.2.3",
+        );
+        const currentVersionPath = resolveSelfUpdateVersionExecutablePath(
+            paths,
+            "1.2.3",
+        );
+        let latestRequestCount = 0;
+        let binaryRequestCount = 0;
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime();
+
+        try {
+            await writeManagedVersion(legacyVersionPath, "legacy-binary");
+
+            const result = await sandbox.run(["update"], {
+                fetcher: async (input, init) => {
+                    const url = toRequest(input, init).url;
+
+                    if (url.endsWith("/latest.json")) {
+                        latestRequestCount += 1;
+                        return new Response(JSON.stringify({
+                            version: "1.2.3",
+                        }));
+                    }
+
+                    if (url.endsWith(`/${releasePlatform}/${process.platform === "win32" ? "oo.exe" : "oo"}`)) {
+                        binaryRequestCount += 1;
+                        return new Response("binary");
+                    }
+
+                    throw new Error(`Unexpected request: ${url}`);
+                },
+                execPath: paths.executablePath,
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
+                version: "1.2.3",
+            });
+
+            expect(createCliSnapshot(result, { sandbox })).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: "Already up to date at 1.2.3.\nAdded <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.\n",
+            });
+            expect(latestRequestCount).toBe(1);
+            expect(binaryRequestCount).toBe(1);
             expect(selfUpdateRuntime.commands).toEqual([
                 {
                     commandArguments: ["skills", "add"],
@@ -686,15 +754,14 @@ describe("self-update commands", () => {
             env: sandbox.env,
             platform: process.platform,
         });
-        const currentVersionPath = resolveSelfUpdateVersionFilePath(
+        const currentVersionPath = resolveSelfUpdateVersionExecutablePath(
             paths,
             "1.2.3",
         );
         let binaryRequestCount = 0;
 
         try {
-            await mkdir(paths.versionsDirectory, { recursive: true });
-            await Bun.write(currentVersionPath, "existing-binary");
+            await writeManagedVersion(currentVersionPath, "existing-binary");
 
             const result = await sandbox.run(["upgrade"], {
                 execPath: "/usr/local/lib/node_modules/@oomol-lab/oo-cli/bin/oo",
@@ -815,6 +882,11 @@ interface CapturedSelfUpdateCommand {
     commandArguments: readonly string[];
     commandPath: string;
     timeoutMs: number;
+}
+
+async function writeManagedVersion(path: string, content: string): Promise<void> {
+    await mkdir(dirname(path), { recursive: true });
+    await Bun.write(path, content);
 }
 
 function createCapturedSelfUpdateRuntime(commandResult?: {

--- a/src/application/commands/self-update.cli.test.ts
+++ b/src/application/commands/self-update.cli.test.ts
@@ -3,7 +3,7 @@ import type {
     CliRunResult,
     CliSnapshotContext,
 } from "../../../__tests__/helpers.ts";
-import { mkdir } from "node:fs/promises";
+import { chmod, mkdir, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import process from "node:process";
 import { describe, expect, test } from "bun:test";
@@ -689,6 +689,9 @@ describe("self-update commands", () => {
                     timeoutMs: 10_000,
                 },
             ]);
+            expect((await stat(legacyVersionPath)).isDirectory()).toBeTrue();
+            await expect(Bun.file(currentVersionPath).exists()).resolves.toBeTrue();
+            expect(await Bun.file(currentVersionPath).text()).toBe("binary");
         }
         finally {
             await sandbox.cleanup();
@@ -887,6 +890,10 @@ interface CapturedSelfUpdateCommand {
 async function writeManagedVersion(path: string, content: string): Promise<void> {
     await mkdir(dirname(path), { recursive: true });
     await Bun.write(path, content);
+
+    if (process.platform !== "win32") {
+        await chmod(path, 0o755);
+    }
 }
 
 function createCapturedSelfUpdateRuntime(commandResult?: {

--- a/src/application/commands/update.ts
+++ b/src/application/commands/update.ts
@@ -4,6 +4,7 @@ import process from "node:process";
 import { z } from "zod";
 import {
     attemptBundledSkillRefreshAfterSelfUpdate,
+    isManagedVersionExecutableInstalled,
     resolveBundledSkillRefreshCommandPath,
 } from "../self-update/bundled-skills.ts";
 import {
@@ -81,6 +82,11 @@ export const updateCommand: CliCommandDefinition<
                     execPath: context.execPath,
                     platform: process.platform,
                 }).method === "native"
+                && await isManagedVersionExecutableInstalled({
+                    env: context.env,
+                    platform: process.platform,
+                    version: context.version,
+                })
             ) {
                 await attemptBundledSkillRefreshAfterSelfUpdate({
                     commandPath: await resolveBundledSkillRefreshCommandPath({

--- a/src/application/self-update/bundled-skills.test.ts
+++ b/src/application/self-update/bundled-skills.test.ts
@@ -1,0 +1,102 @@
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { describe, expect, test } from "bun:test";
+import {
+    createTemporaryDirectory,
+    useTemporaryDirectoryCleanup,
+} from "../../../__tests__/helpers.ts";
+import { isManagedVersionExecutableInstalled } from "./bundled-skills.ts";
+import {
+    resolveSelfUpdatePaths,
+    resolveSelfUpdateVersionExecutablePath,
+} from "./paths.ts";
+
+const { track: trackDirectory } = useTemporaryDirectoryCleanup();
+
+describe("isManagedVersionExecutableInstalled", () => {
+    test("returns true for an executable managed version file", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skills-executable");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const executablePath = resolveSelfUpdateVersionExecutablePath(paths, "1.2.3");
+
+        trackDirectory(rootDirectory);
+        await writeExecutable(executablePath);
+
+        expect(await isManagedVersionExecutableInstalled({
+            env,
+            platform: process.platform,
+            version: "1.2.3",
+        })).toBeTrue();
+    });
+
+    test("returns false when the managed version command path is a directory", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skills-directory");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const executablePath = resolveSelfUpdateVersionExecutablePath(paths, "1.2.3");
+
+        trackDirectory(rootDirectory);
+        await mkdir(executablePath, { recursive: true });
+
+        expect(await isManagedVersionExecutableInstalled({
+            env,
+            platform: process.platform,
+            version: "1.2.3",
+        })).toBeFalse();
+    });
+
+    test("returns false for a non-executable managed version file on POSIX", async () => {
+        if (process.platform === "win32") {
+            return;
+        }
+
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skills-non-executable");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const executablePath = resolveSelfUpdateVersionExecutablePath(paths, "1.2.3");
+
+        trackDirectory(rootDirectory);
+        await mkdir(dirname(executablePath), { recursive: true });
+        await writeFile(executablePath, "binary", { mode: 0o644 });
+
+        expect(await isManagedVersionExecutableInstalled({
+            env,
+            platform: process.platform,
+            version: "1.2.3",
+        })).toBeFalse();
+    });
+});
+
+async function writeExecutable(path: string): Promise<void> {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, "binary");
+
+    if (process.platform !== "win32") {
+        await chmod(path, 0o755);
+    }
+}
+
+function createSelfUpdateEnv(rootDirectory: string): Record<string, string | undefined> {
+    return {
+        APPDATA: join(rootDirectory, "appdata"),
+        HOME: rootDirectory,
+        TEMP: join(rootDirectory, "temp"),
+        TMP: join(rootDirectory, "temp"),
+        TMPDIR: join(rootDirectory, "tmpdir"),
+        USERPROFILE: rootDirectory,
+        XDG_CACHE_HOME: join(rootDirectory, "cache"),
+        XDG_DATA_HOME: join(rootDirectory, "data"),
+        XDG_RUNTIME_DIR: join(rootDirectory, "runtime"),
+    };
+}

--- a/src/application/self-update/bundled-skills.ts
+++ b/src/application/self-update/bundled-skills.ts
@@ -1,4 +1,7 @@
 import type { SelfUpdateCommandRuntime } from "./command-runner.ts";
+import { constants } from "node:fs";
+import { access, stat } from "node:fs/promises";
+import { isPathAccessDeniedError, isPathMissingError } from "../shared/fs-errors.ts";
 import { pathExists } from "../shared/fs-utils.ts";
 import { runSelfUpdateCommandWithLogging } from "./command-runner.ts";
 import {
@@ -40,11 +43,32 @@ export async function isManagedVersionExecutableInstalled(options: {
         env: options.env,
         platform: options.platform,
     });
-
-    return await pathExists(resolveSelfUpdateVersionExecutablePath(
+    const executablePath = resolveSelfUpdateVersionExecutablePath(
         paths,
         options.version,
-    ));
+    );
+
+    try {
+        const metadata = await stat(executablePath);
+
+        if (!metadata.isFile()) {
+            return false;
+        }
+
+        if (options.platform === "win32") {
+            return true;
+        }
+
+        await access(executablePath, constants.X_OK);
+        return true;
+    }
+    catch (error) {
+        if (isPathMissingError(error) || isPathAccessDeniedError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
 }
 
 export async function attemptBundledSkillRefreshAfterSelfUpdate(options: {

--- a/src/application/self-update/bundled-skills.ts
+++ b/src/application/self-update/bundled-skills.ts
@@ -3,7 +3,7 @@ import { pathExists } from "../shared/fs-utils.ts";
 import { runSelfUpdateCommandWithLogging } from "./command-runner.ts";
 import {
     resolveSelfUpdatePaths,
-    resolveSelfUpdateVersionFilePath,
+    resolveSelfUpdateVersionExecutablePath,
 } from "./paths.ts";
 
 const selfUpdateBundledSkillRefreshCommandArguments = [
@@ -21,7 +21,7 @@ export async function resolveBundledSkillRefreshCommandPath(options: {
         env: options.env,
         platform: options.platform,
     });
-    const versionCommandPath = resolveSelfUpdateVersionFilePath(
+    const versionCommandPath = resolveSelfUpdateVersionExecutablePath(
         paths,
         options.version,
     );
@@ -29,6 +29,22 @@ export async function resolveBundledSkillRefreshCommandPath(options: {
     return await pathExists(versionCommandPath)
         ? versionCommandPath
         : paths.executablePath;
+}
+
+export async function isManagedVersionExecutableInstalled(options: {
+    env: Record<string, string | undefined>;
+    platform: NodeJS.Platform;
+    version: string;
+}): Promise<boolean> {
+    const paths = resolveSelfUpdatePaths({
+        env: options.env,
+        platform: options.platform,
+    });
+
+    return await pathExists(resolveSelfUpdateVersionExecutablePath(
+        paths,
+        options.version,
+    ));
 }
 
 export async function attemptBundledSkillRefreshAfterSelfUpdate(options: {

--- a/src/application/self-update/core.test.ts
+++ b/src/application/self-update/core.test.ts
@@ -1,7 +1,7 @@
 import type { SelfUpdateCommandRunOptions } from "../contracts/self-update.ts";
 import type { SelfUpdateProgressEvent } from "./progress.ts";
-import { rmSync, symlinkSync } from "node:fs";
-import { chmod, mkdir, readlink, realpath, writeFile } from "node:fs/promises";
+import { chmodSync, rmSync, symlinkSync } from "node:fs";
+import { chmod, mkdir, readlink, realpath, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import process from "node:process";
 import { describe, expect, test } from "bun:test";
@@ -21,7 +21,8 @@ import {
 import {
     resolveSelfUpdateLockFilePath,
     resolveSelfUpdatePaths,
-    resolveSelfUpdateVersionFilePath,
+    resolveSelfUpdateVersionDirectoryPath,
+    resolveSelfUpdateVersionExecutablePath,
 } from "./paths.ts";
 
 const { track: trackDirectory } = useTemporaryDirectoryCleanup();
@@ -46,7 +47,7 @@ describe("performSelfUpdateOperation", () => {
             env,
             platform: process.platform,
         });
-        const targetVersionPath = resolveSelfUpdateVersionFilePath(
+        const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
             paths,
             "1.2.3",
         );
@@ -99,6 +100,160 @@ describe("performSelfUpdateOperation", () => {
         }
     });
 
+    test("downloads a target version as an executable inside the version directory", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-self-update-version-directory");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const targetVersionDirectoryPath = resolveSelfUpdateVersionDirectoryPath(
+            paths,
+            "2.0.0",
+        );
+        const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
+            paths,
+            "2.0.0",
+        );
+        const logCapture = createLogCapture();
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await performSelfUpdateOperation({
+                currentVersion: "1.0.0",
+                forceReinstall: true,
+                runtime: {
+                    arch: process.arch,
+                    env,
+                    execPath: process.execPath,
+                    fetcher: async () => new Response("binary"),
+                    logger: logCapture.logger,
+                    platform: process.platform,
+                    processId: process.pid,
+                    runCommand: createSuccessfulSelfUpdateCommandRunner(),
+                },
+                targetVersion: "2.0.0",
+            });
+
+            expect(result.status).toBe("installed");
+            expect((await stat(targetVersionDirectoryPath)).isDirectory()).toBeTrue();
+            expect(await Bun.file(targetVersionPath).text()).toBe("binary");
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("replaces a legacy version file with a version directory during reinstall", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-self-update-legacy-version-file");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const legacyVersionPath = resolveSelfUpdateVersionDirectoryPath(
+            paths,
+            "2.0.0",
+        );
+        const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
+            paths,
+            "2.0.0",
+        );
+        const logCapture = createLogCapture();
+
+        trackDirectory(rootDirectory);
+        await mkdir(paths.versionsDirectory, { recursive: true });
+        await writeFile(legacyVersionPath, "legacy-binary");
+
+        try {
+            const result = await performSelfUpdateOperation({
+                currentVersion: "1.0.0",
+                forceReinstall: true,
+                runtime: {
+                    arch: process.arch,
+                    env,
+                    execPath: process.execPath,
+                    fetcher: async () => new Response("new-binary"),
+                    logger: logCapture.logger,
+                    platform: process.platform,
+                    processId: process.pid,
+                    runCommand: createSuccessfulSelfUpdateCommandRunner(),
+                },
+                targetVersion: "2.0.0",
+            });
+
+            expect(result.status).toBe("installed");
+            expect((await stat(legacyVersionPath)).isDirectory()).toBeTrue();
+            expect(await Bun.file(targetVersionPath).text()).toBe("new-binary");
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("restores a legacy version file when same-version activation fails", async () => {
+        if (process.platform === "win32") {
+            return;
+        }
+
+        const rootDirectory = await createTemporaryDirectory("oo-self-update-legacy-activation-fail");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const legacyVersionPath = resolveSelfUpdateVersionDirectoryPath(
+            paths,
+            "1.2.3",
+        );
+        const logCapture = createLogCapture();
+        let blockedActivationDirectory = false;
+
+        trackDirectory(rootDirectory);
+        await Promise.all([
+            mkdir(paths.executableDirectory, { recursive: true }),
+            mkdir(paths.versionsDirectory, { recursive: true }),
+        ]);
+        await writeFile(legacyVersionPath, "legacy-binary");
+        symlinkSync(legacyVersionPath, paths.executablePath);
+
+        try {
+            await expect(performSelfUpdateOperation({
+                currentVersion: "1.2.3",
+                forceReinstall: true,
+                reportStage: (event) => {
+                    if (event.stage !== "activate" || blockedActivationDirectory) {
+                        return;
+                    }
+
+                    blockedActivationDirectory = true;
+                    chmodSync(paths.executableDirectory, 0o555);
+                },
+                runtime: {
+                    arch: process.arch,
+                    env,
+                    execPath: paths.executablePath,
+                    fetcher: async () => new Response("new-binary"),
+                    logger: logCapture.logger,
+                    platform: process.platform,
+                    processId: process.pid,
+                    runCommand: createSuccessfulSelfUpdateCommandRunner(),
+                },
+                targetVersion: "1.2.3",
+            })).rejects.toThrow();
+
+            expect(blockedActivationDirectory).toBeTrue();
+            expect((await stat(legacyVersionPath)).isFile()).toBeTrue();
+            expect(await Bun.file(legacyVersionPath).text()).toBe("legacy-binary");
+            expect(await realpath(paths.executablePath)).toBe(await realpath(legacyVersionPath));
+        }
+        finally {
+            await chmod(paths.executableDirectory, 0o755).catch(() => undefined);
+            logCapture.close();
+        }
+    });
+
     test("keeps versions protected by active locks during cleanup", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-self-update-cleanup");
         const env = createSelfUpdateEnv(rootDirectory);
@@ -114,10 +269,10 @@ describe("performSelfUpdateOperation", () => {
             mkdir(paths.versionsDirectory, { recursive: true }),
         ]);
         await Promise.all([
-            writeManagedVersion(resolveSelfUpdateVersionFilePath(paths, "1.0.0")),
-            writeManagedVersion(resolveSelfUpdateVersionFilePath(paths, "2.0.0")),
-            writeManagedVersion(resolveSelfUpdateVersionFilePath(paths, "9.9.9")),
-            writeManagedVersion(resolveSelfUpdateVersionFilePath(paths, "0.5.0")),
+            writeManagedVersion(resolveSelfUpdateVersionExecutablePath(paths, "1.0.0")),
+            writeManagedVersion(resolveSelfUpdateVersionExecutablePath(paths, "2.0.0")),
+            writeManagedVersion(resolveSelfUpdateVersionExecutablePath(paths, "9.9.9")),
+            writeManagedVersion(resolveSelfUpdateVersionExecutablePath(paths, "0.5.0")),
             writeFile(
                 resolveSelfUpdateLockFilePath(paths, "9.9.9"),
                 `${JSON.stringify({
@@ -150,16 +305,16 @@ describe("performSelfUpdateOperation", () => {
 
             expect(result.status).toBe("installed");
             await expect(
-                Bun.file(resolveSelfUpdateVersionFilePath(paths, "1.0.0")).exists(),
+                Bun.file(resolveSelfUpdateVersionExecutablePath(paths, "1.0.0")).exists(),
             ).resolves.toBeTrue();
             await expect(
-                Bun.file(resolveSelfUpdateVersionFilePath(paths, "2.0.0")).exists(),
+                Bun.file(resolveSelfUpdateVersionExecutablePath(paths, "2.0.0")).exists(),
             ).resolves.toBeTrue();
             await expect(
-                Bun.file(resolveSelfUpdateVersionFilePath(paths, "9.9.9")).exists(),
+                Bun.file(resolveSelfUpdateVersionExecutablePath(paths, "9.9.9")).exists(),
             ).resolves.toBeTrue();
             await expect(
-                Bun.file(resolveSelfUpdateVersionFilePath(paths, "0.5.0")).exists(),
+                Bun.file(resolveSelfUpdateVersionExecutablePath(paths, "0.5.0")).exists(),
             ).resolves.toBeFalse();
         }
         finally {
@@ -178,9 +333,9 @@ describe("performSelfUpdateOperation", () => {
             env,
             platform: process.platform,
         });
-        const currentVersionPath = resolveSelfUpdateVersionFilePath(paths, "1.0.0");
-        const staleVersionPath = resolveSelfUpdateVersionFilePath(paths, "2.0.0");
-        const targetVersionPath = resolveSelfUpdateVersionFilePath(paths, "3.0.0");
+        const currentVersionPath = resolveSelfUpdateVersionExecutablePath(paths, "1.0.0");
+        const staleVersionPath = resolveSelfUpdateVersionExecutablePath(paths, "2.0.0");
+        const targetVersionPath = resolveSelfUpdateVersionExecutablePath(paths, "3.0.0");
         const siblingVersionPath = join(
             dirname(paths.versionsDirectory),
             `${basename(paths.versionsDirectory)}2.0.0`,
@@ -243,7 +398,7 @@ describe("performSelfUpdateOperation", () => {
             env,
             platform: process.platform,
         });
-        const targetVersionPath = resolveSelfUpdateVersionFilePath(
+        const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
             paths,
             "1.2.3",
         );
@@ -313,7 +468,7 @@ describe("performSelfUpdateOperation", () => {
             env,
             platform: process.platform,
         });
-        const targetVersionPath = resolveSelfUpdateVersionFilePath(
+        const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
             paths,
             "1.2.3",
         );
@@ -708,7 +863,7 @@ describe("performSelfUpdateOperation", () => {
             env,
             platform: process.platform,
         });
-        const targetVersionPath = resolveSelfUpdateVersionFilePath(
+        const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
             paths,
             "2.0.0",
         );
@@ -749,7 +904,7 @@ describe("performSelfUpdateOperation", () => {
             env,
             platform: process.platform,
         });
-        const targetVersionPath = resolveSelfUpdateVersionFilePath(
+        const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
             paths,
             "2.0.0",
         );

--- a/src/application/self-update/core.ts
+++ b/src/application/self-update/core.ts
@@ -9,7 +9,7 @@ import process from "node:process";
 import { APP_NAME } from "../config/app-config.ts";
 import { CliUserError } from "../contracts/cli.ts";
 import { isSemver } from "../semver.ts";
-import { isFileMissingError } from "../shared/fs-errors.ts";
+import { isFileMissingError, isPathMissingError } from "../shared/fs-errors.ts";
 import { pathExists, writeChunk } from "../shared/fs-utils.ts";
 import {
     buildCliBinaryDownloadUrl,
@@ -30,8 +30,10 @@ import {
     resolveSelfUpdatePaths,
     resolveSelfUpdateStagingBinaryPath,
     resolveSelfUpdateStagingDirectory,
-    resolveSelfUpdateVersionFilePath,
-    resolveSelfUpdateVersionTempFilePath,
+    resolveSelfUpdateVersionDirectoryPath,
+    resolveSelfUpdateVersionExecutablePath,
+    resolveSelfUpdateVersionTempDirectoryPath,
+    resolveSelfUpdateVersionTempExecutablePath,
 } from "./paths.ts";
 import { detectSelfUpdateReleasePlatform } from "./platform.ts";
 
@@ -71,6 +73,11 @@ export type SelfUpdateOperationOutcome
 
 export interface ProcessLifetimeVersionLockResource {
     close: () => Promise<void>;
+}
+
+interface TargetVersionMaterialization {
+    backupPath?: string;
+    targetVersionDirectoryPath: string;
 }
 
 export async function resolveLatestSelfUpdateVersion(options: {
@@ -137,7 +144,7 @@ export async function performSelfUpdateOperation(options: {
     }
 
     try {
-        await materializeTargetVersion({
+        const materialization = await materializeTargetVersion({
             currentVersion: options.currentVersion,
             forceReinstall: options.forceReinstall,
             paths,
@@ -150,13 +157,20 @@ export async function performSelfUpdateOperation(options: {
             stage: "activate",
             version: options.targetVersion,
         });
-        await activateTargetVersion({
-            paths,
-            platform: options.runtime.platform,
-            processId: options.runtime.processId,
-            targetVersion: options.targetVersion,
-            timestamp: (options.runtime.now ?? Date.now)(),
-        });
+        try {
+            await activateTargetVersion({
+                paths,
+                platform: options.runtime.platform,
+                processId: options.runtime.processId,
+                targetVersion: options.targetVersion,
+                timestamp: (options.runtime.now ?? Date.now)(),
+            });
+        }
+        catch (error) {
+            await rollbackTargetVersionMaterialization(materialization);
+            throw error;
+        }
+        await commitTargetVersionMaterialization(materialization);
 
         await verifyInstalledEntrypoint({
             paths,
@@ -177,7 +191,7 @@ export async function performSelfUpdateOperation(options: {
             targetVersion: options.targetVersion,
         });
         await attemptBundledSkillRefreshAfterSelfUpdate({
-            commandPath: resolveSelfUpdateVersionFilePath(
+            commandPath: resolveSelfUpdateVersionExecutablePath(
                 paths,
                 options.targetVersion,
             ),
@@ -236,7 +250,11 @@ export async function initializeCurrentVersionProcessLock(options: {
         env: options.runtime.env,
         platform: options.runtime.platform,
     });
-    const currentVersionPath = resolveSelfUpdateVersionFilePath(
+    const currentVersionPath = resolveSelfUpdateVersionExecutablePath(
+        paths,
+        options.currentVersion,
+    );
+    const legacyCurrentVersionPath = resolveSelfUpdateVersionDirectoryPath(
         paths,
         options.currentVersion,
     );
@@ -245,7 +263,10 @@ export async function initializeCurrentVersionProcessLock(options: {
         await cleanupWindowsExecutableBackups(paths, options.runtime.logger);
     }
 
-    if (!(await pathExists(currentVersionPath))) {
+    if (
+        !(await pathExists(currentVersionPath))
+        && !(await pathExists(legacyCurrentVersionPath))
+    ) {
         return undefined;
     }
 
@@ -345,21 +366,27 @@ async function materializeTargetVersion(options: {
     reportStage?: (event: SelfUpdateProgressEvent) => void;
     runtime: SelfUpdateRuntime;
     targetVersion: string;
-}): Promise<void> {
-    const targetVersionPath = resolveSelfUpdateVersionFilePath(
+}): Promise<TargetVersionMaterialization> {
+    const targetVersionDirectoryPath = resolveSelfUpdateVersionDirectoryPath(
+        options.paths,
+        options.targetVersion,
+    );
+    const targetVersionExecutablePath = resolveSelfUpdateVersionExecutablePath(
         options.paths,
         options.targetVersion,
     );
 
     if (
         !options.forceReinstall
-        && await pathExists(targetVersionPath)
+        && await pathExists(targetVersionExecutablePath)
     ) {
         options.reportStage?.({
             stage: "reuse",
             version: options.targetVersion,
         });
-        return;
+        return {
+            targetVersionDirectoryPath,
+        };
     }
 
     const timestamp = (options.runtime.now ?? Date.now)();
@@ -374,7 +401,13 @@ async function materializeTargetVersion(options: {
         stagingBinaryPath,
         options.runtime.platform,
     );
-    const versionTempPath = resolveSelfUpdateVersionTempFilePath({
+    const versionTempDirectoryPath = resolveSelfUpdateVersionTempDirectoryPath({
+        paths: options.paths,
+        processId: options.runtime.processId,
+        timestamp,
+        version: options.targetVersion,
+    });
+    const versionTempExecutablePath = resolveSelfUpdateVersionTempExecutablePath({
         paths: options.paths,
         processId: options.runtime.processId,
         timestamp,
@@ -390,6 +423,7 @@ async function materializeTargetVersion(options: {
         version: options.targetVersion,
     });
     await mkdir(stagingDirectory, { recursive: true });
+    await mkdir(versionTempDirectoryPath, { recursive: true });
 
     try {
         await fetchBinaryResponse({
@@ -410,23 +444,22 @@ async function materializeTargetVersion(options: {
             await chmod(stagingBinaryPath, 0o755);
         }
 
-        await copyFile(stagingBinaryPath, versionTempPath);
+        await copyFile(stagingBinaryPath, versionTempExecutablePath);
 
         if (options.runtime.platform !== "win32") {
-            await chmod(versionTempPath, 0o755);
+            await chmod(versionTempExecutablePath, 0o755);
         }
 
-        await replaceTargetVersionFile({
-            platform: options.runtime.platform,
+        return await replaceTargetVersionDirectory({
             processId: options.runtime.processId,
-            targetVersionPath,
-            temporaryVersionPath: versionTempPath,
+            targetVersionDirectoryPath,
+            temporaryVersionDirectoryPath: versionTempDirectoryPath,
             timestamp,
         });
     }
     finally {
         await removePathBestEffort(stagingDirectory);
-        await removePathBestEffort(versionTempPath);
+        await removePathBestEffort(versionTempDirectoryPath);
     }
 }
 
@@ -636,44 +669,69 @@ async function writeBinaryResponseToFile(options: {
     }
 }
 
-async function replaceTargetVersionFile(options: {
-    platform: NodeJS.Platform;
+async function replaceTargetVersionDirectory(options: {
     processId: number;
-    targetVersionPath: string;
-    temporaryVersionPath: string;
+    targetVersionDirectoryPath: string;
+    temporaryVersionDirectoryPath: string;
     timestamp: number;
-}): Promise<void> {
-    if (options.platform !== "win32") {
-        await rename(options.temporaryVersionPath, options.targetVersionPath);
-        return;
-    }
-
+}): Promise<TargetVersionMaterialization> {
     const backupPath
-        = `${options.targetVersionPath}.old.${options.processId}.${options.timestamp}`;
-
-    try {
-        await rename(options.temporaryVersionPath, options.targetVersionPath);
-        return;
-    }
-    catch {}
-
+        = `${options.targetVersionDirectoryPath}.old.${options.processId}.${options.timestamp}`;
     let backupCreated = false;
 
     try {
-        await rename(options.targetVersionPath, backupPath);
+        await rename(options.targetVersionDirectoryPath, backupPath);
         backupCreated = true;
-        await rename(options.temporaryVersionPath, options.targetVersionPath);
+    }
+    catch (error) {
+        if (!isFileMissingError(error)) {
+            throw error;
+        }
+    }
+
+    try {
+        await rename(
+            options.temporaryVersionDirectoryPath,
+            options.targetVersionDirectoryPath,
+        );
+        return {
+            backupPath: backupCreated ? backupPath : undefined,
+            targetVersionDirectoryPath: options.targetVersionDirectoryPath,
+        };
     }
     catch (error) {
         if (backupCreated) {
-            await rename(backupPath, options.targetVersionPath).catch(() => {});
+            await rename(
+                backupPath,
+                options.targetVersionDirectoryPath,
+            ).catch(() => {});
         }
         throw error;
     }
+}
 
-    if (backupCreated) {
-        await removePathBestEffort(backupPath);
+async function rollbackTargetVersionMaterialization(
+    materialization: TargetVersionMaterialization,
+): Promise<void> {
+    if (materialization.backupPath === undefined) {
+        return;
     }
+
+    await removePathBestEffort(materialization.targetVersionDirectoryPath);
+    await rename(
+        materialization.backupPath,
+        materialization.targetVersionDirectoryPath,
+    ).catch(() => {});
+}
+
+async function commitTargetVersionMaterialization(
+    materialization: TargetVersionMaterialization,
+): Promise<void> {
+    if (materialization.backupPath === undefined) {
+        return;
+    }
+
+    await removePathBestEffort(materialization.backupPath);
 }
 
 async function activateTargetVersion(options: {
@@ -697,7 +755,7 @@ async function activateUnixEntrypoint(options: {
     targetVersion: string;
     timestamp: number;
 }): Promise<void> {
-    const targetVersionPath = resolveSelfUpdateVersionFilePath(
+    const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
         options.paths,
         options.targetVersion,
     );
@@ -723,7 +781,7 @@ async function activateWindowsEntrypoint(options: {
     targetVersion: string;
     timestamp: number;
 }): Promise<void> {
-    const targetVersionPath = resolveSelfUpdateVersionFilePath(
+    const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
         options.paths,
         options.targetVersion,
     );
@@ -767,7 +825,7 @@ async function verifyInstalledEntrypoint(options: {
     reportStage?: (event: SelfUpdateProgressEvent) => void;
     targetVersion: string;
 }): Promise<void> {
-    const targetVersionPath = resolveSelfUpdateVersionFilePath(
+    const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
         options.paths,
         options.targetVersion,
     );
@@ -783,7 +841,7 @@ async function verifyInstalledEntrypoint(options: {
             executableMetadata = await lstat(options.paths.executablePath);
         }
         catch (error) {
-            if (isFileMissingError(error)) {
+            if (isPathMissingError(error)) {
                 throw new CliUserError("errors.selfUpdate.verifyEntrypointMissing", 1, {
                     path: options.paths.executablePath,
                 });
@@ -805,7 +863,7 @@ async function verifyInstalledEntrypoint(options: {
                     : join(dirname(options.paths.executablePath), linkedTarget),
             ),
             realpath(targetVersionPath).catch((error) => {
-                if (isFileMissingError(error)) {
+                if (isPathMissingError(error)) {
                     throw new CliUserError("errors.selfUpdate.verifyTargetMissing", 1, {
                         path: targetVersionPath,
                     });
@@ -825,7 +883,7 @@ async function verifyInstalledEntrypoint(options: {
             await stat(options.paths.executablePath);
         }
         catch (error) {
-            if (isFileMissingError(error)) {
+            if (isPathMissingError(error)) {
                 throw new CliUserError("errors.selfUpdate.verifyEntrypointMissing", 1, {
                     path: options.paths.executablePath,
                 });
@@ -935,7 +993,9 @@ async function readActivatedVersion(
         return undefined;
     }
 
-    return activatedVersionPath;
+    const [activatedVersion] = activatedVersionPath.split(sep);
+
+    return activatedVersion === "" ? undefined : activatedVersion;
 }
 
 async function cleanupStagingDirectory(

--- a/src/application/self-update/installation.test.ts
+++ b/src/application/self-update/installation.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { detectInstallationMethodFromExecPath } from "./installation.ts";
 import {
     resolveSelfUpdatePaths,
-    resolveSelfUpdateVersionFilePath,
+    resolveSelfUpdateVersionDirectoryPath,
+    resolveSelfUpdateVersionExecutablePath,
 } from "./paths.ts";
 
 describe("detectInstallationMethodFromExecPath", () => {
@@ -26,7 +27,7 @@ describe("detectInstallationMethodFromExecPath", () => {
         });
     });
 
-    test("returns explicit native for a managed version file path", () => {
+    test("returns explicit native for a managed version executable path", () => {
         const env = {
             HOME: "/tmp/home",
         };
@@ -37,7 +38,27 @@ describe("detectInstallationMethodFromExecPath", () => {
 
         expect(detectInstallationMethodFromExecPath({
             env,
-            execPath: resolveSelfUpdateVersionFilePath(paths, "1.2.3"),
+            execPath: resolveSelfUpdateVersionExecutablePath(paths, "1.2.3"),
+            platform: "linux",
+        })).toEqual({
+            confidence: "explicit",
+            method: "native",
+            source: "managedPath",
+        });
+    });
+
+    test("returns explicit native for a legacy managed version file path", () => {
+        const env = {
+            HOME: "/tmp/home",
+        };
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: "linux",
+        });
+
+        expect(detectInstallationMethodFromExecPath({
+            env,
+            execPath: resolveSelfUpdateVersionDirectoryPath(paths, "1.2.3"),
             platform: "linux",
         })).toEqual({
             confidence: "explicit",

--- a/src/application/self-update/paths.test.ts
+++ b/src/application/self-update/paths.test.ts
@@ -5,7 +5,10 @@ import {
     resolveSelfUpdatePaths,
     resolveSelfUpdateStagingBinaryPath,
     resolveSelfUpdateStagingDirectory,
-    resolveSelfUpdateVersionFilePath,
+    resolveSelfUpdateVersionDirectoryPath,
+    resolveSelfUpdateVersionExecutablePath,
+    resolveSelfUpdateVersionTempDirectoryPath,
+    resolveSelfUpdateVersionTempExecutablePath,
 } from "./paths.ts";
 
 describe("resolveSelfUpdatePaths", () => {
@@ -80,7 +83,7 @@ describe("resolveSelfUpdatePaths", () => {
         });
     });
 
-    test("builds lock, version, and staging paths", () => {
+    test("builds lock, version, version executable, and staging paths", () => {
         const paths = resolveSelfUpdatePaths({
             env: {
                 HOME: "/tmp/home",
@@ -91,8 +94,27 @@ describe("resolveSelfUpdatePaths", () => {
         expect(resolveSelfUpdateLockFilePath(paths, "1.2.3")).toBe(
             posix.join(paths.locksDirectory, "1.2.3.lock"),
         );
-        expect(resolveSelfUpdateVersionFilePath(paths, "1.2.3")).toBe(
+        expect(resolveSelfUpdateVersionDirectoryPath(paths, "1.2.3")).toBe(
             posix.join(paths.versionsDirectory, "1.2.3"),
+        );
+        expect(resolveSelfUpdateVersionExecutablePath(paths, "1.2.3")).toBe(
+            posix.join(paths.versionsDirectory, "1.2.3", "oo"),
+        );
+        expect(resolveSelfUpdateVersionTempDirectoryPath({
+            paths,
+            processId: 123,
+            timestamp: 456,
+            version: "1.2.3",
+        })).toBe(
+            posix.join(paths.versionsDirectory, "1.2.3.tmp.123.456"),
+        );
+        expect(resolveSelfUpdateVersionTempExecutablePath({
+            paths,
+            processId: 123,
+            timestamp: 456,
+            version: "1.2.3",
+        })).toBe(
+            posix.join(paths.versionsDirectory, "1.2.3.tmp.123.456", "oo"),
         );
         expect(resolveSelfUpdateStagingBinaryPath({
             paths,
@@ -126,8 +148,27 @@ describe("resolveSelfUpdatePaths", () => {
         expect(resolveSelfUpdateLockFilePath(paths, "1.2.3")).toBe(
             win32.join(paths.locksDirectory, "1.2.3.lock"),
         );
-        expect(resolveSelfUpdateVersionFilePath(paths, "1.2.3")).toBe(
+        expect(resolveSelfUpdateVersionDirectoryPath(paths, "1.2.3")).toBe(
             win32.join(paths.versionsDirectory, "1.2.3"),
+        );
+        expect(resolveSelfUpdateVersionExecutablePath(paths, "1.2.3")).toBe(
+            win32.join(paths.versionsDirectory, "1.2.3", "oo.exe"),
+        );
+        expect(resolveSelfUpdateVersionTempDirectoryPath({
+            paths,
+            processId: 123,
+            timestamp: 456,
+            version: "1.2.3",
+        })).toBe(
+            win32.join(paths.versionsDirectory, "1.2.3.tmp.123.456"),
+        );
+        expect(resolveSelfUpdateVersionTempExecutablePath({
+            paths,
+            processId: 123,
+            timestamp: 456,
+            version: "1.2.3",
+        })).toBe(
+            win32.join(paths.versionsDirectory, "1.2.3.tmp.123.456", "oo.exe"),
         );
         expect(stagingBinaryPath).toBe(
             win32.join(paths.stagingDirectory, "1.2.3.tmp.123.456", "oo.exe"),

--- a/src/application/self-update/paths.ts
+++ b/src/application/self-update/paths.ts
@@ -21,7 +21,7 @@ export function resolveSelfUpdatePaths(options: {
     const executableDirectory = pathModule.join(homeDirectory, ".local", "bin");
     const executablePath = pathModule.join(
         executableDirectory,
-        options.platform === "win32" ? "oo.exe" : "oo",
+        resolveSelfUpdateExecutableFileName(options.platform),
     );
 
     switch (options.platform) {
@@ -99,7 +99,7 @@ export function resolveSelfUpdateLockFilePath(
     );
 }
 
-export function resolveSelfUpdateVersionFilePath(
+export function resolveSelfUpdateVersionDirectoryPath(
     paths: Pick<SelfUpdatePaths, "platform" | "versionsDirectory">,
     version: string,
 ): string {
@@ -109,7 +109,17 @@ export function resolveSelfUpdateVersionFilePath(
     );
 }
 
-export function resolveSelfUpdateVersionTempFilePath(options: {
+export function resolveSelfUpdateVersionExecutablePath(
+    paths: Pick<SelfUpdatePaths, "platform" | "versionsDirectory">,
+    version: string,
+): string {
+    return readPathModule(paths.platform).join(
+        resolveSelfUpdateVersionDirectoryPath(paths, version),
+        resolveSelfUpdateExecutableFileName(paths.platform),
+    );
+}
+
+export function resolveSelfUpdateVersionTempDirectoryPath(options: {
     paths: Pick<SelfUpdatePaths, "platform" | "versionsDirectory">;
     processId: number;
     timestamp: number;
@@ -118,6 +128,18 @@ export function resolveSelfUpdateVersionTempFilePath(options: {
     return readPathModule(options.paths.platform).join(
         options.paths.versionsDirectory,
         `${options.version}.tmp.${options.processId}.${options.timestamp}`,
+    );
+}
+
+export function resolveSelfUpdateVersionTempExecutablePath(options: {
+    paths: Pick<SelfUpdatePaths, "platform" | "versionsDirectory">;
+    processId: number;
+    timestamp: number;
+    version: string;
+}): string {
+    return readPathModule(options.paths.platform).join(
+        resolveSelfUpdateVersionTempDirectoryPath(options),
+        resolveSelfUpdateExecutableFileName(options.paths.platform),
     );
 }
 
@@ -131,7 +153,7 @@ export function resolveSelfUpdateStagingBinaryPath(options: {
     return readPathModule(options.paths.platform).join(
         options.paths.stagingDirectory,
         `${options.version}.tmp.${options.processId}.${options.timestamp}`,
-        options.platform === "win32" ? "oo.exe" : "oo",
+        resolveSelfUpdateExecutableFileName(options.platform),
     );
 }
 
@@ -156,4 +178,10 @@ export function readPathModule(
     platform: NodeJS.Platform,
 ): typeof posix | typeof win32 {
     return platform === "win32" ? win32 : posix;
+}
+
+export function resolveSelfUpdateExecutableFileName(
+    platform: NodeJS.Platform,
+): string {
+    return platform === "win32" ? "oo.exe" : "oo";
 }

--- a/src/application/shared/fs-errors.ts
+++ b/src/application/shared/fs-errors.ts
@@ -8,6 +8,10 @@ export function isFileMissingError(error: unknown): error is NodeJS.ErrnoExcepti
     return hasErrorCode(error, "ENOENT");
 }
 
+export function isPathMissingError(error: unknown): error is NodeJS.ErrnoException {
+    return isFileMissingError(error) || hasErrorCode(error, "ENOTDIR");
+}
+
 export function isFileAlreadyExistsError(error: unknown): error is NodeJS.ErrnoException {
     return hasErrorCode(error, "EEXIST");
 }

--- a/src/application/shared/fs-errors.ts
+++ b/src/application/shared/fs-errors.ts
@@ -12,6 +12,10 @@ export function isPathMissingError(error: unknown): error is NodeJS.ErrnoExcepti
     return isFileMissingError(error) || hasErrorCode(error, "ENOTDIR");
 }
 
+export function isPathAccessDeniedError(error: unknown): error is NodeJS.ErrnoException {
+    return hasErrorCode(error, "EACCES") || hasErrorCode(error, "EPERM");
+}
+
 export function isFileAlreadyExistsError(error: unknown): error is NodeJS.ErrnoException {
     return hasErrorCode(error, "EEXIST");
 }

--- a/src/application/shared/fs-utils.test.ts
+++ b/src/application/shared/fs-utils.test.ts
@@ -1,9 +1,20 @@
 import type { FileHandle } from "node:fs/promises";
 
 import { describe, expect, test } from "bun:test";
-import { writeChunk } from "./fs-utils.ts";
+import { pathExists, writeChunk } from "./fs-utils.ts";
 
 describe("fs utils", () => {
+    test("pathExists treats a file in the middle of the path as missing", async () => {
+        const metadataReader = async () => {
+            const error = new Error("not a directory") as NodeJS.ErrnoException;
+
+            error.code = "ENOTDIR";
+            throw error;
+        };
+
+        expect(await pathExists("/tmp/version/oo", metadataReader)).toBeFalse();
+    });
+
     test("writeChunk retries partial writes until the chunk is complete", async () => {
         const writtenSegments: number[][] = [];
         const fileHandle = createFileHandleWriteStub((buffer) => {

--- a/src/application/shared/fs-utils.ts
+++ b/src/application/shared/fs-utils.ts
@@ -2,7 +2,7 @@ import type { PathLike } from "node:fs";
 import type { FileHandle } from "node:fs/promises";
 
 import { stat } from "node:fs/promises";
-import { isFileMissingError } from "./fs-errors.ts";
+import { isPathMissingError } from "./fs-errors.ts";
 
 export async function pathExists(
     path: PathLike,
@@ -13,7 +13,7 @@ export async function pathExists(
         return true;
     }
     catch (error) {
-        if (isFileMissingError(error)) {
+        if (isPathMissingError(error)) {
             return false;
         }
 


### PR DESCRIPTION
Each managed version was stored as a single executable file at versions/<version>. This change moves the executable into a per-version directory at versions/<version>/oo (or oo.exe on Windows), so the version slot can hold additional files later and so activation can be rolled back atomically by renaming the whole directory aside before swapping in the new one.

Same-version repairs now detect and replace legacy version-file installs in place, and `oo update` only triggers the bundled skill refresh when the managed executable is present so legacy or broken slots no longer trigger spurious command invocations.