### PR TITLE
feat(self-update): warn when PATH shadows the managed oo executable

### DIFF
--- a/contrib/npm/oo.cjs
+++ b/contrib/npm/oo.cjs
@@ -107,7 +107,11 @@ function detectPackageManagerFromOoPath(paths) {
             return "pnpm";
         }
 
-        if (pathSegments.includes("fnm_multishells")) {
+        if (
+            pathSegments.includes("fnm_multishells")
+            || pathSegments.includes("npm-global")
+            || pathSegments.includes("npm_global")
+        ) {
             return "npm";
         }
     }

--- a/contrib/npm/oo.test.ts
+++ b/contrib/npm/oo.test.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
@@ -30,6 +31,21 @@ describe("oo wrapper", () => {
     test("detects npm from the installed oo path under fnm_multishells", () => {
         expect(wrapperModule.detectPackageManagerFromOoPath([
             "/Users/demo/.local/state/fnm_multishells/12345/bin/oo",
+        ])).toBe("npm");
+    });
+
+    test("detects npm from the installed oo path under npm-global", () => {
+        expect(wrapperModule.detectPackageManagerFromOoPath([
+            join(
+                "Users",
+                "demo",
+                "Library",
+                "Application Support",
+                "QClaw",
+                "npm-global",
+                "bin",
+                "oo",
+            ),
         ])).toBe("npm");
     });
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -122,6 +122,10 @@ Install one managed `oo` release into the local self-managed runtime.
   `yes`, `on`, case-insensitive) is equivalent to `--no-modify-path`. The flag
   and the env var combine with OR semantics: either one being set skips PATH
   configuration.
+- Environment: setting `OO_HIDE_PATH_SHADOWING_WARNING` to a truthy value hides
+  the shadowing note for users who intentionally keep another `oo` earlier on
+  `PATH`. It does not change managed installation, PATH setup, or legacy
+  cleanup behavior.
 - Output: on success, the CLI prints the installed version and the final
   executable path.
 - Output: when `stderr` is an interactive TTY, the CLI also renders colored
@@ -131,7 +135,12 @@ Install one managed `oo` release into the local self-managed runtime.
 - Notes: after a successful install, the CLI best-effort removes legacy global
   `@oomol-lab/oo-cli` package-manager installs that appear anywhere on `PATH`;
   when `PATH` yields no `oo` candidates, the CLI falls back to the current
-  command path. Cleanup failures do not change the command result.
+  command path. For npm installs, cleanup targets the detected global prefix
+  when it can be inferred. Cleanup failures do not change the command result.
+- Notes: after PATH setup and legacy cleanup, if the current `PATH` still
+  resolves `oo` to another executable before the managed executable directory,
+  install prints a shadowing note that identifies that path and the managed
+  directory.
 - Notes: when automatic PATH modification is enabled, install ensures zsh
   startup profiles `.zprofile` and `.zshenv` contain the managed PATH snippet,
   even if the current `PATH` already contains the executable directory. When the
@@ -160,6 +169,10 @@ Update the managed `oo` install to the latest published release.
   `yes`, `on`, case-insensitive) is equivalent to `--no-modify-path`. The flag
   and the env var combine with OR semantics: either one being set skips PATH
   configuration.
+- Environment: setting `OO_HIDE_PATH_SHADOWING_WARNING` to a truthy value hides
+  the shadowing note for users who intentionally keep another `oo` earlier on
+  `PATH`. It does not change managed installation, PATH setup, or legacy
+  cleanup behavior.
 - Output: when the current version is already the latest published release, the
   CLI prints the up-to-date message.
 - Output: when a newer published release is available, the CLI prints the
@@ -174,7 +187,12 @@ Update the managed `oo` install to the latest published release.
 - Notes: after a successful update, the CLI best-effort removes legacy global
   `@oomol-lab/oo-cli` package-manager installs that appear anywhere on `PATH`;
   when `PATH` yields no `oo` candidates, the CLI falls back to the current
-  command path. Cleanup failures do not change the command result.
+  command path. For npm installs, cleanup targets the detected global prefix
+  when it can be inferred. Cleanup failures do not change the command result.
+- Notes: after PATH setup and legacy cleanup, if the current `PATH` still
+  resolves `oo` to another executable before the managed executable directory,
+  update prints a shadowing note that identifies that path and the managed
+  directory.
 - Notes: when automatic PATH modification is enabled, update ensures zsh
   startup profiles `.zprofile` and `.zshenv` contain the managed PATH snippet,
   even if the current `PATH` already contains the executable directory. When the

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -110,13 +110,19 @@
 - 环境变量：将 `OO_NO_MODIFY_PATH` 设为真值（`1`、`true`、`yes`、`on`，大小写不敏感）
   等价于 `--no-modify-path`。标志和环境变量按"任一为跳过即跳过"的或关系组合，
   任一设置都会跳过 PATH 配置。
+- 环境变量：将 `OO_HIDE_PATH_SHADOWING_WARNING` 设为真值会隐藏 shadowing note，
+  适用于有意把另一个 `oo` 放在 `PATH` 更前面的用户。它不会改变托管安装、PATH
+  配置或旧安装清理行为。
 - 输出：成功时，CLI 会打印已安装版本和最终的可执行入口路径。
 - 输出：当 `stderr` 是交互式 TTY 时，CLI 还会在安装过程中向 `stderr`
   渲染带颜色的进度阶段。
 - 说明：install 在报告成功前会校验已安装的 `oo` 命令可正常使用。
 - 说明：install 成功后，CLI 会尽力移除在 `PATH` 中任意位置出现的旧全局
   package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到 `oo`
-  候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
+  候选项，CLI 会回退到当前命令路径进行判断。对于 npm 安装，清理命令会在可推断时
+  使用检测到的 global prefix。清理失败不会改变命令结果。
+- 说明：PATH 配置和旧安装清理结束后，如果当前 `PATH` 仍然会先解析到另一个
+  `oo`，早于托管可执行目录，install 会打印 shadowing note，指出该路径和托管目录。
 - 说明：当自动 PATH 修改启用时，install 会确保 zsh startup profile
   `.zprofile` 和 `.zshenv` 包含托管 PATH 片段，即使当前 `PATH` 已经包含可执行目录。
   如果可执行目录没有出现在 `PATH` 中，install 还会尝试为后续 shell 持久化 PATH
@@ -140,6 +146,9 @@
 - 环境变量：将 `OO_NO_MODIFY_PATH` 设为真值（`1`、`true`、`yes`、`on`，大小写不敏感）
   等价于 `--no-modify-path`。标志和环境变量按"任一为跳过即跳过"的或关系组合，
   任一设置都会跳过 PATH 配置。
+- 环境变量：将 `OO_HIDE_PATH_SHADOWING_WARNING` 设为真值会隐藏 shadowing note，
+  适用于有意把另一个 `oo` 放在 `PATH` 更前面的用户。它不会改变托管安装、PATH
+  配置或旧安装清理行为。
 - 输出：当当前版本已经是最新发布版本时，CLI 会打印“已是最新版本”的消息。
 - 输出：当有更新的发布版本可用时，CLI 会打印版本变更结果。
 - 输出：当 `stderr` 是交互式 TTY 时，CLI 还会在更新过程中向 `stderr`
@@ -150,7 +159,10 @@
   刷新 bundled skills，再输出“已是最新版本”的消息。
 - 说明：update 成功后，CLI 会尽力移除在 `PATH` 中任意位置出现的旧全局
   package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到 `oo`
-  候选项，CLI 会回退到当前命令路径进行判断。清理失败不会改变命令结果。
+  候选项，CLI 会回退到当前命令路径进行判断。对于 npm 安装，清理命令会在可推断时
+  使用检测到的 global prefix。清理失败不会改变命令结果。
+- 说明：PATH 配置和旧安装清理结束后，如果当前 `PATH` 仍然会先解析到另一个
+  `oo`，早于托管可执行目录，update 会打印 shadowing note，指出该路径和托管目录。
 - 说明：当自动 PATH 修改启用时，update 会确保 zsh startup profile
   `.zprofile` 和 `.zshenv` 包含托管 PATH 片段，即使当前 `PATH` 已经包含可执行目录。
   如果可执行目录没有出现在 `PATH` 中，update 还会尝试为后续 shell 持久化 PATH

--- a/src/application/commands/install.ts
+++ b/src/application/commands/install.ts
@@ -10,6 +10,7 @@ import {
     selfUpdateDevelopmentVersion,
 } from "../self-update/core.ts";
 import { resolveSelfUpdateModifyPath } from "../self-update/modify-path-preference.ts";
+import { resolveSelfUpdateShowPathShadowingWarning } from "../self-update/path-shadowing-warning-preference.ts";
 import { isSemver } from "../semver.ts";
 import { writeSelfUpdatePathNoteIfNeeded } from "./self-update-output.ts";
 import { SelfUpdateProgressReporter } from "./self-update-progress.ts";
@@ -140,8 +141,12 @@ export const installCommand: CliCommandDefinition<
             );
 
             writeSelfUpdatePathNoteIfNeeded({
+                commandResolution: result.commandResolution,
                 executableDirectory: result.executableDirectory,
                 pathConfiguration: result.pathConfiguration,
+                showPathShadowingWarning: resolveSelfUpdateShowPathShadowingWarning({
+                    env: context.env,
+                }),
                 stdout: context.stdout,
                 translator: context.translator,
             });

--- a/src/application/commands/self-update-output.test.ts
+++ b/src/application/commands/self-update-output.test.ts
@@ -108,4 +108,57 @@ describe("writeSelfUpdatePathNoteIfNeeded", () => {
 
         expect(stdout.read()).toContain("Add /home/demo/.local/bin to PATH");
     });
+
+    test("prints a shadowing note when PATH resolves another oo before the managed directory", () => {
+        const stdout = createTextBuffer();
+
+        writeSelfUpdatePathNoteIfNeeded({
+            commandResolution: {
+                path: "/opt/old/bin/oo",
+                status: "shadowed",
+            },
+            executableDirectory,
+            pathConfiguration: { status: "already-configured" },
+            stdout: stdout.writer,
+            translator,
+        });
+
+        expect(stdout.read()).toBe(
+            "PATH currently resolves oo to /opt/old/bin/oo before the managed directory /home/demo/.local/bin. Move /home/demo/.local/bin earlier in PATH or remove that oo entry, then restart your shell.\n",
+        );
+    });
+
+    test("does not print a shadowing note when the warning is disabled", () => {
+        const stdout = createTextBuffer();
+
+        writeSelfUpdatePathNoteIfNeeded({
+            commandResolution: {
+                path: "/opt/custom/bin/oo",
+                status: "shadowed",
+            },
+            executableDirectory,
+            pathConfiguration: { status: "already-configured" },
+            showPathShadowingWarning: false,
+            stdout: stdout.writer,
+            translator,
+        });
+
+        expect(stdout.read()).toBe("");
+    });
+
+    test("does not print a shadowing note when the managed directory is missing", () => {
+        const stdout = createTextBuffer();
+
+        writeSelfUpdatePathNoteIfNeeded({
+            commandResolution: {
+                status: "managedDirectoryMissing",
+            },
+            executableDirectory,
+            pathConfiguration: { status: "already-configured" },
+            stdout: stdout.writer,
+            translator,
+        });
+
+        expect(stdout.read()).toBe("");
+    });
 });

--- a/src/application/commands/self-update-output.ts
+++ b/src/application/commands/self-update-output.ts
@@ -1,9 +1,24 @@
 import type { Writer } from "../contracts/cli.ts";
-import type { SelfUpdatePathConfigurationResult } from "../contracts/self-update.ts";
+import type {
+    SelfUpdateCommandResolutionResult,
+    SelfUpdatePathConfigurationResult,
+} from "../contracts/self-update.ts";
 import type { Translator } from "../contracts/translator.ts";
 import { writeLine } from "./shared/output.ts";
 
 export function writeSelfUpdatePathNoteIfNeeded(options: {
+    commandResolution?: SelfUpdateCommandResolutionResult;
+    executableDirectory: string;
+    pathConfiguration: SelfUpdatePathConfigurationResult;
+    showPathShadowingWarning?: boolean;
+    stdout: Writer;
+    translator: Pick<Translator, "t">;
+}): void {
+    writeSelfUpdatePathConfigurationNoteIfNeeded(options);
+    writeSelfUpdateCommandResolutionNoteIfNeeded(options);
+}
+
+function writeSelfUpdatePathConfigurationNoteIfNeeded(options: {
     executableDirectory: string;
     pathConfiguration: SelfUpdatePathConfigurationResult;
     stdout: Writer;
@@ -65,6 +80,29 @@ export function writeSelfUpdatePathNoteIfNeeded(options: {
         options.stdout,
         options.translator.t("selfUpdate.install.pathNote", {
             path: options.executableDirectory,
+        }),
+    );
+}
+
+function writeSelfUpdateCommandResolutionNoteIfNeeded(options: {
+    commandResolution?: SelfUpdateCommandResolutionResult;
+    executableDirectory: string;
+    showPathShadowingWarning?: boolean;
+    stdout: Writer;
+    translator: Pick<Translator, "t">;
+}): void {
+    if (
+        options.showPathShadowingWarning === false
+        || options.commandResolution?.status !== "shadowed"
+    ) {
+        return;
+    }
+
+    writeLine(
+        options.stdout,
+        options.translator.t("selfUpdate.pathShadowedNote", {
+            directory: options.executableDirectory,
+            path: options.commandResolution.path,
         }),
     );
 }

--- a/src/application/commands/self-update.cli.test.ts
+++ b/src/application/commands/self-update.cli.test.ts
@@ -4,14 +4,16 @@ import type {
     CliSnapshotContext,
 } from "../../../__tests__/helpers.ts";
 import { chmod, mkdir, stat } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import process from "node:process";
 import { describe, expect, test } from "bun:test";
 import {
     createCliSandbox,
     createCliSnapshot,
+    joinPathEntries,
     toRequest,
 } from "../../../__tests__/helpers.ts";
+import { selfUpdateHidePathShadowingWarningEnvName } from "../self-update/path-shadowing-warning-preference.ts";
 import {
     resolveSelfUpdatePaths,
     resolveSelfUpdateVersionDirectoryPath,
@@ -563,6 +565,59 @@ describe("self-update commands", () => {
         }
     });
 
+    test("update warns when cleanup leaves another oo before the managed directory", async () => {
+        await withShadowedLegacyUpdateScenario(async ({
+            legacyPrefix,
+            paths,
+            result,
+            sandbox,
+            selfUpdateRuntime,
+        }) => {
+            expect(createCliSnapshot(result, { sandbox })).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: [
+                    "Updated oo from 1.0.0 to 2.0.0.",
+                    "Added <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.",
+                    `PATH currently resolves oo to <CWD>/QClaw/npm-global/bin/${basename(paths.executablePath)} before the managed directory <HOME>/.local/bin. Move <HOME>/.local/bin earlier in PATH or remove that oo entry, then restart your shell.`,
+                    "",
+                ].join("\n"),
+            });
+            expect(selfUpdateRuntime.commands).toContainEqual({
+                commandArguments: [
+                    "uninstall",
+                    "-g",
+                    "--prefix",
+                    legacyPrefix,
+                    "@oomol-lab/oo-cli",
+                ],
+                commandPath: "/mock/bin/npm",
+                timeoutMs: 10_000,
+            });
+        });
+    });
+
+    test("update hides the shadowing warning when the env var is set", async () => {
+        await withShadowedLegacyUpdateScenario(async ({
+            result,
+            sandbox,
+        }) => {
+            expect(createCliSnapshot(result, { sandbox })).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout: [
+                    "Updated oo from 1.0.0 to 2.0.0.",
+                    "Added <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.",
+                    "",
+                ].join("\n"),
+            });
+        }, {
+            env: {
+                [selfUpdateHidePathShadowingWarningEnvName]: "1",
+            },
+        });
+    });
+
     test("update refreshes bundled skills for a same-version native install without downloading a binary", async () => {
         const sandbox = await createCliSandbox();
         const releasePlatform = await detectSelfUpdateReleasePlatform({
@@ -761,13 +816,23 @@ describe("self-update commands", () => {
             paths,
             "1.2.3",
         );
+        const packageManagerPrefix = join(sandbox.cwd, "npm-prefix");
+        const packageManagerExecPath = join(
+            packageManagerPrefix,
+            "lib",
+            "node_modules",
+            "@oomol-lab",
+            "oo-cli",
+            "bin",
+            process.platform === "win32" ? "oo.exe" : "oo",
+        );
         let binaryRequestCount = 0;
 
         try {
             await writeManagedVersion(currentVersionPath, "existing-binary");
 
             const result = await sandbox.run(["upgrade"], {
-                execPath: "/usr/local/lib/node_modules/@oomol-lab/oo-cli/bin/oo",
+                execPath: packageManagerExecPath,
                 fetcher: async (input, init) => {
                     const url = toRequest(input, init).url;
 
@@ -797,7 +862,13 @@ describe("self-update commands", () => {
                     timeoutMs: 10_000,
                 },
                 {
-                    commandArguments: ["uninstall", "-g", "@oomol-lab/oo-cli"],
+                    commandArguments: [
+                        "uninstall",
+                        "-g",
+                        "--prefix",
+                        packageManagerPrefix,
+                        "@oomol-lab/oo-cli",
+                    ],
                     commandPath: "/mock/bin/npm",
                     timeoutMs: 10_000,
                 },
@@ -860,6 +931,79 @@ describe("self-update commands", () => {
         }
     });
 });
+
+async function withShadowedLegacyUpdateScenario(
+    assertion: (scenario: {
+        legacyPrefix: string;
+        paths: ReturnType<typeof resolveSelfUpdatePaths>;
+        result: CliRunResult;
+        sandbox: CliSnapshotContext;
+        selfUpdateRuntime: ReturnType<typeof createCapturedSelfUpdateRuntime>;
+    }) => Promise<void> | void,
+    options: {
+        env?: Record<string, string | undefined>;
+    } = {},
+): Promise<void> {
+    const sandbox = await createCliSandbox();
+    const releasePlatform = await detectSelfUpdateReleasePlatform({
+        arch: process.arch,
+        platform: process.platform,
+    });
+    const paths = resolveSelfUpdatePaths({
+        env: sandbox.env,
+        platform: process.platform,
+    });
+    const legacyPrefix = join(sandbox.cwd, "QClaw", "npm-global");
+    const legacyDirectory = join(legacyPrefix, "bin");
+    const legacyPath = join(legacyDirectory, basename(paths.executablePath));
+    const selfUpdateRuntime = createCapturedSelfUpdateRuntime({
+        exitCode: 1,
+        signalCode: null,
+        stderr: "permission denied",
+        stdout: "",
+    });
+
+    sandbox.env.PATH = joinPathEntries(
+        [legacyDirectory, paths.executableDirectory],
+        process.platform,
+    );
+    Object.assign(sandbox.env, options.env);
+
+    try {
+        await writeManagedVersion(legacyPath, "legacy-binary");
+
+        const result = await sandbox.run(["update"], {
+            fetcher: async (input, init) => {
+                const url = toRequest(input, init).url;
+
+                if (url.endsWith("/latest.json")) {
+                    return new Response(JSON.stringify({
+                        version: "2.0.0",
+                    }));
+                }
+
+                if (url.endsWith(`/${releasePlatform}/${process.platform === "win32" ? "oo.exe" : "oo"}`)) {
+                    return new Response("binary");
+                }
+
+                throw new Error(`Unexpected request: ${url}`);
+            },
+            selfUpdateRuntime: selfUpdateRuntime.runtime,
+            version: "1.0.0",
+        });
+
+        await assertion({
+            legacyPrefix,
+            paths,
+            result,
+            sandbox,
+            selfUpdateRuntime,
+        });
+    }
+    finally {
+        await sandbox.cleanup();
+    }
+}
 
 function createSelfUpdateInstallSnapshot(
     result: CliRunResult,

--- a/src/application/commands/update.ts
+++ b/src/application/commands/update.ts
@@ -1,5 +1,6 @@
 import type { CliCommandDefinition } from "../contracts/cli.ts";
 
+import type { SelfUpdateCommandResolutionResult, SelfUpdatePathConfigurationResult } from "../contracts/self-update.ts";
 import process from "node:process";
 import { z } from "zod";
 import {
@@ -16,6 +17,7 @@ import {
 } from "../self-update/core.ts";
 import { detectInstallationMethodFromExecPath } from "../self-update/installation.ts";
 import { resolveSelfUpdateModifyPath } from "../self-update/modify-path-preference.ts";
+import { resolveSelfUpdateShowPathShadowingWarning } from "../self-update/path-shadowing-warning-preference.ts";
 import { writeSelfUpdatePathNoteIfNeeded } from "./self-update-output.ts";
 import { SelfUpdateProgressReporter } from "./self-update-progress.ts";
 import { writeLine } from "./shared/output.ts";
@@ -44,6 +46,21 @@ export const updateCommand: CliCommandDefinition<
             env: context.env,
             modifyPathFlag: input.modifyPath,
         });
+        const showPathShadowingWarning = resolveSelfUpdateShowPathShadowingWarning({
+            env: context.env,
+        });
+        const writePathNote = (pathNoteResult: {
+            commandResolution: SelfUpdateCommandResolutionResult;
+            executableDirectory: string;
+            pathConfiguration: SelfUpdatePathConfigurationResult;
+        }): void => {
+            writeSelfUpdatePathNoteIfNeeded({
+                ...pathNoteResult,
+                showPathShadowingWarning,
+                stdout: context.stdout,
+                translator: context.translator,
+            });
+        };
 
         if (context.version === selfUpdateDevelopmentVersion) {
             writeLine(
@@ -100,7 +117,7 @@ export const updateCommand: CliCommandDefinition<
                         ...context.selfUpdateRuntime,
                     },
                 });
-                const { executableDirectory, pathConfiguration }
+                const { commandResolution, executableDirectory, pathConfiguration }
                     = await ensureSelfUpdateExecutableDirectoryOnPath({
                         modifyPath: effectiveModifyPath,
                         runtime: {
@@ -117,11 +134,10 @@ export const updateCommand: CliCommandDefinition<
                         version: context.version,
                     }),
                 );
-                writeSelfUpdatePathNoteIfNeeded({
+                writePathNote({
+                    commandResolution,
                     executableDirectory,
                     pathConfiguration,
-                    stdout: context.stdout,
-                    translator: context.translator,
                 });
                 return;
             }
@@ -165,11 +181,10 @@ export const updateCommand: CliCommandDefinition<
                         version: context.version,
                     }),
                 );
-                writeSelfUpdatePathNoteIfNeeded({
+                writePathNote({
+                    commandResolution: result.commandResolution,
                     executableDirectory: result.executableDirectory,
                     pathConfiguration: result.pathConfiguration,
-                    stdout: context.stdout,
-                    translator: context.translator,
                 });
                 return;
             }
@@ -181,11 +196,10 @@ export const updateCommand: CliCommandDefinition<
                     version: latestVersion,
                 }),
             );
-            writeSelfUpdatePathNoteIfNeeded({
+            writePathNote({
+                commandResolution: result.commandResolution,
                 executableDirectory: result.executableDirectory,
                 pathConfiguration: result.pathConfiguration,
-                stdout: context.stdout,
-                translator: context.translator,
             });
         }
         catch (error) {

--- a/src/application/contracts/self-update.ts
+++ b/src/application/contracts/self-update.ts
@@ -30,6 +30,15 @@ export interface SelfUpdatePathConfigurationResult {
     failedTargets?: readonly string[];
 }
 
+export type SelfUpdateCommandResolutionResult
+    = | {
+        status: "managed" | "managedDirectoryMissing" | "missing";
+    }
+    | {
+        path: string;
+        status: "shadowed";
+    };
+
 export interface SelfUpdateRuntimeOverrides {
     /**
      * Gates the Windows HKCU\Environment registry write. Must be true for the
@@ -41,6 +50,7 @@ export interface SelfUpdateRuntimeOverrides {
     configurePath?: (
         options: SelfUpdatePathConfigurationOptions,
     ) => Promise<SelfUpdatePathConfigurationResult>;
+    pathExists?: (path: string) => Promise<boolean>;
     resolveCommandPath?: (commandName: string) => string | null;
     runCommand?: (
         options: SelfUpdateCommandRunOptions,

--- a/src/application/self-update/command-path.test.ts
+++ b/src/application/self-update/command-path.test.ts
@@ -1,0 +1,136 @@
+import type { CommandPathCandidate } from "./command-path.ts";
+import { posix, win32 } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { resolveCommandPathCandidates } from "./command-path.ts";
+
+describe("resolveCommandPathCandidates", () => {
+    test("returns candidates in PATH order", async () => {
+        const firstDirectoryPath = posix.join("first", "bin");
+        const secondDirectoryPath = posix.join("second", "bin");
+        const executableName = "oo";
+        const firstExecutablePath = posix.join(firstDirectoryPath, executableName);
+        const secondExecutablePath = posix.join(secondDirectoryPath, executableName);
+
+        const candidates = await resolveCandidates({
+            env: {
+                PATH: [firstDirectoryPath, secondDirectoryPath].join(posix.delimiter),
+            },
+            executableNames: [executableName],
+            existingPaths: [secondExecutablePath, firstExecutablePath],
+            platform: "linux",
+        });
+
+        expect(candidates).toEqual([
+            {
+                directoryPath: firstDirectoryPath,
+                path: firstExecutablePath,
+            },
+            {
+                directoryPath: secondDirectoryPath,
+                path: secondExecutablePath,
+            },
+        ]);
+    });
+
+    test("preserves POSIX empty PATH segments as current-directory entries", async () => {
+        const executableName = "oo";
+        const currentDirectoryExecutablePath = posix.join(".", executableName);
+        const managedDirectoryPath = posix.join("managed", "bin");
+        const managedExecutablePath = posix.join(managedDirectoryPath, executableName);
+
+        const candidates = await resolveCandidates({
+            env: {
+                PATH: `${posix.delimiter}${managedDirectoryPath}`,
+            },
+            executableNames: [executableName],
+            existingPaths: [currentDirectoryExecutablePath, managedExecutablePath],
+            platform: "linux",
+        });
+
+        expect(candidates).toEqual([
+            {
+                directoryPath: ".",
+                path: currentDirectoryExecutablePath,
+            },
+            {
+                directoryPath: managedDirectoryPath,
+                path: managedExecutablePath,
+            },
+        ]);
+    });
+
+    test("preserves Windows empty PATH segments without rewriting them", async () => {
+        const executableName = "oo.exe";
+        const currentDirectoryExecutablePath = win32.join("", executableName);
+        const managedDirectoryPath = win32.join("managed", "bin");
+        const managedExecutablePath = win32.join(managedDirectoryPath, executableName);
+
+        const candidates = await resolveCandidates({
+            env: {
+                Path: `${win32.delimiter}${managedDirectoryPath}`,
+            },
+            executableNames: [executableName],
+            existingPaths: [currentDirectoryExecutablePath, managedExecutablePath],
+            platform: "win32",
+        });
+
+        expect(candidates).toEqual([
+            {
+                directoryPath: "",
+                path: currentDirectoryExecutablePath,
+            },
+            {
+                directoryPath: managedDirectoryPath,
+                path: managedExecutablePath,
+            },
+        ]);
+    });
+
+    test("resolves Windows PATHEXT shims before later managed executables", async () => {
+        const executableName = "oo.exe";
+        const legacyDirectoryPath = win32.join("legacy", "bin");
+        const managedDirectoryPath = win32.join("managed", "bin");
+        const legacyShimPath = win32.join(legacyDirectoryPath, "oo.cmd");
+        const managedExecutablePath = win32.join(managedDirectoryPath, executableName);
+
+        const candidates = await resolveCandidates({
+            env: {
+                Path: [legacyDirectoryPath, managedDirectoryPath].join(win32.delimiter),
+            },
+            executableNames: [executableName],
+            existingPaths: [managedExecutablePath, legacyShimPath],
+            platform: "win32",
+        });
+
+        expect(candidates).toEqual([
+            {
+                directoryPath: legacyDirectoryPath,
+                path: legacyShimPath,
+            },
+            {
+                directoryPath: managedDirectoryPath,
+                path: managedExecutablePath,
+            },
+        ]);
+    });
+});
+
+function resolveCandidates(options: {
+    env: Record<string, string | undefined>;
+    executableNames: readonly string[];
+    existingPaths: readonly string[];
+    platform: NodeJS.Platform;
+}): Promise<CommandPathCandidate[]> {
+    return resolveCommandPathCandidates({
+        env: options.env,
+        executableNames: options.executableNames,
+        pathExists: createPathExists(options.existingPaths),
+        platform: options.platform,
+    });
+}
+
+function createPathExists(
+    existingPaths: readonly string[],
+): (path: string) => Promise<boolean> {
+    return path => Promise.resolve(existingPaths.includes(path));
+}

--- a/src/application/self-update/command-path.test.ts
+++ b/src/application/self-update/command-path.test.ts
@@ -32,6 +32,36 @@ describe("resolveCommandPathCandidates", () => {
         ]);
     });
 
+    test("skips PATH candidates whose probe rejects", async () => {
+        const brokenDirectoryPath = posix.join("broken", "bin");
+        const managedDirectoryPath = posix.join("managed", "bin");
+        const executableName = "oo";
+        const brokenExecutablePath = posix.join(brokenDirectoryPath, executableName);
+        const managedExecutablePath = posix.join(managedDirectoryPath, executableName);
+
+        const candidates = await resolveCommandPathCandidates({
+            env: {
+                PATH: [brokenDirectoryPath, managedDirectoryPath].join(posix.delimiter),
+            },
+            executableNames: [executableName],
+            pathExists: (path) => {
+                if (path === brokenExecutablePath) {
+                    return Promise.reject(new Error("permission denied"));
+                }
+
+                return Promise.resolve(path === managedExecutablePath);
+            },
+            platform: "linux",
+        });
+
+        expect(candidates).toEqual([
+            {
+                directoryPath: managedDirectoryPath,
+                path: managedExecutablePath,
+            },
+        ]);
+    });
+
     test("preserves POSIX empty PATH segments as current-directory entries", async () => {
         const executableName = "oo";
         const currentDirectoryExecutablePath = posix.join(".", executableName);

--- a/src/application/self-update/command-path.ts
+++ b/src/application/self-update/command-path.ts
@@ -193,7 +193,9 @@ async function resolveFirstPathCandidatePath(options: {
             executableName,
         );
 
-        if (await options.pathExists(candidatePath)) {
+        const exists = await options.pathExists(candidatePath).catch(() => false);
+
+        if (exists) {
             return candidatePath;
         }
     }

--- a/src/application/self-update/command-path.ts
+++ b/src/application/self-update/command-path.ts
@@ -1,0 +1,225 @@
+import { constants } from "node:fs";
+import { access, stat } from "node:fs/promises";
+import { isPathMissingError } from "../shared/fs-errors.ts";
+import { readPathModule } from "./paths.ts";
+
+export interface CommandPathCandidate {
+    directoryPath: string;
+    path: string;
+}
+
+const defaultWindowsExecutableExtensions = [
+    ".com",
+    ".exe",
+    ".bat",
+    ".cmd",
+] as const;
+
+export async function resolveCommandPathCandidates(options: {
+    env: Record<string, string | undefined>;
+    executableNames: readonly string[];
+    pathExists?: (path: string) => Promise<boolean>;
+    platform: NodeJS.Platform;
+}): Promise<CommandPathCandidate[]> {
+    const pathValue = readPathValue(options.env, options.platform);
+
+    if (pathValue === undefined) {
+        return [];
+    }
+
+    const pathModule = readPathModule(options.platform);
+    const pathExists = options.pathExists
+        ?? ((path: string) => commandPathExists(path, options.platform));
+    const executableNames = resolveExecutableNamesForPathLookup({
+        env: options.env,
+        executableNames: options.executableNames,
+        platform: options.platform,
+    });
+    const resolvedCandidates = await Promise.all(
+        splitPathEntries(pathValue, options.platform).map(async (directoryPath) => {
+            const candidatePath = await resolveFirstPathCandidatePath({
+                directoryPath,
+                executableNames,
+                pathExists,
+                pathModule,
+            });
+
+            if (candidatePath === undefined) {
+                return undefined;
+            }
+
+            return {
+                directoryPath,
+                path: candidatePath,
+            } satisfies CommandPathCandidate;
+        }),
+    );
+
+    return resolvedCandidates.filter(
+        (candidate): candidate is CommandPathCandidate => candidate !== undefined,
+    );
+}
+
+function resolveExecutableNamesForPathLookup(options: {
+    env: Record<string, string | undefined>;
+    executableNames: readonly string[];
+    platform: NodeJS.Platform;
+}): string[] {
+    if (options.platform !== "win32") {
+        return [...options.executableNames];
+    }
+
+    const pathModule = readPathModule(options.platform);
+    const executableExtensions = readWindowsExecutableExtensions(options.env);
+    const names: string[] = [];
+    const seenNames = new Set<string>();
+
+    for (const executableName of options.executableNames) {
+        const extension = pathModule.extname(executableName);
+        const stem = extension === ""
+            ? executableName
+            : executableName.slice(0, -extension.length);
+        const normalizedExtension = extension.toLowerCase();
+
+        if (
+            extension === ""
+            || executableExtensions.includes(normalizedExtension)
+        ) {
+            for (const executableExtension of executableExtensions) {
+                pushUniqueLookupName(
+                    names,
+                    seenNames,
+                    `${stem}${executableExtension}`,
+                );
+            }
+        }
+
+        pushUniqueLookupName(names, seenNames, executableName);
+    }
+
+    return names;
+}
+
+function readWindowsExecutableExtensions(
+    env: Record<string, string | undefined>,
+): string[] {
+    const configuredExtensions = env.PATHEXT
+        ?.split(";")
+        .map(normalizeWindowsExecutableExtension)
+        .filter((extension): extension is string => extension !== undefined);
+    const extensions = configuredExtensions === undefined
+        || configuredExtensions.length === 0
+        ? [...defaultWindowsExecutableExtensions]
+        : configuredExtensions;
+    const deduplicatedExtensions: string[] = [];
+    const seenExtensions = new Set<string>();
+
+    for (const extension of extensions) {
+        pushUniqueLookupName(
+            deduplicatedExtensions,
+            seenExtensions,
+            extension,
+        );
+    }
+
+    return deduplicatedExtensions;
+}
+
+function normalizeWindowsExecutableExtension(
+    rawExtension: string,
+): string | undefined {
+    const trimmedExtension = rawExtension.trim().toLowerCase();
+
+    if (trimmedExtension === "") {
+        return undefined;
+    }
+
+    return trimmedExtension.startsWith(".")
+        ? trimmedExtension
+        : `.${trimmedExtension}`;
+}
+
+function pushUniqueLookupName(
+    values: string[],
+    seenValues: Set<string>,
+    value: string,
+): void {
+    const key = value.toLowerCase();
+
+    if (seenValues.has(key)) {
+        return;
+    }
+
+    seenValues.add(key);
+    values.push(value);
+}
+
+function readPathValue(
+    env: Record<string, string | undefined>,
+    platform: NodeJS.Platform,
+): string | undefined {
+    return platform === "win32"
+        ? env.Path ?? env.PATH
+        : env.PATH;
+}
+
+function splitPathEntries(
+    pathValue: string,
+    platform: NodeJS.Platform,
+): string[] {
+    const isWindows = platform === "win32";
+    const pathModule = readPathModule(platform);
+
+    return pathValue
+        .split(pathModule.delimiter)
+        .map((pathEntry) => {
+            const trimmedPathEntry = pathEntry.trim();
+
+            return trimmedPathEntry === "" && !isWindows
+                ? "."
+                : trimmedPathEntry;
+        });
+}
+
+async function resolveFirstPathCandidatePath(options: {
+    directoryPath: string;
+    executableNames: readonly string[];
+    pathExists: (path: string) => Promise<boolean>;
+    pathModule: ReturnType<typeof readPathModule>;
+}): Promise<string | undefined> {
+    for (const executableName of options.executableNames) {
+        const candidatePath = options.pathModule.join(
+            options.directoryPath,
+            executableName,
+        );
+
+        if (await options.pathExists(candidatePath)) {
+            return candidatePath;
+        }
+    }
+
+    return undefined;
+}
+
+async function commandPathExists(
+    path: string,
+    platform: NodeJS.Platform,
+): Promise<boolean> {
+    const metadata = await stat(path).catch((error) => {
+        if (isPathMissingError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    });
+
+    if (metadata === undefined || !metadata.isFile()) {
+        return false;
+    }
+
+    if (platform === "win32") {
+        return true;
+    }
+
+    return access(path, constants.X_OK).then(() => true).catch(() => false);
+}

--- a/src/application/self-update/command-resolution.test.ts
+++ b/src/application/self-update/command-resolution.test.ts
@@ -1,0 +1,201 @@
+import { chmod, mkdir, symlink, writeFile } from "node:fs/promises";
+import { basename, dirname, join, win32 } from "node:path";
+import process from "node:process";
+import { describe, expect, test } from "bun:test";
+import {
+    createTemporaryDirectory,
+    joinPathEntries,
+    useTemporaryDirectoryCleanup,
+} from "../../../__tests__/helpers.ts";
+import { resolveSelfUpdateCommandResolution } from "./command-resolution.ts";
+import { resolveSelfUpdatePaths } from "./paths.ts";
+
+const { track: trackDirectory } = useTemporaryDirectoryCleanup();
+
+describe("resolveSelfUpdateCommandResolution", () => {
+    test("reports managed when PATH resolves oo to the managed executable", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-command-resolution-managed");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries([paths.executableDirectory], process.platform);
+        await writeExecutable(paths.executablePath);
+
+        const result = await resolveSelfUpdateCommandResolution({
+            env,
+            executablePath: paths.executablePath,
+            platform: process.platform,
+        });
+
+        expect(result).toEqual({
+            status: "managed",
+        });
+    });
+
+    test("reports shadowed when another oo appears before the managed directory", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-command-resolution-shadowed");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const legacyDirectory = join(rootDirectory, "legacy", "bin");
+        const legacyPath = join(legacyDirectory, basename(paths.executablePath));
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries(
+            [legacyDirectory, paths.executableDirectory],
+            process.platform,
+        );
+        await Promise.all([
+            writeExecutable(paths.executablePath),
+            writeExecutable(legacyPath),
+        ]);
+
+        const result = await resolveSelfUpdateCommandResolution({
+            env,
+            executablePath: paths.executablePath,
+            platform: process.platform,
+        });
+
+        expect(result).toEqual({
+            path: legacyPath,
+            status: "shadowed",
+        });
+    });
+
+    test("reports shadowed when Windows PATHEXT resolves a shim first", async () => {
+        const rootDirectory = "C:\\Users\\demo";
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: "win32",
+        });
+        const legacyDirectory = win32.join(rootDirectory, "npm-global", "bin");
+        const legacyShimPath = win32.join(legacyDirectory, "oo.cmd");
+        const existingPaths = new Set([
+            legacyShimPath.toLowerCase(),
+            paths.executablePath.toLowerCase(),
+        ]);
+
+        env.Path = [legacyDirectory, paths.executableDirectory].join(win32.delimiter);
+
+        const result = await resolveSelfUpdateCommandResolution({
+            env,
+            executablePath: paths.executablePath,
+            pathExists: path => Promise.resolve(existingPaths.has(path.toLowerCase())),
+            platform: "win32",
+        });
+
+        expect(result).toEqual({
+            path: legacyShimPath,
+            status: "shadowed",
+        });
+    });
+
+    test("reports missing when the managed directory is on PATH but no oo exists", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-command-resolution-missing");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries([paths.executableDirectory], process.platform);
+
+        const result = await resolveSelfUpdateCommandResolution({
+            env,
+            executablePath: paths.executablePath,
+            platform: process.platform,
+        });
+
+        expect(result).toEqual({
+            status: "missing",
+        });
+    });
+
+    test("reports managedDirectoryMissing when the managed directory is not on PATH", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-command-resolution-directory-missing");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries([join(rootDirectory, "empty", "bin")], process.platform);
+        await writeExecutable(paths.executablePath);
+
+        const result = await resolveSelfUpdateCommandResolution({
+            env,
+            executablePath: paths.executablePath,
+            platform: process.platform,
+        });
+
+        expect(result).toEqual({
+            status: "managedDirectoryMissing",
+        });
+    });
+
+    test("reports managed when PATH resolves to a symlink for the managed executable", async () => {
+        if (process.platform === "win32") {
+            return;
+        }
+
+        const rootDirectory = await createTemporaryDirectory("oo-command-resolution-symlink");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const shimDirectory = join(rootDirectory, "shim", "bin");
+        const shimPath = join(shimDirectory, basename(paths.executablePath));
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries(
+            [shimDirectory, paths.executableDirectory],
+            process.platform,
+        );
+        await writeExecutable(paths.executablePath);
+        await mkdir(dirname(shimPath), { recursive: true });
+        await symlink(paths.executablePath, shimPath);
+
+        const result = await resolveSelfUpdateCommandResolution({
+            env,
+            executablePath: paths.executablePath,
+            platform: process.platform,
+        });
+
+        expect(result).toEqual({
+            status: "managed",
+        });
+    });
+});
+
+function createSelfUpdateEnv(rootDirectory: string): Record<string, string | undefined> {
+    return {
+        APPDATA: join(rootDirectory, "appdata"),
+        HOME: rootDirectory,
+        TEMP: join(rootDirectory, "temp"),
+        TMP: join(rootDirectory, "temp"),
+        TMPDIR: join(rootDirectory, "tmpdir"),
+        USERPROFILE: rootDirectory,
+        XDG_CACHE_HOME: join(rootDirectory, "cache"),
+        XDG_DATA_HOME: join(rootDirectory, "data"),
+        XDG_RUNTIME_DIR: join(rootDirectory, "runtime"),
+    };
+}
+
+async function writeExecutable(path: string): Promise<void> {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, "binary");
+
+    if (process.platform !== "win32") {
+        await chmod(path, 0o755);
+    }
+}

--- a/src/application/self-update/command-resolution.ts
+++ b/src/application/self-update/command-resolution.ts
@@ -1,0 +1,68 @@
+import type { SelfUpdateCommandResolutionResult } from "../contracts/self-update.ts";
+import { resolveCommandPathCandidates } from "./command-path.ts";
+import { isSamePath, readRealPathOrFallback } from "./path-comparison.ts";
+import { isExecutableDirectoryOnPath } from "./path-configuration.ts";
+import { readPathModule } from "./paths.ts";
+
+export async function resolveSelfUpdateCommandResolution(options: {
+    env: Record<string, string | undefined>;
+    executablePath: string;
+    pathExists?: (path: string) => Promise<boolean>;
+    platform: NodeJS.Platform;
+}): Promise<SelfUpdateCommandResolutionResult> {
+    const pathModule = readPathModule(options.platform);
+    const executableDirectory = pathModule.dirname(options.executablePath);
+    const candidates = await resolveCommandPathCandidates({
+        env: options.env,
+        executableNames: [pathModule.basename(options.executablePath)],
+        pathExists: options.pathExists,
+        platform: options.platform,
+    });
+    const firstCandidate = candidates[0];
+
+    if (firstCandidate !== undefined && await isSameExecutablePath({
+        leftPath: firstCandidate.path,
+        platform: options.platform,
+        rightPath: options.executablePath,
+    })) {
+        return { status: "managed" };
+    }
+
+    // Distinguish "PATH setup hasn't taken effect" from a true shadow:
+    // when the managed directory is not on PATH yet, prefer
+    // `managedDirectoryMissing` so the PATH setup note covers it instead.
+    const managedDirectoryOnPath = isExecutableDirectoryOnPath(
+        executableDirectory,
+        options.env,
+        options.platform,
+    );
+
+    if (!managedDirectoryOnPath) {
+        return { status: "managedDirectoryMissing" };
+    }
+
+    return firstCandidate === undefined
+        ? { status: "missing" }
+        : { path: firstCandidate.path, status: "shadowed" };
+}
+
+async function isSameExecutablePath(options: {
+    leftPath: string;
+    platform: NodeJS.Platform;
+    rightPath: string;
+}): Promise<boolean> {
+    if (isSamePath(options)) {
+        return true;
+    }
+
+    const [leftRealPath, rightRealPath] = await Promise.all([
+        readRealPathOrFallback(options.leftPath),
+        readRealPathOrFallback(options.rightPath),
+    ]);
+
+    return isSamePath({
+        leftPath: leftRealPath,
+        platform: options.platform,
+        rightPath: rightRealPath,
+    });
+}

--- a/src/application/self-update/core.ts
+++ b/src/application/self-update/core.ts
@@ -1,6 +1,9 @@
 import type { Logger } from "pino";
 import type { CliExecutionContext, Fetcher } from "../contracts/cli.ts";
-import type { SelfUpdatePathConfigurationResult } from "../contracts/self-update.ts";
+import type {
+    SelfUpdateCommandResolutionResult,
+    SelfUpdatePathConfigurationResult,
+} from "../contracts/self-update.ts";
 import type { LegacyPackageManagerCleanupRuntime } from "./legacy-installation.ts";
 import type { SelfUpdateProgressEvent } from "./progress.ts";
 import { chmod, copyFile, lstat, mkdir, open, readdir, readlink, realpath, rename, rm, stat, symlink } from "node:fs/promises";
@@ -17,6 +20,7 @@ import {
     parseLatestCliSemverReleaseVersion,
 } from "../update/release-metadata.ts";
 import { attemptBundledSkillRefreshAfterSelfUpdate } from "./bundled-skills.ts";
+import { resolveSelfUpdateCommandResolution } from "./command-resolution.ts";
 import { attemptLegacyPackageManagerUninstall } from "./legacy-installation.ts";
 import {
     acquireProcessLifetimeVersionLock,
@@ -56,6 +60,7 @@ export const selfUpdateBinaryDownloadStallTimeoutMs = 60_000;
 export const selfUpdateReleaseRequestTimeoutMs = 10_000;
 
 export interface SelfUpdateOperationResult {
+    commandResolution: SelfUpdateCommandResolutionResult;
     executableDirectory: string;
     executablePath: string;
     pathConfiguration: SelfUpdatePathConfigurationResult;
@@ -198,12 +203,14 @@ export async function performSelfUpdateOperation(options: {
             runtime: options.runtime,
         });
         await attemptLegacyPackageManagerUninstall(options.runtime);
-        const { pathConfiguration } = await ensureSelfUpdateExecutableDirectoryOnPath({
-            modifyPath: options.modifyPath,
-            runtime: options.runtime,
-        });
+        const { commandResolution, pathConfiguration }
+            = await ensureSelfUpdateExecutableDirectoryOnPath({
+                modifyPath: options.modifyPath,
+                runtime: options.runtime,
+            });
 
         return {
+            commandResolution,
             executableDirectory: paths.executableDirectory,
             executablePath: paths.executablePath,
             pathConfiguration,
@@ -219,8 +226,9 @@ export async function performSelfUpdateOperation(options: {
 
 export async function ensureSelfUpdateExecutableDirectoryOnPath(options: {
     modifyPath?: boolean;
-    runtime: Pick<SelfUpdateRuntime, "configurePath" | "env" | "logger" | "platform" | "resolveCommandPath" | "runCommand">;
+    runtime: Pick<SelfUpdateRuntime, "configurePath" | "env" | "logger" | "pathExists" | "platform" | "resolveCommandPath" | "runCommand">;
 }): Promise<{
+    commandResolution: SelfUpdateCommandResolutionResult;
     executableDirectory: string;
     pathConfiguration: SelfUpdatePathConfigurationResult;
 }> {
@@ -235,8 +243,15 @@ export async function ensureSelfUpdateExecutableDirectoryOnPath(options: {
         platform: options.runtime.platform,
         runtime: options.runtime,
     });
+    const commandResolution = await resolveSelfUpdateCommandResolution({
+        env: options.runtime.env,
+        executablePath: paths.executablePath,
+        pathExists: options.runtime.pathExists,
+        platform: options.runtime.platform,
+    });
 
     return {
+        commandResolution,
         executableDirectory: paths.executableDirectory,
         pathConfiguration,
     };

--- a/src/application/self-update/installation.test.ts
+++ b/src/application/self-update/installation.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { detectInstallationMethodFromExecPath } from "./installation.ts";
 import {
@@ -127,6 +128,23 @@ describe("detectInstallationMethodFromExecPath", () => {
         expect(detectInstallationMethodFromExecPath({
             env: {},
             execPath: "/Users/demo/.config/yarn/global/npm_global/node_modules/@oomol-lab/oo-cli/bin/oo",
+            platform: "linux",
+        }).method).toBe("npm");
+    });
+
+    test("detects npm from an exact npm-global path segment", () => {
+        expect(detectInstallationMethodFromExecPath({
+            env: {},
+            execPath: join(
+                "Users",
+                "demo",
+                "Library",
+                "Application Support",
+                "QClaw",
+                "npm-global",
+                "bin",
+                "oo",
+            ),
             platform: "linux",
         }).method).toBe("npm");
     });

--- a/src/application/self-update/installation.ts
+++ b/src/application/self-update/installation.ts
@@ -1,4 +1,5 @@
-import { readPathModule, resolveSelfUpdatePaths } from "./paths.ts";
+import { isPathInsideDirectory, isSamePath } from "./path-comparison.ts";
+import { resolveSelfUpdatePaths } from "./paths.ts";
 
 export const packageManagerInstallationMethods = [
     "bun",
@@ -122,6 +123,7 @@ const packageManagerPathDetectors: Array<{
     {
         matches: pathSegments =>
             pathSegments.includes("fnm_multishells")
+            || pathSegments.includes("npm-global")
             || pathSegments.includes("npm_global")
             || pathSegments.includes(".nvm"),
         method: "npm",
@@ -167,50 +169,4 @@ function isManagedNativeExecutablePath(options: {
         directoryPath: paths.versionsDirectory,
         platform: options.platform,
     });
-}
-
-function isSamePath(options: {
-    leftPath: string;
-    platform: NodeJS.Platform;
-    rightPath: string;
-}): boolean {
-    return normalizeComparablePath(options.leftPath, options.platform)
-        === normalizeComparablePath(options.rightPath, options.platform);
-}
-
-function isPathInsideDirectory(options: {
-    candidatePath: string;
-    directoryPath: string;
-    platform: NodeJS.Platform;
-}): boolean {
-    const pathModule = readPathModule(options.platform);
-    const comparableCandidatePath = normalizeComparablePath(
-        options.candidatePath,
-        options.platform,
-    );
-    const comparableDirectoryPath = normalizeComparablePath(
-        options.directoryPath,
-        options.platform,
-    );
-    const relativePath = pathModule.relative(
-        comparableDirectoryPath,
-        comparableCandidatePath,
-    );
-
-    return relativePath !== ""
-        && relativePath !== "."
-        && !relativePath.startsWith("..")
-        && !pathModule.isAbsolute(relativePath);
-}
-
-function normalizeComparablePath(
-    path: string,
-    platform: NodeJS.Platform,
-): string {
-    const pathModule = readPathModule(platform);
-    const normalizedPath = pathModule.normalize(path.trim());
-
-    return platform === "win32"
-        ? normalizedPath.toLowerCase()
-        : normalizedPath;
 }

--- a/src/application/self-update/legacy-installation.test.ts
+++ b/src/application/self-update/legacy-installation.test.ts
@@ -227,6 +227,45 @@ describe("attemptLegacyPackageManagerUninstall", () => {
         }
     });
 
+    test("preserves npm prefix when fallback uses an npm-global execPath", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-fallback-npm-prefix");
+        const env = createLegacyCleanupEnv(rootDirectory);
+        const npmPrefix = join(rootDirectory, "QClaw", "npm-global");
+        const commands = createRecordedCommands();
+        const logCapture = createLogCapture();
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries([join(rootDirectory, "empty", "bin")], process.platform);
+
+        try {
+            await attemptLegacyPackageManagerUninstall({
+                env,
+                execPath: join(npmPrefix, "bin", readExecutableName(process.platform)),
+                logger: logCapture.logger,
+                platform: process.platform,
+                resolveCommandPath: commandName => `/mock/bin/${commandName}`,
+                runCommand: commands.runCommand,
+            });
+
+            expect(commands.read()).toEqual([
+                {
+                    commandArguments: [
+                        "uninstall",
+                        "-g",
+                        "--prefix",
+                        npmPrefix,
+                        "@oomol-lab/oo-cli",
+                    ],
+                    commandPath: "/mock/bin/npm",
+                    timeoutMs: 10_000,
+                },
+            ]);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
     test("passes the detected npm prefix when uninstalling a custom npm-global PATH candidate", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-legacy-npm-prefix");
         const env = createLegacyCleanupEnv(rootDirectory);

--- a/src/application/self-update/legacy-installation.test.ts
+++ b/src/application/self-update/legacy-installation.test.ts
@@ -1,6 +1,6 @@
 import type { SelfUpdateCommandRunOptions } from "../contracts/self-update.ts";
-import { chmod, mkdir, writeFile } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { chmod, mkdir, realpath, symlink, writeFile } from "node:fs/promises";
+import { basename, dirname, join, win32 } from "node:path";
 import process from "node:process";
 import { describe, expect, test } from "bun:test";
 import {
@@ -227,38 +227,199 @@ describe("attemptLegacyPackageManagerUninstall", () => {
         }
     });
 
-    test("ignores oo.cmd PATH candidates on Windows and falls back to execPath", async () => {
-        const rootDirectory = await createTemporaryDirectory("oo-legacy-win32");
+    test("passes the detected npm prefix when uninstalling a custom npm-global PATH candidate", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-npm-prefix");
         const env = createLegacyCleanupEnv(rootDirectory);
+        const npmPrefix = join(rootDirectory, "QClaw", "npm-global");
+        const npmBinDirectory = join(npmPrefix, "bin");
         const commands = createRecordedCommands();
         const logCapture = createLogCapture();
-        const probedPaths: string[] = [];
 
         trackDirectory(rootDirectory);
-        env.PATH = "legacy-bin;managed-bin";
+        env.PATH = joinPathEntries([npmBinDirectory], process.platform);
+        await writeExecutable(join(npmBinDirectory, readExecutableName(process.platform)));
+
+        try {
+            await attemptLegacyPackageManagerUninstall({
+                env,
+                execPath: join(rootDirectory, "downloads", readExecutableName(process.platform)),
+                logger: logCapture.logger,
+                platform: process.platform,
+                resolveCommandPath: commandName => `/mock/bin/${commandName}`,
+                runCommand: commands.runCommand,
+            });
+
+            expect(commands.read()).toEqual([
+                {
+                    commandArguments: [
+                        "uninstall",
+                        "-g",
+                        "--prefix",
+                        npmPrefix,
+                        "@oomol-lab/oo-cli",
+                    ],
+                    commandPath: "/mock/bin/npm",
+                    timeoutMs: 10_000,
+                },
+            ]);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("passes the npm prefix resolved from a PATH candidate symlink realpath", async () => {
+        if (process.platform === "win32") {
+            return;
+        }
+
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-npm-realpath-prefix");
+        const env = createLegacyCleanupEnv(rootDirectory);
+        const npmPrefix = join(rootDirectory, "custom-prefix");
+        const npmBinDirectory = join(npmPrefix, "bin");
+        const packageEntrypoint = join(
+            npmPrefix,
+            "lib",
+            "node_modules",
+            "@oomol-lab",
+            "oo-cli",
+            "bin",
+            readExecutableName(process.platform),
+        );
+        const binEntrypoint = join(npmBinDirectory, readExecutableName(process.platform));
+        const commands = createRecordedCommands();
+        const logCapture = createLogCapture();
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries([npmBinDirectory], process.platform);
+        await writeExecutable(packageEntrypoint);
+        await mkdir(dirname(binEntrypoint), { recursive: true });
+        await symlink(packageEntrypoint, binEntrypoint);
+        const resolvedNpmPrefix = await realpath(npmPrefix);
+
+        try {
+            await attemptLegacyPackageManagerUninstall({
+                env,
+                execPath: join(rootDirectory, "downloads", readExecutableName(process.platform)),
+                logger: logCapture.logger,
+                platform: process.platform,
+                resolveCommandPath: commandName => `/mock/bin/${commandName}`,
+                runCommand: commands.runCommand,
+            });
+
+            expect(commands.read()).toEqual([
+                {
+                    commandArguments: [
+                        "uninstall",
+                        "-g",
+                        "--prefix",
+                        resolvedNpmPrefix,
+                        "@oomol-lab/oo-cli",
+                    ],
+                    commandPath: "/mock/bin/npm",
+                    timeoutMs: 10_000,
+                },
+            ]);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("deduplicates npm cleanup targets by package manager and prefix", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-npm-prefixes");
+        const env = createLegacyCleanupEnv(rootDirectory);
+        const firstPrefix = join(rootDirectory, "first", "npm-global");
+        const secondPrefix = join(rootDirectory, "second", "npm-global");
+        const firstBinDirectory = join(firstPrefix, "bin");
+        const secondBinDirectory = join(secondPrefix, "bin");
+        const commands = createRecordedCommands();
+        const logCapture = createLogCapture();
+
+        trackDirectory(rootDirectory);
+        env.PATH = joinPathEntries(
+            [firstBinDirectory, firstBinDirectory, secondBinDirectory],
+            process.platform,
+        );
+        await Promise.all([
+            writeExecutable(join(firstBinDirectory, readExecutableName(process.platform))),
+            writeExecutable(join(secondBinDirectory, readExecutableName(process.platform))),
+        ]);
+
+        try {
+            await attemptLegacyPackageManagerUninstall({
+                env,
+                execPath: join(rootDirectory, "downloads", readExecutableName(process.platform)),
+                logger: logCapture.logger,
+                platform: process.platform,
+                resolveCommandPath: commandName => `/mock/bin/${commandName}`,
+                runCommand: commands.runCommand,
+            });
+
+            expect(commands.read()).toEqual([
+                {
+                    commandArguments: [
+                        "uninstall",
+                        "-g",
+                        "--prefix",
+                        firstPrefix,
+                        "@oomol-lab/oo-cli",
+                    ],
+                    commandPath: "/mock/bin/npm",
+                    timeoutMs: 10_000,
+                },
+                {
+                    commandArguments: [
+                        "uninstall",
+                        "-g",
+                        "--prefix",
+                        secondPrefix,
+                        "@oomol-lab/oo-cli",
+                    ],
+                    commandPath: "/mock/bin/npm",
+                    timeoutMs: 10_000,
+                },
+            ]);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("detects Windows PATHEXT shims when resolving PATH candidates", async () => {
+        const rootDirectory = "C:\\Users\\demo";
+        const env = createLegacyCleanupEnv(rootDirectory);
+        const npmPrefix = win32.join(rootDirectory, "npm-global");
+        const npmBinDirectory = win32.join(npmPrefix, "bin");
+        const npmShimPath = win32.join(npmBinDirectory, "oo.cmd");
+        const commands = createRecordedCommands();
+        const logCapture = createLogCapture();
+
+        env.Path = [npmBinDirectory, "managed-bin"].join(win32.delimiter);
 
         try {
             await attemptLegacyPackageManagerUninstall({
                 env,
                 execPath: "C:\\Users\\demo\\.bun\\install\\global\\node_modules\\@oomol-lab\\oo-cli\\bin\\oo.exe",
                 logger: logCapture.logger,
-                pathExists: async (path) => {
-                    probedPaths.push(path);
-                    return path === "legacy-bin\\oo.cmd";
-                },
+                pathExists: path => Promise.resolve(
+                    path.toLowerCase() === npmShimPath.toLowerCase(),
+                ),
                 platform: "win32",
                 resolveCommandPath: commandName => `/mock/bin/${commandName}`,
                 runCommand: commands.runCommand,
             });
 
-            expect(probedPaths).toEqual([
-                "legacy-bin\\oo.exe",
-                "managed-bin\\oo.exe",
-            ]);
             expect(commands.read()).toEqual([
                 {
-                    commandArguments: ["remove", "-g", "@oomol-lab/oo-cli"],
-                    commandPath: "/mock/bin/bun",
+                    commandArguments: [
+                        "uninstall",
+                        "-g",
+                        "--prefix",
+                        npmPrefix,
+                        "@oomol-lab/oo-cli",
+                    ],
+                    commandPath: "/mock/bin/npm",
                     timeoutMs: 10_000,
                 },
             ]);

--- a/src/application/self-update/legacy-installation.ts
+++ b/src/application/self-update/legacy-installation.ts
@@ -73,6 +73,8 @@ async function resolveLegacyPackageManagersToUninstall(
         : [{
                 method: installation.method,
                 prefix: resolvePackageManagerPrefix({
+                    candidateDirectoryPath: readPathModule(runtime.platform)
+                        .dirname(runtime.execPath),
                     installation,
                     platform: runtime.platform,
                     resolvedPath: runtime.execPath,

--- a/src/application/self-update/legacy-installation.ts
+++ b/src/application/self-update/legacy-installation.ts
@@ -1,9 +1,9 @@
 import type { SelfUpdateCommandRuntime } from "./command-runner.ts";
 import type { InstallationDetection, PackageManagerInstallationMethod } from "./installation.ts";
-import { realpath } from "node:fs/promises";
-import { pathExists } from "../shared/fs-utils.ts";
+import { resolveCommandPathCandidates } from "./command-path.ts";
 import { runSelfUpdateCommandWithLogging } from "./command-runner.ts";
 import { detectInstallationMethodFromExecPath } from "./installation.ts";
+import { readRealPathOrFallback } from "./path-comparison.ts";
 import { readPathModule, resolveSelfUpdatePaths } from "./paths.ts";
 
 const legacyCliPackageName = "@oomol-lab/oo-cli";
@@ -11,46 +11,55 @@ const legacyPackageManagerUninstallTimeoutMs = 10_000;
 
 const legacyPackageManagerConfigurations = {
     bun: {
-        commandArguments: ["remove", "-g", legacyCliPackageName],
+        createCommandArguments: () => ["remove", "-g", legacyCliPackageName],
     },
     npm: {
-        commandArguments: ["uninstall", "-g", legacyCliPackageName],
+        createCommandArguments: (target: LegacyPackageManagerUninstallTarget) => [
+            "uninstall",
+            "-g",
+            ...(target.prefix === undefined ? [] : ["--prefix", target.prefix]),
+            legacyCliPackageName,
+        ],
     },
     pnpm: {
-        commandArguments: ["remove", "-g", legacyCliPackageName],
+        createCommandArguments: () => ["remove", "-g", legacyCliPackageName],
     },
     yarn: {
-        commandArguments: ["global", "remove", legacyCliPackageName],
+        createCommandArguments: () => ["global", "remove", legacyCliPackageName],
     },
 } as const;
 
+interface LegacyPackageManagerUninstallTarget {
+    method: PackageManagerInstallationMethod;
+    prefix?: string;
+}
+
 export interface LegacyPackageManagerCleanupRuntime extends SelfUpdateCommandRuntime {
     execPath: string;
-    pathExists?: (path: string) => Promise<boolean>;
     platform: NodeJS.Platform;
 }
 
 export async function attemptLegacyPackageManagerUninstall(
     runtime: LegacyPackageManagerCleanupRuntime,
 ): Promise<void> {
-    const packageManagers = await resolveLegacyPackageManagersToUninstall(runtime);
+    const targets = await resolveLegacyPackageManagersToUninstall(runtime);
 
-    if (packageManagers.length === 0) {
+    if (targets.length === 0) {
         return;
     }
 
-    for (const packageManager of packageManagers) {
-        await runLegacyPackageManagerUninstall(packageManager, runtime);
+    for (const target of targets) {
+        await runLegacyPackageManagerUninstall(target, runtime);
     }
 }
 
 async function resolveLegacyPackageManagersToUninstall(
     runtime: LegacyPackageManagerCleanupRuntime,
-): Promise<PackageManagerInstallationMethod[]> {
+): Promise<LegacyPackageManagerUninstallTarget[]> {
     const pathResolution = await resolveLegacyPackageManagersFromPath(runtime);
 
     if (pathResolution.encounteredCandidate) {
-        return pathResolution.packageManagers;
+        return pathResolution.targets;
     }
 
     const installation = detectInstallationMethodFromExecPath({
@@ -61,51 +70,40 @@ async function resolveLegacyPackageManagersToUninstall(
 
     return installation.method === "native" || installation.method === "unknown"
         ? []
-        : [installation.method];
+        : [{
+                method: installation.method,
+                prefix: resolvePackageManagerPrefix({
+                    installation,
+                    platform: runtime.platform,
+                    resolvedPath: runtime.execPath,
+                }),
+            }];
 }
 
 async function resolveLegacyPackageManagersFromPath(
     runtime: LegacyPackageManagerCleanupRuntime,
 ): Promise<{
     encounteredCandidate: boolean;
-    packageManagers: PackageManagerInstallationMethod[];
+    targets: LegacyPackageManagerUninstallTarget[];
 }> {
-    const pathValue = runtime.env.PATH?.trim();
-
-    if (pathValue === undefined || pathValue === "") {
-        return {
-            encounteredCandidate: false,
-            packageManagers: [],
-        };
-    }
-
     const paths = resolveSelfUpdatePaths({
         env: runtime.env,
         platform: runtime.platform,
     });
     const pathModule = readPathModule(runtime.platform);
     const executableName = pathModule.basename(paths.executablePath);
-    const packageManagers: PackageManagerInstallationMethod[] = [];
-    const seenPackageManagers = new Set<PackageManagerInstallationMethod>();
-    let encounteredCandidate = false;
+    const targets: LegacyPackageManagerUninstallTarget[] = [];
+    const seenTargets = new Set<string>();
+    const candidates = await resolveCommandPathCandidates({
+        env: runtime.env,
+        executableNames: [executableName],
+        pathExists: runtime.pathExists,
+        platform: runtime.platform,
+    });
 
-    for (const directoryPath of splitPathEntries(pathValue, runtime.platform)) {
-        const candidatePath = await resolveFirstPathCandidatePath({
-            directoryPath,
-            executableNames: [executableName],
-            pathExists: candidatePath =>
-                runtime.pathExists?.(candidatePath)
-                ?? pathExists(candidatePath),
-            pathModule,
-        });
-
-        if (candidatePath === undefined) {
-            continue;
-        }
-
-        encounteredCandidate = true;
+    for (const candidate of candidates) {
         const installation = await detectInstallationMethodFromPathCandidate({
-            candidatePath,
+            candidatePath: candidate.path,
             env: runtime.env,
             platform: runtime.platform,
         });
@@ -114,64 +112,37 @@ async function resolveLegacyPackageManagersFromPath(
             continue;
         }
 
-        if (seenPackageManagers.has(installation.method)) {
+        const target = {
+            method: installation.method,
+            prefix: resolvePackageManagerPrefix({
+                candidateDirectoryPath: candidate.directoryPath,
+                installation,
+                platform: runtime.platform,
+                resolvedPath: installation.resolvedPath,
+            }),
+        };
+        const targetKey = createLegacyPackageManagerTargetKey(target);
+
+        if (seenTargets.has(targetKey)) {
             continue;
         }
 
-        seenPackageManagers.add(installation.method);
-        packageManagers.push(installation.method);
+        seenTargets.add(targetKey);
+        targets.push(target);
     }
 
     return {
-        encounteredCandidate,
-        packageManagers,
+        encounteredCandidate: candidates.length > 0,
+        targets,
     };
-}
-
-function splitPathEntries(
-    pathValue: string,
-    platform: NodeJS.Platform,
-): string[] {
-    const pathEntries = pathValue
-        .split(readPathDelimiter(platform))
-        .map(pathEntry => pathEntry.trim())
-        .filter(Boolean);
-
-    return pathEntries;
-}
-
-function readPathDelimiter(
-    platform: NodeJS.Platform,
-): string {
-    return platform === "win32"
-        ? ";"
-        : ":";
-}
-
-async function resolveFirstPathCandidatePath(options: {
-    directoryPath: string;
-    executableNames: readonly string[];
-    pathExists: (path: string) => Promise<boolean>;
-    pathModule: ReturnType<typeof readPathModule>;
-}): Promise<string | undefined> {
-    for (const executableName of options.executableNames) {
-        const candidatePath = options.pathModule.join(options.directoryPath, executableName);
-
-        if (await options.pathExists(candidatePath)) {
-            return candidatePath;
-        }
-    }
-
-    return undefined;
 }
 
 async function detectInstallationMethodFromPathCandidate(options: {
     candidatePath: string;
     env: Record<string, string | undefined>;
     platform: NodeJS.Platform;
-}): Promise<InstallationDetection> {
-    const resolvedCandidatePath = await realpath(options.candidatePath)
-        .catch(() => options.candidatePath);
+}): Promise<InstallationDetection & { resolvedPath: string }> {
+    const resolvedCandidatePath = await readRealPathOrFallback(options.candidatePath);
     const resolvedInstallation = detectInstallationMethodFromExecPath({
         env: options.env,
         execPath: resolvedCandidatePath,
@@ -182,28 +153,140 @@ async function detectInstallationMethodFromPathCandidate(options: {
         resolvedInstallation.method !== "unknown"
         || resolvedCandidatePath === options.candidatePath
     ) {
-        return resolvedInstallation;
+        return {
+            ...resolvedInstallation,
+            resolvedPath: resolvedCandidatePath,
+        };
     }
 
-    return detectInstallationMethodFromExecPath({
-        env: options.env,
-        execPath: options.candidatePath,
-        platform: options.platform,
+    return {
+        ...detectInstallationMethodFromExecPath({
+            env: options.env,
+            execPath: options.candidatePath,
+            platform: options.platform,
+        }),
+        resolvedPath: options.candidatePath,
+    };
+}
+
+function resolvePackageManagerPrefix(options: {
+    candidateDirectoryPath?: string;
+    installation: InstallationDetection;
+    platform: NodeJS.Platform;
+    resolvedPath: string;
+}): string | undefined {
+    if (options.installation.method !== "npm") {
+        return undefined;
+    }
+
+    const fromInstallPath = resolveNpmGlobalPrefixFromInstallPath(
+        options.resolvedPath,
+        options.platform,
+    );
+
+    if (fromInstallPath !== undefined) {
+        return fromInstallPath;
+    }
+
+    if (options.candidateDirectoryPath === undefined) {
+        return undefined;
+    }
+
+    return resolveNpmGlobalPrefixFromBinDirectory(
+        options.candidateDirectoryPath,
+        options.platform,
+    );
+}
+
+function resolveNpmGlobalPrefixFromInstallPath(
+    rawPath: string,
+    platform: NodeJS.Platform,
+): string | undefined {
+    return joinNpmPrefixSegments(rawPath, platform, (segments) => {
+        const normalizedSegments = segments.map(segment => segment.toLowerCase());
+        const nodeModulesIndex = normalizedSegments.lastIndexOf("node_modules");
+
+        if (nodeModulesIndex < 0) {
+            return undefined;
+        }
+
+        return normalizedSegments[nodeModulesIndex - 1] === "lib"
+            ? nodeModulesIndex - 1
+            : nodeModulesIndex;
     });
 }
 
+function resolveNpmGlobalPrefixFromBinDirectory(
+    rawPath: string,
+    platform: NodeJS.Platform,
+): string | undefined {
+    return joinNpmPrefixSegments(rawPath, platform, (segments) => {
+        const finalSegment = segments.at(-1);
+
+        return finalSegment?.toLowerCase() === "bin"
+            ? segments.length - 1
+            : undefined;
+    });
+}
+
+function joinNpmPrefixSegments(
+    rawPath: string,
+    platform: NodeJS.Platform,
+    findPrefixEndIndex: (segments: readonly string[]) => number | undefined,
+): string | undefined {
+    const pathParts = splitAbsolutePath(rawPath, platform);
+    const prefixEndIndex = findPrefixEndIndex(pathParts.segments);
+
+    if (prefixEndIndex === undefined || prefixEndIndex <= 0) {
+        return undefined;
+    }
+
+    const pathModule = readPathModule(platform);
+
+    return pathModule.join(
+        pathParts.root,
+        ...pathParts.segments.slice(0, prefixEndIndex),
+    );
+}
+
+function splitAbsolutePath(
+    rawPath: string,
+    platform: NodeJS.Platform,
+): {
+    root: string;
+    segments: string[];
+} {
+    const pathModule = readPathModule(platform);
+    const normalizedPath = pathModule.normalize(rawPath);
+    const root = pathModule.parse(normalizedPath).root;
+    const relativePath = pathModule.relative(root, normalizedPath);
+
+    return {
+        root,
+        segments: relativePath === ""
+            ? []
+            : relativePath.split(pathModule.sep).filter(Boolean),
+    };
+}
+
+function createLegacyPackageManagerTargetKey(
+    target: LegacyPackageManagerUninstallTarget,
+): string {
+    return `${target.method}\0${target.prefix ?? ""}`;
+}
+
 async function runLegacyPackageManagerUninstall(
-    packageManager: PackageManagerInstallationMethod,
+    target: LegacyPackageManagerUninstallTarget,
     runtime: LegacyPackageManagerCleanupRuntime,
 ): Promise<void> {
-    const configuration = legacyPackageManagerConfigurations[packageManager];
-    const commandPath = runtime.resolveCommandPath?.(packageManager)
-        ?? Bun.which(packageManager);
+    const configuration = legacyPackageManagerConfigurations[target.method];
+    const commandPath = runtime.resolveCommandPath?.(target.method)
+        ?? Bun.which(target.method);
 
     if (commandPath === null) {
         runtime.logger.warn(
             {
-                packageManager,
+                packageManager: target.method,
             },
             "Legacy package-manager oo-cli uninstall skipped because the executable was not found.",
         );
@@ -211,11 +294,12 @@ async function runLegacyPackageManagerUninstall(
     }
 
     await runSelfUpdateCommandWithLogging({
-        commandArguments: configuration.commandArguments,
+        commandArguments: configuration.createCommandArguments(target),
         commandPath,
         failureMessage: "Legacy package-manager oo-cli uninstall failed.",
         logContext: {
-            packageManager,
+            packageManager: target.method,
+            prefix: target.prefix,
         },
         runtime,
         successMessage: "Legacy package-manager oo-cli uninstall completed.",

--- a/src/application/self-update/path-comparison.ts
+++ b/src/application/self-update/path-comparison.ts
@@ -1,0 +1,52 @@
+import { realpath } from "node:fs/promises";
+import { readPathModule } from "./paths.ts";
+
+export async function readRealPathOrFallback(path: string): Promise<string> {
+    return realpath(path).catch(() => path);
+}
+
+export function isSamePath(options: {
+    leftPath: string;
+    platform: NodeJS.Platform;
+    rightPath: string;
+}): boolean {
+    return normalizeComparablePath(options.leftPath, options.platform)
+        === normalizeComparablePath(options.rightPath, options.platform);
+}
+
+export function isPathInsideDirectory(options: {
+    candidatePath: string;
+    directoryPath: string;
+    platform: NodeJS.Platform;
+}): boolean {
+    const pathModule = readPathModule(options.platform);
+    const comparableCandidatePath = normalizeComparablePath(
+        options.candidatePath,
+        options.platform,
+    );
+    const comparableDirectoryPath = normalizeComparablePath(
+        options.directoryPath,
+        options.platform,
+    );
+    const relativePath = pathModule.relative(
+        comparableDirectoryPath,
+        comparableCandidatePath,
+    );
+
+    return relativePath !== ""
+        && relativePath !== "."
+        && !relativePath.startsWith("..")
+        && !pathModule.isAbsolute(relativePath);
+}
+
+function normalizeComparablePath(
+    path: string,
+    platform: NodeJS.Platform,
+): string {
+    const pathModule = readPathModule(platform);
+    const normalizedPath = pathModule.normalize(path.trim());
+
+    return platform === "win32"
+        ? normalizedPath.toLowerCase()
+        : normalizedPath;
+}

--- a/src/application/self-update/path-shadowing-warning-preference.test.ts
+++ b/src/application/self-update/path-shadowing-warning-preference.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import {
+    resolveSelfUpdateShowPathShadowingWarning,
+    selfUpdateHidePathShadowingWarningEnvName,
+} from "./path-shadowing-warning-preference.ts";
+
+describe("resolveSelfUpdateShowPathShadowingWarning", () => {
+    test("shows the warning by default", () => {
+        expect(resolveSelfUpdateShowPathShadowingWarning({
+            env: {},
+        })).toBeTrue();
+    });
+
+    test("hides the warning when the env var is truthy", () => {
+        for (const value of ["1", "true", "YES"]) {
+            expect(resolveSelfUpdateShowPathShadowingWarning({
+                env: { [selfUpdateHidePathShadowingWarningEnvName]: value },
+            })).toBeFalse();
+        }
+    });
+
+    test("shows the warning when the env var is falsy or unrecognized", () => {
+        for (const value of ["0", "false", "no", "", "maybe"]) {
+            expect(resolveSelfUpdateShowPathShadowingWarning({
+                env: { [selfUpdateHidePathShadowingWarningEnvName]: value },
+            })).toBeTrue();
+        }
+    });
+});

--- a/src/application/self-update/path-shadowing-warning-preference.ts
+++ b/src/application/self-update/path-shadowing-warning-preference.ts
@@ -1,0 +1,12 @@
+import { readEnvBoolean } from "../shared/env-boolean.ts";
+
+export const selfUpdateHidePathShadowingWarningEnvName
+    = "OO_HIDE_PATH_SHADOWING_WARNING";
+
+export function resolveSelfUpdateShowPathShadowingWarning(options: {
+    env: Record<string, string | undefined>;
+}): boolean {
+    return readEnvBoolean(
+        options.env[selfUpdateHidePathShadowingWarningEnvName],
+    ) !== true;
+}

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -566,6 +566,8 @@ export const enMessages = {
         "Restart your shell to reload PATH and use oo.",
     "selfUpdate.install.pathNote":
         "Add {path} to PATH to run oo in new shells.",
+    "selfUpdate.pathShadowedNote":
+        "PATH currently resolves oo to {path} before the managed directory {directory}. Move {directory} earlier in PATH or remove that oo entry, then restart your shell.",
     "selfUpdate.progress.install.header": "Installing oo",
     "selfUpdate.progress.update.header": "Updating oo",
     "selfUpdate.progress.resolve.start": "Resolving latest release...",
@@ -1292,6 +1294,8 @@ export const zhMessages = {
         "请重启 shell 以重新加载 PATH 后使用 oo。",
     "selfUpdate.install.pathNote":
         "请把 {path} 加入 PATH，新的 shell 才能直接运行 oo。",
+    "selfUpdate.pathShadowedNote":
+        "当前 PATH 会先解析到 {path}，早于托管目录 {directory}。请把 {directory} 移到 PATH 更靠前的位置，或移除该 oo 入口，然后重启 shell。",
     "selfUpdate.progress.install.header": "正在安装 oo",
     "selfUpdate.progress.update.header": "正在更新 oo",
     "selfUpdate.progress.resolve.start": "正在解析最新发布版本...",


### PR DESCRIPTION
After install or update, the CLI now checks whether PATH still resolves oo to another executable before the managed directory and prints a shadowing note so users notice their shell will keep running the old binary. Set OO_HIDE_PATH_SHADOWING_WARNING to a truthy value to suppress the note when keeping another oo earlier on PATH is intentional.

Also harden the legacy npm cleanup: detect installs under npm-global and npm_global path segments, and pass the inferred global prefix to npm uninstall so cleanup works for non-default prefixes.

close: #135