### PR TITLE
[codex] Avoid folded YAML in skill init descriptions

### DIFF
--- a/src/application/commands/skills/init.test.ts
+++ b/src/application/commands/skills/init.test.ts
@@ -74,7 +74,7 @@ describe("skills init command", () => {
                 "description: Write campaign briefs using a known package workflow.",
                 `compatibility: ${installedRegistrySkillCompatibility}`,
                 "metadata:",
-                "  icon: ':lucide:wrench:'",
+                "  icon: \":lucide:wrench:\"",
                 "  title: Campaign Writer",
                 "---",
                 "",
@@ -132,6 +132,46 @@ describe("skills init command", () => {
                 "TODO: Describe the workflow this skill should follow.",
                 "",
             ].join("\n"));
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("writes a long description as a single-line frontmatter string", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "gpt-image-2",
+        );
+        const description = "Generate new images or edit existing images with GPT Image 2. Use when the user asks for GPT text-to-image, image generation, image-to-image editing, replacing objects, preserving a person or product, or turning local reference images into edited PNG JPEG or WebP outputs.";
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "init",
+                "gpt-image-2",
+                "--description",
+                description,
+            ]);
+
+            expect(result.exitCode).toBe(0);
+
+            const content = await readFile(
+                join(canonicalSkillDirectoryPath, "SKILL.md"),
+                "utf8",
+            );
+
+            expect(content).toContain(`description: ${description}`);
+            expect(content).not.toContain("description: >-");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/init.ts
+++ b/src/application/commands/skills/init.ts
@@ -3,7 +3,6 @@ import type { BundledSkillAgentName } from "./embedded-assets.ts";
 
 import { lstat, mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import matter from "gray-matter";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { writeLine } from "../shared/output.ts";
@@ -47,18 +46,6 @@ export interface LocalSkillHostPublicationTarget {
 export interface LocalSkillHostPublicationResult {
     mode: "copy" | "symlink";
     path: string;
-}
-
-interface OOSkillFrontmatter {
-    compatibility: string;
-    description: string;
-    metadata?: OOSkillFrontmatterMetadata;
-    name: string;
-}
-
-interface OOSkillFrontmatterMetadata {
-    icon?: string;
-    title?: string;
 }
 
 export const skillsInitCommand: CliCommandDefinition<SkillsInitInput> = {
@@ -314,25 +301,28 @@ function renderInitializedSkillMarkdown(
     icon: string | undefined,
     title: string | undefined,
 ): string {
-    const frontmatter: OOSkillFrontmatter = {
-        name: skillName,
-        description,
-        compatibility: installedRegistrySkillCompatibility,
-    };
+    const frontmatterLines = [
+        "---",
+        `name: ${renderYamlString(skillName)}`,
+        `description: ${renderYamlString(description)}`,
+        `compatibility: ${renderYamlString(installedRegistrySkillCompatibility)}`,
+    ];
 
     if (icon !== undefined || title !== undefined) {
-        frontmatter.metadata = {};
+        frontmatterLines.push("metadata:");
 
         if (icon !== undefined) {
-            frontmatter.metadata.icon = icon;
+            frontmatterLines.push(`  icon: ${renderYamlString(icon)}`);
         }
 
         if (title !== undefined) {
-            frontmatter.metadata.title = title;
+            frontmatterLines.push(`  title: ${renderYamlString(title)}`);
         }
     }
 
-    const body = [
+    return [
+        ...frontmatterLines,
+        "---",
         "",
         `# ${title ?? renderSkillTitle(skillName)}`,
         "",
@@ -341,8 +331,85 @@ function renderInitializedSkillMarkdown(
         "TODO: Describe the workflow this skill should follow.",
         "",
     ].join("\n");
+}
 
-    return matter.stringify(body, frontmatter);
+function renderYamlString(value: string): string {
+    if (canRenderPlainYamlString(value)) {
+        return value;
+    }
+
+    return JSON.stringify(value);
+}
+
+function canRenderPlainYamlString(value: string): boolean {
+    if (value === "" || value !== value.trim()) {
+        return false;
+    }
+
+    if (value.includes("\n") || value.includes("\r") || value.includes("\t")) {
+        return false;
+    }
+
+    if (startsWithYamlIndicator(value) || value.includes(": ") || containsYamlComment(value)) {
+        return false;
+    }
+
+    return !isYamlKeyword(value) && !isYamlNumberLike(value);
+}
+
+function startsWithYamlIndicator(value: string): boolean {
+    const firstChar = value[0];
+
+    return firstChar === "-"
+        || firstChar === "?"
+        || firstChar === ":"
+        || firstChar === ","
+        || firstChar === "["
+        || firstChar === "]"
+        || firstChar === "{"
+        || firstChar === "}"
+        || firstChar === "#"
+        || firstChar === "&"
+        || firstChar === "*"
+        || firstChar === "!"
+        || firstChar === "|"
+        || firstChar === ">"
+        || firstChar === "'"
+        || firstChar === "\""
+        || firstChar === "%"
+        || firstChar === "@"
+        || firstChar === "`";
+}
+
+function containsYamlComment(value: string): boolean {
+    for (let index = 0; index < value.length; index += 1) {
+        if (value[index] === "#" && (index === 0 || value[index - 1] === " ")) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function isYamlKeyword(value: string): boolean {
+    const normalized = value.toLowerCase();
+
+    return normalized === "true"
+        || normalized === "false"
+        || normalized === "null"
+        || normalized === "~"
+        || normalized === "nan"
+        || normalized === ".nan"
+        || normalized === "inf"
+        || normalized === ".inf"
+        || normalized === "-inf"
+        || normalized === "-.inf";
+}
+
+function isYamlNumberLike(value: string): boolean {
+    const parsed = Number(value);
+
+    return value !== "" && !Number.isNaN(parsed);
 }
 
 function normalizeSkillName(value: string): string {


### PR DESCRIPTION
## Summary

- Render `oo skills init` frontmatter directly instead of relying on `gray-matter` serialization.
- Keep long skill descriptions as single-line YAML values so generated skills do not show `description: >-`.
- Add coverage for long descriptions and update the initialized icon YAML expectation.

## Why

`gray-matter` automatically serializes long strings as folded YAML block scalars. That output is valid YAML, but it is noisy in generated `SKILL.md` files and can look like extra user-facing characters in editor previews.

## Validation

- `bun run lint:fix`
- `bun run ts-check`
- `bun run test`
