### PR TITLE
fix(self-update): always configure zsh startup profiles

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -132,10 +132,13 @@ Install one managed `oo` release into the local self-managed runtime.
   `@oomol-lab/oo-cli` package-manager installs that appear anywhere on `PATH`;
   when `PATH` yields no `oo` candidates, the CLI falls back to the current
   command path. Cleanup failures do not change the command result.
-- Notes: when the executable directory is not on `PATH`, install attempts to
-  persist it for future shells. When automatic PATH configuration succeeds,
-  install tells the user to restart their shell; when it fails, install prints
-  a setup note that tells the user which directory to add.
+- Notes: when automatic PATH modification is enabled, install ensures zsh
+  startup profiles `.zprofile` and `.zshenv` contain the managed PATH snippet,
+  even if the current `PATH` already contains the executable directory. When the
+  executable directory is not on `PATH`, install also attempts to persist it for
+  future shells. When automatic PATH configuration succeeds, install tells the
+  user to restart their shell; when it fails, install prints a setup note that
+  tells the user which directory to add.
 - Notes: when some shell profiles were updated and others could not be,
   install lists both — the profiles that were updated and the profiles that
   could not be updated — followed by the restart-shell note. The user can
@@ -172,10 +175,13 @@ Update the managed `oo` install to the latest published release.
   `@oomol-lab/oo-cli` package-manager installs that appear anywhere on `PATH`;
   when `PATH` yields no `oo` candidates, the CLI falls back to the current
   command path. Cleanup failures do not change the command result.
-- Notes: when the executable directory is not on `PATH`, update attempts to
-  persist it for future shells. When automatic PATH configuration succeeds,
-  update tells the user to restart their shell; when it fails, update prints a
-  setup note that tells the user which directory to add.
+- Notes: when automatic PATH modification is enabled, update ensures zsh
+  startup profiles `.zprofile` and `.zshenv` contain the managed PATH snippet,
+  even if the current `PATH` already contains the executable directory. When the
+  executable directory is not on `PATH`, update also attempts to persist it for
+  future shells. When automatic PATH configuration succeeds, update tells the
+  user to restart their shell; when it fails, update prints a setup note that
+  tells the user which directory to add.
 - Notes: when some shell profiles were updated and others could not be,
   update lists both — the profiles that were updated and the profiles that
   could not be updated — followed by the restart-shell note. The user can

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -117,8 +117,10 @@
 - 说明：install 成功后，CLI 会尽力移除在 `PATH` 中任意位置出现的旧全局
   package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到 `oo`
   候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
-- 说明：如果可执行目录没有出现在 `PATH` 中，install 会尝试为后续 shell
-  持久化 PATH 配置；如果自动配置成功，install 会提示用户重启 shell；如果自动配置失败，
+- 说明：当自动 PATH 修改启用时，install 会确保 zsh startup profile
+  `.zprofile` 和 `.zshenv` 包含托管 PATH 片段，即使当前 `PATH` 已经包含可执行目录。
+  如果可执行目录没有出现在 `PATH` 中，install 还会尝试为后续 shell 持久化 PATH
+  配置；如果自动配置成功，install 会提示用户重启 shell；如果自动配置失败，
   install 会打印 setup note，告知用户应当把哪个目录加入 `PATH`。
 - 说明：当部分 shell profile 配置成功、另一部分失败时，install 会分别列出两组
   ——已配置的 profile 和未能配置的 profile，并附带重启 shell 的提示；用户可据此
@@ -149,8 +151,10 @@
 - 说明：update 成功后，CLI 会尽力移除在 `PATH` 中任意位置出现的旧全局
   package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到 `oo`
   候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
-- 说明：如果可执行目录没有出现在 `PATH` 中，update 会尝试为后续 shell
-  持久化 PATH 配置；如果自动配置成功，update 会提示用户重启 shell；如果自动配置失败，
+- 说明：当自动 PATH 修改启用时，update 会确保 zsh startup profile
+  `.zprofile` 和 `.zshenv` 包含托管 PATH 片段，即使当前 `PATH` 已经包含可执行目录。
+  如果可执行目录没有出现在 `PATH` 中，update 还会尝试为后续 shell 持久化 PATH
+  配置；如果自动配置成功，update 会提示用户重启 shell；如果自动配置失败，
   update 会打印 setup note，告知用户应当把哪个目录加入 `PATH`。
 - 说明：当部分 shell profile 配置成功、另一部分失败时，update 会分别列出两组
   ——已配置的 profile 和未能配置的 profile，并附带重启 shell 的提示；用户可据此

--- a/src/application/self-update/path-configuration.test.ts
+++ b/src/application/self-update/path-configuration.test.ts
@@ -21,6 +21,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
         const homeDirectory = toPortablePath(rootDirectory);
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");
         const zshrcPath = posix.join(homeDirectory, ".zshrc");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
         const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
@@ -47,19 +48,13 @@ describe("ensureExecutableDirectoryOnPath", () => {
 
             expect(result).toEqual({
                 status: "configured",
-                target: [zshrcPath, zshenvPath],
+                target: [zshrcPath, zshenvPath, zprofilePath],
             });
-            const expectedSnippet = [
-                "# Added by oo CLI",
-                "case \":$PATH:\" in",
-                "    *\":$HOME/.local/bin:\"*) ;;",
-                "    *) export PATH=\"$HOME/.local/bin:$PATH\" ;;",
-                "esac",
-                "",
-            ].join("\n");
+            const expectedSnippet = createExpectedPosixPathSnippet();
 
             expect(await readFile(zshrcPath, "utf8")).toBe(expectedSnippet);
             expect(await readFile(zshenvPath, "utf8")).toBe(expectedSnippet);
+            expect(await readFile(zprofilePath, "utf8")).toBe(expectedSnippet);
         }
         finally {
             logCapture.close();
@@ -108,11 +103,104 @@ describe("ensureExecutableDirectoryOnPath", () => {
         }
     });
 
+    test("writes zsh startup profiles when the executable directory is already on PATH", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-darwin-zsh-on-path");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: `/usr/bin:${executableDirectory}`,
+            SHELL: "/bin/bash",
+        };
+
+        trackDirectory(rootDirectory);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "darwin",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "darwin",
+                    resolveCommandPath: () => null,
+                },
+            });
+
+            expect(result).toEqual({
+                status: "configured",
+                target: [zprofilePath, zshenvPath],
+            });
+            expect(await readFile(zprofilePath, "utf8")).toBe(
+                createExpectedPosixPathSnippet(),
+            );
+            expect(await readFile(zshenvPath, "utf8")).toBe(
+                createExpectedPosixPathSnippet(),
+            );
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("does not rewrite marked zsh startup profiles when the executable directory is already on PATH", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-darwin-zsh-marked");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: `/usr/bin:${executableDirectory}`,
+            SHELL: "/bin/bash",
+        };
+        const expectedSnippet = createExpectedPosixPathSnippet();
+
+        trackDirectory(rootDirectory);
+        await Bun.write(zprofilePath, expectedSnippet);
+        await Bun.write(zshenvPath, expectedSnippet);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "darwin",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "darwin",
+                    resolveCommandPath: () => null,
+                },
+            });
+
+            expect(result).toEqual({
+                status: "already-configured",
+            });
+            expect(countOccurrences(
+                await readFile(zprofilePath, "utf8"),
+                "# Added by oo CLI",
+            )).toBe(1);
+            expect(countOccurrences(
+                await readFile(zshenvPath, "utf8"),
+                "# Added by oo CLI",
+            )).toBe(1);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
     test("separates PATH setup from existing shell profile content with a blank line", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-path-existing-content");
         const homeDirectory = toPortablePath(rootDirectory);
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");
         const zshrcPath = posix.join(homeDirectory, ".zshrc");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
         const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
@@ -138,9 +226,12 @@ describe("ensureExecutableDirectoryOnPath", () => {
                 },
             });
 
-            expect(result.target).toEqual([zshrcPath, zshenvPath]);
+            expect(result.target).toEqual([zshrcPath, zshenvPath, zprofilePath]);
             expect(await readFile(zshrcPath, "utf8")).toContain(
                 "# existing zshrc\n\n# Added by oo CLI\n",
+            );
+            expect(await readFile(zprofilePath, "utf8")).toStartWith(
+                "# Added by oo CLI\n",
             );
             expect(await readFile(zshenvPath, "utf8")).toStartWith(
                 "# Added by oo CLI\n",
@@ -157,6 +248,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
         const configHomeDirectory = posix.join(homeDirectory, "xdg");
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");
         const zshProfilePath = posix.join(homeDirectory, ".zshrc");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
         const bashProfilePath = posix.join(homeDirectory, ".bashrc");
         const fishProfilePath = posix.join(configHomeDirectory, "fish", "conf.d", "oo.fish");
         const logCapture = createLogCapture();
@@ -196,9 +288,11 @@ describe("ensureExecutableDirectoryOnPath", () => {
                     bashProfilePath,
                     profilePath,
                     fishProfilePath,
+                    zprofilePath,
                 ],
             });
             await expect(Bun.file(zshProfilePath).exists()).resolves.toBeTrue();
+            await expect(Bun.file(zprofilePath).exists()).resolves.toBeTrue();
             await expect(Bun.file(zshenvPath).exists()).resolves.toBeTrue();
             await expect(Bun.file(bashProfilePath).exists()).resolves.toBeTrue();
             await expect(Bun.file(profilePath).exists()).resolves.toBeTrue();
@@ -215,6 +309,8 @@ describe("ensureExecutableDirectoryOnPath", () => {
         const configHomeDirectory = posix.join(homeDirectory, "xdg");
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");
         const profilePath = posix.join(configHomeDirectory, "fish", "conf.d", "oo.fish");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
             HOME: homeDirectory,
@@ -255,7 +351,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
             expect(firstResult.status).toBe("configured");
             expect(secondResult).toEqual({
                 status: "already-configured",
-                target: [profilePath],
+                target: [zshenvPath, profilePath, zprofilePath],
             });
             expect(countOccurrences(
                 profileContent,
@@ -273,6 +369,8 @@ describe("ensureExecutableDirectoryOnPath", () => {
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");
         const bashLoginPath = posix.join(homeDirectory, ".bash_login");
         const bashrcPath = posix.join(homeDirectory, ".bashrc");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
             HOME: homeDirectory,
@@ -297,7 +395,12 @@ describe("ensureExecutableDirectoryOnPath", () => {
                 },
             });
 
-            expect(result.target).toEqual([bashLoginPath, bashrcPath]);
+            expect(result.target).toEqual([
+                bashLoginPath,
+                bashrcPath,
+                zprofilePath,
+                zshenvPath,
+            ]);
             expect(await readFile(bashLoginPath, "utf8")).toContain(
                 "# existing bash login profile\n\n# Added by oo CLI\n",
             );
@@ -316,6 +419,8 @@ describe("ensureExecutableDirectoryOnPath", () => {
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");
         const bashrcPath = posix.join(homeDirectory, ".bashrc");
         const profilePath = posix.join(homeDirectory, ".profile");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
             HOME: homeDirectory,
@@ -340,7 +445,12 @@ describe("ensureExecutableDirectoryOnPath", () => {
                 },
             });
 
-            expect(result.target).toEqual([bashrcPath, profilePath]);
+            expect(result.target).toEqual([
+                bashrcPath,
+                profilePath,
+                zprofilePath,
+                zshenvPath,
+            ]);
             expect(await readFile(bashrcPath, "utf8")).toContain(
                 "# existing bashrc\n\n# Added by oo CLI\n",
             );
@@ -360,6 +470,8 @@ describe("ensureExecutableDirectoryOnPath", () => {
         const bashrcPath = posix.join(homeDirectory, ".bashrc");
         const profilePath = posix.join(homeDirectory, ".profile");
         const bashProfilePath = posix.join(homeDirectory, ".bash_profile");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
             HOME: homeDirectory,
@@ -386,7 +498,12 @@ describe("ensureExecutableDirectoryOnPath", () => {
             });
 
             expect(result.status).toBe("configured");
-            expect(result.target).toEqual([bashrcPath, profilePath]);
+            expect(result.target).toEqual([
+                bashrcPath,
+                profilePath,
+                zprofilePath,
+                zshenvPath,
+            ]);
             expect(await readFile(bashrcPath, "utf8")).toContain(
                 "# existing bashrc\n\n# Added by oo CLI\n",
             );
@@ -407,6 +524,8 @@ describe("ensureExecutableDirectoryOnPath", () => {
         const bashrcPath = posix.join(homeDirectory, ".bashrc");
         const bashProfilePath = posix.join(homeDirectory, ".bash_profile");
         const profilePath = posix.join(homeDirectory, ".profile");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
             HOME: homeDirectory,
@@ -432,7 +551,12 @@ describe("ensureExecutableDirectoryOnPath", () => {
 
             // .bashrc covers interactive non-login; .profile covers SSH/login
             // bash when .bash_profile and .bash_login are absent.
-            expect(result.target).toEqual([bashrcPath, profilePath]);
+            expect(result.target).toEqual([
+                bashrcPath,
+                profilePath,
+                zprofilePath,
+                zshenvPath,
+            ]);
             await expect(Bun.file(bashrcPath).exists()).resolves.toBeTrue();
             await expect(Bun.file(profilePath).exists()).resolves.toBeTrue();
             await expect(Bun.file(bashProfilePath).exists()).resolves.toBeFalse();
@@ -448,6 +572,8 @@ describe("ensureExecutableDirectoryOnPath", () => {
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");
         const bashrcPath = posix.join(homeDirectory, ".bashrc");
         const profilePath = posix.join(homeDirectory, ".profile");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
             HOME: homeDirectory,
@@ -473,7 +599,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
 
             expect(result).toEqual({
                 status: "configured",
-                target: [bashrcPath, profilePath],
+                target: [bashrcPath, profilePath, zprofilePath, zshenvPath],
             });
         }
         finally {
@@ -487,6 +613,8 @@ describe("ensureExecutableDirectoryOnPath", () => {
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");
         const bashProfilePath = posix.join(homeDirectory, ".bash_profile");
         const bashrcPath = posix.join(homeDirectory, ".bashrc");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
             HOME: homeDirectory,
@@ -512,7 +640,12 @@ describe("ensureExecutableDirectoryOnPath", () => {
 
             // .bash_profile covers login (Terminal.app default); .bashrc
             // covers nested bash and `bash -c` invocations.
-            expect(result.target).toEqual([bashProfilePath, bashrcPath]);
+            expect(result.target).toEqual([
+                bashProfilePath,
+                bashrcPath,
+                zprofilePath,
+                zshenvPath,
+            ]);
             expect(await readFile(bashProfilePath, "utf8")).toContain(
                 "# Added by oo CLI\n",
             );
@@ -535,6 +668,8 @@ describe("ensureExecutableDirectoryOnPath", () => {
             "nushell",
             "config.nu",
         );
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
             HOME: homeDirectory,
@@ -559,7 +694,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
                 },
             });
 
-            expect(result.target).toEqual([profilePath]);
+            expect(result.target).toEqual([profilePath, zprofilePath, zshenvPath]);
             const profileContent = await readFile(profilePath, "utf8");
 
             expect(profileContent).toContain("# Added by oo CLI\n");
@@ -584,6 +719,8 @@ describe("ensureExecutableDirectoryOnPath", () => {
             "powershell",
             "Microsoft.PowerShell_profile.ps1",
         );
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
             HOME: homeDirectory,
@@ -608,7 +745,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
                 },
             });
 
-            expect(result.target).toEqual([profilePath]);
+            expect(result.target).toEqual([profilePath, zprofilePath, zshenvPath]);
             const profileContent = await readFile(profilePath, "utf8");
 
             expect(profileContent).toContain("$pathEntry = Join-Path $HOME '.local/bin'");
@@ -689,6 +826,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
         const homeDirectory = toPortablePath(rootDirectory);
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");
         const zshrcPath = posix.join(homeDirectory, ".zshrc");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
         const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
@@ -718,7 +856,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
 
             expect(result).toEqual({
                 status: "partial-configured",
-                target: [zshrcPath],
+                target: [zshrcPath, zprofilePath],
                 failedTargets: [zshenvPath],
             });
             await expect(Bun.file(zshrcPath).exists()).resolves.toBeTrue();
@@ -733,6 +871,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
         const homeDirectory = toPortablePath(rootDirectory);
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");
         const zshrcPath = posix.join(homeDirectory, ".zshrc");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
         const zshenvPath = posix.join(homeDirectory, ".zshenv");
         const logCapture = createLogCapture();
         const env = {
@@ -743,6 +882,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
 
         trackDirectory(rootDirectory);
         await mkdir(zshrcPath, { recursive: true });
+        await mkdir(zprofilePath, { recursive: true });
         await mkdir(zshenvPath, { recursive: true });
 
         try {
@@ -760,7 +900,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
             });
 
             expect(result.status).toBe("failed");
-            expect(result.failedTargets).toEqual([zshrcPath, zshenvPath]);
+            expect(result.failedTargets).toEqual([zshrcPath, zshenvPath, zprofilePath]);
         }
         finally {
             logCapture.close();
@@ -963,6 +1103,17 @@ describe("isExecutableDirectoryOnPath", () => {
 
 function countOccurrences(value: string, searchValue: string): number {
     return value.split(searchValue).length - 1;
+}
+
+function createExpectedPosixPathSnippet(): string {
+    return [
+        "# Added by oo CLI",
+        "case \":$PATH:\" in",
+        "    *\":$HOME/.local/bin:\"*) ;;",
+        "    *) export PATH=\"$HOME/.local/bin:$PATH\" ;;",
+        "esac",
+        "",
+    ].join("\n");
 }
 
 function toPortablePath(path: string): string {

--- a/src/application/self-update/path-configuration.test.ts
+++ b/src/application/self-update/path-configuration.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./path-configuration.ts";
 
 const { track: trackDirectory } = useTemporaryDirectoryCleanup();
+const posixHostTest = process.platform === "win32" ? test.skip : test;
 
 describe("ensureExecutableDirectoryOnPath", () => {
     test("writes zsh profile PATH setup when the executable directory is missing from PATH", async () => {
@@ -103,7 +104,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
         }
     });
 
-    test("writes zsh startup profiles when the executable directory is already on PATH", async () => {
+    posixHostTest("writes zsh startup profiles when the executable directory is already on PATH", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-path-darwin-zsh-on-path");
         const homeDirectory = toPortablePath(rootDirectory);
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");
@@ -147,7 +148,7 @@ describe("ensureExecutableDirectoryOnPath", () => {
         }
     });
 
-    test("does not rewrite marked zsh startup profiles when the executable directory is already on PATH", async () => {
+    posixHostTest("does not rewrite marked zsh startup profiles when the executable directory is already on PATH", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-path-darwin-zsh-marked");
         const homeDirectory = toPortablePath(rootDirectory);
         const executableDirectory = posix.join(homeDirectory, ".local", "bin");

--- a/src/application/self-update/path-configuration.test.ts
+++ b/src/application/self-update/path-configuration.test.ts
@@ -1,5 +1,5 @@
 import type { SelfUpdateCommandRunOptions } from "../contracts/self-update.ts";
-import { mkdir, readFile } from "node:fs/promises";
+import { chmod, mkdir, readFile } from "node:fs/promises";
 import { posix, win32 } from "node:path";
 import process from "node:process";
 import { describe, expect, test } from "bun:test";
@@ -192,6 +192,51 @@ describe("ensureExecutableDirectoryOnPath", () => {
             )).toBe(1);
         }
         finally {
+            logCapture.close();
+        }
+    });
+
+    posixHostTest("continues zsh startup profile writes when another startup profile cannot be read", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-path-darwin-zsh-read-failure");
+        const homeDirectory = toPortablePath(rootDirectory);
+        const executableDirectory = posix.join(homeDirectory, ".local", "bin");
+        const zprofilePath = posix.join(homeDirectory, ".zprofile");
+        const zshenvPath = posix.join(homeDirectory, ".zshenv");
+        const logCapture = createLogCapture();
+        const env = {
+            HOME: homeDirectory,
+            PATH: `/usr/bin:${executableDirectory}`,
+            SHELL: "/bin/bash",
+        };
+
+        trackDirectory(rootDirectory);
+        await Bun.write(zprofilePath, "# unreadable zprofile\n");
+        await chmod(zprofilePath, 0);
+
+        try {
+            const result = await ensureExecutableDirectoryOnPath({
+                env,
+                executableDirectory,
+                platform: "darwin",
+                runtime: {
+                    env,
+                    logger: logCapture.logger,
+                    platform: "darwin",
+                    resolveCommandPath: () => null,
+                },
+            });
+
+            expect(result).toEqual({
+                status: "partial-configured",
+                target: [zshenvPath],
+                failedTargets: [zprofilePath],
+            });
+            expect(await readFile(zshenvPath, "utf8")).toBe(
+                createExpectedPosixPathSnippet(),
+            );
+        }
+        finally {
+            await chmod(zprofilePath, 0o600).catch(() => undefined);
             logCapture.close();
         }
     });

--- a/src/application/self-update/path-configuration.ts
+++ b/src/application/self-update/path-configuration.ts
@@ -30,6 +30,15 @@ interface ShellProfileConfiguration {
     snippet: string;
 }
 
+interface ShellProfileReadFailure {
+    error: unknown;
+    profilePath: string;
+}
+
+type ShellProfileConfigurationEntry
+    = | ShellProfileConfiguration
+        | ShellProfileReadFailure;
+
 type AlreadyConfiguredTargetMode = "include" | "omit";
 
 interface ShellProfileCandidate extends ShellProfileConfiguration {
@@ -37,6 +46,25 @@ interface ShellProfileCandidate extends ShellProfileConfiguration {
     profileExists: boolean;
     shellNames: readonly string[];
 }
+
+interface ShellProfileCandidateReadFailure extends ShellProfileReadFailure {
+    installed: boolean;
+    profileExists: true;
+    shellNames: readonly string[];
+}
+
+type ShellProfileCandidateEntry
+    = | ShellProfileCandidate
+        | ShellProfileCandidateReadFailure;
+
+interface ShellProfileContent {
+    content: string;
+    profileExists: boolean;
+}
+
+type ShellProfileContentReadResult
+    = | ShellProfileContent
+        | ShellProfileReadFailure;
 
 const pathConfigurationMarker = "Added by oo CLI";
 const pathConfigurationSentinel = `# ${pathConfigurationMarker}`;
@@ -188,7 +216,7 @@ async function configureZshStartupProfiles(
 }
 
 async function writeShellProfileConfigurations(
-    configurations: readonly ShellProfileConfiguration[],
+    configurations: readonly ShellProfileConfigurationEntry[],
     options: EnsureExecutableDirectoryOnPathOptions,
     alreadyConfiguredTargetMode: AlreadyConfiguredTargetMode,
 ): Promise<SelfUpdatePathConfigurationResult> {
@@ -197,6 +225,19 @@ async function writeShellProfileConfigurations(
     const failedTargets: string[] = [];
 
     for (const configuration of configurations) {
+        if (isShellProfileReadFailure(configuration)) {
+            failedTargets.push(configuration.profilePath);
+            options.runtime.logger.warn(
+                {
+                    err: configuration.error,
+                    executableDirectory: options.executableDirectory,
+                    profilePath: configuration.profilePath,
+                },
+                "CLI executable directory shell profile PATH configuration failed.",
+            );
+            continue;
+        }
+
         if (configuration.content.includes(pathConfigurationSentinel)) {
             alreadyConfiguredTargets.push(configuration.profilePath);
             continue;
@@ -268,7 +309,7 @@ async function writeShellProfileConfigurations(
 
 async function resolveShellProfileConfigurations(
     options: EnsureExecutableDirectoryOnPathOptions,
-): Promise<ShellProfileConfiguration[]> {
+): Promise<ShellProfileConfigurationEntry[]> {
     const homeDirectory = resolveHomeDirectory(options.env);
     const pathModule = readPathModule(options.platform);
     const xdgConfigHome = options.env.XDG_CONFIG_HOME
@@ -353,9 +394,18 @@ async function resolveShellProfileConfigurations(
     ];
     const selectedConfigurations = candidates
         .filter(candidate => shouldConfigureShellProfile(candidate, shellName))
-        .map(({ installed, profileExists, shellNames, ...configuration }) =>
-            configuration,
-        );
+        .map((candidate) => {
+            if (isShellProfileReadFailure(candidate)) {
+                return {
+                    error: candidate.error,
+                    profilePath: candidate.profilePath,
+                };
+            }
+
+            const { installed, profileExists, shellNames, ...configuration } = candidate;
+
+            return configuration;
+        });
     const profileFallbackPath = pathModule.join(homeDirectory, ".profile");
     const needsProfileFallback = selectedConfigurations.length === 0
         || (shellName !== undefined && !knownUnixShellNames.has(shellName));
@@ -385,7 +435,7 @@ async function resolveShellProfileConfigurations(
 async function createBashProfileCandidates(
     homeDirectory: string,
     options: EnsureExecutableDirectoryOnPathOptions,
-): Promise<ShellProfileCandidate[]> {
+): Promise<ShellProfileCandidateEntry[]> {
     // bash reads different files for login vs. non-login shells, and a single
     // machine routinely starts bash both ways (terminal emulator vs. SSH).
     // Writing to every rc file that exists matches what rustup/bun do — the
@@ -396,13 +446,13 @@ async function createBashProfileCandidates(
     const profileNames = options.platform === "darwin"
         ? [".bash_profile", ".bash_login", ".bashrc", ".profile"]
         : [".bashrc", ".bash_profile", ".bash_login", ".profile"];
-    const [installed, ...contents] = await Promise.all([
+    const [installed, ...contentResults] = await Promise.all([
         isShellCommandAvailable("bash", options.runtime),
         ...profileNames.map(name =>
-            readTextFileIfExists(pathModule.join(homeDirectory, name)),
+            readShellProfileContent(pathModule.join(homeDirectory, name)),
         ),
     ]);
-    const existing: ShellProfileCandidate[] = [];
+    const existing: ShellProfileCandidateEntry[] = [];
     const existingProfileNames = new Set<string>();
     const createCandidate = (
         profileName: string,
@@ -421,16 +471,36 @@ async function createBashProfileCandidates(
             snippet: createPosixPathSnippet(),
         };
     };
+    const createFailedCandidate = (
+        profileName: string,
+        error: unknown,
+    ): ShellProfileCandidateReadFailure => ({
+        error,
+        installed,
+        profileExists: true,
+        profilePath: pathModule.join(homeDirectory, profileName),
+        shellNames: bashShellNames,
+    });
 
     for (const [index, profileName] of profileNames.entries()) {
-        const content = contents[index];
+        const contentResult = contentResults[index];
 
-        if (content === undefined) {
+        if (contentResult === undefined) {
+            continue;
+        }
+
+        if (isShellProfileReadFailure(contentResult)) {
+            existingProfileNames.add(profileName);
+            existing.push(createFailedCandidate(profileName, contentResult.error));
+            continue;
+        }
+
+        if (!contentResult.profileExists) {
             continue;
         }
 
         existingProfileNames.add(profileName);
-        existing.push(createCandidate(profileName, content, true));
+        existing.push(createCandidate(profileName, contentResult.content, true));
     }
 
     const hasInteractiveProfile = existingProfileNames.has(interactiveProfileName);
@@ -466,18 +536,31 @@ async function createBashProfileCandidates(
 }
 
 function deduplicateShellProfileConfigurations(
-    configurations: readonly ShellProfileConfiguration[],
-): ShellProfileConfiguration[] {
-    const deduplicatedConfigurations: ShellProfileConfiguration[] = [];
-    const seenProfilePaths = new Set<string>();
+    configurations: readonly ShellProfileConfigurationEntry[],
+): ShellProfileConfigurationEntry[] {
+    const deduplicatedConfigurations: ShellProfileConfigurationEntry[] = [];
+    const indexByProfilePath = new Map<string, number>();
 
     for (const configuration of configurations) {
-        if (seenProfilePaths.has(configuration.profilePath)) {
+        const existingIndex = indexByProfilePath.get(configuration.profilePath);
+
+        if (existingIndex === undefined) {
+            indexByProfilePath.set(
+                configuration.profilePath,
+                deduplicatedConfigurations.length,
+            );
+            deduplicatedConfigurations.push(configuration);
             continue;
         }
 
-        seenProfilePaths.add(configuration.profilePath);
-        deduplicatedConfigurations.push(configuration);
+        const existingConfiguration = deduplicatedConfigurations[existingIndex]!;
+
+        if (
+            isShellProfileReadFailure(existingConfiguration)
+            && !isShellProfileReadFailure(configuration)
+        ) {
+            deduplicatedConfigurations[existingIndex] = configuration;
+        }
     }
 
     return deduplicatedConfigurations;
@@ -485,7 +568,7 @@ function deduplicateShellProfileConfigurations(
 
 async function resolveZshStartupProfileConfigurations(
     options: EnsureExecutableDirectoryOnPathOptions,
-): Promise<ShellProfileConfiguration[]> {
+): Promise<ShellProfileConfigurationEntry[]> {
     const homeDirectory = resolveHomeDirectory(options.env);
     const pathModule = readPathModule(options.platform);
     const zshDirectory = options.env.ZDOTDIR ?? homeDirectory;
@@ -511,20 +594,33 @@ async function createShellProfileCandidate(
         snippet: string;
     },
     runtimeOptions: EnsureExecutableDirectoryOnPathOptions,
-): Promise<ShellProfileCandidate> {
+): Promise<ShellProfileCandidateEntry> {
     const pathModule = readPathModule(runtimeOptions.platform);
-    const content = await readTextFileIfExists(options.profilePath);
-    const installedResults = await Promise.all(
-        options.shellNames.map(shellName =>
-            isShellCommandAvailable(shellName, runtimeOptions.runtime),
+    const [contentResult, installedResults] = await Promise.all([
+        readShellProfileContent(options.profilePath),
+        Promise.all(
+            options.shellNames.map(shellName =>
+                isShellCommandAvailable(shellName, runtimeOptions.runtime),
+            ),
         ),
-    );
+    ]);
+    const installed = installedResults.some(Boolean);
+
+    if (isShellProfileReadFailure(contentResult)) {
+        return {
+            error: contentResult.error,
+            installed,
+            profileExists: true,
+            profilePath: options.profilePath,
+            shellNames: options.shellNames,
+        };
+    }
 
     return {
-        content: content ?? "",
-        installed: installedResults.some(Boolean),
+        content: contentResult.content,
+        installed,
         profileDirectory: pathModule.dirname(options.profilePath),
-        profileExists: content !== undefined,
+        profileExists: contentResult.profileExists,
         profilePath: options.profilePath,
         shellNames: options.shellNames,
         snippet: options.snippet,
@@ -532,7 +628,7 @@ async function createShellProfileCandidate(
 }
 
 function shouldConfigureShellProfile(
-    candidate: ShellProfileCandidate,
+    candidate: ShellProfileCandidateEntry,
     currentShellName: string | undefined,
 ): boolean {
     return candidate.installed
@@ -547,11 +643,19 @@ async function createShellProfileConfiguration(
     profilePath: string,
     platform: NodeJS.Platform,
     snippet: string,
-): Promise<ShellProfileConfiguration> {
+): Promise<ShellProfileConfigurationEntry> {
     const pathModule = readPathModule(platform);
+    const contentResult = await readShellProfileContent(profilePath);
+
+    if (isShellProfileReadFailure(contentResult)) {
+        return {
+            error: contentResult.error,
+            profilePath,
+        };
+    }
 
     return {
-        content: await readTextFileIfExists(profilePath) ?? "",
+        content: contentResult.content,
         profileDirectory: pathModule.dirname(profilePath),
         profilePath,
         snippet,
@@ -865,6 +969,34 @@ function normalizePathForComparison(
     return platform === "win32"
         ? resolvedValue.toLowerCase()
         : resolvedValue;
+}
+
+async function readShellProfileContent(
+    profilePath: string,
+): Promise<ShellProfileContentReadResult> {
+    try {
+        const content = await readTextFileIfExists(profilePath);
+
+        return {
+            content: content ?? "",
+            profileExists: content !== undefined,
+        };
+    }
+    catch (error) {
+        return {
+            error,
+            profilePath,
+        };
+    }
+}
+
+function isShellProfileReadFailure(
+    result:
+        | ShellProfileCandidateEntry
+        | ShellProfileConfigurationEntry
+        | ShellProfileContentReadResult,
+): result is ShellProfileReadFailure {
+    return "error" in result;
 }
 
 async function readTextFileIfExists(path: string): Promise<string | undefined> {

--- a/src/application/self-update/path-configuration.ts
+++ b/src/application/self-update/path-configuration.ts
@@ -30,6 +30,8 @@ interface ShellProfileConfiguration {
     snippet: string;
 }
 
+type AlreadyConfiguredTargetMode = "include" | "omit";
+
 interface ShellProfileCandidate extends ShellProfileConfiguration {
     installed: boolean;
     profileExists: boolean;
@@ -58,20 +60,20 @@ const knownUnixShellNames = new Set<string>([
 export async function ensureExecutableDirectoryOnPath(
     options: EnsureExecutableDirectoryOnPathOptions,
 ): Promise<SelfUpdatePathConfigurationResult> {
-    if (isExecutableDirectoryOnPath(
+    const executableDirectoryOnPath = isExecutableDirectoryOnPath(
         options.executableDirectory,
         options.env,
         options.platform,
-    )) {
-        return {
-            status: "already-configured",
-        };
-    }
+    );
 
     if (options.modifyPath === false) {
-        return {
-            status: "skipped",
-        };
+        return executableDirectoryOnPath
+            ? {
+                    status: "already-configured",
+                }
+            : {
+                    status: "skipped",
+                };
     }
 
     const overriddenResult = await options.runtime.configurePath?.({
@@ -83,6 +85,14 @@ export async function ensureExecutableDirectoryOnPath(
 
     if (overriddenResult !== undefined) {
         return overriddenResult;
+    }
+
+    if (executableDirectoryOnPath) {
+        return options.platform === "win32"
+            ? {
+                    status: "already-configured",
+                }
+            : await configureZshStartupProfiles(options);
     }
 
     return options.platform === "win32"
@@ -120,73 +130,20 @@ async function configureUnixShellProfile(
     options: EnsureExecutableDirectoryOnPathOptions,
 ): Promise<SelfUpdatePathConfigurationResult> {
     try {
-        const configurations = await resolveShellProfileConfigurations(options);
-        const alreadyConfiguredTargets: string[] = [];
-        const configuredTargets: string[] = [];
-        const failedTargets: string[] = [];
+        const [shellConfigurations, zshStartupConfigurations] = await Promise.all([
+            resolveShellProfileConfigurations(options),
+            resolveZshStartupProfileConfigurations(options),
+        ]);
+        const configurations = deduplicateShellProfileConfigurations([
+            ...shellConfigurations,
+            ...zshStartupConfigurations,
+        ]);
 
-        for (const configuration of configurations) {
-            if (configuration.content.includes(pathConfigurationSentinel)) {
-                alreadyConfiguredTargets.push(configuration.profilePath);
-                continue;
-            }
-
-            try {
-                await writeShellProfileConfiguration(configuration);
-                configuredTargets.push(configuration.profilePath);
-                options.runtime.logger.info(
-                    {
-                        executableDirectory: options.executableDirectory,
-                        profilePath: configuration.profilePath,
-                    },
-                    "CLI executable directory was added to the shell profile PATH.",
-                );
-            }
-            catch (error) {
-                failedTargets.push(configuration.profilePath);
-                options.runtime.logger.warn(
-                    {
-                        err: error,
-                        executableDirectory: options.executableDirectory,
-                        profilePath: configuration.profilePath,
-                    },
-                    "CLI executable directory shell profile PATH configuration failed.",
-                );
-            }
-        }
-
-        if (configuredTargets.length > 0 && failedTargets.length > 0) {
-            return {
-                status: "partial-configured",
-                target: configuredTargets,
-                failedTargets,
-            };
-        }
-
-        if (configuredTargets.length > 0) {
-            return {
-                status: "configured",
-                target: configuredTargets,
-            };
-        }
-
-        if (failedTargets.length > 0) {
-            return {
-                status: "failed",
-                failedTargets,
-            };
-        }
-
-        if (alreadyConfiguredTargets.length > 0) {
-            return {
-                status: "already-configured",
-                target: alreadyConfiguredTargets,
-            };
-        }
-
-        return {
-            status: "failed",
-        };
+        return await writeShellProfileConfigurations(
+            configurations,
+            options,
+            "include",
+        );
     }
     catch (error) {
         options.runtime.logger.warn(
@@ -201,6 +158,112 @@ async function configureUnixShellProfile(
             status: "failed",
         };
     }
+}
+
+async function configureZshStartupProfiles(
+    options: EnsureExecutableDirectoryOnPathOptions,
+): Promise<SelfUpdatePathConfigurationResult> {
+    try {
+        const configurations = await resolveZshStartupProfileConfigurations(options);
+
+        return await writeShellProfileConfigurations(
+            configurations,
+            options,
+            "omit",
+        );
+    }
+    catch (error) {
+        options.runtime.logger.warn(
+            {
+                err: error,
+                executableDirectory: options.executableDirectory,
+            },
+            "CLI executable directory shell profile PATH configuration failed.",
+        );
+
+        return {
+            status: "failed",
+        };
+    }
+}
+
+async function writeShellProfileConfigurations(
+    configurations: readonly ShellProfileConfiguration[],
+    options: EnsureExecutableDirectoryOnPathOptions,
+    alreadyConfiguredTargetMode: AlreadyConfiguredTargetMode,
+): Promise<SelfUpdatePathConfigurationResult> {
+    const alreadyConfiguredTargets: string[] = [];
+    const configuredTargets: string[] = [];
+    const failedTargets: string[] = [];
+
+    for (const configuration of configurations) {
+        if (configuration.content.includes(pathConfigurationSentinel)) {
+            alreadyConfiguredTargets.push(configuration.profilePath);
+            continue;
+        }
+
+        try {
+            await writeShellProfileConfiguration(configuration);
+            configuredTargets.push(configuration.profilePath);
+            options.runtime.logger.info(
+                {
+                    executableDirectory: options.executableDirectory,
+                    profilePath: configuration.profilePath,
+                },
+                "CLI executable directory was added to the shell profile PATH.",
+            );
+        }
+        catch (error) {
+            failedTargets.push(configuration.profilePath);
+            options.runtime.logger.warn(
+                {
+                    err: error,
+                    executableDirectory: options.executableDirectory,
+                    profilePath: configuration.profilePath,
+                },
+                "CLI executable directory shell profile PATH configuration failed.",
+            );
+        }
+    }
+
+    if (configuredTargets.length > 0 && failedTargets.length > 0) {
+        return {
+            status: "partial-configured",
+            target: configuredTargets,
+            failedTargets,
+        };
+    }
+
+    if (configuredTargets.length > 0) {
+        return {
+            status: "configured",
+            target: configuredTargets,
+        };
+    }
+
+    if (failedTargets.length > 0) {
+        return {
+            status: "failed",
+            failedTargets,
+        };
+    }
+
+    if (alreadyConfiguredTargets.length > 0) {
+        if (alreadyConfiguredTargetMode === "omit") {
+            return {
+                status: "already-configured",
+            };
+        }
+
+        return {
+            status: "already-configured",
+            target: alreadyConfiguredTargets,
+        };
+    }
+
+    return {
+        status: "failed",
+    };
 }
 
 async function resolveShellProfileConfigurations(
@@ -400,6 +463,45 @@ async function createBashProfileCandidates(
         ...existing,
         ...fallbackNames.map(profileName => createCandidate(profileName, "", false)),
     ];
+}
+
+function deduplicateShellProfileConfigurations(
+    configurations: readonly ShellProfileConfiguration[],
+): ShellProfileConfiguration[] {
+    const deduplicatedConfigurations: ShellProfileConfiguration[] = [];
+    const seenProfilePaths = new Set<string>();
+
+    for (const configuration of configurations) {
+        if (seenProfilePaths.has(configuration.profilePath)) {
+            continue;
+        }
+
+        seenProfilePaths.add(configuration.profilePath);
+        deduplicatedConfigurations.push(configuration);
+    }
+
+    return deduplicatedConfigurations;
+}
+
+async function resolveZshStartupProfileConfigurations(
+    options: EnsureExecutableDirectoryOnPathOptions,
+): Promise<ShellProfileConfiguration[]> {
+    const homeDirectory = resolveHomeDirectory(options.env);
+    const pathModule = readPathModule(options.platform);
+    const zshDirectory = options.env.ZDOTDIR ?? homeDirectory;
+
+    return await Promise.all([
+        createShellProfileConfiguration(
+            pathModule.join(zshDirectory, ".zprofile"),
+            options.platform,
+            createPosixPathSnippet(),
+        ),
+        createShellProfileConfiguration(
+            pathModule.join(zshDirectory, ".zshenv"),
+            options.platform,
+            createPosixPathSnippet(),
+        ),
+    ]);
 }
 
 async function createShellProfileCandidate(


### PR DESCRIPTION
Self-managed installs now ensure .zprofile and .zshenv contain the managed PATH snippet whenever automatic PATH modification is enabled, even when the current process already has the executable directory on PATH.

This keeps future zsh sessions able to find the managed oo entrypoint without relying on the current environment.