### PR TITLE
feat(sync): implement skills sync upload and apply commands with support for ignore patterns

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -577,6 +577,44 @@ Install bundled or published skills into supported local skill directories.
   non-empty `version`. Otherwise `oo` treats it as a different skill and will
   not overwrite it.
 
+### `oo skills sync upload`
+
+Upload installed oo-managed registry skills to the skills sync service.
+
+- Options: `--source <source>` selects the sync source. The only supported value
+  is `registry`; when omitted, the command uses `registry`.
+- Options: `-i, --ignore <patterns...>` excludes registry skills from upload by
+  matching patterns against either `packageName` or skill name. The option may
+  be repeated, and each value may contain comma-separated patterns. Patterns use
+  gitignore-style matching.
+- Scope: the command uploads only installed published registry skills whose
+  `.oo-metadata.json` contains both `packageName` and `version`; bundled and
+  local skills are never uploaded.
+- Request: the command sends `PUT https://api.<endpoint>/v1/skills` with a JSON
+  array of `{ "packageName": string, "version": string, "skillName": string }`.
+  The active account's `Authorization` header is included.
+- Behavior: the server-side manifest is overwritten, including with an empty
+  array when no registry skills remain after filtering.
+- Output: on success, text output prints the number of uploaded registry skills.
+
+### `oo skills sync apply`
+
+Install uploaded oo-managed registry skills into supported local skill
+directories.
+
+- Aliases: `oo skills sync download`, `oo skills sync install`.
+- Options: `--source <source>` selects the sync source. The only supported value
+  is `registry`; when omitted, the command uses `registry`.
+- Request: the command reads `GET https://api.<endpoint>/v1/skills`. The active
+  account's `Authorization` header is included.
+- Behavior: each uploaded entry is installed from its recorded `packageName` and
+  `version`, and only the recorded `skillName` is selected from that package.
+- Scope: only registry skills are applied. Bundled and local skills are never
+  restored by this command.
+- Output: when the uploaded manifest is empty, text output reports that no
+  uploaded registry skills were found. Otherwise, regular install summaries are
+  printed, followed by a final applied-count line.
+
 ### `oo skills update [skills...]`
 
 Update installed oo-managed published skills.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -491,6 +491,38 @@ skills。
   含非空的 `version` 时，`oo` 才会认为这是自己管理的内置 skill；否则会视
   为其他 skill，并拒绝覆盖。
 
+### `oo skills sync upload`
+
+将已安装且由 oo 管理的 registry skill 上传到 skills sync 服务。
+
+- 选项：`--source <source>` 选择同步来源。当前唯一支持的值为 `registry`；
+  未提供时默认使用 `registry`。
+- 选项：`-i, --ignore <patterns...>` 会按 `packageName` 或 skill 名称匹配并排除
+  部分 registry skill。该选项可以重复使用，每个值也可以包含逗号分隔的多个模式。
+  模式使用 gitignore 风格匹配。
+- 范围：命令只上传 `.oo-metadata.json` 中同时包含 `packageName` 和 `version`
+  的已发布 registry skill；bundled 和 local skill 永远不会被上传。
+- 请求：命令会发送 `PUT https://api.<endpoint>/v1/skills`，请求体是
+  `{ "packageName": string, "version": string, "skillName": string }` 的 JSON
+  数组，并携带当前账号的 `Authorization` header。
+- 行为：服务端清单会被覆盖；如果过滤后没有 registry skill，也会上传空数组。
+- 输出：成功时，文本输出会显示已上传的 registry skill 数量。
+
+### `oo skills sync apply`
+
+将已上传且由 oo 管理的 registry skill 安装到受支持的本地 skill 目录。
+
+- 别名：`oo skills sync download`、`oo skills sync install`。
+- 选项：`--source <source>` 选择同步来源。当前唯一支持的值为 `registry`；
+  未提供时默认使用 `registry`。
+- 请求：命令会读取 `GET https://api.<endpoint>/v1/skills`，并携带当前账号的
+  `Authorization` header。
+- 行为：每条已上传记录都会按记录中的 `packageName` 和 `version` 安装，并且只从该
+  package 中选择记录里的 `skillName`。
+- 范围：该命令只应用 registry skill。bundled 和 local skill 永远不会通过该命令恢复。
+- 输出：当已上传清单为空时，文本输出会提示未找到已上传的 registry skill。否则会先
+  输出常规安装摘要，再输出最终应用数量。
+
 ### `oo skills update [skills...]`
 
 更新已安装且由 oo 管理的已发布 skill。

--- a/src/application/commands/shared/keywords.ts
+++ b/src/application/commands/shared/keywords.ts
@@ -1,23 +1,7 @@
+import { parseCommaSeparatedValues } from "./list-parsing.ts";
+
 export function parseCommaSeparatedKeywords(
     value: string | undefined,
 ): string[] {
-    if (value === undefined) {
-        return [];
-    }
-
-    const keywords: string[] = [];
-    const seen = new Set<string>();
-
-    for (const segment of value.split(",")) {
-        const keyword = segment.trim();
-
-        if (keyword === "" || seen.has(keyword)) {
-            continue;
-        }
-
-        seen.add(keyword);
-        keywords.push(keyword);
-    }
-
-    return keywords;
+    return parseCommaSeparatedValues(value === undefined ? undefined : [value]);
 }

--- a/src/application/commands/shared/list-parsing.ts
+++ b/src/application/commands/shared/list-parsing.ts
@@ -1,0 +1,25 @@
+export function parseCommaSeparatedValues(
+    values: readonly string[] | undefined,
+): string[] {
+    if (!values) {
+        return [];
+    }
+
+    const parsedValues: string[] = [];
+    const seen = new Set<string>();
+
+    for (const value of values) {
+        for (const segment of value.split(",")) {
+            const parsedValue = segment.trim();
+
+            if (parsedValue === "" || seen.has(parsedValue)) {
+                continue;
+            }
+
+            seen.add(parsedValue);
+            parsedValues.push(parsedValue);
+        }
+    }
+
+    return parsedValues;
+}

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -1843,7 +1843,7 @@ describe("skills commands", () => {
             expect(requests[0]).toMatchObject({
                 authorization: "secret-1",
                 method: "PUT",
-                url: "https://api.oomol.com/v1/skills",
+                url: "https://cli-api.oomol.com/v1/skills",
             });
             expect(requests[0]!.body).toEqual([
                 {
@@ -1960,7 +1960,7 @@ describe("skills commands", () => {
 
                     requests.push(request);
 
-                    if (request.url === "https://api.oomol.com/v1/skills") {
+                    if (request.url === "https://cli-api.oomol.com/v1/skills") {
                         return new Response(JSON.stringify([
                             {
                                 packageName: "openai",
@@ -2031,7 +2031,7 @@ describe("skills commands", () => {
 
                         requests.push(request);
 
-                        if (request.url === "https://api.oomol.com/v1/skills") {
+                        if (request.url === "https://cli-api.oomol.com/v1/skills") {
                             return new Response(JSON.stringify([
                                 {
                                     packageName: "openai",

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -1754,6 +1754,336 @@ describe("skills commands", () => {
         }
     });
 
+    test("uploads installed registry skills while excluding bundled and local skills", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const registrySkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const bundledSkillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const localSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "local-helper",
+        );
+        const registryCanonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+        const requests: Array<{
+            authorization: string | null;
+            body: unknown;
+            method: string;
+            url: string;
+        }> = [];
+
+        try {
+            await Promise.all([
+                mkdir(registrySkillDirectoryPath, { recursive: true }),
+                mkdir(bundledSkillDirectoryPath, { recursive: true }),
+                mkdir(localSkillDirectoryPath, { recursive: true }),
+                mkdir(registryCanonicalSkillDirectoryPath, { recursive: true }),
+            ]);
+            await writeAuthFile(sandbox);
+            await Bun.write(join(registrySkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
+            await Bun.write(join(registryCanonicalSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(registrySkillDirectoryPath),
+                renderSkillMetadataJson({
+                    packageName: "openai",
+                    version: "0.0.3",
+                }),
+            );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(registryCanonicalSkillDirectoryPath),
+                renderSkillMetadataJson({
+                    packageName: "openai",
+                    version: "0.0.4",
+                }),
+            );
+            await Bun.write(
+                resolveBundledSkillMetadataFilePath(bundledSkillDirectoryPath),
+                renderSkillMetadataJson({
+                    version: "9.9.9",
+                }),
+            );
+            await Bun.write(
+                join(localSkillDirectoryPath, "SKILL.md"),
+                [
+                    "---",
+                    "name: local-helper",
+                    "description: Local helper",
+                    "---",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["skills", "sync", "upload"], {
+                fetcher: async (input, init) => {
+                    const request = toRequest(input, init);
+                    const body = await request.json();
+
+                    requests.push({
+                        authorization: request.headers.get("Authorization"),
+                        body,
+                        method: request.method,
+                        url: request.url,
+                    });
+
+                    return new Response(JSON.stringify(body));
+                },
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe("Uploaded 1 registry skills.\n");
+            expect(requests).toHaveLength(1);
+            expect(requests[0]).toMatchObject({
+                authorization: "secret-1",
+                method: "PUT",
+                url: "https://api.oomol.com/v1/skills",
+            });
+            expect(requests[0]!.body).toEqual([
+                {
+                    packageName: "openai",
+                    skillName: "chatgpt",
+                    version: "0.0.4",
+                },
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("uploads registry skills with ignore patterns and explicit source", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const chatSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const captionSkillDirectoryPath = join(codexHomeDirectory, "skills", "caption");
+        const requests: Array<{
+            body: unknown;
+        }> = [];
+
+        try {
+            await Promise.all([
+                mkdir(chatSkillDirectoryPath, { recursive: true }),
+                mkdir(captionSkillDirectoryPath, { recursive: true }),
+            ]);
+            await writeAuthFile(sandbox);
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(chatSkillDirectoryPath),
+                renderSkillMetadataJson({
+                    packageName: "openai",
+                    version: "0.0.3",
+                }),
+            );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(captionSkillDirectoryPath),
+                renderSkillMetadataJson({
+                    packageName: "@private/vision",
+                    version: "1.0.0",
+                }),
+            );
+
+            const result = await sandbox.run([
+                "skills",
+                "sync",
+                "upload",
+                "--source",
+                "registry",
+                "--ignore",
+                "@private/*,missing",
+                "-i",
+                "chat*",
+            ], {
+                fetcher: async (input, init) => {
+                    const request = toRequest(input, init);
+                    const body = await request.json();
+
+                    requests.push({ body });
+
+                    return new Response(JSON.stringify(body));
+                },
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe("Uploaded 0 registry skills.\n");
+            expect(requests[0]!.body).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects unsupported skill sync sources", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run([
+                "skills",
+                "sync",
+                "upload",
+                "--source",
+                "local",
+            ]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Invalid sync source: local. Use registry.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("applies uploaded registry skills using exact package versions", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const requests: Request[] = [];
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["skills", "sync", "apply"], {
+                fetcher: async (input, init) => {
+                    const request = toRequest(input, init);
+
+                    requests.push(request);
+
+                    if (request.url === "https://api.oomol.com/v1/skills") {
+                        return new Response(JSON.stringify([
+                            {
+                                packageName: "openai",
+                                skillName: "chatgpt",
+                                version: "0.0.3",
+                            },
+                        ]));
+                    }
+
+                    if (request.url.includes("/package-info/")) {
+                        return new Response(JSON.stringify({
+                            packageName: "openai",
+                            version: "0.0.3",
+                            skills: [
+                                {
+                                    description: "Chat with a model",
+                                    name: "chatgpt",
+                                    title: "ChatGPT",
+                                },
+                            ],
+                        }));
+                    }
+
+                    if (request.url.endsWith("/openai/-/meta/openai-0.0.3.tgz")) {
+                        return new Response(await createRegistrySkillArchiveBytes({
+                            "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
+                        }));
+                    }
+
+                    throw new Error(`Unexpected request: ${request.url}`);
+                },
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain(`Installed skill chatgpt to ${skillDirectoryPath}.\n`);
+            expect(result.stdout).toContain("Applied 1 uploaded registry skills.\n");
+            expect(requests.map(request => request.url)).toContain(
+                "https://registry.oomol.com/-/oomol/package-info/openai/0.0.3",
+            );
+            expect(requests.every(request =>
+                request.headers.get("Authorization") === "secret-1",
+            )).toBeTrue();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports download and install aliases for applying exact uploaded registry versions", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            for (const [alias, version] of [
+                ["download", "0.0.4"],
+                ["install", "0.0.5"],
+            ] as const) {
+                const skillName = `${alias}-skill`;
+                const requests: Request[] = [];
+
+                const result = await sandbox.run(["skills", "sync", alias], {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.url === "https://api.oomol.com/v1/skills") {
+                            return new Response(JSON.stringify([
+                                {
+                                    packageName: "openai",
+                                    skillName,
+                                    version,
+                                },
+                            ]));
+                        }
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                skills: [
+                                    {
+                                        description: `Install ${skillName}`,
+                                        name: skillName,
+                                        title: skillName,
+                                    },
+                                ],
+                                version,
+                            }));
+                        }
+
+                        if (request.url.endsWith(`/openai/-/meta/openai-${version}.tgz`)) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                [`package/package/skills/${skillName}/SKILL.md`]: `# ${skillName}\n`,
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                });
+
+                expect(result.exitCode).toBe(0);
+                expect(result.stderr).toBe("");
+                expect(result.stdout).toContain(`Applied 1 uploaded registry skills.\n`);
+                expect(requests.map(request => request.url)).toContain(
+                    `https://registry.oomol.com/-/oomol/package-info/openai/${version}`,
+                );
+                expect(requests.map(request => request.url)).toContain(
+                    `https://registry.oomol.com/openai/-/meta/openai-${version}.tgz`,
+                );
+                expect(requests.every(request =>
+                    request.headers.get("Authorization") === "secret-1",
+                )).toBeTrue();
+            }
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("installs a published registry skill into every existing supported host", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -6,6 +6,7 @@ import { skillsInstallCommand } from "./install.ts";
 import { skillsListCommand } from "./list.ts";
 import { skillsPublishCommand } from "./publish.ts";
 import { skillsSearchCommand } from "./search.ts";
+import { skillsSyncCommand } from "./sync.ts";
 import { skillsUninstallCommand } from "./uninstall.ts";
 import { skillsUpdateCommand } from "./update.ts";
 import { skillsValidateCommand } from "./validate.ts";
@@ -17,6 +18,7 @@ export const skillsCommand: CliCommandDefinition = {
     children: [
         skillsSearchCommand,
         skillsListCommand,
+        skillsSyncCommand,
         skillsCheckCommand,
         skillsInitCommand,
         skillsValidateCommand,

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -52,6 +52,7 @@ interface ManagedSkillPathState {
 export interface RegistrySkillInstallRequest {
     all: boolean;
     packageName: string;
+    packageVersion?: string;
     skillNames: string[];
     yes: boolean;
 }
@@ -90,6 +91,7 @@ export async function installRegistrySkills(
         request.packageName,
         account,
         context,
+        request.packageVersion,
     );
 
     if (packageInfo.skills.length === 0) {

--- a/src/application/commands/skills/registry-skill-source.ts
+++ b/src/application/commands/skills/registry-skill-source.ts
@@ -34,9 +34,10 @@ export interface RegistryPackageSkillInfo {
 export function createRegistryPackageInfoRequestUrl(
     endpoint: string,
     packageName: string,
+    packageVersion = "latest",
 ): URL {
     return new URL(
-        `https://registry.${endpoint}/-/oomol/package-info/${encodeURIComponent(packageName)}/latest`,
+        `https://registry.${endpoint}/-/oomol/package-info/${encodeURIComponent(packageName)}/${encodeURIComponent(packageVersion)}`,
     );
 }
 
@@ -57,10 +58,12 @@ export async function loadRegistryPackageSkillInfo(
     packageName: string,
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
     context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
+    packageVersion = "latest",
 ): Promise<RegistryPackageSkillInfo> {
     const requestUrl = createRegistryPackageInfoRequestUrl(
         account.endpoint,
         packageName,
+        packageVersion,
     );
     const rawResponse = await requestText({
         context,
@@ -79,7 +82,7 @@ export async function loadRegistryPackageSkillInfo(
             },
         ),
         fields: {
-            common: withPackageIdentity(packageName, "latest"),
+            common: withPackageIdentity(packageName, packageVersion),
         },
         init: {
             headers: {

--- a/src/application/commands/skills/sync.test.ts
+++ b/src/application/commands/skills/sync.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { CliUserError } from "../../contracts/cli.ts";
+import {
+    createSkillSyncRequestUrl,
+    filterSkillSyncRecords,
+    parseSkillSyncResponse,
+} from "./sync.ts";
+
+describe("skills sync", () => {
+    test("creates the sync API request URL", () => {
+        expect(createSkillSyncRequestUrl("oomol.com").toString()).toBe(
+            "https://api.oomol.com/v1/skills",
+        );
+    });
+
+    test("parses skill sync records", () => {
+        expect(parseSkillSyncResponse(JSON.stringify([
+            {
+                packageName: "@oomol/text-tools",
+                skillName: "summarize",
+                version: "1.2.3",
+            },
+        ]))).toEqual([
+            {
+                packageName: "@oomol/text-tools",
+                skillName: "summarize",
+                version: "1.2.3",
+            },
+        ]);
+    });
+
+    test("rejects unsupported sync responses", () => {
+        expect(() => parseSkillSyncResponse(JSON.stringify({
+            packageName: "@oomol/text-tools",
+        }))).toThrow(CliUserError);
+    });
+
+    test("filters sync records by package and skill patterns", () => {
+        const records = [
+            {
+                packageName: "@oomol/text-tools",
+                skillName: "summarize",
+                version: "1.2.3",
+            },
+            {
+                packageName: "@private/vision",
+                skillName: "caption",
+                version: "2.0.0",
+            },
+            {
+                packageName: "openai",
+                skillName: "chatgpt",
+                version: "0.0.3",
+            },
+        ];
+
+        expect(filterSkillSyncRecords(records, ["@private/*", "chat*"])).toEqual([
+            {
+                packageName: "@oomol/text-tools",
+                skillName: "summarize",
+                version: "1.2.3",
+            },
+        ]);
+    });
+});

--- a/src/application/commands/skills/sync.test.ts
+++ b/src/application/commands/skills/sync.test.ts
@@ -9,7 +9,7 @@ import {
 describe("skills sync", () => {
     test("creates the sync API request URL", () => {
         expect(createSkillSyncRequestUrl("oomol.com").toString()).toBe(
-            "https://api.oomol.com/v1/skills",
+            "https://cli-api.oomol.com/v1/skills",
         );
     });
 

--- a/src/application/commands/skills/sync.ts
+++ b/src/application/commands/skills/sync.ts
@@ -1,0 +1,360 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+import type { AuthAccount } from "../../schemas/auth.ts";
+import type { ManagedSkillListItem } from "./list.ts";
+import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
+
+import ignore from "ignore";
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { compareSemver } from "../../semver.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
+import { parseCommaSeparatedValues } from "../shared/list-parsing.ts";
+import { writeLine } from "../shared/output.ts";
+import { requestText } from "../shared/request.ts";
+import {
+    listManagedSkillInstallations,
+    listManagedSkillInstallationsForHosts,
+} from "./list.ts";
+import {
+    createMissingManagedSkillHostError,
+    resolveAvailableManagedSkillHosts,
+} from "./managed-skill-hosts.ts";
+import {
+    resolveManagedSkillCanonicalRootDirectoryPath,
+} from "./managed-skill-paths.ts";
+import { installRegistrySkills } from "./registry-skill-install.ts";
+
+const skillSyncSourceValues = ["registry"] as const;
+const skillSyncRecordSchema = z.object({
+    packageName: z.string().min(1),
+    skillName: z.string().min(1),
+    version: z.string().min(1),
+}).strict();
+const skillSyncRecordsSchema = z.array(skillSyncRecordSchema);
+
+type SkillSyncSource = typeof skillSyncSourceValues[number];
+
+export type SkillSyncRecord = z.output<typeof skillSyncRecordSchema>;
+
+interface SkillsSyncUploadInput {
+    ignore?: string[];
+    source?: string;
+}
+
+interface SkillsSyncApplyInput {
+    source?: string;
+}
+
+export const skillsSyncCommand: CliCommandDefinition = {
+    name: "sync",
+    summaryKey: "commands.skills.sync.summary",
+    descriptionKey: "commands.skills.sync.description",
+    children: [
+        {
+            name: "upload",
+            summaryKey: "commands.skills.sync.upload.summary",
+            descriptionKey: "commands.skills.sync.upload.description",
+            options: [
+                {
+                    name: "source",
+                    longFlag: "--source",
+                    valueName: "source",
+                    descriptionKey: "options.skillSyncSource",
+                },
+                {
+                    name: "ignore",
+                    longFlag: "--ignore",
+                    shortFlag: "-i",
+                    valueName: "patterns...",
+                    descriptionKey: "options.skillSyncIgnore",
+                },
+            ],
+            inputSchema: z.object({
+                ignore: z.array(z.string()).optional(),
+                source: z.string().optional(),
+            }),
+            handler: async (input, context) => {
+                parseSkillSyncSource(input.source);
+                await uploadRegistrySkills(
+                    {
+                        ignorePatterns: parseCommaSeparatedValues(input.ignore),
+                    },
+                    context,
+                );
+            },
+        } satisfies CliCommandDefinition<SkillsSyncUploadInput>,
+        {
+            name: "apply",
+            aliases: ["download", "install"],
+            summaryKey: "commands.skills.sync.apply.summary",
+            descriptionKey: "commands.skills.sync.apply.description",
+            options: [
+                {
+                    name: "source",
+                    longFlag: "--source",
+                    valueName: "source",
+                    descriptionKey: "options.skillSyncSource",
+                },
+            ],
+            inputSchema: z.object({
+                source: z.string().optional(),
+            }),
+            handler: async (input, context) => {
+                parseSkillSyncSource(input.source);
+                await applyRegistrySkills(context);
+            },
+        } satisfies CliCommandDefinition<SkillsSyncApplyInput>,
+    ],
+};
+
+export async function uploadRegistrySkills(
+    request: {
+        ignorePatterns: readonly string[];
+    },
+    context: CliExecutionContext,
+): Promise<void> {
+    const account = await requireCurrentAccount(context);
+    const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
+    const records = filterSkillSyncRecords(
+        await collectRegistrySkillSyncRecords(
+            availableHosts,
+            context.settingsStore.getFilePath(),
+        ),
+        request.ignorePatterns,
+    );
+
+    await requestSkillSyncUpload(records, account, context);
+    writeLine(
+        context.stdout,
+        context.translator.t("skills.sync.upload.success", {
+            count: records.length,
+        }),
+    );
+}
+
+export async function applyRegistrySkills(context: CliExecutionContext): Promise<void> {
+    const account = await requireCurrentAccount(context);
+    const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
+
+    if (availableHosts.length === 0) {
+        throw createMissingManagedSkillHostError(context.env);
+    }
+
+    const records = await requestSkillSyncDownload(account, context);
+
+    if (records.length === 0) {
+        writeLine(context.stdout, context.translator.t("skills.sync.apply.noResults"));
+        return;
+    }
+
+    for (const record of records) {
+        await installRegistrySkills(
+            {
+                all: false,
+                packageName: record.packageName,
+                packageVersion: record.version,
+                skillNames: [record.skillName],
+                yes: true,
+            },
+            context,
+        );
+    }
+
+    writeLine(
+        context.stdout,
+        context.translator.t("skills.sync.apply.success", {
+            count: records.length,
+        }),
+    );
+}
+
+export function createSkillSyncRequestUrl(endpoint: string): URL {
+    return new URL(`https://cli-api.${endpoint}/v1/skills`);
+}
+
+export function parseSkillSyncResponse(rawResponse: string): SkillSyncRecord[] {
+    try {
+        return skillSyncRecordsSchema.parse(JSON.parse(rawResponse) as unknown);
+    }
+    catch {
+        throw new CliUserError("errors.skills.sync.invalidResponse", 1);
+    }
+}
+
+export function filterSkillSyncRecords(
+    records: readonly SkillSyncRecord[],
+    ignorePatterns: readonly string[],
+): SkillSyncRecord[] {
+    if (ignorePatterns.length === 0) {
+        return [...records];
+    }
+
+    const matcher = ignore().add([...ignorePatterns]);
+
+    return records.filter(record =>
+        !matcher.ignores(record.packageName)
+        && !matcher.ignores(record.skillName),
+    );
+}
+
+async function collectRegistrySkillSyncRecords(
+    availableHosts: readonly ManagedSkillHost[],
+    settingsFilePath: string,
+): Promise<SkillSyncRecord[]> {
+    const [canonicalSkills, hostSkills] = await Promise.all([
+        listManagedSkillInstallations(
+            resolveManagedSkillCanonicalRootDirectoryPath(settingsFilePath),
+        ),
+        listManagedSkillInstallationsForHosts(availableHosts, settingsFilePath),
+    ]);
+
+    return deduplicateSkillSyncRecords(
+        [...canonicalSkills, ...hostSkills].map(createSkillSyncRecord),
+    );
+}
+
+function createSkillSyncRecord(
+    skill: Pick<ManagedSkillListItem, "metadata" | "name">,
+): SkillSyncRecord | undefined {
+    const packageName = skill.metadata?.packageName;
+    const version = skill.metadata?.version;
+
+    if (packageName === undefined || version === undefined) {
+        return undefined;
+    }
+
+    return {
+        packageName,
+        skillName: skill.name,
+        version,
+    };
+}
+
+function deduplicateSkillSyncRecords(
+    records: readonly (SkillSyncRecord | undefined)[],
+): SkillSyncRecord[] {
+    const recordsByIdentity = new Map<string, SkillSyncRecord>();
+
+    for (const record of records) {
+        if (record === undefined) {
+            continue;
+        }
+
+        const key = createSkillSyncRecordIdentity(record);
+        const existingRecord = recordsByIdentity.get(key);
+
+        if (
+            existingRecord === undefined
+            || compareSemver(record.version, existingRecord.version) > 0
+        ) {
+            recordsByIdentity.set(key, record);
+        }
+    }
+
+    return Array.from(recordsByIdentity.values()).sort(compareSkillSyncRecords);
+}
+
+function createSkillSyncRecordIdentity(
+    record: Pick<SkillSyncRecord, "packageName" | "skillName">,
+): string {
+    return JSON.stringify({
+        packageName: record.packageName,
+        skillName: record.skillName,
+    });
+}
+
+function compareSkillSyncRecords(
+    left: SkillSyncRecord,
+    right: SkillSyncRecord,
+): number {
+    const packageDifference = left.packageName.localeCompare(right.packageName);
+
+    if (packageDifference !== 0) {
+        return packageDifference;
+    }
+
+    return left.skillName.localeCompare(right.skillName);
+}
+
+async function requestSkillSyncUpload(
+    records: readonly SkillSyncRecord[],
+    account: Pick<AuthAccount, "apiKey" | "endpoint">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
+): Promise<void> {
+    parseSkillSyncResponse(
+        await requestText({
+            context,
+            createRequestFailedError: status => new CliUserError(
+                "errors.skills.sync.requestFailed",
+                1,
+                { status },
+            ),
+            createUnexpectedError: error => new CliUserError(
+                "errors.skills.sync.requestError",
+                1,
+                {
+                    message: error instanceof Error ? error.message : String(error),
+                },
+            ),
+            fields: {
+                common: {
+                    skillCount: records.length,
+                },
+            },
+            init: {
+                body: JSON.stringify(records),
+                headers: {
+                    "Authorization": account.apiKey,
+                    "Content-Type": "application/json",
+                },
+                method: "PUT",
+            },
+            requestLabel: "Skills sync upload",
+            requestUrl: createSkillSyncRequestUrl(account.endpoint),
+        }),
+    );
+}
+
+async function requestSkillSyncDownload(
+    account: Pick<AuthAccount, "apiKey" | "endpoint">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
+): Promise<SkillSyncRecord[]> {
+    return parseSkillSyncResponse(
+        await requestText({
+            context,
+            createRequestFailedError: status => new CliUserError(
+                "errors.skills.sync.requestFailed",
+                1,
+                { status },
+            ),
+            createUnexpectedError: error => new CliUserError(
+                "errors.skills.sync.requestError",
+                1,
+                {
+                    message: error instanceof Error ? error.message : String(error),
+                },
+            ),
+            init: {
+                headers: {
+                    Authorization: account.apiKey,
+                },
+            },
+            requestLabel: "Skills sync download",
+            requestUrl: createSkillSyncRequestUrl(account.endpoint),
+        }),
+    );
+}
+
+function parseSkillSyncSource(value: string | undefined): SkillSyncSource {
+    if (value === undefined) {
+        return "registry";
+    }
+
+    if (skillSyncSourceValues.includes(value as SkillSyncSource)) {
+        return value as SkillSyncSource;
+    }
+
+    throw new CliUserError("errors.skills.sync.invalidSource", 2, {
+        value,
+    });
+}

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -129,6 +129,15 @@ export const enMessages = {
         "List bundled, registry, and local skills.",
     "commands.skills.list.summary":
         "List skills",
+    "commands.skills.sync.description":
+        "Sync oo-managed registry skills through the skills sync API.",
+    "commands.skills.sync.summary": "Sync registry skills",
+    "commands.skills.sync.upload.description":
+        "Upload installed oo-managed registry skills to the skills sync API.",
+    "commands.skills.sync.upload.summary": "Upload registry skills",
+    "commands.skills.sync.apply.description":
+        "Install uploaded oo-managed registry skills into supported local skill directories.",
+    "commands.skills.sync.apply.summary": "Apply uploaded registry skills",
     "commands.skills.check.description":
         "Check whether this environment can edit local skills.",
     "commands.skills.check.summary": "Preflight local skill editing",
@@ -424,6 +433,14 @@ export const enMessages = {
         "Package {packageName} has multiple skills. Use --skill <name>, --all -y, or run in an interactive terminal.",
     "errors.skills.list.invalidSource":
         "Invalid source: {value}. Use bundled, registry, or local.",
+    "errors.skills.sync.invalidResponse":
+        "The skills sync service returned an unsupported response body.",
+    "errors.skills.sync.invalidSource":
+        "Invalid sync source: {value}. Use registry.",
+    "errors.skills.sync.requestError":
+        "The skills sync request failed: {message}",
+    "errors.skills.sync.requestFailed":
+        "The skills sync request returned HTTP {status}.",
     "errors.skills.install.packageDownloadError":
         "The skills package download failed: {message}",
     "errors.skills.install.packageDownloadFailed":
@@ -533,6 +550,10 @@ export const enMessages = {
         "Specify comma-separated keywords to refine the skill search",
     "options.skillListSource":
         "Filter by skill source (bundled, registry, or local)",
+    "options.skillSyncSource":
+        "Select the skill sync source (registry; default registry)",
+    "options.skillSyncIgnore":
+        "Ignore registry skills by package or skill name pattern",
     "options.icon": "Set the generated skill icon reference",
     "options.title": "Set the generated skill display title",
     "options.visibility":
@@ -682,6 +703,12 @@ export const enMessages = {
     "skills.update.progress.updated": "updated",
     "skills.update.progress.failed": "failed",
     "skills.update.success": "Updated skill {name} to {path}.",
+    "skills.sync.apply.noResults":
+        "No uploaded registry skills were found.",
+    "skills.sync.apply.success":
+        "Applied {count} uploaded registry skills.",
+    "skills.sync.upload.success":
+        "Uploaded {count} registry skills.",
     "skills.uninstall.success": "Removed skill {name} from {path}.",
     "skills.validate.success": "Skill at {path} is valid.",
     "versionInfo.buildTime": "Build Time",
@@ -873,6 +900,15 @@ export const zhMessages = {
         "列出 bundled、registry 和 local skill。",
     "commands.skills.list.summary":
         "列出 skill",
+    "commands.skills.sync.description":
+        "通过 skills sync API 同步由 oo 管理的 registry skill。",
+    "commands.skills.sync.summary": "同步 registry skill",
+    "commands.skills.sync.upload.description":
+        "将已安装且由 oo 管理的 registry skill 上传到 skills sync API。",
+    "commands.skills.sync.upload.summary": "上传 registry skill",
+    "commands.skills.sync.apply.description":
+        "将已上传且由 oo 管理的 registry skill 安装到受支持的本地 skill 目录。",
+    "commands.skills.sync.apply.summary": "应用已上传的 registry skill",
     "commands.skills.check.description":
         "检查当前环境是否有权限编辑本地 skills。",
     "commands.skills.check.summary": "预检本地 skill 编辑环境",
@@ -1156,6 +1192,14 @@ export const zhMessages = {
         "包 {packageName} 包含多个 skill。请使用 --skill <name>、--all -y，或在交互终端中运行。",
     "errors.skills.list.invalidSource":
         "无效的 source：{value}。请使用 bundled、registry 或 local。",
+    "errors.skills.sync.invalidResponse":
+        "skills sync 服务返回了不受支持的响应内容。",
+    "errors.skills.sync.invalidSource":
+        "无效的 sync source：{value}。请使用 registry。",
+    "errors.skills.sync.requestError":
+        "skills sync 请求失败：{message}",
+    "errors.skills.sync.requestFailed":
+        "skills sync 请求返回了 HTTP {status}。",
     "errors.skills.install.packageDownloadError":
         "下载 skills 包失败：{message}",
     "errors.skills.install.packageDownloadFailed":
@@ -1260,6 +1304,10 @@ export const zhMessages = {
         "指定用于细化 skill 搜索的逗号分隔关键词",
     "options.skillListSource":
         "按 skill 来源过滤（bundled、registry 或 local）",
+    "options.skillSyncSource":
+        "选择 skill 同步来源（registry；默认 registry）",
+    "options.skillSyncIgnore":
+        "按 package 或 skill 名称模式忽略 registry skill",
     "options.icon": "设置生成的 skill icon 引用",
     "options.title": "设置生成的 skill 显示标题",
     "options.visibility":
@@ -1408,6 +1456,12 @@ export const zhMessages = {
     "skills.update.progress.updated": "已更新",
     "skills.update.progress.failed": "失败",
     "skills.update.success": "已将 skill {name} 更新到 {path}。",
+    "skills.sync.apply.noResults":
+        "未找到已上传的 registry skill。",
+    "skills.sync.apply.success":
+        "已应用 {count} 个已上传的 registry skill。",
+    "skills.sync.upload.success":
+        "已上传 {count} 个 registry skill。",
     "skills.uninstall.success": "已从 {path} 移除 skill {name}。",
     "skills.validate.success": "{path} 中的 skill 有效。",
     "versionInfo.buildTime": "构建时间",


### PR DESCRIPTION
# Registry-Only Skills Sync

closes #138

## Summary
- Add `oo skills sync upload` and `oo skills sync apply`.
- `apply` also supports aliases: `download` and `install`.
- Both commands accept `--source registry`, default to `registry`, and reject other sources.

## Key Changes
- Add a `sync` child under `oo skills` with:
  - `upload`
  - `apply` aliases: `download`, `install`
- `upload` scans installed oo-managed registry skills only, then `PUT https://cli-api.<endpoint>/v1/skills` with:
  ```ts
  { packageName: string; version: string; skillName: string }[]
  ```
- `apply` / `download` / `install` reads `GET https://cli-api.<endpoint>/v1/skills` and installs those registry skills into supported local agent directories.
- Extend registry install internals to support an explicit package version, so sync restores uploaded versions instead of always installing latest.
- Add `-i, --ignore <patterns...>` to `upload`; repeated flags and comma-separated values are accepted, matched via the existing `ignore` package against `packageName` or `skillName`.

## User-Facing Behavior
- Supported forms:
  - `oo skills sync upload`
  - `oo skills sync upload --source registry`
  - `oo skills sync apply`
  - `oo skills sync download`
  - `oo skills sync install`
- `upload` overwrites the remote registry-skill manifest, including uploading `[]` when none are installed.
- Reverse-sync commands install/apply the cloud registry-skill manifest; local and bundled skills are never synced.

## Tests
- Test API request URLs, methods, headers, payload validation, and invalid-response errors.
- Test upload excludes bundled/local skills, deduplicates registry installs, and honors `--ignore`.
- Test `apply`, `download`, and `install` aliases all install exact versions from the remote manifest.
- Test `--source` default and invalid source errors.
- Update `docs/commands.md` and `docs/commands.zh-CN.md`.
- Run `bun run lint:fix`, `bun run ts-check`, and `bun run test`.

## Assumptions
- `/v1/skills` is served at `https://cli-api.<account.endpoint>/v1/skills`.
- Server auth should use the current account `Authorization` header.
- `apply` remains the canonical documented verb; `download` and `install` are aliases for discoverability.
