### PR TITLE
feat(skills): add Trae CN as a supported skill host

### DIFF
--- a/README-ZH_CN.md
+++ b/README-ZH_CN.md
@@ -64,6 +64,9 @@ skills：
   `~/.codebuddy/skills/oo-find-skills`
 - WorkBuddy：`~/.workbuddy/skills/oo` 和
   `~/.workbuddy/skills/oo-find-skills`
+- Trae：`~/.trae/skills/oo` 和 `~/.trae/skills/oo-find-skills`
+- Trae CN：`~/.trae-cn/skills/oo` 和
+  `~/.trae-cn/skills/oo-find-skills`
 - OpenClaw：`${OPENCLAW_HOME:-~/.openclaw}/skills/oo` 和
   `${OPENCLAW_HOME:-~/.openclaw}/skills/oo-find-skills`
 - QoderWork：`~/.qoderwork/skills/oo` 和

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ supported local host that already exists:
   `~/.codebuddy/skills/oo-find-skills`
 - WorkBuddy: `~/.workbuddy/skills/oo` and
   `~/.workbuddy/skills/oo-find-skills`
+- Trae: `~/.trae/skills/oo` and `~/.trae/skills/oo-find-skills`
+- Trae CN: `~/.trae-cn/skills/oo` and
+  `~/.trae-cn/skills/oo-find-skills`
 - OpenClaw: `${OPENCLAW_HOME:-~/.openclaw}/skills/oo` and
   `${OPENCLAW_HOME:-~/.openclaw}/skills/oo-find-skills`
 - QoderWork: `~/.qoderwork/skills/oo` and

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -291,7 +291,7 @@ supported host directory that already exists.
 
 - Bundled skills: `oo` ensures `oo`, `oo-find-skills`, `oo-create-skill`, and
   `oo-publish-skill` are installed for each detected Codex, Claude Code,
-  Hermes, CodeBuddy, WorkBuddy, Trae, OpenClaw, and QoderWork host.
+  Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, OpenClaw, and QoderWork host.
   Existing oo-managed bundled skill targets are refreshed to the current `oo`
   version, except that `0.0.0-development` startup runs do not refresh
   existing bundled targets.
@@ -311,7 +311,7 @@ List bundled, registry, and local skills.
 - Managed ownership rule: the command scans each existing supported local skill root:
   `${CODEX_HOME:-~/.codex}/skills`, `~/.claude/skills`,
   `${HERMES_HOME:-~/.hermes}/skills`, `~/.codebuddy/skills`,
-  `~/.workbuddy/skills`, `~/.trae/skills`,
+  `~/.workbuddy/skills`, `~/.trae/skills`, `~/.trae-cn/skills`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills`, and `~/.qoderwork/skills`. It keeps
   only child directories whose
   `.oo-metadata.json` can be parsed and contains a non-empty `version`.
@@ -325,7 +325,7 @@ List bundled, registry, and local skills.
   `oo-find-skills` before `oo-create-skill` before `oo-publish-skill`; the
   remaining skills are ordered by skill name. Host names within a managed block
   follow `Codex`, `Claude Code`, `Hermes`, `CodeBuddy`, `WorkBuddy`, `Trae`,
-  `OpenClaw`, `QoderWork` order.
+  `Trae CN`, `OpenClaw`, `QoderWork` order.
 - Output: each skill block shows the skill name plus `Host`, `Source`, and
   `Version`. `Source` is `bundled`, `registry`, or `local`. Registry and local
   blocks also show `Package`; local blocks also show `Path`. `Host` lists
@@ -340,8 +340,8 @@ List bundled, registry, and local skills.
 Check whether this environment has permission to edit local skills.
 
 - Options: `--agent <agent>` restricts the host check to one supported agent:
-  `codex`, `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`,
-  or `qoderwork`.
+  `codex`, `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `trae-cn`,
+  `openclaw`, or `qoderwork`.
 - Host check: without `--agent`, at least one supported agent home directory
   must already exist. With `--agent`, that specific agent home directory must
   exist.
@@ -378,9 +378,10 @@ directory that already exists.
   `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`,
   `~/.codebuddy/skills/<skill-id>`, `~/.workbuddy/skills/<skill-id>`,
   `~/.trae/skills/<skill-id>`,
+  `~/.trae-cn/skills/<skill-id>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
   `~/.qoderwork/skills/<skill-id>`.
-- Publication mode: Codex, Claude Code, Trae, and QoderWork targets are
+- Publication mode: Codex, Claude Code, Trae, Trae CN, and QoderWork targets are
   published as symlinks to the canonical directory when the current platform
   and environment allow it. Hermes, CodeBuddy, WorkBuddy, and OpenClaw targets
   are copied.
@@ -417,8 +418,8 @@ Convert one skill into an OOMOL package and run the publish step.
   Accepted values are `private` and `public`. The default is `private`.
 - Options: `--agent <agent>` is a source hint used only when the skill is not
   found in local, bundled, or registry storage. Accepted values are `codex`,
-  `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`, and
-  `qoderwork`.
+  `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `trae-cn`,
+  `openclaw`, and `qoderwork`.
 - Options: `-y, --yes` answers publish confirmation prompts with yes.
 - Source resolution: the command first checks
   `<config-dir>/skills/local/<skill-id>`. If present, that local skill is
@@ -520,7 +521,8 @@ Install bundled or published skills into supported local skill directories.
 - Canonical directory: bundled skills are materialized under
   `<config-dir>/skills/bundled/<agent>/<skill-id>`, where `<config-dir>` is the
   directory that contains `settings.toml` and `<agent>` is `codex`, `claude`,
-  `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`, or `qoderwork`.
+  `hermes`, `codebuddy`, `workbuddy`, `trae`, `trae-cn`, `openclaw`, or
+  `qoderwork`.
 - Canonical directory: published skills are materialized to
   `<config-dir>/skills/registry/<skill-id>`.
 - Migration: on first run after upgrading, `oo skills install` removes legacy
@@ -537,14 +539,15 @@ Install bundled or published skills into supported local skill directories.
   `~/.codebuddy/skills/<skill-id>`,
   `~/.workbuddy/skills/<skill-id>`,
   `~/.trae/skills/<skill-id>`,
+  `~/.trae-cn/skills/<skill-id>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
   `~/.qoderwork/skills/<skill-id>`.
 - Target directory: if an existing supported host is missing its `skills` root,
   the command creates that root before publishing the selected skill.
 - Path rule: published skill names are accepted only when their resolved
   canonical and target directories remain under those local `skills` roots.
-- Installation mode: bundled and published Codex, Claude Code, Trae, and
-  QoderWork skills are published to the target directory as a symlink to the
+- Installation mode: bundled and published Codex, Claude Code, Trae, Trae CN,
+  and QoderWork skills are published to the target directory as a symlink to the
   canonical directory when the current platform and environment allow it. When
   symlink creation fails, `oo` falls back to copying the canonical files into
   the target skills directory.
@@ -567,8 +570,8 @@ Install bundled or published skills into supported local skill directories.
 - Notes: in the interactive picker, conflicting skills are marked in the list;
   selecting one means it will be overwritten.
 - Notes: the command exits with an error when none of the supported Codex,
-  Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae, OpenClaw, or QoderWork home
-  directories exists.
+  Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, OpenClaw, or
+  QoderWork home directories exists.
 - Notes: an existing bundled skill installation is considered managed by `oo`
   only when its `.oo-metadata.json` file can be parsed and contains a
   non-empty `version`. Otherwise `oo` treats it as a different skill and will
@@ -626,6 +629,7 @@ Remove oo-managed skills from supported local skill directories.
   `${HERMES_HOME:-~/.hermes}/skills/<skill>`,
   `~/.codebuddy/skills/<skill>`, `~/.workbuddy/skills/<skill>`,
   `~/.trae/skills/<skill>`,
+  `~/.trae-cn/skills/<skill>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`, and
   `~/.qoderwork/skills/<skill>`.
 - Path rule: `[skill]` must resolve to child directories under those local

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -252,7 +252,7 @@
 skills。
 
 - 内置 skill：`oo` 会确保每个检测到的 Codex、Claude Code、Hermes、
-  CodeBuddy、WorkBuddy、Trae、OpenClaw 和 QoderWork Agent 都安装了 `oo`、
+  CodeBuddy、WorkBuddy、Trae、Trae CN、OpenClaw 和 QoderWork Agent 都安装了 `oo`、
   `oo-find-skills`、`oo-create-skill` 与 `oo-publish-skill`。已经由 oo 管理的
   内置 skill 目标会刷新到当前 `oo` 版本；
   但当启动中的当前版本为 `0.0.0-development` 时，不会刷新已存在的内置 skill
@@ -272,7 +272,7 @@ skills。
 - managed 所有权规则：命令会扫描每个已存在的受支持本地 skill 根目录：
   `${CODEX_HOME:-~/.codex}/skills`、`~/.claude/skills`，以及
   `${HERMES_HOME:-~/.hermes}/skills`、`~/.codebuddy/skills`、
-  `~/.workbuddy/skills`、`~/.trae/skills`、
+  `~/.workbuddy/skills`、`~/.trae/skills`、`~/.trae-cn/skills`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills`、`~/.qoderwork/skills`。只保留包含
   可解析 `.oo-metadata.json` 且其中包含非空 `version` 的子目录。
 - local 所有权规则：命令会扫描 `<config-dir>/skills/local`，只保留
@@ -283,7 +283,8 @@ skills。
 - 排序：bundled skills 会排在最前面；其中 `oo` 优先，其次
   `oo-find-skills`，再其次 `oo-create-skill`，再其次 `oo-publish-skill`；其余
   skill 按名称排序。managed 块内的 Agent 名称按 `Codex`、`Claude Code`、
-  `Hermes`、`CodeBuddy`、`WorkBuddy`、`Trae`、`OpenClaw`、`QoderWork` 顺序显示。
+  `Hermes`、`CodeBuddy`、`WorkBuddy`、`Trae`、`Trae CN`、`OpenClaw`、
+  `QoderWork` 顺序显示。
 - 输出：每个 skill 块会显示 skill 名称，以及 `Host`、`Source` 和 `Version`。
   `Source` 为 `bundled`、`registry` 或 `local`。registry 和 local 块还会显示
   `Package`；local 块还会显示 `Path`。`Host` 会列出匹配的受支持 Agent；如果
@@ -297,8 +298,8 @@ skills。
 检查当前环境是否有权限编辑本地 skills。
 
 - 选项：`--agent <agent>` 将 Agent 检查限制为一个受支持 Agent：`codex`、
-  `claude`、`hermes`、`codebuddy`、`workbuddy`、`trae`、`openclaw` 或
-  `qoderwork`。
+  `claude`、`hermes`、`codebuddy`、`workbuddy`、`trae`、`trae-cn`、
+  `openclaw` 或 `qoderwork`。
 - Agent 检查：未提供 `--agent` 时，至少需要存在一个受支持 Agent home 目录。
   提供 `--agent` 时，该指定 Agent home 目录必须存在。
 - 存储检查：命令会在需要时创建 `<config-dir>/skills/local` 和每个已检查 Agent
@@ -328,9 +329,10 @@ skills。
   `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`、
   `~/.codebuddy/skills/<skill-id>`、`~/.workbuddy/skills/<skill-id>`、
   `~/.trae/skills/<skill-id>`、
+  `~/.trae-cn/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`，以及
   `~/.qoderwork/skills/<skill-id>`。
-- 发布方式：Codex、Claude Code、Trae 和 QoderWork 目标会在当前平台和环境允许时
+- 发布方式：Codex、Claude Code、Trae、Trae CN 和 QoderWork 目标会在当前平台和环境允许时
   发布为指向 canonical 目录的软连接；Hermes、CodeBuddy、WorkBuddy 和 OpenClaw
   目标会复制。
 - 失败行为：如果没有受支持的 Agent home，或 canonical 本地目录、任意目标目录
@@ -360,7 +362,7 @@ skills。
   `private` 和 `public`，默认值为 `private`。
 - 选项：`--agent <agent>` 仅在 local、bundled 和 registry 存储中都没有匹配时
   作为来源提示。可选值为 `codex`、`claude`、`hermes`、`codebuddy`、
-  `workbuddy`、`trae`、`openclaw` 和 `qoderwork`。
+  `workbuddy`、`trae`、`trae-cn`、`openclaw` 和 `qoderwork`。
 - 选项：`-y, --yes` 会对发布过程中的确认提示自动回答 yes。
 - 来源解析：命令会先检查 `<config-dir>/skills/local/<skill-id>`。如果存在，则发布
   这个本地 skill。
@@ -443,7 +445,8 @@ skills。
 - canonical 目录：内置 skill 会先释放到
   `<config-dir>/skills/bundled/<agent>/<skill-id>`，其中 `<config-dir>` 是
   `settings.toml` 所在目录，`<agent>` 为 `codex`、`claude`、`hermes`、
-  `codebuddy`、`workbuddy`、`trae`、`openclaw` 或 `qoderwork`。
+  `codebuddy`、`workbuddy`、`trae`、`trae-cn`、`openclaw` 或
+  `qoderwork`。
 - canonical 目录：已发布 skill 会先释放到
   `<config-dir>/skills/registry/<skill-id>`。
 - 迁移：升级后首次运行 `oo skills install` 时，命令会清理历史遗留的 canonical
@@ -457,12 +460,13 @@ skills。
   `~/.codebuddy/skills/<skill-id>`、
   `~/.workbuddy/skills/<skill-id>`、
   `~/.trae/skills/<skill-id>`、
+  `~/.trae-cn/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`、
   `~/.qoderwork/skills/<skill-id>`。
 - 目标目录：当已存在的受支持 Agent 缺少 `skills` 根目录时，命令会先创建该目录，
   再发布所选 skill。
-- 安装方式：内置和已发布的 Codex / Claude Code / Trae / QoderWork skill 会优
-  先把目标目录发布为指向 canonical 目录的软连接。如果当前平台或环境下创建
+- 安装方式：内置和已发布的 Codex / Claude Code / Trae / Trae CN / QoderWork
+  skill 会优先把目标目录发布为指向 canonical 目录的软连接。如果当前平台或环境下创建
   软连接失败，则会回退为把 canonical 目录内容复制到目标 skills 目录。
 - 安装方式：内置和已发布的 Hermes / CodeBuddy / WorkBuddy / OpenClaw skill
   会直接复制到目标 skills 目录。
@@ -481,8 +485,8 @@ skills。
   skill，命令不会覆盖它。
 - 说明：在交互选择页面中，存在重名冲突的 skill 会在列表中显示状态标记；
   只要用户仍然选择该项，就会执行覆盖。
-- 说明：当 Codex、Claude Code、Hermes、CodeBuddy、WorkBuddy、Trae、OpenClaw
-  和 QoderWork 的受支持根目录都不存在时，命令会直接报错退出。
+- 说明：当 Codex、Claude Code、Hermes、CodeBuddy、WorkBuddy、Trae、Trae CN、
+  OpenClaw 和 QoderWork 的受支持根目录都不存在时，命令会直接报错退出。
 - 说明：只有当 bundled skill 的 `.oo-metadata.json` 可以被解析，且其中包
   含非空的 `version` 时，`oo` 才会认为这是自己管理的内置 skill；否则会视
   为其他 skill，并拒绝覆盖。
@@ -530,6 +534,7 @@ skills。
   `~/.codebuddy/skills/<skill>`、
   `~/.workbuddy/skills/<skill>`、
   `~/.trae/skills/<skill>`、
+  `~/.trae-cn/skills/<skill>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`、
   `~/.qoderwork/skills/<skill>`。
 - 路径规则：`[skill]` 解析后必须仍然落在这些本地 `skills` 根目录的子目录中。

--- a/src/application/commands/skills/bundled-skill-observation.test.ts
+++ b/src/application/commands/skills/bundled-skill-observation.test.ts
@@ -13,7 +13,10 @@ import {
     requireCodexHomeDirectory,
     writeInstalledBundledSkillMetadata,
 } from "./bundled-skill-observation.ts";
-import { resolveTraeHomeDirectory } from "./bundled-skill-paths.ts";
+import {
+    resolveTraeCnHomeDirectory,
+    resolveTraeHomeDirectory,
+} from "./bundled-skill-paths.ts";
 
 describe("bundled skill observation", () => {
     test("reports directory and file existence from stat-backed wrappers", async () => {
@@ -290,6 +293,33 @@ describe("bundled skill observation", () => {
                 traeHomeDirectory,
             );
             expect(resolveTraeHomeDirectory(env)).toBe(traeHomeDirectory);
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("requires the resolved Trae CN home directory to exist", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const traeCnHomeDirectory = join(rootDirectory, ".trae-cn");
+        const env = {
+            HOME: rootDirectory,
+        };
+
+        try {
+            await expect(
+                requireBundledSkillHomeDirectory({ env }, "trae-cn"),
+            ).rejects.toMatchObject({
+                exitCode: 1,
+                key: "errors.skills.traeCnNotInstalled",
+            });
+
+            await mkdir(traeCnHomeDirectory, { recursive: true });
+
+            expect(await requireBundledSkillHomeDirectory({ env }, "trae-cn")).toBe(
+                traeCnHomeDirectory,
+            );
+            expect(resolveTraeCnHomeDirectory(env)).toBe(traeCnHomeDirectory);
         }
         finally {
             await rm(rootDirectory, { force: true, recursive: true });

--- a/src/application/commands/skills/bundled-skill-paths.ts
+++ b/src/application/commands/skills/bundled-skill-paths.ts
@@ -9,6 +9,7 @@ const codeBuddyDirectoryName = ".codebuddy";
 const hermesDirectoryName = ".hermes";
 const openClawDirectoryName = ".openclaw";
 const qoderWorkDirectoryName = ".qoderwork";
+const traeCnDirectoryName = ".trae-cn";
 const traeDirectoryName = ".trae";
 const workBuddyDirectoryName = ".workbuddy";
 export const codexSkillsDirectoryName = "skills";
@@ -78,6 +79,12 @@ export function resolveTraeHomeDirectory(
     return join(resolveHomeDirectory(env), traeDirectoryName);
 }
 
+export function resolveTraeCnHomeDirectory(
+    env: Record<string, string | undefined>,
+): string {
+    return join(resolveHomeDirectory(env), traeCnDirectoryName);
+}
+
 export function resolveWorkBuddyHomeDirectory(
     env: Record<string, string | undefined>,
 ): string {
@@ -103,6 +110,8 @@ export function resolveBundledSkillHomeDirectory(
             return resolveQoderWorkHomeDirectory(env);
         case "trae":
             return resolveTraeHomeDirectory(env);
+        case "trae-cn":
+            return resolveTraeCnHomeDirectory(env);
         case "workbuddy":
             return resolveWorkBuddyHomeDirectory(env);
     }

--- a/src/application/commands/skills/check.test.ts
+++ b/src/application/commands/skills/check.test.ts
@@ -12,6 +12,7 @@ import {
     resolveCodexHomeDirectory,
     resolveHermesHomeDirectory,
     resolveQoderWorkHomeDirectory,
+    resolveTraeCnHomeDirectory,
     resolveTraeHomeDirectory,
     resolveWorkBuddyHomeDirectory,
 } from "./bundled-skill-paths.ts";
@@ -234,6 +235,40 @@ describe("skills preflight command", () => {
                 "preflight",
                 "--agent",
                 "trae",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Local skill editing is ready. Writable storage: ${canonicalRootDirectoryPath}. Supported hosts: 1.\n`,
+            );
+            expect(await readdir(canonicalRootDirectoryPath)).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("checks Trae CN as a requested agent", async () => {
+        const sandbox = await createCliSandbox();
+        const traeCnHomeDirectory = resolveTraeCnHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalRootDirectoryPath = resolveLocalSkillCanonicalRootDirectoryPath(
+            storePaths.settingsFilePath,
+        );
+
+        try {
+            await mkdir(traeCnHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "preflight",
+                "--agent",
+                "trae-cn",
             ]);
 
             expect(result.exitCode).toBe(0);

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -69,6 +69,15 @@ describe("embedded skill assets", () => {
             "references/file-transfer.md",
             "references/task-lifecycle.md",
         ]);
+        expect(getBundledSkillFiles("oo", "trae-cn").map(file => file.relativePath)).toEqual([
+            "SKILL.md",
+            "references/auth-and-billing.md",
+            "references/search-and-selection.md",
+            "references/package-execution.md",
+            "references/connector-execution.md",
+            "references/file-transfer.md",
+            "references/task-lifecycle.md",
+        ]);
         expect(getBundledSkillFiles("oo", "openclaw").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "references/auth-and-billing.md",
@@ -137,6 +146,14 @@ describe("embedded skill assets", () => {
             "references/oo-cli-contract.md",
         ]);
         expect(
+            getBundledSkillFiles("oo-find-skills", "trae-cn").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+            "references/oo-cli-contract.md",
+        ]);
+        expect(
             getBundledSkillFiles("oo-find-skills", "openclaw").map(
                 file => file.relativePath,
             ),
@@ -190,6 +207,13 @@ describe("embedded skill assets", () => {
         ]);
         expect(
             getBundledSkillFiles("oo-create-skill", "trae").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-create-skill", "trae-cn").map(
                 file => file.relativePath,
             ),
         ).toEqual([
@@ -253,6 +277,13 @@ describe("embedded skill assets", () => {
             "SKILL.md",
         ]);
         expect(
+            getBundledSkillFiles("oo-publish-skill", "trae-cn").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
             getBundledSkillFiles("oo-publish-skill", "openclaw").map(
                 file => file.relativePath,
             ),
@@ -276,6 +307,7 @@ describe("embedded skill assets", () => {
             "codebuddy",
             "workbuddy",
             "trae",
+            "trae-cn",
             "openclaw",
             "qoderwork",
         ]);
@@ -471,7 +503,7 @@ describe("embedded skill assets", () => {
     });
 
     test("keeps non-Claude skill frontmatter free of Claude allowed tools", async () => {
-        for (const agentName of ["qoderwork", "trae", "workbuddy"] as const) {
+        for (const agentName of ["qoderwork", "trae", "trae-cn", "workbuddy"] as const) {
             for (const skillName of availableBundledSkillNames) {
                 const skillFile = getBundledSkillFiles(skillName, agentName)
                     .find(file => file.relativePath === "SKILL.md");
@@ -507,6 +539,7 @@ function readBundledSkillSourceAgentName(
         case "hermes":
             return "claude";
         case "trae":
+        case "trae-cn":
         case "workbuddy":
             return "codebuddy";
         default:

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -58,7 +58,7 @@ import ooQoderWorkSearchAndSelectionReferencePath from "../../../../contrib/skil
 import ooQoderWorkTaskLifecycleReferencePath from "../../../../contrib/skills/qoderwork/oo/references/task-lifecycle.md" with { type: "file" };
 import ooQoderWorkSkillPath from "../../../../contrib/skills/qoderwork/oo/SKILL.md" with { type: "file" };
 
-export const availableBundledSkillAgentNames = ["codex", "claude", "hermes", "codebuddy", "workbuddy", "trae", "openclaw", "qoderwork"] as const;
+export const availableBundledSkillAgentNames = ["codex", "claude", "hermes", "codebuddy", "workbuddy", "trae", "trae-cn", "openclaw", "qoderwork"] as const;
 export type BundledSkillAgentName = (typeof availableBundledSkillAgentNames)[number];
 
 export const availableBundledSkillNames = ["oo", "oo-find-skills", "oo-create-skill", "oo-publish-skill"] as const;
@@ -122,7 +122,7 @@ const ooQoderWorkReferenceFiles = createOoReferenceFiles({
 // Keep this registry aligned with contrib/skills/<agent>/<skill> or its compatible source so Bun embeds the files.
 const bundledSkillRegistry = {
     "oo": {
-        codex: {
+        "codex": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -135,7 +135,7 @@ const bundledSkillRegistry = {
                 ...ooCodexReferenceFiles,
             ],
         },
-        claude: {
+        "claude": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -144,7 +144,7 @@ const bundledSkillRegistry = {
                 ...ooClaudeCompatibleReferenceFiles,
             ],
         },
-        hermes: {
+        "hermes": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -153,7 +153,7 @@ const bundledSkillRegistry = {
                 ...ooClaudeCompatibleReferenceFiles,
             ],
         },
-        codebuddy: {
+        "codebuddy": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -162,7 +162,7 @@ const bundledSkillRegistry = {
                 ...ooCodeBuddyReferenceFiles,
             ],
         },
-        workbuddy: {
+        "workbuddy": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -171,7 +171,7 @@ const bundledSkillRegistry = {
                 ...ooCodeBuddyReferenceFiles,
             ],
         },
-        trae: {
+        "trae": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -180,7 +180,16 @@ const bundledSkillRegistry = {
                 ...ooCodeBuddyReferenceFiles,
             ],
         },
-        openclaw: {
+        "trae-cn": {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCodeBuddySkillPath,
+                },
+                ...ooCodeBuddyReferenceFiles,
+            ],
+        },
+        "openclaw": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -189,7 +198,7 @@ const bundledSkillRegistry = {
                 ...ooOpenClawReferenceFiles,
             ],
         },
-        qoderwork: {
+        "qoderwork": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -200,7 +209,7 @@ const bundledSkillRegistry = {
         },
     },
     "oo-find-skills": {
-        codex: {
+        "codex": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -216,7 +225,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        claude: {
+        "claude": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -228,7 +237,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        hermes: {
+        "hermes": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -240,7 +249,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        codebuddy: {
+        "codebuddy": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -252,7 +261,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        workbuddy: {
+        "workbuddy": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -264,7 +273,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        trae: {
+        "trae": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -276,7 +285,19 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        openclaw: {
+        "trae-cn": {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooFindSkillsCodeBuddySkillPath,
+                },
+                {
+                    relativePath: "references/oo-cli-contract.md",
+                    sourcePath: ooFindSkillsCodeBuddyCliContractPath,
+                },
+            ],
+        },
+        "openclaw": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -288,7 +309,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        qoderwork: {
+        "qoderwork": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -302,7 +323,7 @@ const bundledSkillRegistry = {
         },
     },
     "oo-create-skill": {
-        codex: {
+        "codex": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -314,7 +335,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        claude: {
+        "claude": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -322,7 +343,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        hermes: {
+        "hermes": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -330,7 +351,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        codebuddy: {
+        "codebuddy": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -338,7 +359,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        workbuddy: {
+        "workbuddy": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -346,7 +367,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        trae: {
+        "trae": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -354,7 +375,15 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        openclaw: {
+        "trae-cn": {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCreateSkillCodeBuddySkillPath,
+                },
+            ],
+        },
+        "openclaw": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -362,7 +391,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        qoderwork: {
+        "qoderwork": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -372,7 +401,7 @@ const bundledSkillRegistry = {
         },
     },
     "oo-publish-skill": {
-        codex: {
+        "codex": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -384,7 +413,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        claude: {
+        "claude": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -392,7 +421,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        hermes: {
+        "hermes": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -400,7 +429,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        codebuddy: {
+        "codebuddy": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -408,7 +437,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        workbuddy: {
+        "workbuddy": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -416,7 +445,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        trae: {
+        "trae": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -424,7 +453,15 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        openclaw: {
+        "trae-cn": {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooPublishSkillCodeBuddySkillPath,
+                },
+            ],
+        },
+        "openclaw": {
             files: [
                 {
                     relativePath: "SKILL.md",
@@ -432,7 +469,7 @@ const bundledSkillRegistry = {
                 },
             ],
         },
-        qoderwork: {
+        "qoderwork": {
             files: [
                 {
                     relativePath: "SKILL.md",

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -29,6 +29,7 @@ import {
     resolveHermesHomeDirectory,
     resolveOpenClawHomeDirectory,
     resolveQoderWorkHomeDirectory,
+    resolveTraeCnHomeDirectory,
     resolveTraeHomeDirectory,
     resolveWorkBuddyHomeDirectory,
 } from "./bundled-skill-paths.ts";
@@ -821,6 +822,65 @@ describe("skills commands", () => {
         }
     });
 
+    test("installs bundled skills into Trae CN using the CodeBuddy skill template", async () => {
+        const sandbox = await createCliSandbox();
+        const traeCnHomeDirectory = resolveTraeCnHomeDirectory(sandbox.env);
+        const traeCnSkillsDirectoryPath = join(traeCnHomeDirectory, "skills");
+        const skillDirectoryPath = join(traeCnHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+            "trae-cn",
+        );
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const skillFilePath = join(skillDirectoryPath, "SKILL.md");
+        const traeCnSkillFile = getBundledSkillFiles("oo", "trae-cn")
+            .find(file => file.relativePath === "SKILL.md");
+
+        try {
+            if (traeCnSkillFile === undefined) {
+                throw new Error("Missing Trae CN oo SKILL.md fixture");
+            }
+
+            await mkdir(traeCnHomeDirectory, { recursive: true });
+            await expect(stat(traeCnSkillsDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+
+            const result = await sandbox.run(["skills", "install", "oo"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Installed skill oo to ${skillDirectoryPath}.\n`,
+            );
+            expect((await stat(traeCnSkillsDirectoryPath)).isDirectory()).toBeTrue();
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson({ version: "9.9.9" }),
+            );
+            expect(await readFile(skillFilePath, "utf8")).toBe(
+                await Bun.file(traeCnSkillFile.sourcePath).text(),
+            );
+            await expect(
+                stat(join(skillDirectoryPath, "agents", "openai.yaml")),
+            ).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("refuses to overwrite an existing non-OOMOL skill with the same name", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -986,6 +1046,7 @@ describe("skills commands", () => {
         const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
         const workBuddyHomeDirectory = resolveWorkBuddyHomeDirectory(sandbox.env);
         const traeHomeDirectory = resolveTraeHomeDirectory(sandbox.env);
+        const traeCnHomeDirectory = resolveTraeCnHomeDirectory(sandbox.env);
         const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
         const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
         const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
@@ -994,6 +1055,7 @@ describe("skills commands", () => {
         const codeBuddySkillDirectoryPath = join(codeBuddyHomeDirectory, "skills", "chatgpt");
         const workBuddySkillDirectoryPath = join(workBuddyHomeDirectory, "skills", "chatgpt");
         const traeSkillDirectoryPath = join(traeHomeDirectory, "skills", "chatgpt");
+        const traeCnSkillDirectoryPath = join(traeCnHomeDirectory, "skills", "chatgpt");
         const openClawSkillDirectoryPath = join(openClawHomeDirectory, "skills", "chatgpt");
         const qoderWorkSkillDirectoryPath = join(qoderWorkHomeDirectory, "skills", "chatgpt");
         const storePaths = resolveStorePaths({
@@ -1014,6 +1076,7 @@ describe("skills commands", () => {
                 codeBuddySkillDirectoryPath,
                 workBuddySkillDirectoryPath,
                 traeSkillDirectoryPath,
+                traeCnSkillDirectoryPath,
                 openClawSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
             ]) {
@@ -1029,6 +1092,7 @@ describe("skills commands", () => {
                 codeBuddySkillDirectoryPath,
                 workBuddySkillDirectoryPath,
                 traeSkillDirectoryPath,
+                traeCnSkillDirectoryPath,
                 openClawSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
             ]) {
@@ -1051,6 +1115,7 @@ describe("skills commands", () => {
                     `Removed skill chatgpt from ${codeBuddySkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${workBuddySkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${traeSkillDirectoryPath}.`,
+                    `Removed skill chatgpt from ${traeCnSkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${openClawSkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${qoderWorkSkillDirectoryPath}.`,
                     "",
@@ -1064,6 +1129,7 @@ describe("skills commands", () => {
                 codeBuddySkillDirectoryPath,
                 workBuddySkillDirectoryPath,
                 traeSkillDirectoryPath,
+                traeCnSkillDirectoryPath,
                 openClawSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
             ]) {
@@ -1694,6 +1760,7 @@ describe("skills commands", () => {
         const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
         const workBuddyHomeDirectory = resolveWorkBuddyHomeDirectory(sandbox.env);
         const traeHomeDirectory = resolveTraeHomeDirectory(sandbox.env);
+        const traeCnHomeDirectory = resolveTraeCnHomeDirectory(sandbox.env);
         const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
         const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
         const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
@@ -1702,6 +1769,7 @@ describe("skills commands", () => {
         const codeBuddySkillDirectoryPath = join(codeBuddyHomeDirectory, "skills", "chatgpt");
         const workBuddySkillDirectoryPath = join(workBuddyHomeDirectory, "skills", "chatgpt");
         const traeSkillDirectoryPath = join(traeHomeDirectory, "skills", "chatgpt");
+        const traeCnSkillDirectoryPath = join(traeCnHomeDirectory, "skills", "chatgpt");
         const openClawSkillDirectoryPath = join(openClawHomeDirectory, "skills", "chatgpt");
         const qoderWorkSkillDirectoryPath = join(qoderWorkHomeDirectory, "skills", "chatgpt");
         const storePaths = resolveStorePaths({
@@ -1722,6 +1790,7 @@ describe("skills commands", () => {
                 mkdir(codeBuddyHomeDirectory, { recursive: true }),
                 mkdir(workBuddyHomeDirectory, { recursive: true }),
                 mkdir(traeHomeDirectory, { recursive: true }),
+                mkdir(traeCnHomeDirectory, { recursive: true }),
                 mkdir(openClawHomeDirectory, { recursive: true }),
                 mkdir(qoderWorkHomeDirectory, { recursive: true }),
             ]);
@@ -1761,7 +1830,7 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
-                "Installed skill chatgpt to 8 agents: Codex, Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae, OpenClaw, QoderWork.\n",
+                "Installed skill chatgpt to 9 agents: Codex, Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, OpenClaw, QoderWork.\n",
             );
             const canonicalSkillRealPath = await realpath(canonicalSkillDirectoryPath);
 
@@ -1769,6 +1838,7 @@ describe("skills commands", () => {
                 codexSkillDirectoryPath,
                 claudeSkillDirectoryPath,
                 traeSkillDirectoryPath,
+                traeCnSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
             ]) {
                 expect(await realpath(linkedSkillDirectoryPath)).toBe(
@@ -1794,6 +1864,7 @@ describe("skills commands", () => {
                 codeBuddySkillDirectoryPath,
                 workBuddySkillDirectoryPath,
                 traeSkillDirectoryPath,
+                traeCnSkillDirectoryPath,
                 openClawSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
             ]) {

--- a/src/application/commands/skills/init.test.ts
+++ b/src/application/commands/skills/init.test.ts
@@ -10,6 +10,7 @@ import {
     resolveClaudeHomeDirectory,
     resolveCodeBuddyHomeDirectory,
     resolveCodexHomeDirectory,
+    resolveTraeCnHomeDirectory,
     resolveTraeHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { resolveLocalSkillCanonicalDirectoryPath } from "./managed-skill-paths.ts";
@@ -210,6 +211,48 @@ describe("skills init command", () => {
                 [
                     `Initialized skill trae-skill in canonical storage at ${canonicalSkillDirectoryPath}.`,
                     `Linked skill trae-skill to ${skillDirectoryPath}.`,
+                    "",
+                ].join("\n"),
+            );
+            expect(await realpath(skillDirectoryPath)).toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("initializes a local skill by linking for Trae CN", async () => {
+        const sandbox = await createCliSandbox();
+        const traeCnHomeDirectory = resolveTraeCnHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(traeCnHomeDirectory, "skills", "trae-cn-skill");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "trae-cn-skill",
+        );
+
+        try {
+            await mkdir(traeCnHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "init",
+                "trae-cn-skill",
+                "--description",
+                "Use a known package workflow.",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                [
+                    `Initialized skill trae-cn-skill in canonical storage at ${canonicalSkillDirectoryPath}.`,
+                    `Linked skill trae-cn-skill to ${skillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -14,6 +14,7 @@ import {
     resolveHermesHomeDirectory,
     resolveOpenClawHomeDirectory,
     resolveQoderWorkHomeDirectory,
+    resolveTraeCnHomeDirectory,
     resolveTraeHomeDirectory,
     resolveWorkBuddyHomeDirectory,
 } from "./bundled-skill-paths.ts";
@@ -375,6 +376,35 @@ describe("skills list CLI", () => {
                     "✓ Found 4 skills.",
                     "",
                     ...createExpectedBundledSkillLines("Trae"),
+                ].join("\n"),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("lists startup-synchronized Trae CN bundled installs when Codex is not installed", async () => {
+        const sandbox = await createCliSandbox();
+        const traeCnHomeDirectory = resolveTraeCnHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(traeCnHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install", "oo"], {
+                version: "9.9.9",
+            });
+
+            const result = await sandbox.run(["skills", "list"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    "✓ Found 4 skills.",
+                    "",
+                    ...createExpectedBundledSkillLines("Trae CN"),
                 ].join("\n"),
             );
         }

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -54,14 +54,15 @@ const skillListSourceOrder = {
     local: 2,
 } as const satisfies Record<SkillListSource, number>;
 const managedSkillHostOrder = {
-    codex: 0,
-    claude: 1,
-    hermes: 2,
-    codebuddy: 3,
-    workbuddy: 4,
-    trae: 5,
-    openclaw: 6,
-    qoderwork: 7,
+    "codex": 0,
+    "claude": 1,
+    "hermes": 2,
+    "codebuddy": 3,
+    "workbuddy": 4,
+    "trae": 5,
+    "trae-cn": 6,
+    "openclaw": 7,
+    "qoderwork": 8,
 } as const satisfies Record<BundledSkillAgentName, number>;
 
 type SkillListSource = (typeof skillListSourceValues)[number];

--- a/src/application/commands/skills/managed-skill-host-errors.ts
+++ b/src/application/commands/skills/managed-skill-host-errors.ts
@@ -7,6 +7,7 @@ export type ManagedSkillHostMissingErrorKey
         | "errors.skills.hermesNotInstalled"
         | "errors.skills.openclawNotInstalled"
         | "errors.skills.qoderworkNotInstalled"
+        | "errors.skills.traeCnNotInstalled"
         | "errors.skills.traeNotInstalled"
         | "errors.skills.workbuddyNotInstalled";
 
@@ -28,6 +29,8 @@ export function resolveManagedSkillHostMissingErrorKey(
             return "errors.skills.qoderworkNotInstalled";
         case "trae":
             return "errors.skills.traeNotInstalled";
+        case "trae-cn":
+            return "errors.skills.traeCnNotInstalled";
         case "workbuddy":
             return "errors.skills.workbuddyNotInstalled";
     }

--- a/src/application/commands/skills/managed-skill-host-labels.ts
+++ b/src/application/commands/skills/managed-skill-host-labels.ts
@@ -22,6 +22,8 @@ export function readManagedSkillHostLabel(
             return translator.t("skills.list.host.qoderwork");
         case "trae":
             return translator.t("skills.list.host.trae");
+        case "trae-cn":
+            return translator.t("skills.list.host.traeCn");
         case "workbuddy":
             return translator.t("skills.list.host.workbuddy");
         default:

--- a/src/application/commands/skills/managed-skill-publication.test.ts
+++ b/src/application/commands/skills/managed-skill-publication.test.ts
@@ -13,14 +13,15 @@ describe("managed skill publication policy", () => {
         );
 
         expect(modes).toEqual({
-            claude: "symlink-or-copy",
-            codebuddy: "copy",
-            codex: "symlink-or-copy",
-            hermes: "copy",
-            openclaw: "copy",
-            qoderwork: "symlink-or-copy",
-            trae: "symlink-or-copy",
-            workbuddy: "copy",
+            "claude": "symlink-or-copy",
+            "codebuddy": "copy",
+            "codex": "symlink-or-copy",
+            "hermes": "copy",
+            "openclaw": "copy",
+            "qoderwork": "symlink-or-copy",
+            "trae": "symlink-or-copy",
+            "trae-cn": "symlink-or-copy",
+            "workbuddy": "copy",
         });
     });
 });

--- a/src/application/commands/skills/managed-skill-publication.ts
+++ b/src/application/commands/skills/managed-skill-publication.ts
@@ -6,6 +6,7 @@ const symlinkCapableManagedSkillAgentNames: ReadonlySet<BundledSkillAgentName> =
     "codex",
     "qoderwork",
     "trae",
+    "trae-cn",
 ]);
 
 export function resolveManagedSkillPublicationMode(

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -802,7 +802,7 @@ describe("skills publish command", () => {
 
             expect(result.exitCode).toBe(2);
             expect(result.stderr).toBe(
-                "Unsupported skill agent: unknown. Use codex, claude, hermes, codebuddy, workbuddy, trae, openclaw, or qoderwork.\n",
+                "Unsupported skill agent: unknown. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, or qoderwork.\n",
             );
         }
         finally {

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -309,7 +309,7 @@ export const enMessages = {
     "errors.skills.publish.invalidPackageMetadata":
         "Invalid skill package metadata: {message}",
     "errors.skills.publish.invalidAgent":
-        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, openclaw, or qoderwork.",
+        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, or qoderwork.",
     "errors.skills.publish.invalidSkillFile":
         "Cannot publish the skill at {path}: {message}",
     "errors.skills.publish.invalidVisibility":
@@ -406,6 +406,8 @@ export const enMessages = {
         "QoderWork is not installed. Expected the QoderWork home directory at {path}.",
     "errors.skills.traeNotInstalled":
         "Trae is not installed. Expected the Trae home directory at {path}.",
+    "errors.skills.traeCnNotInstalled":
+        "Trae CN is not installed. Expected the Trae CN home directory at {path}.",
     "errors.skills.workbuddyNotInstalled":
         "WorkBuddy is not installed. Expected the WorkBuddy home directory at {path}.",
     "errors.skills.noSupportedBundledSkillHosts":
@@ -606,6 +608,7 @@ export const enMessages = {
     "skills.list.host.openclaw": "OpenClaw",
     "skills.list.host.qoderwork": "QoderWork",
     "skills.list.host.trae": "Trae",
+    "skills.list.host.traeCn": "Trae CN",
     "skills.list.host.workbuddy": "WorkBuddy",
     "skills.list.source": "Source",
     "skills.list.package": "Package",
@@ -1038,7 +1041,7 @@ export const zhMessages = {
     "errors.skills.publish.invalidPackageMetadata":
         "skill 包元数据无效：{message}",
     "errors.skills.publish.invalidAgent":
-        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、openclaw 或 qoderwork。",
+        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw 或 qoderwork。",
     "errors.skills.publish.invalidSkillFile":
         "无法发布 {path} 中的 skill：{message}",
     "errors.skills.publish.invalidVisibility":
@@ -1135,6 +1138,8 @@ export const zhMessages = {
         "未检测到 QoderWork 安装。期望的 QoderWork 根目录为 {path}。",
     "errors.skills.traeNotInstalled":
         "未检测到 Trae 安装。期望的 Trae 根目录为 {path}。",
+    "errors.skills.traeCnNotInstalled":
+        "未检测到 Trae CN 安装。期望的 Trae CN 根目录为 {path}。",
     "errors.skills.workbuddyNotInstalled":
         "未检测到 WorkBuddy 安装。期望的 WorkBuddy 根目录为 {path}。",
     "errors.skills.noSupportedBundledSkillHosts":
@@ -1329,6 +1334,7 @@ export const zhMessages = {
     "skills.list.host.openclaw": "OpenClaw",
     "skills.list.host.qoderwork": "QoderWork",
     "skills.list.host.trae": "Trae",
+    "skills.list.host.traeCn": "Trae CN",
     "skills.list.host.workbuddy": "WorkBuddy",
     "skills.list.source": "来源",
     "skills.list.package": "Package",


### PR DESCRIPTION
Trae CN ships under a separate `~/.trae-cn` home directory, so users of that variant could not receive oo-managed skills through any of the existing host code paths. Register `trae-cn` as a first-class agent across path resolution, bundled skill assets, host labels and errors, the i18n catalog, and the preflight, list, install, publish, and remove commands, reusing the CodeBuddy-derived SKILL content already embedded for Trae. Documentation and tests are updated to match.