### PR TITLE
[codex] Improve self-update PATH shadowing handling

### DIFF
--- a/contrib/npm/oo.cjs
+++ b/contrib/npm/oo.cjs
@@ -107,7 +107,11 @@ function detectPackageManagerFromOoPath(paths) {
             return "pnpm";
         }
 
-        if (pathSegments.includes("fnm_multishells")) {
+        if (
+            pathSegments.includes("fnm_multishells")
+            || pathSegments.includes("npm-global")
+            || pathSegments.includes("npm_global")
+        ) {
             return "npm";
         }
     }

--- a/contrib/npm/oo.test.ts
+++ b/contrib/npm/oo.test.ts
@@ -33,6 +33,12 @@ describe("oo wrapper", () => {
         ])).toBe("npm");
     });
 
+    test("detects npm from the installed oo path under npm-global", () => {
+        expect(wrapperModule.detectPackageManagerFromOoPath([
+            "/Users/demo/Library/Application Support/QClaw/npm-global/bin/oo",
+        ])).toBe("npm");
+    });
+
     test("does not match unrelated path segments by substring", () => {
         expect(wrapperModule.detectPackageManagerFromOoPath([
             "/Users/demo/aabunxx/install/global/node_modules/@oomol-lab/oo-cli/bin/oo.cjs",

--- a/contrib/npm/oo.test.ts
+++ b/contrib/npm/oo.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
@@ -35,7 +36,16 @@ describe("oo wrapper", () => {
 
     test("detects npm from the installed oo path under npm-global", () => {
         expect(wrapperModule.detectPackageManagerFromOoPath([
-            "/Users/demo/Library/Application Support/QClaw/npm-global/bin/oo",
+            join(
+                "Users",
+                "demo",
+                "Library",
+                "Application Support",
+                "QClaw",
+                "npm-global",
+                "bin",
+                "oo",
+            ),
         ])).toBe("npm");
     });
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -131,7 +131,13 @@ Install one managed `oo` release into the local self-managed runtime.
 - Notes: after a successful install, the CLI best-effort removes legacy global
   `@oomol-lab/oo-cli` package-manager installs that appear anywhere on `PATH`;
   when `PATH` yields no `oo` candidates, the CLI falls back to the current
-  command path. Cleanup failures do not change the command result.
+  command path. For npm installs, the cleanup command targets the detected
+  global prefix when it can be inferred. Cleanup failures do not change the
+  command result.
+- Notes: after PATH setup and legacy cleanup, if the current `PATH` still
+  resolves `oo` to a different executable before the managed executable
+  directory, install prints a shadowing note that identifies the earlier path
+  and the managed directory.
 - Notes: when automatic PATH modification is enabled, install ensures zsh
   startup profiles `.zprofile` and `.zshenv` contain the managed PATH snippet,
   even if the current `PATH` already contains the executable directory. When the
@@ -174,7 +180,13 @@ Update the managed `oo` install to the latest published release.
 - Notes: after a successful update, the CLI best-effort removes legacy global
   `@oomol-lab/oo-cli` package-manager installs that appear anywhere on `PATH`;
   when `PATH` yields no `oo` candidates, the CLI falls back to the current
-  command path. Cleanup failures do not change the command result.
+  command path. For npm installs, the cleanup command targets the detected
+  global prefix when it can be inferred. Cleanup failures do not change the
+  command result.
+- Notes: after PATH setup and legacy cleanup, if the current `PATH` still
+  resolves `oo` to a different executable before the managed executable
+  directory, update prints a shadowing note that identifies the earlier path
+  and the managed directory.
 - Notes: when automatic PATH modification is enabled, update ensures zsh
   startup profiles `.zprofile` and `.zshenv` contain the managed PATH snippet,
   even if the current `PATH` already contains the executable directory. When the

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -116,7 +116,11 @@
 - 说明：install 在报告成功前会校验已安装的 `oo` 命令可正常使用。
 - 说明：install 成功后，CLI 会尽力移除在 `PATH` 中任意位置出现的旧全局
   package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到 `oo`
-  候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
+  候选项，CLI 会回退到当前命令路径进行判断。对于 npm 安装，清理命令会在可推断时
+  使用检测到的 global prefix。清理失败不会改变命令结果。
+- 说明：PATH 配置和旧安装清理结束后，如果当前 `PATH` 仍然会先解析到另一个
+  `oo`，早于托管可执行目录，install 会打印 shadowing note，指出更靠前的路径和
+  托管目录。
 - 说明：当自动 PATH 修改启用时，install 会确保 zsh startup profile
   `.zprofile` 和 `.zshenv` 包含托管 PATH 片段，即使当前 `PATH` 已经包含可执行目录。
   如果可执行目录没有出现在 `PATH` 中，install 还会尝试为后续 shell 持久化 PATH
@@ -150,7 +154,11 @@
   刷新 bundled skills，再输出“已是最新版本”的消息。
 - 说明：update 成功后，CLI 会尽力移除在 `PATH` 中任意位置出现的旧全局
   package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到 `oo`
-  候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
+  候选项，CLI 会回退到当前命令路径进行判断。对于 npm 安装，清理命令会在可推断时
+  使用检测到的 global prefix。清理失败不会改变命令结果。
+- 说明：PATH 配置和旧安装清理结束后，如果当前 `PATH` 仍然会先解析到另一个
+  `oo`，早于托管可执行目录，update 会打印 shadowing note，指出更靠前的路径和
+  托管目录。
 - 说明：当自动 PATH 修改启用时，update 会确保 zsh startup profile
   `.zprofile` 和 `.zshenv` 包含托管 PATH 片段，即使当前 `PATH` 已经包含可执行目录。
   如果可执行目录没有出现在 `PATH` 中，update 还会尝试为后续 shell 持久化 PATH

--- a/src/application/commands/install.ts
+++ b/src/application/commands/install.ts
@@ -140,6 +140,7 @@ export const installCommand: CliCommandDefinition<
             );
 
             writeSelfUpdatePathNoteIfNeeded({
+                commandResolution: result.commandResolution,
                 executableDirectory: result.executableDirectory,
                 pathConfiguration: result.pathConfiguration,
                 stdout: context.stdout,

--- a/src/application/commands/self-update-output.test.ts
+++ b/src/application/commands/self-update-output.test.ts
@@ -108,4 +108,23 @@ describe("writeSelfUpdatePathNoteIfNeeded", () => {
 
         expect(stdout.read()).toContain("Add /home/demo/.local/bin to PATH");
     });
+
+    test("prints a shadowing note when PATH still resolves another oo first", () => {
+        const stdout = createTextBuffer();
+
+        writeSelfUpdatePathNoteIfNeeded({
+            commandResolution: {
+                path: "/opt/old/bin/oo",
+                status: "shadowed",
+            },
+            executableDirectory,
+            pathConfiguration: { status: "already-configured" },
+            stdout: stdout.writer,
+            translator,
+        });
+
+        expect(stdout.read()).toBe(
+            "PATH currently resolves oo to /opt/old/bin/oo before the managed directory /home/demo/.local/bin. Move /home/demo/.local/bin earlier in PATH or remove the older oo entry, then restart your shell.\n",
+        );
+    });
 });

--- a/src/application/commands/self-update-output.ts
+++ b/src/application/commands/self-update-output.ts
@@ -1,9 +1,23 @@
 import type { Writer } from "../contracts/cli.ts";
-import type { SelfUpdatePathConfigurationResult } from "../contracts/self-update.ts";
+import type {
+    SelfUpdateCommandResolutionResult,
+    SelfUpdatePathConfigurationResult,
+} from "../contracts/self-update.ts";
 import type { Translator } from "../contracts/translator.ts";
 import { writeLine } from "./shared/output.ts";
 
 export function writeSelfUpdatePathNoteIfNeeded(options: {
+    commandResolution?: SelfUpdateCommandResolutionResult;
+    executableDirectory: string;
+    pathConfiguration: SelfUpdatePathConfigurationResult;
+    stdout: Writer;
+    translator: Pick<Translator, "t">;
+}): void {
+    writeSelfUpdatePathConfigurationNoteIfNeeded(options);
+    writeSelfUpdateCommandResolutionNoteIfNeeded(options);
+}
+
+function writeSelfUpdatePathConfigurationNoteIfNeeded(options: {
     executableDirectory: string;
     pathConfiguration: SelfUpdatePathConfigurationResult;
     stdout: Writer;
@@ -65,6 +79,25 @@ export function writeSelfUpdatePathNoteIfNeeded(options: {
         options.stdout,
         options.translator.t("selfUpdate.install.pathNote", {
             path: options.executableDirectory,
+        }),
+    );
+}
+
+function writeSelfUpdateCommandResolutionNoteIfNeeded(options: {
+    commandResolution?: SelfUpdateCommandResolutionResult;
+    executableDirectory: string;
+    stdout: Writer;
+    translator: Pick<Translator, "t">;
+}): void {
+    if (options.commandResolution?.status !== "shadowed") {
+        return;
+    }
+
+    writeLine(
+        options.stdout,
+        options.translator.t("selfUpdate.pathShadowedNote", {
+            directory: options.executableDirectory,
+            path: options.commandResolution.path,
         }),
     );
 }

--- a/src/application/commands/self-update.cli.test.ts
+++ b/src/application/commands/self-update.cli.test.ts
@@ -4,12 +4,13 @@ import type {
     CliSnapshotContext,
 } from "../../../__tests__/helpers.ts";
 import { chmod, mkdir, stat } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import process from "node:process";
 import { describe, expect, test } from "bun:test";
 import {
     createCliSandbox,
     createCliSnapshot,
+    joinPathEntries,
     toRequest,
 } from "../../../__tests__/helpers.ts";
 import {
@@ -563,6 +564,81 @@ describe("self-update commands", () => {
         }
     });
 
+    test("update warns when an older oo still shadows the managed executable on PATH", async () => {
+        const sandbox = await createCliSandbox();
+        const releasePlatform = await detectSelfUpdateReleasePlatform({
+            arch: process.arch,
+            platform: process.platform,
+        });
+        const paths = resolveSelfUpdatePaths({
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const legacyPrefix = join(sandbox.cwd, "QClaw", "npm-global");
+        const legacyDirectory = join(legacyPrefix, "bin");
+        const legacyPath = join(legacyDirectory, basename(paths.executablePath));
+        const selfUpdateRuntime = createCapturedSelfUpdateRuntime({
+            exitCode: 1,
+            signalCode: null,
+            stderr: "permission denied",
+            stdout: "",
+        });
+
+        sandbox.env.PATH = joinPathEntries(
+            [legacyDirectory, paths.executableDirectory],
+            process.platform,
+        );
+
+        try {
+            await writeManagedVersion(legacyPath, "legacy-binary");
+
+            const result = await sandbox.run(["update"], {
+                fetcher: async (input, init) => {
+                    const url = toRequest(input, init).url;
+
+                    if (url.endsWith("/latest.json")) {
+                        return new Response(JSON.stringify({
+                            version: "2.0.0",
+                        }));
+                    }
+
+                    if (url.endsWith(`/${releasePlatform}/${process.platform === "win32" ? "oo.exe" : "oo"}`)) {
+                        return new Response("binary");
+                    }
+
+                    throw new Error(`Unexpected request: ${url}`);
+                },
+                selfUpdateRuntime: selfUpdateRuntime.runtime,
+                version: "1.0.0",
+            });
+
+            expect(createCliSnapshot(result, { sandbox })).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: [
+                    "Updated oo from 1.0.0 to 2.0.0.",
+                    "Added <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.",
+                    `PATH currently resolves oo to <CWD>/QClaw/npm-global/bin/${basename(paths.executablePath)} before the managed directory <HOME>/.local/bin. Move <HOME>/.local/bin earlier in PATH or remove the older oo entry, then restart your shell.`,
+                    "",
+                ].join("\n"),
+            });
+            expect(selfUpdateRuntime.commands).toContainEqual({
+                commandArguments: [
+                    "uninstall",
+                    "-g",
+                    "--prefix",
+                    legacyPrefix,
+                    "@oomol-lab/oo-cli",
+                ],
+                commandPath: "/mock/bin/npm",
+                timeoutMs: 10_000,
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("update refreshes bundled skills for a same-version native install without downloading a binary", async () => {
         const sandbox = await createCliSandbox();
         const releasePlatform = await detectSelfUpdateReleasePlatform({
@@ -761,13 +837,23 @@ describe("self-update commands", () => {
             paths,
             "1.2.3",
         );
+        const packageManagerPrefix = join(sandbox.cwd, "npm-prefix");
+        const packageManagerExecPath = join(
+            packageManagerPrefix,
+            "lib",
+            "node_modules",
+            "@oomol-lab",
+            "oo-cli",
+            "bin",
+            process.platform === "win32" ? "oo.exe" : "oo",
+        );
         let binaryRequestCount = 0;
 
         try {
             await writeManagedVersion(currentVersionPath, "existing-binary");
 
             const result = await sandbox.run(["upgrade"], {
-                execPath: "/usr/local/lib/node_modules/@oomol-lab/oo-cli/bin/oo",
+                execPath: packageManagerExecPath,
                 fetcher: async (input, init) => {
                     const url = toRequest(input, init).url;
 
@@ -797,7 +883,13 @@ describe("self-update commands", () => {
                     timeoutMs: 10_000,
                 },
                 {
-                    commandArguments: ["uninstall", "-g", "@oomol-lab/oo-cli"],
+                    commandArguments: [
+                        "uninstall",
+                        "-g",
+                        "--prefix",
+                        packageManagerPrefix,
+                        "@oomol-lab/oo-cli",
+                    ],
                     commandPath: "/mock/bin/npm",
                     timeoutMs: 10_000,
                 },

--- a/src/application/commands/update.ts
+++ b/src/application/commands/update.ts
@@ -100,7 +100,7 @@ export const updateCommand: CliCommandDefinition<
                         ...context.selfUpdateRuntime,
                     },
                 });
-                const { executableDirectory, pathConfiguration }
+                const { commandResolution, executableDirectory, pathConfiguration }
                     = await ensureSelfUpdateExecutableDirectoryOnPath({
                         modifyPath: effectiveModifyPath,
                         runtime: {
@@ -118,6 +118,7 @@ export const updateCommand: CliCommandDefinition<
                     }),
                 );
                 writeSelfUpdatePathNoteIfNeeded({
+                    commandResolution,
                     executableDirectory,
                     pathConfiguration,
                     stdout: context.stdout,
@@ -166,6 +167,7 @@ export const updateCommand: CliCommandDefinition<
                     }),
                 );
                 writeSelfUpdatePathNoteIfNeeded({
+                    commandResolution: result.commandResolution,
                     executableDirectory: result.executableDirectory,
                     pathConfiguration: result.pathConfiguration,
                     stdout: context.stdout,
@@ -182,6 +184,7 @@ export const updateCommand: CliCommandDefinition<
                 }),
             );
             writeSelfUpdatePathNoteIfNeeded({
+                commandResolution: result.commandResolution,
                 executableDirectory: result.executableDirectory,
                 pathConfiguration: result.pathConfiguration,
                 stdout: context.stdout,

--- a/src/application/contracts/self-update.ts
+++ b/src/application/contracts/self-update.ts
@@ -30,6 +30,15 @@ export interface SelfUpdatePathConfigurationResult {
     failedTargets?: readonly string[];
 }
 
+export type SelfUpdateCommandResolutionResult
+    = | {
+        status: "managed" | "missing";
+    }
+    | {
+        path: string;
+        status: "shadowed";
+    };
+
 export interface SelfUpdateRuntimeOverrides {
     /**
      * Gates the Windows HKCU\Environment registry write. Must be true for the

--- a/src/application/self-update/command-path.test.ts
+++ b/src/application/self-update/command-path.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { resolveCommandPathCandidates } from "./command-path.ts";
+
+describe("resolveCommandPathCandidates", () => {
+    test("treats an empty POSIX PATH value as the current-directory entry", async () => {
+        const candidates = await resolveCommandPathCandidates({
+            env: {
+                PATH: "",
+            },
+            executableNames: ["oo"],
+            pathExists: async path => path === "oo",
+            platform: "linux",
+        });
+
+        expect(candidates).toEqual([
+            {
+                directoryPath: ".",
+                path: "oo",
+            },
+        ]);
+    });
+
+    test("preserves POSIX empty PATH segments as current-directory entries", async () => {
+        const candidates = await resolveCommandPathCandidates({
+            env: {
+                PATH: ":/managed/bin",
+            },
+            executableNames: ["oo"],
+            pathExists: async path => path === "oo" || path === "/managed/bin/oo",
+            platform: "linux",
+        });
+
+        expect(candidates).toEqual([
+            {
+                directoryPath: ".",
+                path: "oo",
+            },
+            {
+                directoryPath: "/managed/bin",
+                path: "/managed/bin/oo",
+            },
+        ]);
+    });
+
+    test("preserves Windows empty PATH segments without rewriting them", async () => {
+        const candidates = await resolveCommandPathCandidates({
+            env: {
+                Path: ";C:\\managed\\bin",
+            },
+            executableNames: ["oo.exe"],
+            pathExists: async path => (
+                path === "oo.exe" || path === "C:\\managed\\bin\\oo.exe"
+            ),
+            platform: "win32",
+        });
+
+        expect(candidates).toEqual([
+            {
+                directoryPath: "",
+                path: "oo.exe",
+            },
+            {
+                directoryPath: "C:\\managed\\bin",
+                path: "C:\\managed\\bin\\oo.exe",
+            },
+        ]);
+    });
+});

--- a/src/application/self-update/command-path.test.ts
+++ b/src/application/self-update/command-path.test.ts
@@ -1,68 +1,98 @@
+import type { CommandPathCandidate } from "./command-path.ts";
+import { posix, win32 } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { resolveCommandPathCandidates } from "./command-path.ts";
 
 describe("resolveCommandPathCandidates", () => {
     test("treats an empty POSIX PATH value as the current-directory entry", async () => {
-        const candidates = await resolveCommandPathCandidates({
+        const executableName = "oo";
+        const executablePath = posix.join(".", executableName);
+        const candidates = await resolveCandidates({
             env: {
                 PATH: "",
             },
-            executableNames: ["oo"],
-            pathExists: async path => path === "oo",
+            executableNames: [executableName],
+            existingPaths: [executablePath],
             platform: "linux",
         });
 
         expect(candidates).toEqual([
             {
                 directoryPath: ".",
-                path: "oo",
+                path: executablePath,
             },
         ]);
     });
 
     test("preserves POSIX empty PATH segments as current-directory entries", async () => {
-        const candidates = await resolveCommandPathCandidates({
+        const executableName = "oo";
+        const currentDirectoryExecutablePath = posix.join(".", executableName);
+        const managedDirectoryPath = posix.join("managed", "bin");
+        const managedExecutablePath = posix.join(managedDirectoryPath, executableName);
+        const candidates = await resolveCandidates({
             env: {
-                PATH: ":/managed/bin",
+                PATH: `${posix.delimiter}${managedDirectoryPath}`,
             },
-            executableNames: ["oo"],
-            pathExists: async path => path === "oo" || path === "/managed/bin/oo",
+            executableNames: [executableName],
+            existingPaths: [currentDirectoryExecutablePath, managedExecutablePath],
             platform: "linux",
         });
 
         expect(candidates).toEqual([
             {
                 directoryPath: ".",
-                path: "oo",
+                path: currentDirectoryExecutablePath,
             },
             {
-                directoryPath: "/managed/bin",
-                path: "/managed/bin/oo",
+                directoryPath: managedDirectoryPath,
+                path: managedExecutablePath,
             },
         ]);
     });
 
     test("preserves Windows empty PATH segments without rewriting them", async () => {
-        const candidates = await resolveCommandPathCandidates({
+        const executableName = "oo.exe";
+        const currentDirectoryExecutablePath = win32.join("", executableName);
+        const managedDirectoryPath = win32.join("managed", "bin");
+        const managedExecutablePath = win32.join(managedDirectoryPath, executableName);
+        const candidates = await resolveCandidates({
             env: {
-                Path: ";C:\\managed\\bin",
+                Path: `${win32.delimiter}${managedDirectoryPath}`,
             },
-            executableNames: ["oo.exe"],
-            pathExists: async path => (
-                path === "oo.exe" || path === "C:\\managed\\bin\\oo.exe"
-            ),
+            executableNames: [executableName],
+            existingPaths: [currentDirectoryExecutablePath, managedExecutablePath],
             platform: "win32",
         });
 
         expect(candidates).toEqual([
             {
                 directoryPath: "",
-                path: "oo.exe",
+                path: currentDirectoryExecutablePath,
             },
             {
-                directoryPath: "C:\\managed\\bin",
-                path: "C:\\managed\\bin\\oo.exe",
+                directoryPath: managedDirectoryPath,
+                path: managedExecutablePath,
             },
         ]);
     });
 });
+
+function resolveCandidates(options: {
+    env: Record<string, string | undefined>;
+    executableNames: readonly string[];
+    existingPaths: readonly string[];
+    platform: NodeJS.Platform;
+}): Promise<CommandPathCandidate[]> {
+    return resolveCommandPathCandidates({
+        env: options.env,
+        executableNames: options.executableNames,
+        pathExists: createPathExists(options.existingPaths),
+        platform: options.platform,
+    });
+}
+
+function createPathExists(
+    existingPaths: readonly string[],
+): (path: string) => Promise<boolean> {
+    return path => Promise.resolve(existingPaths.includes(path));
+}

--- a/src/application/self-update/command-path.ts
+++ b/src/application/self-update/command-path.ts
@@ -1,0 +1,82 @@
+import { pathExists as defaultPathExists } from "../shared/fs-utils.ts";
+import { readPathModule } from "./paths.ts";
+
+export interface CommandPathCandidate {
+    directoryPath: string;
+    path: string;
+}
+
+export async function resolveCommandPathCandidates(options: {
+    env: Record<string, string | undefined>;
+    executableNames: readonly string[];
+    pathExists?: (path: string) => Promise<boolean>;
+    platform: NodeJS.Platform;
+}): Promise<CommandPathCandidate[]> {
+    const pathValue = readPathValue(options.env, options.platform);
+
+    if (pathValue === undefined || pathValue.trim() === "") {
+        return [];
+    }
+
+    const pathModule = readPathModule(options.platform);
+    const candidates: CommandPathCandidate[] = [];
+
+    for (const directoryPath of splitPathEntries(pathValue, options.platform)) {
+        const candidatePath = await resolveFirstPathCandidatePath({
+            directoryPath,
+            executableNames: options.executableNames,
+            pathExists: options.pathExists ?? defaultPathExists,
+            pathModule,
+        });
+
+        if (candidatePath === undefined) {
+            continue;
+        }
+
+        candidates.push({
+            directoryPath,
+            path: candidatePath,
+        });
+    }
+
+    return candidates;
+}
+
+function readPathValue(
+    env: Record<string, string | undefined>,
+    platform: NodeJS.Platform,
+): string | undefined {
+    return platform === "win32"
+        ? env.Path ?? env.PATH
+        : env.PATH;
+}
+
+function splitPathEntries(
+    pathValue: string,
+    platform: NodeJS.Platform,
+): string[] {
+    return pathValue
+        .split(readPathModule(platform).delimiter)
+        .map(pathEntry => pathEntry.trim())
+        .filter(Boolean);
+}
+
+async function resolveFirstPathCandidatePath(options: {
+    directoryPath: string;
+    executableNames: readonly string[];
+    pathExists: (path: string) => Promise<boolean>;
+    pathModule: ReturnType<typeof readPathModule>;
+}): Promise<string | undefined> {
+    for (const executableName of options.executableNames) {
+        const candidatePath = options.pathModule.join(
+            options.directoryPath,
+            executableName,
+        );
+
+        if (await options.pathExists(candidatePath)) {
+            return candidatePath;
+        }
+    }
+
+    return undefined;
+}

--- a/src/application/self-update/command-path.ts
+++ b/src/application/self-update/command-path.ts
@@ -14,7 +14,7 @@ export async function resolveCommandPathCandidates(options: {
 }): Promise<CommandPathCandidate[]> {
     const pathValue = readPathValue(options.env, options.platform);
 
-    if (pathValue === undefined || pathValue.trim() === "") {
+    if (pathValue === undefined) {
         return [];
     }
 
@@ -55,10 +55,20 @@ function splitPathEntries(
     pathValue: string,
     platform: NodeJS.Platform,
 ): string[] {
+    const isWindows = platform === "win32";
+    const pathModule = readPathModule(platform);
+
     return pathValue
-        .split(readPathModule(platform).delimiter)
-        .map(pathEntry => pathEntry.trim())
-        .filter(Boolean);
+        .split(pathModule.delimiter)
+        .map((pathEntry) => {
+            const trimmedPathEntry = pathEntry.trim();
+
+            if (trimmedPathEntry === "" && !isWindows) {
+                return ".";
+            }
+
+            return trimmedPathEntry;
+        });
 }
 
 async function resolveFirstPathCandidatePath(options: {

--- a/src/application/self-update/command-path.ts
+++ b/src/application/self-update/command-path.ts
@@ -19,27 +19,30 @@ export async function resolveCommandPathCandidates(options: {
     }
 
     const pathModule = readPathModule(options.platform);
-    const candidates: CommandPathCandidate[] = [];
+    const pathExists = options.pathExists ?? defaultPathExists;
+    const resolvedCandidates = await Promise.all(
+        splitPathEntries(pathValue, options.platform).map(async (directoryPath) => {
+            const candidatePath = await resolveFirstPathCandidatePath({
+                directoryPath,
+                executableNames: options.executableNames,
+                pathExists,
+                pathModule,
+            });
 
-    for (const directoryPath of splitPathEntries(pathValue, options.platform)) {
-        const candidatePath = await resolveFirstPathCandidatePath({
-            directoryPath,
-            executableNames: options.executableNames,
-            pathExists: options.pathExists ?? defaultPathExists,
-            pathModule,
-        });
+            if (candidatePath === undefined) {
+                return undefined;
+            }
 
-        if (candidatePath === undefined) {
-            continue;
-        }
+            return {
+                directoryPath,
+                path: candidatePath,
+            } satisfies CommandPathCandidate;
+        }),
+    );
 
-        candidates.push({
-            directoryPath,
-            path: candidatePath,
-        });
-    }
-
-    return candidates;
+    return resolvedCandidates.filter(
+        (candidate): candidate is CommandPathCandidate => candidate !== undefined,
+    );
 }
 
 function readPathValue(

--- a/src/application/self-update/command-resolution.test.ts
+++ b/src/application/self-update/command-resolution.test.ts
@@ -1,0 +1,116 @@
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import process from "node:process";
+import { describe, expect, test } from "bun:test";
+import {
+    createTemporaryDirectory,
+    joinPathEntries,
+    useTemporaryDirectoryCleanup,
+} from "../../../__tests__/helpers.ts";
+import { resolveSelfUpdateCommandResolution } from "./command-resolution.ts";
+import { resolveSelfUpdatePaths } from "./paths.ts";
+
+const { track: trackDirectory } = useTemporaryDirectoryCleanup();
+
+describe("resolveSelfUpdateCommandResolution", () => {
+    test("reports managed when PATH resolves oo to the managed executable", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-command-resolution-managed");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries([paths.executableDirectory], process.platform);
+        await writeExecutable(paths.executablePath);
+
+        const result = await resolveSelfUpdateCommandResolution({
+            env,
+            executablePath: paths.executablePath,
+            platform: process.platform,
+        });
+
+        expect(result).toEqual({
+            status: "managed",
+        });
+    });
+
+    test("reports shadowed when another oo appears earlier on PATH", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-command-resolution-shadowed");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const legacyDirectory = join(rootDirectory, "legacy", "bin");
+        const legacyPath = join(legacyDirectory, basename(paths.executablePath));
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries(
+            [legacyDirectory, paths.executableDirectory],
+            process.platform,
+        );
+        await Promise.all([
+            writeExecutable(paths.executablePath),
+            writeExecutable(legacyPath),
+        ]);
+
+        const result = await resolveSelfUpdateCommandResolution({
+            env,
+            executablePath: paths.executablePath,
+            platform: process.platform,
+        });
+
+        expect(result).toEqual({
+            path: legacyPath,
+            status: "shadowed",
+        });
+    });
+
+    test("reports missing when PATH has no oo executable", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-command-resolution-missing");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries([join(rootDirectory, "empty", "bin")], process.platform);
+        await writeExecutable(paths.executablePath);
+
+        const result = await resolveSelfUpdateCommandResolution({
+            env,
+            executablePath: paths.executablePath,
+            platform: process.platform,
+        });
+
+        expect(result).toEqual({
+            status: "missing",
+        });
+    });
+});
+
+function createSelfUpdateEnv(rootDirectory: string): Record<string, string | undefined> {
+    return {
+        APPDATA: join(rootDirectory, "appdata"),
+        HOME: rootDirectory,
+        TEMP: join(rootDirectory, "temp"),
+        TMP: join(rootDirectory, "temp"),
+        TMPDIR: join(rootDirectory, "tmpdir"),
+        USERPROFILE: rootDirectory,
+        XDG_CACHE_HOME: join(rootDirectory, "cache"),
+        XDG_DATA_HOME: join(rootDirectory, "data"),
+        XDG_RUNTIME_DIR: join(rootDirectory, "runtime"),
+    };
+}
+
+async function writeExecutable(path: string): Promise<void> {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, "binary");
+
+    if (process.platform !== "win32") {
+        await chmod(path, 0o755);
+    }
+}

--- a/src/application/self-update/command-resolution.ts
+++ b/src/application/self-update/command-resolution.ts
@@ -1,0 +1,67 @@
+import type { SelfUpdateCommandResolutionResult } from "../contracts/self-update.ts";
+import { realpath } from "node:fs/promises";
+import { resolveCommandPathCandidates } from "./command-path.ts";
+import { isSamePath } from "./path-comparison.ts";
+import { readPathModule } from "./paths.ts";
+
+export async function resolveSelfUpdateCommandResolution(options: {
+    env: Record<string, string | undefined>;
+    executablePath: string;
+    pathExists?: (path: string) => Promise<boolean>;
+    platform: NodeJS.Platform;
+}): Promise<SelfUpdateCommandResolutionResult> {
+    const pathModule = readPathModule(options.platform);
+    const candidates = await resolveCommandPathCandidates({
+        env: options.env,
+        executableNames: [pathModule.basename(options.executablePath)],
+        pathExists: options.pathExists,
+        platform: options.platform,
+    });
+    const firstCandidate = candidates[0];
+
+    if (firstCandidate === undefined) {
+        return {
+            status: "missing",
+        };
+    }
+
+    if (await isSameExecutablePath({
+        leftPath: firstCandidate.path,
+        platform: options.platform,
+        rightPath: options.executablePath,
+    })) {
+        return {
+            status: "managed",
+        };
+    }
+
+    return {
+        path: firstCandidate.path,
+        status: "shadowed",
+    };
+}
+
+async function isSameExecutablePath(options: {
+    leftPath: string;
+    platform: NodeJS.Platform;
+    rightPath: string;
+}): Promise<boolean> {
+    if (isSamePath(options)) {
+        return true;
+    }
+
+    const [leftRealPath, rightRealPath] = await Promise.all([
+        readRealPath(options.leftPath),
+        readRealPath(options.rightPath),
+    ]);
+
+    return isSamePath({
+        leftPath: leftRealPath,
+        platform: options.platform,
+        rightPath: rightRealPath,
+    });
+}
+
+async function readRealPath(path: string): Promise<string> {
+    return await realpath(path).catch(() => path);
+}

--- a/src/application/self-update/core.ts
+++ b/src/application/self-update/core.ts
@@ -1,6 +1,9 @@
 import type { Logger } from "pino";
 import type { CliExecutionContext, Fetcher } from "../contracts/cli.ts";
-import type { SelfUpdatePathConfigurationResult } from "../contracts/self-update.ts";
+import type {
+    SelfUpdateCommandResolutionResult,
+    SelfUpdatePathConfigurationResult,
+} from "../contracts/self-update.ts";
 import type { LegacyPackageManagerCleanupRuntime } from "./legacy-installation.ts";
 import type { SelfUpdateProgressEvent } from "./progress.ts";
 import { chmod, copyFile, lstat, mkdir, open, readdir, readlink, realpath, rename, rm, stat, symlink } from "node:fs/promises";
@@ -17,6 +20,7 @@ import {
     parseLatestCliSemverReleaseVersion,
 } from "../update/release-metadata.ts";
 import { attemptBundledSkillRefreshAfterSelfUpdate } from "./bundled-skills.ts";
+import { resolveSelfUpdateCommandResolution } from "./command-resolution.ts";
 import { attemptLegacyPackageManagerUninstall } from "./legacy-installation.ts";
 import {
     acquireProcessLifetimeVersionLock,
@@ -56,6 +60,7 @@ export const selfUpdateBinaryDownloadStallTimeoutMs = 60_000;
 export const selfUpdateReleaseRequestTimeoutMs = 10_000;
 
 export interface SelfUpdateOperationResult {
+    commandResolution: SelfUpdateCommandResolutionResult;
     executableDirectory: string;
     executablePath: string;
     pathConfiguration: SelfUpdatePathConfigurationResult;
@@ -198,12 +203,14 @@ export async function performSelfUpdateOperation(options: {
             runtime: options.runtime,
         });
         await attemptLegacyPackageManagerUninstall(options.runtime);
-        const { pathConfiguration } = await ensureSelfUpdateExecutableDirectoryOnPath({
-            modifyPath: options.modifyPath,
-            runtime: options.runtime,
-        });
+        const { commandResolution, pathConfiguration }
+            = await ensureSelfUpdateExecutableDirectoryOnPath({
+                modifyPath: options.modifyPath,
+                runtime: options.runtime,
+            });
 
         return {
+            commandResolution,
             executableDirectory: paths.executableDirectory,
             executablePath: paths.executablePath,
             pathConfiguration,
@@ -219,8 +226,9 @@ export async function performSelfUpdateOperation(options: {
 
 export async function ensureSelfUpdateExecutableDirectoryOnPath(options: {
     modifyPath?: boolean;
-    runtime: Pick<SelfUpdateRuntime, "configurePath" | "env" | "logger" | "platform" | "resolveCommandPath" | "runCommand">;
+    runtime: Pick<SelfUpdateRuntime, "configurePath" | "env" | "logger" | "pathExists" | "platform" | "resolveCommandPath" | "runCommand">;
 }): Promise<{
+    commandResolution: SelfUpdateCommandResolutionResult;
     executableDirectory: string;
     pathConfiguration: SelfUpdatePathConfigurationResult;
 }> {
@@ -235,8 +243,15 @@ export async function ensureSelfUpdateExecutableDirectoryOnPath(options: {
         platform: options.runtime.platform,
         runtime: options.runtime,
     });
+    const commandResolution = await resolveSelfUpdateCommandResolution({
+        env: options.runtime.env,
+        executablePath: paths.executablePath,
+        pathExists: options.runtime.pathExists,
+        platform: options.runtime.platform,
+    });
 
     return {
+        commandResolution,
         executableDirectory: paths.executableDirectory,
         pathConfiguration,
     };

--- a/src/application/self-update/installation.test.ts
+++ b/src/application/self-update/installation.test.ts
@@ -131,6 +131,14 @@ describe("detectInstallationMethodFromExecPath", () => {
         }).method).toBe("npm");
     });
 
+    test("detects npm from an exact npm-global path segment", () => {
+        expect(detectInstallationMethodFromExecPath({
+            env: {},
+            execPath: "/Users/demo/Library/Application Support/QClaw/npm-global/bin/oo",
+            platform: "linux",
+        }).method).toBe("npm");
+    });
+
     test("detects npm from an exact .nvm path segment", () => {
         expect(detectInstallationMethodFromExecPath({
             env: {},

--- a/src/application/self-update/installation.ts
+++ b/src/application/self-update/installation.ts
@@ -1,4 +1,5 @@
-import { readPathModule, resolveSelfUpdatePaths } from "./paths.ts";
+import { isPathInsideDirectory, isSamePath } from "./path-comparison.ts";
+import { resolveSelfUpdatePaths } from "./paths.ts";
 
 export const packageManagerInstallationMethods = [
     "bun",
@@ -122,6 +123,7 @@ const packageManagerPathDetectors: Array<{
     {
         matches: pathSegments =>
             pathSegments.includes("fnm_multishells")
+            || pathSegments.includes("npm-global")
             || pathSegments.includes("npm_global")
             || pathSegments.includes(".nvm"),
         method: "npm",
@@ -167,50 +169,4 @@ function isManagedNativeExecutablePath(options: {
         directoryPath: paths.versionsDirectory,
         platform: options.platform,
     });
-}
-
-function isSamePath(options: {
-    leftPath: string;
-    platform: NodeJS.Platform;
-    rightPath: string;
-}): boolean {
-    return normalizeComparablePath(options.leftPath, options.platform)
-        === normalizeComparablePath(options.rightPath, options.platform);
-}
-
-function isPathInsideDirectory(options: {
-    candidatePath: string;
-    directoryPath: string;
-    platform: NodeJS.Platform;
-}): boolean {
-    const pathModule = readPathModule(options.platform);
-    const comparableCandidatePath = normalizeComparablePath(
-        options.candidatePath,
-        options.platform,
-    );
-    const comparableDirectoryPath = normalizeComparablePath(
-        options.directoryPath,
-        options.platform,
-    );
-    const relativePath = pathModule.relative(
-        comparableDirectoryPath,
-        comparableCandidatePath,
-    );
-
-    return relativePath !== ""
-        && relativePath !== "."
-        && !relativePath.startsWith("..")
-        && !pathModule.isAbsolute(relativePath);
-}
-
-function normalizeComparablePath(
-    path: string,
-    platform: NodeJS.Platform,
-): string {
-    const pathModule = readPathModule(platform);
-    const normalizedPath = pathModule.normalize(path.trim());
-
-    return platform === "win32"
-        ? normalizedPath.toLowerCase()
-        : normalizedPath;
 }

--- a/src/application/self-update/legacy-installation.test.ts
+++ b/src/application/self-update/legacy-installation.test.ts
@@ -227,6 +227,47 @@ describe("attemptLegacyPackageManagerUninstall", () => {
         }
     });
 
+    test("passes the detected npm prefix when uninstalling a custom npm-global PATH candidate", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-npm-prefix");
+        const env = createLegacyCleanupEnv(rootDirectory);
+        const npmPrefix = join(rootDirectory, "QClaw", "npm-global");
+        const npmBinDirectory = join(npmPrefix, "bin");
+        const commands = createRecordedCommands();
+        const logCapture = createLogCapture();
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries([npmBinDirectory], process.platform);
+        await writeExecutable(join(npmBinDirectory, readExecutableName(process.platform)));
+
+        try {
+            await attemptLegacyPackageManagerUninstall({
+                env,
+                execPath: join(rootDirectory, "downloads", readExecutableName(process.platform)),
+                logger: logCapture.logger,
+                platform: process.platform,
+                resolveCommandPath: commandName => `/mock/bin/${commandName}`,
+                runCommand: commands.runCommand,
+            });
+
+            expect(commands.read()).toEqual([
+                {
+                    commandArguments: [
+                        "uninstall",
+                        "-g",
+                        "--prefix",
+                        npmPrefix,
+                        "@oomol-lab/oo-cli",
+                    ],
+                    commandPath: "/mock/bin/npm",
+                    timeoutMs: 10_000,
+                },
+            ]);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
     test("ignores oo.cmd PATH candidates on Windows and falls back to execPath", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-legacy-win32");
         const env = createLegacyCleanupEnv(rootDirectory);

--- a/src/application/self-update/legacy-installation.ts
+++ b/src/application/self-update/legacy-installation.ts
@@ -1,7 +1,7 @@
 import type { SelfUpdateCommandRuntime } from "./command-runner.ts";
 import type { InstallationDetection, PackageManagerInstallationMethod } from "./installation.ts";
 import { realpath } from "node:fs/promises";
-import { pathExists } from "../shared/fs-utils.ts";
+import { resolveCommandPathCandidates } from "./command-path.ts";
 import { runSelfUpdateCommandWithLogging } from "./command-runner.ts";
 import { detectInstallationMethodFromExecPath } from "./installation.ts";
 import { readPathModule, resolveSelfUpdatePaths } from "./paths.ts";
@@ -11,18 +11,28 @@ const legacyPackageManagerUninstallTimeoutMs = 10_000;
 
 const legacyPackageManagerConfigurations = {
     bun: {
-        commandArguments: ["remove", "-g", legacyCliPackageName],
+        createCommandArguments: () => ["remove", "-g", legacyCliPackageName],
     },
     npm: {
-        commandArguments: ["uninstall", "-g", legacyCliPackageName],
+        createCommandArguments: (target: LegacyPackageManagerUninstallTarget) => [
+            "uninstall",
+            "-g",
+            ...(target.prefix === undefined ? [] : ["--prefix", target.prefix]),
+            legacyCliPackageName,
+        ],
     },
     pnpm: {
-        commandArguments: ["remove", "-g", legacyCliPackageName],
+        createCommandArguments: () => ["remove", "-g", legacyCliPackageName],
     },
     yarn: {
-        commandArguments: ["global", "remove", legacyCliPackageName],
+        createCommandArguments: () => ["global", "remove", legacyCliPackageName],
     },
 } as const;
+
+interface LegacyPackageManagerUninstallTarget {
+    method: PackageManagerInstallationMethod;
+    prefix?: string;
+}
 
 export interface LegacyPackageManagerCleanupRuntime extends SelfUpdateCommandRuntime {
     execPath: string;
@@ -33,24 +43,24 @@ export interface LegacyPackageManagerCleanupRuntime extends SelfUpdateCommandRun
 export async function attemptLegacyPackageManagerUninstall(
     runtime: LegacyPackageManagerCleanupRuntime,
 ): Promise<void> {
-    const packageManagers = await resolveLegacyPackageManagersToUninstall(runtime);
+    const targets = await resolveLegacyPackageManagersToUninstall(runtime);
 
-    if (packageManagers.length === 0) {
+    if (targets.length === 0) {
         return;
     }
 
-    for (const packageManager of packageManagers) {
-        await runLegacyPackageManagerUninstall(packageManager, runtime);
+    for (const target of targets) {
+        await runLegacyPackageManagerUninstall(target, runtime);
     }
 }
 
 async function resolveLegacyPackageManagersToUninstall(
     runtime: LegacyPackageManagerCleanupRuntime,
-): Promise<PackageManagerInstallationMethod[]> {
+): Promise<LegacyPackageManagerUninstallTarget[]> {
     const pathResolution = await resolveLegacyPackageManagersFromPath(runtime);
 
     if (pathResolution.encounteredCandidate) {
-        return pathResolution.packageManagers;
+        return pathResolution.targets;
     }
 
     const installation = detectInstallationMethodFromExecPath({
@@ -61,51 +71,40 @@ async function resolveLegacyPackageManagersToUninstall(
 
     return installation.method === "native" || installation.method === "unknown"
         ? []
-        : [installation.method];
+        : [{
+                method: installation.method,
+                prefix: resolvePackageManagerPrefix({
+                    installation,
+                    platform: runtime.platform,
+                    resolvedPath: runtime.execPath,
+                }),
+            }];
 }
 
 async function resolveLegacyPackageManagersFromPath(
     runtime: LegacyPackageManagerCleanupRuntime,
 ): Promise<{
     encounteredCandidate: boolean;
-    packageManagers: PackageManagerInstallationMethod[];
+    targets: LegacyPackageManagerUninstallTarget[];
 }> {
-    const pathValue = runtime.env.PATH?.trim();
-
-    if (pathValue === undefined || pathValue === "") {
-        return {
-            encounteredCandidate: false,
-            packageManagers: [],
-        };
-    }
-
     const paths = resolveSelfUpdatePaths({
         env: runtime.env,
         platform: runtime.platform,
     });
     const pathModule = readPathModule(runtime.platform);
     const executableName = pathModule.basename(paths.executablePath);
-    const packageManagers: PackageManagerInstallationMethod[] = [];
-    const seenPackageManagers = new Set<PackageManagerInstallationMethod>();
-    let encounteredCandidate = false;
+    const targets: LegacyPackageManagerUninstallTarget[] = [];
+    const seenTargets = new Set<string>();
+    const candidates = await resolveCommandPathCandidates({
+        env: runtime.env,
+        executableNames: [executableName],
+        pathExists: runtime.pathExists,
+        platform: runtime.platform,
+    });
 
-    for (const directoryPath of splitPathEntries(pathValue, runtime.platform)) {
-        const candidatePath = await resolveFirstPathCandidatePath({
-            directoryPath,
-            executableNames: [executableName],
-            pathExists: candidatePath =>
-                runtime.pathExists?.(candidatePath)
-                ?? pathExists(candidatePath),
-            pathModule,
-        });
-
-        if (candidatePath === undefined) {
-            continue;
-        }
-
-        encounteredCandidate = true;
+    for (const candidate of candidates) {
         const installation = await detectInstallationMethodFromPathCandidate({
-            candidatePath,
+            candidatePath: candidate.path,
             env: runtime.env,
             platform: runtime.platform,
         });
@@ -114,62 +113,36 @@ async function resolveLegacyPackageManagersFromPath(
             continue;
         }
 
-        if (seenPackageManagers.has(installation.method)) {
+        const target = {
+            method: installation.method,
+            prefix: resolvePackageManagerPrefix({
+                candidateDirectoryPath: candidate.directoryPath,
+                installation,
+                platform: runtime.platform,
+                resolvedPath: installation.resolvedPath,
+            }),
+        };
+        const targetKey = createLegacyPackageManagerTargetKey(target);
+
+        if (seenTargets.has(targetKey)) {
             continue;
         }
 
-        seenPackageManagers.add(installation.method);
-        packageManagers.push(installation.method);
+        seenTargets.add(targetKey);
+        targets.push(target);
     }
 
     return {
-        encounteredCandidate,
-        packageManagers,
+        encounteredCandidate: candidates.length > 0,
+        targets,
     };
-}
-
-function splitPathEntries(
-    pathValue: string,
-    platform: NodeJS.Platform,
-): string[] {
-    const pathEntries = pathValue
-        .split(readPathDelimiter(platform))
-        .map(pathEntry => pathEntry.trim())
-        .filter(Boolean);
-
-    return pathEntries;
-}
-
-function readPathDelimiter(
-    platform: NodeJS.Platform,
-): string {
-    return platform === "win32"
-        ? ";"
-        : ":";
-}
-
-async function resolveFirstPathCandidatePath(options: {
-    directoryPath: string;
-    executableNames: readonly string[];
-    pathExists: (path: string) => Promise<boolean>;
-    pathModule: ReturnType<typeof readPathModule>;
-}): Promise<string | undefined> {
-    for (const executableName of options.executableNames) {
-        const candidatePath = options.pathModule.join(options.directoryPath, executableName);
-
-        if (await options.pathExists(candidatePath)) {
-            return candidatePath;
-        }
-    }
-
-    return undefined;
 }
 
 async function detectInstallationMethodFromPathCandidate(options: {
     candidatePath: string;
     env: Record<string, string | undefined>;
     platform: NodeJS.Platform;
-}): Promise<InstallationDetection> {
+}): Promise<InstallationDetection & { resolvedPath: string }> {
     const resolvedCandidatePath = await realpath(options.candidatePath)
         .catch(() => options.candidatePath);
     const resolvedInstallation = detectInstallationMethodFromExecPath({
@@ -182,28 +155,133 @@ async function detectInstallationMethodFromPathCandidate(options: {
         resolvedInstallation.method !== "unknown"
         || resolvedCandidatePath === options.candidatePath
     ) {
-        return resolvedInstallation;
+        return {
+            ...resolvedInstallation,
+            resolvedPath: resolvedCandidatePath,
+        };
     }
 
-    return detectInstallationMethodFromExecPath({
-        env: options.env,
-        execPath: options.candidatePath,
-        platform: options.platform,
-    });
+    return {
+        ...detectInstallationMethodFromExecPath({
+            env: options.env,
+            execPath: options.candidatePath,
+            platform: options.platform,
+        }),
+        resolvedPath: options.candidatePath,
+    };
+}
+
+function resolvePackageManagerPrefix(options: {
+    candidateDirectoryPath?: string;
+    installation: InstallationDetection;
+    platform: NodeJS.Platform;
+    resolvedPath: string;
+}): string | undefined {
+    if (options.installation.method !== "npm") {
+        return undefined;
+    }
+
+    return resolveNpmGlobalPrefixFromInstallPath(
+        options.resolvedPath,
+        options.platform,
+    ) ?? (
+        options.candidateDirectoryPath === undefined
+            ? undefined
+            : resolveNpmGlobalPrefixFromBinDirectory(
+                    options.candidateDirectoryPath,
+                    options.platform,
+                )
+    );
+}
+
+function resolveNpmGlobalPrefixFromInstallPath(
+    rawPath: string,
+    platform: NodeJS.Platform,
+): string | undefined {
+    const pathModule = readPathModule(platform);
+    const pathParts = splitAbsolutePath(rawPath, platform);
+    const normalizedSegments = pathParts.segments.map(segment =>
+        segment.toLowerCase(),
+    );
+    const nodeModulesIndex = normalizedSegments.lastIndexOf("node_modules");
+
+    if (nodeModulesIndex < 0) {
+        return undefined;
+    }
+
+    const prefixEndIndex = normalizedSegments[nodeModulesIndex - 1] === "lib"
+        ? nodeModulesIndex - 1
+        : nodeModulesIndex;
+
+    if (prefixEndIndex <= 0) {
+        return undefined;
+    }
+
+    return pathModule.join(
+        pathParts.root,
+        ...pathParts.segments.slice(0, prefixEndIndex),
+    );
+}
+
+function resolveNpmGlobalPrefixFromBinDirectory(
+    rawPath: string,
+    platform: NodeJS.Platform,
+): string | undefined {
+    const pathModule = readPathModule(platform);
+    const pathParts = splitAbsolutePath(rawPath, platform);
+    const finalSegment = pathParts.segments.at(-1);
+
+    if (finalSegment?.toLowerCase() !== "bin") {
+        return undefined;
+    }
+
+    const prefixSegments = pathParts.segments.slice(0, -1);
+
+    if (prefixSegments.length === 0) {
+        return undefined;
+    }
+
+    return pathModule.join(pathParts.root, ...prefixSegments);
+}
+
+function splitAbsolutePath(
+    rawPath: string,
+    platform: NodeJS.Platform,
+): {
+    root: string;
+    segments: string[];
+} {
+    const pathModule = readPathModule(platform);
+    const normalizedPath = pathModule.normalize(rawPath);
+    const root = pathModule.parse(normalizedPath).root;
+    const relativePath = pathModule.relative(root, normalizedPath);
+
+    return {
+        root,
+        segments: relativePath === ""
+            ? []
+            : relativePath.split(pathModule.sep).filter(Boolean),
+    };
+}
+
+function createLegacyPackageManagerTargetKey(
+    target: LegacyPackageManagerUninstallTarget,
+): string {
+    return `${target.method}\0${target.prefix ?? ""}`;
 }
 
 async function runLegacyPackageManagerUninstall(
-    packageManager: PackageManagerInstallationMethod,
+    target: LegacyPackageManagerUninstallTarget,
     runtime: LegacyPackageManagerCleanupRuntime,
 ): Promise<void> {
-    const configuration = legacyPackageManagerConfigurations[packageManager];
-    const commandPath = runtime.resolveCommandPath?.(packageManager)
-        ?? Bun.which(packageManager);
+    const configuration = legacyPackageManagerConfigurations[target.method];
+    const commandPath = runtime.resolveCommandPath?.(target.method)
+        ?? Bun.which(target.method);
 
     if (commandPath === null) {
         runtime.logger.warn(
             {
-                packageManager,
+                packageManager: target.method,
             },
             "Legacy package-manager oo-cli uninstall skipped because the executable was not found.",
         );
@@ -211,11 +289,12 @@ async function runLegacyPackageManagerUninstall(
     }
 
     await runSelfUpdateCommandWithLogging({
-        commandArguments: configuration.commandArguments,
+        commandArguments: configuration.createCommandArguments(target),
         commandPath,
         failureMessage: "Legacy package-manager oo-cli uninstall failed.",
         logContext: {
-            packageManager,
+            packageManager: target.method,
+            prefix: target.prefix,
         },
         runtime,
         successMessage: "Legacy package-manager oo-cli uninstall completed.",

--- a/src/application/self-update/path-comparison.ts
+++ b/src/application/self-update/path-comparison.ts
@@ -1,0 +1,47 @@
+import { readPathModule } from "./paths.ts";
+
+export function isSamePath(options: {
+    leftPath: string;
+    platform: NodeJS.Platform;
+    rightPath: string;
+}): boolean {
+    return normalizeComparablePath(options.leftPath, options.platform)
+        === normalizeComparablePath(options.rightPath, options.platform);
+}
+
+export function isPathInsideDirectory(options: {
+    candidatePath: string;
+    directoryPath: string;
+    platform: NodeJS.Platform;
+}): boolean {
+    const pathModule = readPathModule(options.platform);
+    const comparableCandidatePath = normalizeComparablePath(
+        options.candidatePath,
+        options.platform,
+    );
+    const comparableDirectoryPath = normalizeComparablePath(
+        options.directoryPath,
+        options.platform,
+    );
+    const relativePath = pathModule.relative(
+        comparableDirectoryPath,
+        comparableCandidatePath,
+    );
+
+    return relativePath !== ""
+        && relativePath !== "."
+        && !relativePath.startsWith("..")
+        && !pathModule.isAbsolute(relativePath);
+}
+
+function normalizeComparablePath(
+    path: string,
+    platform: NodeJS.Platform,
+): string {
+    const pathModule = readPathModule(platform);
+    const normalizedPath = pathModule.normalize(path.trim());
+
+    return platform === "win32"
+        ? normalizedPath.toLowerCase()
+        : normalizedPath;
+}

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -566,6 +566,8 @@ export const enMessages = {
         "Restart your shell to reload PATH and use oo.",
     "selfUpdate.install.pathNote":
         "Add {path} to PATH to run oo in new shells.",
+    "selfUpdate.pathShadowedNote":
+        "PATH currently resolves oo to {path} before the managed directory {directory}. Move {directory} earlier in PATH or remove the older oo entry, then restart your shell.",
     "selfUpdate.progress.install.header": "Installing oo",
     "selfUpdate.progress.update.header": "Updating oo",
     "selfUpdate.progress.resolve.start": "Resolving latest release...",
@@ -1292,6 +1294,8 @@ export const zhMessages = {
         "请重启 shell 以重新加载 PATH 后使用 oo。",
     "selfUpdate.install.pathNote":
         "请把 {path} 加入 PATH，新的 shell 才能直接运行 oo。",
+    "selfUpdate.pathShadowedNote":
+        "当前 PATH 会先解析到 {path}，早于托管目录 {directory}。请把 {directory} 移到 PATH 更靠前的位置，或移除旧的 oo 入口，然后重启 shell。",
     "selfUpdate.progress.install.header": "正在安装 oo",
     "selfUpdate.progress.update.header": "正在更新 oo",
     "selfUpdate.progress.resolve.start": "正在解析最新发布版本...",


### PR DESCRIPTION
## Summary

- Detect when `oo install` or `oo update` leaves another `oo` executable earlier on `PATH` and print an explicit shadowing note.
- Reuse shared command path/path comparison helpers for self-update resolution checks.
- Improve legacy npm global cleanup by recognizing `npm-global` paths and passing the detected `--prefix` when uninstalling old `@oomol-lab/oo-cli` installs.
- Update npm wrapper detection, localized output, tests, and command docs for the new behavior.

## Root Cause

`oo update` correctly installed and activated the managed executable under `~/.local/bin`, but it did not verify that the current shell would actually resolve `oo` to that managed entrypoint. A prior npm-global installation, such as a custom `QClaw/npm-global/bin/oo`, could remain earlier on `PATH`, making `oo --version` continue to report the old version after a successful update.

## Validation

- `bun run lint:fix`
- `bun run ts-check`
- `bun run test src/application/self-update/command-resolution.test.ts src/application/self-update/legacy-installation.test.ts src/application/self-update/installation.test.ts src/application/commands/self-update-output.test.ts src/application/commands/self-update.cli.test.ts contrib/npm/oo.test.ts`
- `bun run test` with Bun `1.3.13`: `799 pass`, `9 skip`, `0 fail`
