### PR TITLE
feat: add Feishu release follow-up mention

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -204,6 +204,7 @@ jobs:
       RELEASE_TAG: ${{ needs.compute-version.outputs.tag_name }}
       FEISHU_RELEASE_WEBHOOK: ${{ secrets.FEISHU_RELEASE_WEBHOOK }}
       FEISHU_RELEASE_SECRET: ${{ secrets.FEISHU_RELEASE_SECRET }}
+      FEISHU_RELEASE_FOLLOWUP_AT_USER_ID: ${{ secrets.FEISHU_RELEASE_FOLLOWUP_AT_USER_ID }}
 
     steps:
       - name: Checkout

--- a/contrib/ci/release-steps.ts
+++ b/contrib/ci/release-steps.ts
@@ -58,15 +58,7 @@ export function buildFeishuReleaseNotification(input: {
     timestamp?: string;
     sign?: string;
 }): string {
-    const releaseVersion = input.releaseVersion.trim();
-    if (releaseVersion === "") {
-        throw new Error("RELEASE_VERSION is required.");
-    }
-
-    const releaseTag = input.releaseTag.trim();
-    if (releaseTag === "") {
-        throw new Error("RELEASE_TAG is required.");
-    }
+    const { releaseVersion, releaseTag } = normalizeReleaseInput(input);
 
     const releaseUrl = `${input.serverUrl}/${input.repository}/releases/tag/${releaseTag}`;
     const runUrl = `${input.serverUrl}/${input.repository}/actions/runs/${input.runId}`;
@@ -84,10 +76,58 @@ export function buildFeishuReleaseNotification(input: {
         },
     };
 
+    return stringifyFeishuCustomBotPayload(payload, input);
+}
+
+export function buildFeishuReleaseFollowupNotification(input: {
+    atUserId: string;
+    timestamp?: string;
+    sign?: string;
+}): string {
+    const atUserId = input.atUserId.trim();
+    if (atUserId === "") {
+        throw new Error("FEISHU_RELEASE_FOLLOWUP_AT_USER_ID is required.");
+    }
+
+    const payload: Record<string, unknown> = {
+        msg_type: "text",
+        content: {
+            text: `<at user_id="${escapeFeishuTextAttribute(atUserId)}">follow-up bot</at> 更新 oo-cli`,
+        },
+    };
+
+    return stringifyFeishuCustomBotPayload(payload, input);
+}
+
+function normalizeReleaseInput(input: {
+    releaseVersion: string;
+    releaseTag: string;
+}): { releaseVersion: string; releaseTag: string } {
+    const releaseVersion = input.releaseVersion.trim();
+    if (releaseVersion === "") {
+        throw new Error("RELEASE_VERSION is required.");
+    }
+
+    const releaseTag = input.releaseTag.trim();
+    if (releaseTag === "") {
+        throw new Error("RELEASE_TAG is required.");
+    }
+
+    return { releaseVersion, releaseTag };
+}
+
+function stringifyFeishuCustomBotPayload(payload: Record<string, unknown>, input: {
+    timestamp?: string;
+    sign?: string;
+}): string {
     if (input.timestamp !== undefined && input.sign !== undefined) {
         payload.timestamp = input.timestamp;
         payload.sign = input.sign;
     }
 
     return JSON.stringify(payload);
+}
+
+function escapeFeishuTextAttribute(value: string): string {
+    return value.replaceAll("&", "&amp;").replaceAll("\"", "&quot;");
 }

--- a/contrib/ci/release-workflow.test.ts
+++ b/contrib/ci/release-workflow.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
     buildCreateReleaseCommand,
+    buildFeishuReleaseFollowupNotification,
     buildFeishuReleaseNotification,
     preparePackageManifest,
 } from "./release-steps.ts";
@@ -130,6 +131,40 @@ describe("release-workflow", () => {
             sign: "signature",
             msg_type: "text",
         });
+    });
+
+    test("builds the Feishu release follow-up notification payload", () => {
+        expect(JSON.parse(buildFeishuReleaseFollowupNotification({
+            atUserId: "ou_followup_bot",
+        }))).toEqual({
+            msg_type: "text",
+            content: {
+                text: "<at user_id=\"ou_followup_bot\">follow-up bot</at> 更新 oo-cli",
+            },
+        });
+    });
+
+    test("builds the signed Feishu release follow-up notification payload", () => {
+        expect(JSON.parse(buildFeishuReleaseFollowupNotification({
+            atUserId: "ou_\"bot&reviewer",
+            timestamp: "1710000000",
+            sign: "signature",
+        }))).toEqual({
+            timestamp: "1710000000",
+            sign: "signature",
+            msg_type: "text",
+            content: {
+                text: "<at user_id=\"ou_&quot;bot&amp;reviewer\">follow-up bot</at> 更新 oo-cli",
+            },
+        });
+    });
+
+    test("rejects Feishu follow-up notifications without an at user id", () => {
+        expect(() =>
+            buildFeishuReleaseFollowupNotification({
+                atUserId: "",
+            }),
+        ).toThrow("FEISHU_RELEASE_FOLLOWUP_AT_USER_ID is required.");
     });
 
     test("rejects Feishu notifications without a release tag", () => {

--- a/contrib/ci/release-workflow.ts
+++ b/contrib/ci/release-workflow.ts
@@ -7,6 +7,7 @@ import {
 } from "./npm-packages.ts";
 import {
     buildCreateReleaseCommand,
+    buildFeishuReleaseFollowupNotification,
     buildFeishuReleaseNotification,
     preparePackageManifest,
 } from "./release-steps.ts";
@@ -41,11 +42,13 @@ async function runCreateGitHubRelease(assets: readonly string[]): Promise<void> 
 }
 
 async function runNotifyFeishuRelease(): Promise<void> {
+    const releaseVersion = readRequiredEnv("RELEASE_VERSION");
+    const releaseTag = readRequiredEnv("RELEASE_TAG");
     const webhookUrl = readRequiredEnv("FEISHU_RELEASE_WEBHOOK");
     const feishuSignature = createFeishuSignature(process.env.FEISHU_RELEASE_SECRET ?? "");
     const payload = buildFeishuReleaseNotification({
-        releaseVersion: readRequiredEnv("RELEASE_VERSION"),
-        releaseTag: readRequiredEnv("RELEASE_TAG"),
+        releaseVersion,
+        releaseTag,
         repository: readRequiredEnv("GITHUB_REPOSITORY"),
         serverUrl: readRequiredEnv("GITHUB_SERVER_URL"),
         runId: readRequiredEnv("GITHUB_RUN_ID"),
@@ -53,6 +56,24 @@ async function runNotifyFeishuRelease(): Promise<void> {
         sign: feishuSignature?.sign,
     });
 
+    await sendFeishuCustomBotMessage(webhookUrl, payload, "Feishu release group");
+
+    const atUserId = process.env.FEISHU_RELEASE_FOLLOWUP_AT_USER_ID;
+    if (atUserId === undefined || atUserId === "") {
+        return;
+    }
+
+    const followupSignature = createFeishuSignature(process.env.FEISHU_RELEASE_SECRET ?? "");
+    const followupPayload = buildFeishuReleaseFollowupNotification({
+        atUserId,
+        timestamp: followupSignature?.timestamp,
+        sign: followupSignature?.sign,
+    });
+
+    await sendFeishuCustomBotMessage(webhookUrl, followupPayload, "Feishu release follow-up bot");
+}
+
+async function sendFeishuCustomBotMessage(webhookUrl: string, payload: string, targetName: string): Promise<void> {
     const response = await fetch(webhookUrl, {
         method: "POST",
         headers: {
@@ -64,13 +85,13 @@ async function runNotifyFeishuRelease(): Promise<void> {
     const responseText = await response.text();
 
     if (!response.ok) {
-        throw new Error(`Failed to notify Feishu release group: ${response.status} ${response.statusText}`);
+        throw new Error(`Failed to notify ${targetName}: ${response.status} ${response.statusText}\n${responseText}`);
     }
 
     const responseBody = JSON.parse(responseText) as Record<string, unknown>;
     const errorCode = responseBody.code ?? responseBody.StatusCode;
     if (errorCode !== 0) {
-        throw new Error(`Failed to notify Feishu release group: ${responseText}`);
+        throw new Error(`Failed to notify ${targetName}: ${responseText}`);
     }
 }
 


### PR DESCRIPTION
## Summary
- send an optional second Feishu custom bot message after the release notification succeeds
- reuse the existing `FEISHU_RELEASE_WEBHOOK` and `FEISHU_RELEASE_SECRET` for the follow-up message
- generate a fresh signature for the follow-up message
- mention a configured follow-up bot/user with Feishu `<at user_id="...">` syntax
- keep the follow-up message fixed as `更新 oo-cli`

## Configuration
- `FEISHU_RELEASE_FOLLOWUP_AT_USER_ID` secret: Feishu user/open id to mention

If `FEISHU_RELEASE_FOLLOWUP_AT_USER_ID` is not configured, the existing release notification behavior is unchanged.

## Issue
- Closes #147

## Tests
- `bun test contrib/ci/release-workflow.test.ts`
- `bun run ts-check`
- `bun run lint`