### PR TITLE
refactor(skills): enhance skills listing

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -304,39 +304,36 @@ supported host directory that already exists.
 
 ### `oo skills list`
 
-List oo-managed skills from supported local skill directories.
+List bundled, registry, and local skills.
 
-- Ownership rule: the command scans each existing supported local skill root:
+- Options: `--source <source>`, `-s <source>` filters the list to one source:
+  `bundled`, `registry`, or `local`.
+- Managed ownership rule: the command scans each existing supported local skill root:
   `${CODEX_HOME:-~/.codex}/skills`, `~/.claude/skills`,
   `${HERMES_HOME:-~/.hermes}/skills`, `~/.codebuddy/skills`,
   `~/.workbuddy/skills`, `~/.trae/skills`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills`, and `~/.qoderwork/skills`. It keeps
   only child directories whose
   `.oo-metadata.json` can be parsed and contains a non-empty `version`.
+- Local ownership rule: the command scans `<config-dir>/skills/local` and keeps
+  child directories whose `SKILL.md` frontmatter includes a matching non-empty
+  `name` and a non-empty `description`.
 - Output: text output prints a summary line and one block per unique visible
-  skill identity. Identical `name`/source/version installs across multiple
-  hosts are folded into one block.
+  skill identity. Identical `name`/source/package/version installs across
+  multiple hosts are folded into one block.
 - Ordering: bundled skills are listed first when present, with `oo` before
   `oo-find-skills` before `oo-create-skill` before `oo-publish-skill`; the
-  remaining skills are ordered by skill name. Host names within a block follow
-  `Codex`, `Claude Code`, `Hermes`, `CodeBuddy`, `WorkBuddy`, `Trae`,
+  remaining skills are ordered by skill name. Host names within a managed block
+  follow `Codex`, `Claude Code`, `Hermes`, `CodeBuddy`, `WorkBuddy`, `Trae`,
   `OpenClaw`, `QoderWork` order.
-- Output: each skill block shows the skill name, host, source package or
-  bundled/local marker, and recorded version.
+- Output: each skill block shows the skill name plus `Host`, `Source`, and
+  `Version`. `Source` is `bundled`, `registry`, or `local`. Registry and local
+  blocks also show `Package`; local blocks also show `Path`. `Host` lists
+  matching supported hosts, or `<local>` when the skill only exists in canonical
+  local storage. Local `Path` shows the skill body path, not the host
+  installation path.
 - Notes: when a folded skill is installed in multiple supported hosts, the
   `Host` field lists all matching hosts.
-
-### `oo skills list-local`
-
-List skills from local canonical skill storage.
-
-- Ownership rule: the command scans `<config-dir>/skills/local` and keeps child
-  directories whose `SKILL.md` frontmatter includes a matching non-empty `name`
-  and a non-empty `description`.
-- Output: text output prints a summary line and one block per local skill.
-- Ordering: local skills are ordered by skill name.
-- Output: each skill block shows the skill name, local source marker, recorded
-  frontmatter `metadata.version` when present, and canonical local path.
 
 ### `oo skills preflight`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -265,35 +265,32 @@ skills。
 
 ### `oo skills list`
 
-列出受支持的本地 skill 目录中由 oo 管理的 skill。
+列出 bundled、registry 和 local skill。
 
-- 所有权规则：命令会扫描每个已存在的受支持本地 skill 根目录：
+- 选项：`--source <source>`、`-s <source>` 将列表过滤为一个来源：
+  `bundled`、`registry` 或 `local`。
+- managed 所有权规则：命令会扫描每个已存在的受支持本地 skill 根目录：
   `${CODEX_HOME:-~/.codex}/skills`、`~/.claude/skills`，以及
   `${HERMES_HOME:-~/.hermes}/skills`、`~/.codebuddy/skills`、
   `~/.workbuddy/skills`、`~/.trae/skills`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills`、`~/.qoderwork/skills`。只保留包含
   可解析 `.oo-metadata.json` 且其中包含非空 `version` 的子目录。
+- local 所有权规则：命令会扫描 `<config-dir>/skills/local`，只保留
+  `SKILL.md` frontmatter 中包含匹配的非空 `name` 和非空 `description` 的子目录。
 - 输出：文本输出会先打印摘要行，再为每个唯一的可见 skill 身份打印一个块。
-  如果多个 Agent 中的安装具有相同 `name`、来源和版本，则会折叠到同一个块中。
+  如果多个 Agent 中的安装具有相同 `name`、来源、package 和版本，则会折叠到同一个
+  块中。
 - 排序：bundled skills 会排在最前面；其中 `oo` 优先，其次
   `oo-find-skills`，再其次 `oo-create-skill`，再其次 `oo-publish-skill`；其余
-  skill 按名称排序。每个块内的 Agent 名称按 `Codex`、`Claude Code`、
+  skill 按名称排序。managed 块内的 Agent 名称按 `Codex`、`Claude Code`、
   `Hermes`、`CodeBuddy`、`WorkBuddy`、`Trae`、`OpenClaw`、`QoderWork` 顺序显示。
-- 输出：每个 skill 块会显示 skill 名称、Agents、来源 package、内置或本地标记，以
-  及记录的版本号。
-- 说明：如果折叠后的 skill 安装在多个受支持 Agent 中，`Agents` 字段会列出所有
-  匹配的 Agent。
-
-### `oo skills list-local`
-
-列出本地 canonical skill 存储中的 skill。
-
-- 所有权规则：命令会扫描 `<config-dir>/skills/local`，只保留 `SKILL.md`
-  frontmatter 中包含匹配的非空 `name` 和非空 `description` 的子目录。
-- 输出：文本输出会先打印摘要行，再为每个本地 skill 打印一个块。
-- 排序：本地 skill 按名称排序。
-- 输出：每个 skill 块会显示 skill 名称、本地来源标记、frontmatter 中记录的
-  `metadata.version`（如果存在），以及 canonical 本地路径。
+- 输出：每个 skill 块会显示 skill 名称，以及 `Host`、`Source` 和 `Version`。
+  `Source` 为 `bundled`、`registry` 或 `local`。registry 和 local 块还会显示
+  `Package`；local 块还会显示 `Path`。`Host` 会列出匹配的受支持 Agent；如果
+  skill 仅存在于 canonical 本地存储，则为 `<local>`。local 的 `Path` 显示 skill
+  本体路径，不显示 Agent 安装路径。
+- 说明：如果折叠后的 skill 安装在多个受支持 Agent 中，`Host` 字段会列出所有匹配的
+  Agent。
 
 ### `oo skills preflight`
 

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -3,7 +3,7 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import { skillsCheckCommand } from "./check.ts";
 import { skillsInitCommand } from "./init.ts";
 import { skillsInstallCommand } from "./install.ts";
-import { skillsListCommand, skillsListLocalCommand } from "./list.ts";
+import { skillsListCommand } from "./list.ts";
 import { skillsPublishCommand } from "./publish.ts";
 import { skillsSearchCommand } from "./search.ts";
 import { skillsUninstallCommand } from "./uninstall.ts";
@@ -17,7 +17,6 @@ export const skillsCommand: CliCommandDefinition = {
     children: [
         skillsSearchCommand,
         skillsListCommand,
-        skillsListLocalCommand,
         skillsCheckCommand,
         skillsInitCommand,
         skillsValidateCommand,

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -1,8 +1,8 @@
 import { mkdir } from "node:fs/promises";
+
 import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
-
 import { createCliSandbox } from "../../../../__tests__/helpers.ts";
 import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../config/app-config.ts";
@@ -17,15 +17,25 @@ import {
     resolveTraeHomeDirectory,
     resolveWorkBuddyHomeDirectory,
 } from "./bundled-skill-paths.ts";
-import { resolveLocalSkillCanonicalDirectoryPath } from "./managed-skill-paths.ts";
+import {
+    resolveLocalSkillCanonicalDirectoryPath,
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillMetadataFilePath,
+} from "./managed-skill-paths.ts";
 import { renderSkillMetadataJson } from "./skill-metadata.ts";
 
 const managedSkillNameColor = "#59F78D";
 const managedSkillSourceColor = "#CAA8FA";
 const managedSkillVersionColor = "#7DD3FC";
+const bundledSkillNames = [
+    "oo",
+    "oo-find-skills",
+    "oo-create-skill",
+    "oo-publish-skill",
+] as const;
 
 describe("skills list CLI", () => {
-    test("lists oo-managed skills with source and version details", async () => {
+    test("lists skills with source, package, and version details", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const skillsDirectoryPath = join(codexHomeDirectory, "skills");
@@ -55,31 +65,13 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 5 oo-managed skills.",
+                    "✓ Found 5 skills.",
                     "",
-                    "oo",
-                    "  Host: Codex",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-find-skills",
-                    "  Host: Codex",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-create-skill",
-                    "  Host: Codex",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-publish-skill",
-                    "  Host: Codex",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
+                    ...createExpectedBundledSkillLines("Codex"),
                     "alpha-skill",
                     "  Host: Codex",
-                    "  Source: @oomol/alpha",
+                    "  Source: registry",
+                    "  Package: @oomol/alpha",
                     "  Version: 1.2.3",
                     "",
                 ].join("\n"),
@@ -92,7 +84,7 @@ describe("skills list CLI", () => {
 
     test("lists local canonical skills created by init", async () => {
         const sandbox = await createCliSandbox();
-        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
@@ -104,7 +96,7 @@ describe("skills list CLI", () => {
         );
 
         try {
-            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(codeBuddyHomeDirectory, { recursive: true });
 
             const initResult = await sandbox.run([
                 "skills",
@@ -113,17 +105,26 @@ describe("skills list CLI", () => {
                 "--description",
                 "Write campaign briefs using a known package workflow.",
             ]);
-            const result = await sandbox.run(["skills", "list-local"]);
+            const allSourcesResult = await sandbox.run(["skills", "list"], {
+                version: "9.9.9",
+            });
+            const result = await sandbox.run(["skills", "list", "--source", "local"]);
 
             expect(initResult.exitCode).toBe(0);
+            expect(allSourcesResult.exitCode).toBe(0);
+            expect(allSourcesResult.stderr).toBe("");
+            expect(allSourcesResult.stdout).toContain("campaign-writer\n");
+            expect(allSourcesResult.stdout).toContain("  Source: local\n");
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 1 local skills.",
+                    "✓ Found 1 skills.",
                     "",
                     "campaign-writer",
+                    "  Host: CodeBuddy",
                     "  Source: local",
+                    "  Package: <local>",
                     "  Version: unknown",
                     `  Path: ${canonicalSkillDirectoryPath}`,
                     "",
@@ -135,15 +136,102 @@ describe("skills list CLI", () => {
         }
     });
 
+    test("filters listed skills by source with the short option", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "alpha-skill",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
+            });
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(canonicalSkillDirectoryPath, "SKILL.md"),
+                "# Alpha\n",
+            );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath),
+                renderSkillMetadataJson({
+                    packageName: "@oomol/alpha",
+                    version: "1.2.3",
+                }),
+            );
+
+            const result = await sandbox.run(["skills", "list", "-s", "registry"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    "✓ Found 1 skills.",
+                    "",
+                    "alpha-skill",
+                    "  Host: Codex",
+                    "  Source: registry",
+                    "  Package: @oomol/alpha",
+                    "  Version: 1.2.3",
+                    "",
+                ].join("\n"),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("validates the source filter", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["skills", "list", "--source", "unknown"]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Invalid source: unknown. Use bundled, registry, or local.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("prints a no-results message when no local skills exist", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["skills", "list", "--source", "local"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe("! No skills were found.\n");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("treats the removed list-local command as unknown", async () => {
         const sandbox = await createCliSandbox();
 
         try {
             const result = await sandbox.run(["skills", "list-local"]);
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toBe("! No local skills were found.\n");
+            expect(result.exitCode).toBe(2);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toContain("Unknown command: list-local.");
         }
         finally {
             await sandbox.cleanup();
@@ -168,28 +256,9 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 4 oo-managed skills.",
+                    "✓ Found 4 skills.",
                     "",
-                    "oo",
-                    "  Host: OpenClaw",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-find-skills",
-                    "  Host: OpenClaw",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-create-skill",
-                    "  Host: OpenClaw",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-publish-skill",
-                    "  Host: OpenClaw",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
+                    ...createExpectedBundledSkillLines("OpenClaw"),
                 ].join("\n"),
             );
         }
@@ -216,28 +285,9 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 4 oo-managed skills.",
+                    "✓ Found 4 skills.",
                     "",
-                    "oo",
-                    "  Host: QoderWork",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-find-skills",
-                    "  Host: QoderWork",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-create-skill",
-                    "  Host: QoderWork",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-publish-skill",
-                    "  Host: QoderWork",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
+                    ...createExpectedBundledSkillLines("QoderWork"),
                 ].join("\n"),
             );
         }
@@ -264,28 +314,9 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 4 oo-managed skills.",
+                    "✓ Found 4 skills.",
                     "",
-                    "oo",
-                    "  Host: CodeBuddy",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-find-skills",
-                    "  Host: CodeBuddy",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-create-skill",
-                    "  Host: CodeBuddy",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-publish-skill",
-                    "  Host: CodeBuddy",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
+                    ...createExpectedBundledSkillLines("CodeBuddy"),
                 ].join("\n"),
             );
         }
@@ -312,28 +343,9 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 4 oo-managed skills.",
+                    "✓ Found 4 skills.",
                     "",
-                    "oo",
-                    "  Host: WorkBuddy",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-find-skills",
-                    "  Host: WorkBuddy",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-create-skill",
-                    "  Host: WorkBuddy",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-publish-skill",
-                    "  Host: WorkBuddy",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
+                    ...createExpectedBundledSkillLines("WorkBuddy"),
                 ].join("\n"),
             );
         }
@@ -360,28 +372,9 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 4 oo-managed skills.",
+                    "✓ Found 4 skills.",
                     "",
-                    "oo",
-                    "  Host: Trae",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-find-skills",
-                    "  Host: Trae",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-create-skill",
-                    "  Host: Trae",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-publish-skill",
-                    "  Host: Trae",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
+                    ...createExpectedBundledSkillLines("Trae"),
                 ].join("\n"),
             );
         }
@@ -408,28 +401,9 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 4 oo-managed skills.",
+                    "✓ Found 4 skills.",
                     "",
-                    "oo",
-                    "  Host: Hermes",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-find-skills",
-                    "  Host: Hermes",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-create-skill",
-                    "  Host: Hermes",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-publish-skill",
-                    "  Host: Hermes",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
+                    ...createExpectedBundledSkillLines("Hermes"),
                 ].join("\n"),
             );
         }
@@ -458,28 +432,9 @@ describe("skills list CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
                 [
-                    "✓ Found 4 oo-managed skills.",
+                    "✓ Found 4 skills.",
                     "",
-                    "oo",
-                    "  Host: Codex, Claude Code",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-find-skills",
-                    "  Host: Codex, Claude Code",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-create-skill",
-                    "  Host: Codex, Claude Code",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
-                    "oo-publish-skill",
-                    "  Host: Codex, Claude Code",
-                    "  Source: bundled",
-                    "  Version: 9.9.9",
-                    "",
+                    ...createExpectedBundledSkillLines("Codex, Claude Code"),
                 ].join("\n"),
             );
         }
@@ -496,7 +451,7 @@ describe("skills list CLI", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
-            expect(result.stdout).toBe("! No oo-managed skills were found.\n");
+            expect(result.stdout).toBe("! No skills were found.\n");
         }
         finally {
             await sandbox.cleanup();
@@ -534,14 +489,30 @@ describe("skills list CLI", () => {
                 `${colors.dim("Host:")} ${colors.hex(managedSkillSourceColor)("Codex")}`,
             );
             expect(result.stdout).toContain(
-                `${colors.dim("Source:")} ${colors.hex(managedSkillSourceColor)("@oomol/alpha")}`,
+                `${colors.dim("Source:")} ${colors.hex(managedSkillSourceColor)("registry")}`,
+            );
+            expect(result.stdout).toContain(
+                `${colors.dim("Package:")} ${colors.hex(managedSkillSourceColor)("@oomol/alpha")}`,
             );
             expect(result.stdout).toContain(
                 `${colors.dim("Version:")} ${colors.hex(managedSkillVersionColor)("1.2.3")}`,
             );
+            expect(result.stdout).not.toContain(colors.dim("Path:"));
         }
         finally {
             await sandbox.cleanup();
         }
     });
 });
+
+function createExpectedBundledSkillLines(
+    hostName: string,
+): string[] {
+    return bundledSkillNames.flatMap(skillName => [
+        skillName,
+        `  Host: ${hostName}`,
+        "  Source: bundled",
+        "  Version: 9.9.9",
+        "",
+    ]);
+}

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -1,7 +1,10 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 import type { TerminalColors } from "../../terminal-colors.ts";
 import type { BundledSkillAgentName } from "./embedded-assets.ts";
-import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
+import type {
+    ManagedSkillHost,
+    ManagedSkillHostInstallation,
+} from "./managed-skill-hosts.ts";
 
 import type { ManagedSkillMetadata } from "./managed-skill-metadata.ts";
 import { readdir, readFile, realpath } from "node:fs/promises";
@@ -9,15 +12,21 @@ import { join } from "node:path";
 import { isPlainObject } from "@wopjs/cast";
 import matter from "gray-matter";
 import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
 import { compareSemver } from "../../semver.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
 import {
+    hasMatchingSkillFileContent,
+    readSkillFileContent,
+} from "./local-skill-ownership.ts";
+import {
     readManagedSkillHostLabels,
 } from "./managed-skill-host-labels.ts";
 import {
     resolveAvailableManagedSkillHosts,
+    resolveManagedSkillHostInstallations,
 } from "./managed-skill-hosts.ts";
 import { parseManagedSkillMetadataContent } from "./managed-skill-metadata.ts";
 import {
@@ -35,6 +44,15 @@ import {
 const managedSkillNameColor = "#59F78D";
 const managedSkillSourceColor = "#CAA8FA";
 const managedSkillVersionColor = "#7DD3FC";
+const skillListInternalPackageName = "<internal>";
+const skillListLocalHostName = "<local>";
+const skillListLocalPackageName = "<local>";
+const skillListSourceValues = ["bundled", "registry", "local"] as const;
+const skillListSourceOrder = {
+    bundled: 0,
+    registry: 1,
+    local: 2,
+} as const satisfies Record<SkillListSource, number>;
 const managedSkillHostOrder = {
     codex: 0,
     claude: 1,
@@ -45,6 +63,8 @@ const managedSkillHostOrder = {
     openclaw: 6,
     qoderwork: 7,
 } as const satisfies Record<BundledSkillAgentName, number>;
+
+type SkillListSource = (typeof skillListSourceValues)[number];
 
 export interface ManagedSkillListItem {
     metadata?: ManagedSkillMetadata;
@@ -57,12 +77,18 @@ export interface ManagedSkillHostListItem extends ManagedSkillListItem {
     hostName: BundledSkillAgentName;
 }
 
-interface ManagedSkillOutputListItem {
+interface SkillListOutputItem {
     hostNames: BundledSkillAgentName[];
     metadata?: ManagedSkillMetadata;
     name: string;
     paths: string[];
-    source?: "local";
+    source: SkillListSource;
+}
+
+interface SkillListSortableItem {
+    metadata?: ManagedSkillMetadata;
+    name: string;
+    source?: SkillListSource;
 }
 
 export interface LocalSkillListItem {
@@ -73,14 +99,35 @@ export interface LocalSkillListItem {
 
 type ManagedSkillListTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
 
-export const skillsListCommand: CliCommandDefinition<Record<string, never>> = {
+interface SkillsListInput {
+    source?: SkillListSource;
+}
+
+export const skillsListCommand: CliCommandDefinition<SkillsListInput> = {
     name: "list",
     summaryKey: "commands.skills.list.summary",
     descriptionKey: "commands.skills.list.description",
-    inputSchema: z.object({}),
-    handler: async (_, context) => {
-        const skills = groupManagedSkillInstallationsByIdentity(
-            await listManagedSkillInstallationsByHost(context),
+    options: [
+        {
+            name: "source",
+            longFlag: "--source",
+            shortFlag: "-s",
+            valueName: "source",
+            descriptionKey: "options.skillListSource",
+        },
+    ],
+    inputSchema: z.object({
+        source: z.enum(skillListSourceValues).optional(),
+    }),
+    mapInputError: (_, rawInput) => new CliUserError(
+        "errors.skills.list.invalidSource",
+        2,
+        { value: String(rawInput.source ?? "") },
+    ),
+    handler: async (input, context) => {
+        const skills = filterSkillListOutputItems(
+            await listSkillOutputItems(context),
+            input.source,
         );
 
         context.logger.info(
@@ -88,59 +135,20 @@ export const skillsListCommand: CliCommandDefinition<Record<string, never>> = {
                 count: skills.length,
                 paths: skills.flatMap(skill => skill.paths),
                 skillNames: skills.map(skill => skill.name),
+                source: input.source,
             },
-            "Managed skills listed.",
+            "Skills listed.",
         );
 
         context.stdout.write(
             `${
-                formatManagedSkillListAsText({
+                formatSkillListAsText({
                     skills,
                 }, context)
             }\n`,
         );
     },
 };
-
-export const skillsListLocalCommand: CliCommandDefinition<Record<string, never>> = {
-    name: "list-local",
-    summaryKey: "commands.skills.listLocal.summary",
-    descriptionKey: "commands.skills.listLocal.description",
-    inputSchema: z.object({}),
-    handler: async (_, context) => {
-        const skills = await listLocalSkillInstallations(
-            resolveLocalSkillCanonicalRootDirectoryPath(
-                context.settingsStore.getFilePath(),
-            ),
-        );
-
-        context.logger.info(
-            {
-                count: skills.length,
-                paths: skills.map(skill => skill.path),
-                skillNames: skills.map(skill => skill.name),
-            },
-            "Local skills listed.",
-        );
-
-        context.stdout.write(
-            `${
-                formatLocalSkillListAsText({
-                    skills,
-                }, context)
-            }\n`,
-        );
-    },
-};
-
-async function listManagedSkillInstallationsByHost(
-    context: Pick<CliExecutionContext, "env" | "settingsStore">,
-): Promise<ManagedSkillHostListItem[]> {
-    return listManagedSkillInstallationsForHosts(
-        await resolveAvailableManagedSkillHosts(context.env),
-        context.settingsStore.getFilePath(),
-    );
-}
 
 export async function listManagedSkillInstallationsForHosts(
     hosts: readonly ManagedSkillHost[],
@@ -164,32 +172,135 @@ export async function listManagedSkillInstallationsForHosts(
         .sort(compareManagedSkillHostListItems);
 }
 
-function groupManagedSkillInstallationsByIdentity(
-    installations: readonly ManagedSkillHostListItem[],
-): ManagedSkillOutputListItem[] {
-    const groups: ManagedSkillOutputListItem[] = [];
+async function listSkillOutputItems(
+    context: Pick<CliExecutionContext, "env" | "settingsStore">,
+): Promise<SkillListOutputItem[]> {
+    const settingsFilePath = context.settingsStore.getFilePath();
+    const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
+    const [managedInstallations, localInstallations] = await Promise.all([
+        listManagedSkillInstallationsForHosts(availableHosts, settingsFilePath),
+        listLocalSkillInstallations(
+            resolveLocalSkillCanonicalRootDirectoryPath(settingsFilePath),
+        ),
+    ]);
+    const localOutputItems = await createLocalSkillOutputItems(
+        localInstallations,
+        availableHosts,
+    );
+
+    return groupSkillListInstallationsByIdentity([
+        ...managedInstallations.map(createManagedSkillOutputItem),
+        ...localOutputItems,
+    ]);
+}
+
+function createManagedSkillOutputItem(
+    installation: ManagedSkillHostListItem,
+): SkillListOutputItem {
+    const source = readManagedSkillListSource(installation);
+
+    return {
+        hostNames: [installation.hostName],
+        metadata: installation.metadata,
+        name: installation.name,
+        paths: [installation.path],
+        source,
+    };
+}
+
+function createLocalSkillOutputItems(
+    installations: readonly LocalSkillListItem[],
+    hosts: readonly ManagedSkillHost[],
+): Promise<SkillListOutputItem[]> {
+    return Promise.all(installations.map(installation =>
+        createLocalSkillOutputItem(
+            installation,
+            resolveManagedSkillHostInstallations(hosts, installation.name),
+        ),
+    ));
+}
+
+async function createLocalSkillOutputItem(
+    installation: LocalSkillListItem,
+    hostInstallations: readonly ManagedSkillHostInstallation[],
+): Promise<SkillListOutputItem> {
+    const matchingHostInstallations = await resolveLocalSkillHostInstallations(
+        installation.path,
+        hostInstallations,
+    );
+
+    return {
+        hostNames: matchingHostInstallations.map(host => host.agentName),
+        metadata: installation.metadata,
+        name: installation.name,
+        paths: [installation.path],
+        source: "local",
+    };
+}
+
+async function resolveLocalSkillHostInstallations(
+    canonicalSkillDirectoryPath: string,
+    hostInstallations: readonly ManagedSkillHostInstallation[],
+): Promise<ManagedSkillHostInstallation[]> {
+    const skillFileContent = await readSkillFileContent(canonicalSkillDirectoryPath);
+
+    if (skillFileContent === undefined) {
+        return [];
+    }
+
+    const matches = await Promise.all(
+        hostInstallations.map(async installation =>
+            await hasMatchingSkillFileContent({
+                expectedContent: skillFileContent,
+                skillDirectoryPath: installation.installedSkillDirectoryPath,
+            })
+                ? installation
+                : undefined,
+        ),
+    );
+
+    return matches.filter(match => match !== undefined);
+}
+
+function groupSkillListInstallationsByIdentity(
+    installations: readonly SkillListOutputItem[],
+): SkillListOutputItem[] {
+    const groups: SkillListOutputItem[] = [];
 
     for (const installation of installations) {
         const group = groups.find(candidate =>
-            hasSameManagedSkillIdentity(candidate, installation),
+            hasSameSkillListIdentity(candidate, installation),
         );
 
         if (group === undefined) {
-            groups.push({
-                hostNames: [installation.hostName],
-                metadata: installation.metadata,
-                name: installation.name,
-                paths: [installation.path],
-                source: installation.source,
-            });
+            groups.push(installation);
             continue;
         }
 
-        group.hostNames.push(installation.hostName);
-        group.paths.push(installation.path);
+        appendUniqueValues(group.hostNames, installation.hostNames);
+        appendUniqueValues(group.paths, installation.paths);
     }
 
-    return groups.sort(compareManagedSkillOutputListItems);
+    return groups.sort(compareSkillListOutputItems);
+}
+
+function appendUniqueValues<Value>(target: Value[], values: readonly Value[]): void {
+    for (const value of values) {
+        if (!target.includes(value)) {
+            target.push(value);
+        }
+    }
+}
+
+function filterSkillListOutputItems(
+    skills: readonly SkillListOutputItem[],
+    source?: SkillListSource,
+): SkillListOutputItem[] {
+    if (source === undefined) {
+        return [...skills];
+    }
+
+    return skills.filter(skill => skill.source === source);
 }
 
 export async function listManagedSkillInstallations(
@@ -249,9 +360,9 @@ export async function listLocalSkillInstallations(
         .sort(compareLocalSkillListItems);
 }
 
-export function formatManagedSkillListAsText(
+function formatSkillListAsText(
     inventory: {
-        skills: readonly ManagedSkillOutputListItem[];
+        skills: readonly SkillListOutputItem[];
     },
     context: ManagedSkillListTextContext,
 ): string {
@@ -262,38 +373,12 @@ export function formatManagedSkillListAsText(
     }
 
     const blocks = inventory.skills.map(
-        skill => formatManagedSkillListItem(skill, context, colors),
+        skill => formatSkillListItem(skill, context, colors),
     );
 
     return [
         `${colors.green("✓")} ${
             context.translator.t("skills.list.summary", {
-                count: inventory.skills.length,
-            })
-        }`,
-        ...blocks,
-    ].join("\n\n");
-}
-
-export function formatLocalSkillListAsText(
-    inventory: {
-        skills: readonly LocalSkillListItem[];
-    },
-    context: ManagedSkillListTextContext,
-): string {
-    const colors = createWriterColors(context.stdout);
-
-    if (inventory.skills.length === 0) {
-        return `${colors.yellow("!")} ${context.translator.t("skills.listLocal.noResults")}`;
-    }
-
-    const blocks = inventory.skills.map(
-        skill => formatLocalSkillListItem(skill, context, colors),
-    );
-
-    return [
-        `${colors.green("✓")} ${
-            context.translator.t("skills.listLocal.summary", {
                 count: inventory.skills.length,
             })
         }`,
@@ -399,25 +484,40 @@ function parseLocalSkillListItem(
     };
 }
 
-function formatManagedSkillListItem(
-    skill: ManagedSkillOutputListItem,
+function formatSkillListItem(
+    skill: SkillListOutputItem,
     context: ManagedSkillListTextContext,
     colors: TerminalColors,
 ): string {
+    const packageLine = skill.source === "bundled"
+        ? undefined
+        : formatManagedSkillDetailLine(
+                context.translator.t("skills.list.package"),
+                colors.hex(managedSkillSourceColor)(
+                    readSkillListPackageName(skill, context),
+                ),
+                colors,
+            );
+    const pathLine = skill.source === "local"
+        ? formatManagedSkillDetailLine(
+                context.translator.t("skills.list.path"),
+                colors.hex(managedSkillSourceColor)(skill.paths.join(", ")),
+                colors,
+            )
+        : undefined;
     const lines = [
         colors.bold(colors.hex(managedSkillNameColor)(skill.name)),
         formatManagedSkillDetailLine(
             context.translator.t("skills.list.host"),
-            colors.hex(managedSkillSourceColor)(
-                readManagedSkillHostLabels(skill.hostNames, context.translator),
-            ),
+            colors.hex(managedSkillSourceColor)(readSkillListHostName(skill, context)),
             colors,
         ),
         formatManagedSkillDetailLine(
             context.translator.t("skills.list.source"),
-            colors.hex(managedSkillSourceColor)(readManagedSkillSource(skill, context)),
+            colors.hex(managedSkillSourceColor)(skill.source),
             colors,
         ),
+        packageLine,
         formatManagedSkillDetailLine(
             context.translator.t("labels.version"),
             colors.hex(managedSkillVersionColor)(
@@ -425,40 +525,12 @@ function formatManagedSkillListItem(
             ),
             colors,
         ),
+        pathLine,
     ];
 
-    return lines.join("\n");
-}
-
-function formatLocalSkillListItem(
-    skill: LocalSkillListItem,
-    context: ManagedSkillListTextContext,
-    colors: TerminalColors,
-): string {
-    const lines = [
-        colors.bold(colors.hex(managedSkillNameColor)(skill.name)),
-        formatManagedSkillDetailLine(
-            context.translator.t("skills.list.source"),
-            colors.hex(managedSkillSourceColor)(
-                context.translator.t("skills.list.source.local"),
-            ),
-            colors,
-        ),
-        formatManagedSkillDetailLine(
-            context.translator.t("labels.version"),
-            colors.hex(managedSkillVersionColor)(
-                skill.metadata?.version ?? context.translator.t("versionInfo.unknown"),
-            ),
-            colors,
-        ),
-        formatManagedSkillDetailLine(
-            context.translator.t("skills.list.path"),
-            colors.hex(managedSkillSourceColor)(skill.path),
-            colors,
-        ),
-    ];
-
-    return lines.join("\n");
+    return lines
+        .filter(line => line !== undefined)
+        .join("\n");
 }
 
 function formatManagedSkillDetailLine(
@@ -469,55 +541,81 @@ function formatManagedSkillDetailLine(
     return `  ${colors.dim(`${label}:`)} ${value}`;
 }
 
-function readManagedSkillSource(
+function readManagedSkillListSource(
     skill: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
+): SkillListSource {
+    if (skill.source === "local") {
+        return "local";
+    }
+
+    if (skill.metadata?.packageName === undefined && isBundledSkillName(skill.name)) {
+        return "bundled";
+    }
+
+    return "registry";
+}
+
+function readSkillListHostName(
+    skill: Pick<SkillListOutputItem, "hostNames">,
+    context: Pick<CliExecutionContext, "translator">,
+): string {
+    if (skill.hostNames.length === 0) {
+        return skillListLocalHostName;
+    }
+
+    return readManagedSkillHostLabels(skill.hostNames, context.translator);
+}
+
+function readSkillListPackageName(
+    skill: Pick<SkillListOutputItem, "metadata" | "source">,
     context: Pick<CliExecutionContext, "translator">,
 ): string {
     if (skill.metadata?.packageName !== undefined) {
         return skill.metadata.packageName;
     }
 
-    if ("source" in skill && skill.source === "local") {
-        return context.translator.t("skills.list.source.local");
+    switch (skill.source) {
+        case "bundled":
+            return skillListInternalPackageName;
+        case "local":
+            return skillListLocalPackageName;
+        case "registry":
+            return context.translator.t("versionInfo.unknown");
     }
-
-    if (isBundledSkillName(skill.name)) {
-        return context.translator.t("skills.list.source.bundled");
-    }
-
-    return context.translator.t("versionInfo.unknown");
 }
 
-function readManagedSkillSourceIdentity(
-    skill: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
+function readSkillListPackageIdentity(
+    skill: Pick<SkillListOutputItem, "metadata" | "source">,
 ): string {
-    if (skill.metadata?.packageName !== undefined) {
-        return `package:${skill.metadata.packageName}`;
-    }
-
-    if (skill.source === "local") {
-        return "local";
-    }
-
-    if (isBundledSkillName(skill.name)) {
-        return "bundled";
-    }
-
-    return "unknown";
+    return skill.metadata?.packageName ?? readSkillListFallbackPackageIdentity(skill);
 }
 
-function hasSameManagedSkillIdentity(
-    left: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
-    right: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
+function readSkillListFallbackPackageIdentity(
+    skill: Pick<SkillListOutputItem, "source">,
+): string {
+    switch (skill.source) {
+        case "bundled":
+            return skillListInternalPackageName;
+        case "local":
+            return skillListLocalPackageName;
+        case "registry":
+            return "";
+    }
+}
+
+function hasSameSkillListIdentity(
+    left: SkillListOutputItem,
+    right: SkillListOutputItem,
 ): boolean {
     return left.name === right.name
-        && readManagedSkillSourceIdentity(left) === readManagedSkillSourceIdentity(right)
+        && left.source === right.source
+        && readSkillListPackageIdentity(left) === readSkillListPackageIdentity(right)
         && (left.metadata?.version ?? "") === (right.metadata?.version ?? "");
 }
 
 function compareManagedSkillListItems(
-    left: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
-    right: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
+    left: SkillListSortableItem,
+    right: SkillListSortableItem,
 ): number {
     const leftBundledOrder = readBundledSkillNameOrder(left);
     const rightBundledOrder = readBundledSkillNameOrder(right);
@@ -538,7 +636,7 @@ function compareManagedSkillListItems(
 }
 
 function readBundledSkillNameOrder(
-    skill: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
+    skill: SkillListSortableItem,
 ): number | undefined {
     if (
         skill.metadata?.packageName !== undefined
@@ -578,9 +676,9 @@ async function readManagedSkillLocalSource(
     }
 }
 
-function compareManagedSkillOutputListItems(
-    left: ManagedSkillOutputListItem,
-    right: ManagedSkillOutputListItem,
+function compareSkillListOutputItems(
+    left: SkillListOutputItem,
+    right: SkillListOutputItem,
 ): number {
     const nameDifference = compareManagedSkillListItems(left, right);
 
@@ -588,11 +686,18 @@ function compareManagedSkillOutputListItems(
         return nameDifference;
     }
 
-    const sourceDifference = readManagedSkillSourceIdentity(left)
-        .localeCompare(readManagedSkillSourceIdentity(right));
+    const sourceDifference = skillListSourceOrder[left.source]
+        - skillListSourceOrder[right.source];
 
     if (sourceDifference !== 0) {
         return sourceDifference;
+    }
+
+    const packageDifference = readSkillListPackageIdentity(left)
+        .localeCompare(readSkillListPackageIdentity(right));
+
+    if (packageDifference !== 0) {
+        return packageDifference;
     }
 
     return compareSemver(

--- a/src/application/commands/skills/local-skill-ownership.ts
+++ b/src/application/commands/skills/local-skill-ownership.ts
@@ -1,0 +1,27 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
+
+export async function readSkillFileContent(
+    skillDirectoryPath: string,
+): Promise<string | undefined> {
+    try {
+        return await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8");
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
+}
+
+export async function hasMatchingSkillFileContent(options: {
+    expectedContent: string;
+    skillDirectoryPath: string;
+}): Promise<boolean> {
+    return await readSkillFileContent(options.skillDirectoryPath)
+        === options.expectedContent;
+}

--- a/src/application/commands/skills/managed-skill-uninstall.ts
+++ b/src/application/commands/skills/managed-skill-uninstall.ts
@@ -4,15 +4,9 @@ import type {
     BundledSkillName,
 } from "./embedded-assets.ts";
 import type { ManagedSkillHostInstallation } from "./managed-skill-hosts.ts";
-import {
-    readFile,
-    realpath,
-} from "node:fs/promises";
-import { join } from "node:path";
 import { CliUserError } from "../../contracts/cli.ts";
 import { writeLine } from "../shared/output.ts";
 import {
-    isNodeNotFoundError,
     removePath,
 } from "./bundled-skill-filesystem.ts";
 import {
@@ -23,7 +17,15 @@ import {
     readInstalledBundledSkillMetadata,
 } from "./bundled-skill-observation.ts";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
-import { createMissingManagedSkillHostError, resolveAvailableManagedSkillHosts, resolveManagedSkillHostInstallations } from "./managed-skill-hosts.ts";
+import {
+    hasMatchingSkillFileContent,
+    readSkillFileContent,
+} from "./local-skill-ownership.ts";
+import {
+    createMissingManagedSkillHostError,
+    resolveAvailableManagedSkillHosts,
+    resolveManagedSkillHostInstallations,
+} from "./managed-skill-hosts.ts";
 import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
 import {
     isLocalSkillPathContained,
@@ -494,10 +496,10 @@ async function resolveLocalSkillUninstallTargets(options: {
         }
 
         if (
-            await isManagedLocalSkillInstallation({
-                installedSkillDirectoryPath: installation.installedSkillDirectoryPath,
-                localCanonicalSkillDirectoryPath: options.canonicalSkillDirectoryPath,
-                localSkillFileContent,
+            localSkillFileContent !== undefined
+            && await hasMatchingSkillFileContent({
+                expectedContent: localSkillFileContent,
+                skillDirectoryPath: installation.installedSkillDirectoryPath,
             })
         ) {
             targets.push(installation);
@@ -526,64 +528,6 @@ async function resolveUnmanagedSkillUninstallInstallations(options: {
     }
 
     return unmanagedInstallations;
-}
-
-async function isManagedLocalSkillInstallation(options: {
-    installedSkillDirectoryPath: string;
-    localCanonicalSkillDirectoryPath: string;
-    localSkillFileContent: string | undefined;
-}): Promise<boolean> {
-    if (
-        await isSameRealPath(
-            options.installedSkillDirectoryPath,
-            options.localCanonicalSkillDirectoryPath,
-        )
-    ) {
-        return true;
-    }
-
-    if (options.localSkillFileContent === undefined) {
-        return false;
-    }
-
-    const installedSkillFileContent = await readSkillFileContent(
-        options.installedSkillDirectoryPath,
-    );
-
-    return installedSkillFileContent === options.localSkillFileContent;
-}
-
-async function isSameRealPath(leftPath: string, rightPath: string): Promise<boolean> {
-    try {
-        const [leftRealPath, rightRealPath] = await Promise.all([
-            realpath(leftPath),
-            realpath(rightPath),
-        ]);
-
-        return leftRealPath === rightRealPath;
-    }
-    catch (error) {
-        if (isNodeNotFoundError(error)) {
-            return false;
-        }
-
-        throw error;
-    }
-}
-
-async function readSkillFileContent(
-    skillDirectoryPath: string,
-): Promise<string | undefined> {
-    try {
-        return await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8");
-    }
-    catch (error) {
-        if (isNodeNotFoundError(error)) {
-            return undefined;
-        }
-
-        throw error;
-    }
 }
 
 async function removeLocalCanonicalSkillOnly(options: {

--- a/src/i18n/catalog.test.ts
+++ b/src/i18n/catalog.test.ts
@@ -16,6 +16,9 @@ describe("message catalog", () => {
         expect(enMessages["errors.shared.invalidPositiveIntegerOption"]).toBe(
             "Invalid value for {option}: {value}. Use an integer greater than or equal to 1.",
         );
+        expect(enMessages["errors.skills.list.invalidSource"]).toBe(
+            "Invalid source: {value}. Use bundled, registry, or local.",
+        );
         expect(enMessages["labels.blocks"]).toBe("Blocks:");
         expect(enMessages["labels.status"]).toBe("Status");
         expect(enMessages["labels.version"]).toBe("Version");
@@ -30,6 +33,9 @@ describe("message catalog", () => {
         );
         expect(zhMessages["errors.shared.invalidPositiveIntegerOption"]).toBe(
             "{option} 的值无效：{value}。请使用大于等于 1 的整数。",
+        );
+        expect(zhMessages["errors.skills.list.invalidSource"]).toBe(
+            "无效的 source：{value}。请使用 bundled、registry 或 local。",
         );
         expect(zhMessages["labels.blocks"]).toBe("功能块：");
         expect(zhMessages["labels.status"]).toBe("状态");
@@ -54,6 +60,12 @@ describe("message catalog", () => {
             "packageInfo.text.blocks",
             "search.text.blocks",
             "skills.list.version",
+            "skills.list.source.bundled",
+            "skills.list.source.local",
+            "skills.listLocal.noResults",
+            "skills.listLocal.summary",
+            "commands.skills.listLocal.description",
+            "commands.skills.listLocal.summary",
             "versionInfo.version",
         ] as const;
 

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -126,13 +126,9 @@ export const enMessages = {
     "commands.skills.search.summary":
         "Search published skills",
     "commands.skills.list.description":
-        "List oo-managed skills from supported local skill directories.",
+        "List bundled, registry, and local skills.",
     "commands.skills.list.summary":
-        "List oo-managed skills",
-    "commands.skills.listLocal.description":
-        "List skills from local canonical skill storage.",
-    "commands.skills.listLocal.summary":
-        "List local skills",
+        "List skills",
     "commands.skills.check.description":
         "Check whether this environment can edit local skills.",
     "commands.skills.check.summary": "Preflight local skill editing",
@@ -424,6 +420,8 @@ export const enMessages = {
         "Package {packageName} does not publish any skills.",
     "errors.skills.install.nonInteractiveSelection":
         "Package {packageName} has multiple skills. Use --skill <name>, --all -y, or run in an interactive terminal.",
+    "errors.skills.list.invalidSource":
+        "Invalid source: {value}. Use bundled, registry, or local.",
     "errors.skills.install.packageDownloadError":
         "The skills package download failed: {message}",
     "errors.skills.install.packageDownloadFailed":
@@ -531,6 +529,8 @@ export const enMessages = {
     "options.json": "Alias for --format=json",
     "options.keywords":
         "Specify comma-separated keywords to refine the skill search",
+    "options.skillListSource":
+        "Filter by skill source (bundled, registry, or local)",
     "options.icon": "Set the generated skill icon reference",
     "options.title": "Set the generated skill display title",
     "options.visibility":
@@ -597,7 +597,7 @@ export const enMessages = {
     "skills.check.success":
         "Local skill editing is ready. Writable storage: {path}. Supported hosts: {count}.",
     "skills.list.noResults":
-        "No oo-managed skills were found.",
+        "No skills were found.",
     "skills.list.host": "Host",
     "skills.list.host.claude": "Claude Code",
     "skills.list.host.codebuddy": "CodeBuddy",
@@ -608,15 +608,10 @@ export const enMessages = {
     "skills.list.host.trae": "Trae",
     "skills.list.host.workbuddy": "WorkBuddy",
     "skills.list.source": "Source",
-    "skills.list.source.bundled": "bundled",
-    "skills.list.source.local": "local",
+    "skills.list.package": "Package",
     "skills.list.path": "Path",
     "skills.list.summary":
-        "Found {count} oo-managed skills.",
-    "skills.listLocal.noResults":
-        "No local skills were found.",
-    "skills.listLocal.summary":
-        "Found {count} local skills.",
+        "Found {count} skills.",
     "labels.blocks": "Blocks:",
     "labels.status": "Status",
     "labels.version": "Version",
@@ -872,13 +867,9 @@ export const zhMessages = {
     "commands.skills.search.summary":
         "搜索已发布的 skill",
     "commands.skills.list.description":
-        "列出受支持的本地 skill 目录中由 oo 管理的 skill。",
+        "列出 bundled、registry 和 local skill。",
     "commands.skills.list.summary":
-        "列出由 oo 管理的 skill",
-    "commands.skills.listLocal.description":
-        "列出本地 canonical skill 存储中的 skill。",
-    "commands.skills.listLocal.summary":
-        "列出本地 skill",
+        "列出 skill",
     "commands.skills.check.description":
         "检查当前环境是否有权限编辑本地 skills。",
     "commands.skills.check.summary": "预检本地 skill 编辑环境",
@@ -1158,6 +1149,8 @@ export const zhMessages = {
         "包 {packageName} 没有发布任何 skill。",
     "errors.skills.install.nonInteractiveSelection":
         "包 {packageName} 包含多个 skill。请使用 --skill <name>、--all -y，或在交互终端中运行。",
+    "errors.skills.list.invalidSource":
+        "无效的 source：{value}。请使用 bundled、registry 或 local。",
     "errors.skills.install.packageDownloadError":
         "下载 skills 包失败：{message}",
     "errors.skills.install.packageDownloadFailed":
@@ -1260,6 +1253,8 @@ export const zhMessages = {
     "options.json": "--format=json 的别名",
     "options.keywords":
         "指定用于细化 skill 搜索的逗号分隔关键词",
+    "options.skillListSource":
+        "按 skill 来源过滤（bundled、registry 或 local）",
     "options.icon": "设置生成的 skill icon 引用",
     "options.title": "设置生成的 skill 显示标题",
     "options.visibility":
@@ -1325,7 +1320,7 @@ export const zhMessages = {
     "skills.check.success":
         "本地 skill 编辑环境可用。可写存储：{path}。受支持 Agents：{count}。",
     "skills.list.noResults":
-        "未找到由 oo 管理的 skill。",
+        "未找到 skill。",
     "skills.list.host": "Agents",
     "skills.list.host.claude": "Claude Code",
     "skills.list.host.codebuddy": "CodeBuddy",
@@ -1336,15 +1331,10 @@ export const zhMessages = {
     "skills.list.host.trae": "Trae",
     "skills.list.host.workbuddy": "WorkBuddy",
     "skills.list.source": "来源",
-    "skills.list.source.bundled": "内置",
-    "skills.list.source.local": "本地",
+    "skills.list.package": "Package",
     "skills.list.path": "路径",
     "skills.list.summary":
-        "找到 {count} 个由 oo 管理的 skill。",
-    "skills.listLocal.noResults":
-        "未找到本地 skill。",
-    "skills.listLocal.summary":
-        "找到 {count} 个本地 skill。",
+        "找到 {count} 个 skill。",
     "labels.blocks": "功能块：",
     "labels.status": "状态",
     "labels.version": "版本",


### PR DESCRIPTION
This PR updates `oo skills list` to show all skill sources in one command: bundled, registry, and local. The output now separates `Source` from `Package`, where `Source` is one of `bundled`, `registry`, or `local`, and `Package` shows the package name when available.

It also adds `--source` / `-s` filtering, removes the old `oo skills list-local` command, and updates CLI tests, i18n messages, and command documentation to match the new user-facing contract.