### PR TITLE
feat(telemetry): add privacy-constrained command usage telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,18 @@
 - When generating UUIDs, you must use v7 and must use bun's `randomUUIDv7` function
 - Avoid using regular expressions when possible
 
+### Command Telemetry
+
+- Every new or changed user-facing CLI command must make an explicit telemetry decision during implementation and review.
+- The generic `executeCli` path already emits the command event, so do not add manual command-level emit calls.
+- For useful command-specific dimensions, call `context.telemetry?.recordProperties(...)` from the command handler with only low-cardinality, privacy-safe enums, booleans, counts, or buckets. Prefer helpers in `src/application/telemetry/buckets.ts`; for skill-related command properties, use `src/application/commands/skills/telemetry.ts`.
+- Never record raw user input, paths, cwd, filenames, URL hosts, account IDs/names/emails, usernames, hostnames, error messages, stack traces, tokens, secrets, or free-form option values. Record bucketed values or stable enums instead.
+- Commands that must not be reported, such as `oo telemetry *` and the internal telemetry flush command, must set `excludeFromTelemetry: true` or call `context.telemetry?.suppressCurrentInvocation()`; do not rely on handler branching alone.
+- Every registered command path must have an explicit entry in `src/application/commands/telemetry-decisions.test.ts`; add or update that manifest whenever adding, renaming, removing, or changing telemetry behavior for a command. This architecture test is the hard guard that makes forgotten telemetry decisions fail in `bun run test`.
+- The same architecture test rejects forbidden/private property names, common sensitive suffixes, and base telemetry property names declared in the command telemetry decision manifest; extend that guard before allowing any new sensitive key pattern.
+- Do not pass base telemetry property names such as `command_full`, `distinct_id`, `schema_version`, or privacy control properties through `recordProperties(...)`; both the architecture test and the payload builder reject command-specific properties that attempt to override base telemetry fields.
+- When adding command-specific telemetry properties, add or update tests that assert the expected safe property shape and absence of raw/private values. For command behavior changes, still update `docs/commands*.md` only for the user-facing CLI contract, not internal telemetry details.
+
 ## Code Quality Rules
 
 These rules are extracted from past refactoring sessions to prevent recurring code smells.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,18 @@
 - When generating UUIDs, you must use v7 and must use bun's `randomUUIDv7` function
 - Avoid using regular expressions when possible
 
+### Command Telemetry
+
+- Every new or changed user-facing CLI command must make an explicit telemetry decision during implementation and review.
+- The generic `executeCli` path already emits the command event, so do not add manual command-level emit calls.
+- For useful command-specific dimensions, call `context.telemetry?.recordProperties(...)` from the command handler with only low-cardinality, privacy-safe enums, booleans, counts, or buckets. Prefer helpers in `src/application/telemetry/buckets.ts`; for skill-related command properties, use `src/application/commands/skills/telemetry.ts`.
+- Never record raw user input, paths, cwd, filenames, URL hosts, account IDs/names/emails, usernames, hostnames, error messages, stack traces, tokens, secrets, or free-form option values. Record bucketed values or stable enums instead.
+- Commands that must not be reported, such as `oo telemetry *` and the internal telemetry flush command, must set `excludeFromTelemetry: true` or call `context.telemetry?.suppressCurrentInvocation()`; do not rely on handler branching alone.
+- Every registered command path must have an explicit entry in `src/application/commands/telemetry-decisions.test.ts`; add or update that manifest whenever adding, renaming, removing, or changing telemetry behavior for a command. This architecture test is the hard guard that makes forgotten telemetry decisions fail in `bun run test`.
+- The same architecture test rejects forbidden/private property names, common sensitive suffixes, and base telemetry property names declared in the command telemetry decision manifest; extend that guard before allowing any new sensitive key pattern.
+- Do not pass base telemetry property names such as `command_full`, `distinct_id`, `schema_version`, or privacy control properties through `recordProperties(...)`; both the architecture test and the payload builder reject command-specific properties that attempt to override base telemetry fields.
+- When adding command-specific telemetry properties, add or update tests that assert the expected safe property shape and absence of raw/private values. For command behavior changes, still update `docs/commands*.md` only for the user-facing CLI contract, not internal telemetry details.
+
 @import CODE_QUALITY_RULES.md
 
 ## Testing

--- a/PRIVACY-ZH_CN.md
+++ b/PRIVACY-ZH_CN.md
@@ -1,0 +1,59 @@
+# 隐私
+
+`oo` 默认记录受隐私约束的命令使用 telemetry。Telemetry 用于了解命令使用分布、错误率、
+更新通道健康度，以及 package 或 skill 维度的使用分布。
+
+Telemetry 事件发送到 OOMOL 的 telemetry endpoint，后端使用 EU 区域的 PostHog Cloud。
+每条事件都会关闭 PostHog person profile 处理，并使用本地随机 device id 做设备级聚合。
+该 device id 不从 OOMOL 账号派生。
+
+## 不采集的数据
+
+Telemetry 事件不包含：
+
+- free-form 输入文本，例如搜索关键词或 connector payload
+- 文件路径、工作目录、文件名、用户名或 hostname
+- IP 地址
+- 真实 OOMOL 账号 ID、账号名或账号邮箱
+- 账号化名、`$set`、`$set_once` 或 `$identify` properties
+- 错误消息全文、堆栈、崩溃 dump 或性能 profiling
+- URL host 或完整 URL
+
+CLI 只会用 `authenticated`、`anonymous` 或 `unknown` 记录账号状态。
+
+## 可能采集的数据
+
+Telemetry 事件可能包含：
+
+- 命令名、退出码、成功状态、耗时、参数数量和 flag 数量
+- CLI 版本、commit、安装方式、操作系统、架构、运行时、语言、CI 状态和 TTY 状态
+- package name、package version、skill id、bundled skill name、connector service name、
+  connector action name，以及公开 enum 类选项值
+- 桶化后的数量、字节数和字符串长度
+
+## 用户控制
+
+使用任一环境变量可关闭当前 invocation 的 telemetry：
+
+- `OO_TELEMETRY_DISABLED=1`
+- `DO_NOT_TRACK=1`
+
+使用以下命令可持久化关闭 telemetry：
+
+- `oo telemetry disable`
+- `oo config set telemetry.enabled false`
+
+使用以下命令可持久化重新开启 telemetry：
+
+- `oo telemetry enable`
+- `oo config set telemetry.enabled true`
+- `oo config unset telemetry.enabled`
+
+使用以下命令查看实际开关状态、已存在的本地 device id 前缀、本地待发送事件数量和最后
+flush 时间：
+
+- `oo telemetry status`
+
+`oo telemetry disable` 和 `oo config set telemetry.enabled false` 会立即尝试删除本地待发送
+telemetry 事件。即使本地 telemetry store 暂时不可用，它们也会阻止后续 telemetry 发送，
+但无法撤回已经通过网络发出的字节。

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,64 @@
+# Privacy
+
+`oo` records privacy-constrained command usage telemetry by default. Telemetry is
+used to understand command adoption, error rates, update health, and package or
+skill usage distribution.
+
+Telemetry events are sent to OOMOL's telemetry endpoint and are backed by
+PostHog Cloud in the EU region. Each event disables PostHog person profile
+processing and uses a random local device id for device-level aggregation.
+The device id is not derived from an OOMOL account.
+
+## Data Not Collected
+
+Telemetry events do not include:
+
+- free-form input text, such as search queries or connector payloads
+- file paths, working directories, filenames, usernames, or hostnames
+- IP addresses
+- real OOMOL account ids, account names, or account emails
+- account pseudonyms, `$set`, `$set_once`, or `$identify` properties
+- full error messages, stack traces, crash dumps, or performance profiles
+- URL hosts or full URLs
+
+The CLI only records account state as `authenticated`, `anonymous`, or
+`unknown`.
+
+## Data That Can Be Collected
+
+Telemetry events can include:
+
+- command name, exit code, success state, duration, argument count, and flag count
+- CLI version, commit, install method, operating system, architecture, runtime,
+  language, CI state, and TTY state
+- package names, package versions, skill ids, bundled skill names, connector
+  service names, connector action names, and public enum-like option values
+- bucketed counts, byte sizes, and string lengths
+
+## User Control
+
+Disable telemetry for the current invocation with either environment variable:
+
+- `OO_TELEMETRY_DISABLED=1`
+- `DO_NOT_TRACK=1`
+
+Disable telemetry persistently with:
+
+- `oo telemetry disable`
+- `oo config set telemetry.enabled false`
+
+Re-enable telemetry persistently with:
+
+- `oo telemetry enable`
+- `oo config set telemetry.enabled true`
+- `oo config unset telemetry.enabled`
+
+Inspect the effective state, local device id prefix if it already exists,
+pending local event count, and last flush time with:
+
+- `oo telemetry status`
+
+`oo telemetry disable` and `oo config set telemetry.enabled false` attempt to
+delete pending local telemetry events immediately. They prevent future telemetry
+sends even if the local telemetry store is temporarily unavailable, but they
+cannot retract bytes that have already been sent over the network.

--- a/README-ZH_CN.md
+++ b/README-ZH_CN.md
@@ -90,6 +90,17 @@ oo skills install
 oo skills install oo-find-skills
 ```
 
+## Telemetry
+
+`oo` 默认记录受隐私约束的命令使用 telemetry。Telemetry 事件不包含
+free-form 输入文本、路径、用户名、hostname、IP 地址、真实 OOMOL 账号 ID
+或账号名。事件会关闭 PostHog person profile 处理，并使用本地随机 device id
+做设备级聚合。
+
+可以通过 `oo telemetry disable`、`OO_TELEMETRY_DISABLED=1` 或
+`DO_NOT_TRACK=1` 关闭 telemetry。使用 `oo telemetry status` 查看实际开关状态和本地待发送事件数量。
+完整边界见 [PRIVACY-ZH_CN.md](./PRIVACY-ZH_CN.md)。
+
 ## 文档
 
 - [命令参考](./docs/commands.zh-CN.md)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ And you can install the search helper explicitly with:
 oo skills install oo-find-skills
 ```
 
+## Telemetry
+
+`oo` records privacy-constrained command usage telemetry by default. Telemetry
+events do not include free-form input text, paths, usernames, hostnames, IP
+addresses, real OOMOL account ids, or account names. Events are sent with
+PostHog person profile processing disabled and use a random local device id for
+device-level aggregation.
+
+Disable telemetry with `oo telemetry disable`, `OO_TELEMETRY_DISABLED=1`, or
+`DO_NOT_TRACK=1`. Use `oo telemetry status` to inspect the effective state and
+pending local event count. See [PRIVACY.md](./PRIVACY.md) for the full
+telemetry boundary.
+
 ## Documentation
 
 - [Command reference](./docs/commands.md)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -81,7 +81,7 @@ List persisted configuration values that are currently set.
 Read one persisted configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported values:
-  `lang`, `file.download.out_dir`.
+  `lang`, `file.download.out_dir`, `telemetry.enabled`.
 
 ### `oo config path`
 
@@ -92,19 +92,75 @@ Print the path to the persisted configuration file.
 Persist one configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported values:
-  `lang`, `file.download.out_dir`.
+  `lang`, `file.download.out_dir`, `telemetry.enabled`.
 - Arguments: `<value>` is the value for the selected key.
 - Value rules: for `lang`, supported values are `en` and `zh`.
 - Value rules: for `file.download.out_dir`, use any non-empty path string. Relative
   paths resolve from the current working directory when `oo file download` runs. A
   leading `~` expands to the current user's home directory.
+- Value rules: for `telemetry.enabled`, supported values are lowercase `true`
+  and `false`. Other boolean-like spellings such as `1`, `0`, `True`, and `yes`
+  are rejected. Setting `telemetry.enabled` to `false` also attempts to purge
+  pending telemetry events immediately and the current `config set` invocation is
+  not recorded as telemetry.
 
 ### `oo config unset <key>`
 
 Remove one persisted configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported values:
-  `lang`, `file.download.out_dir`.
+  `lang`, `file.download.out_dir`, `telemetry.enabled`.
+
+## Telemetry
+
+The CLI records privacy-constrained command usage telemetry by default. Events do
+not include free-form input text, paths, usernames, hostnames, IP addresses,
+error messages, real OOMOL account ids, account names, `$set`, or `$identify`.
+Each event uses a local random device id and sets `$process_person_profile` to
+`false`. Package names and skill ids can be included in telemetry events,
+including private package names, because they are treated as published product
+artifacts.
+
+- Environment: setting `OO_TELEMETRY_DISABLED` to a truthy value (`1`, `true`,
+  `yes`, `on`, case-insensitive) disables telemetry for the current invocation.
+- Environment: setting `DO_NOT_TRACK` to a truthy value (`1`, `true`, `yes`,
+  `on`, case-insensitive) also disables telemetry for the current invocation.
+- Persistence: `oo telemetry disable` and
+  `oo config set telemetry.enabled false` persist telemetry disablement in
+  `settings.toml`.
+- Boundary: disabling telemetry prevents future telemetry sends and attempts to
+  purge pending local telemetry events immediately. If the local telemetry store
+  is temporarily unavailable, disabling still takes effect before future sends.
+  It cannot retract bytes that were already sent over an active TCP connection.
+
+### `oo telemetry status`
+
+Show the effective telemetry state, local device id prefix if one already
+exists, pending event count, and last successful flush time.
+
+- Output: `enabled: true` when telemetry is enabled.
+- Output: `enabled: false (env)` when disabled by `OO_TELEMETRY_DISABLED` or
+  `DO_NOT_TRACK`.
+- Output: `enabled: false (config)` when disabled by persisted
+  `telemetry.enabled = false`.
+- Output: `device_id` is `none` until telemetry has created a local device id.
+- Output: `pending` is the number of local telemetry events queued for sending,
+  including events already being sent but not yet confirmed.
+- Notes: `status` does not create a device id and is not recorded as telemetry.
+
+### `oo telemetry enable`
+
+Persist `telemetry.enabled = true`.
+
+- Notes: enabling telemetry does not purge pending events and is not recorded as
+  telemetry.
+
+### `oo telemetry disable`
+
+Persist `telemetry.enabled = false` and attempt to purge all pending local
+telemetry events immediately.
+
+- Notes: disabling telemetry is not recorded as telemetry.
 
 ## Updates
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -72,7 +72,7 @@
 读取一个持久化配置值。
 
 - 参数：`<key>` 为配置键。目前支持
-  `lang`、`file.download.out_dir`。
+  `lang`、`file.download.out_dir`、`telemetry.enabled`。
 
 ### `oo config path`
 
@@ -83,19 +83,68 @@
 写入一个持久化配置值。
 
 - 参数：`<key>` 为配置键。目前支持
-  `lang`、`file.download.out_dir`。
+  `lang`、`file.download.out_dir`、`telemetry.enabled`。
 - 参数：`<value>` 为对应配置值。
 - 取值规则：当 `<key>` 为 `lang` 时，支持的值为 `en` 和 `zh`。
 - 取值规则：当 `<key>` 为 `file.download.out_dir` 时，支持任意非空路径字符串。
   相对路径会在执行 `oo file download` 时相对于当前工作目录解析；如果以 `~`
   开头，则会展开为当前用户的 home 目录。
+- 取值规则：当 `<key>` 为 `telemetry.enabled` 时，仅支持小写 `true` 和 `false`。
+  `1`、`0`、`True`、`yes` 等其他 boolean-like 写法会被拒绝。设置为 `false` 时，
+  CLI 还会立即尝试清空待发送 telemetry 事件，并且本次 `config set` 调用自身不会被记录为
+  telemetry。
 
 ### `oo config unset <key>`
 
 删除一个持久化配置值。
 
 - 参数：`<key>` 为配置键。目前支持
-  `lang`、`file.download.out_dir`。
+  `lang`、`file.download.out_dir`、`telemetry.enabled`。
+
+## Telemetry
+
+CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-form 输入文本、路径、
+用户名、hostname、IP 地址、错误消息全文、真实 OOMOL 账号 ID、账号名、`$set` 或
+`$identify`。每条事件使用本地随机 device id，并设置
+`$process_person_profile = false`。package name 和 skill id 可能出现在 telemetry
+事件中，包括 private package name，因为它们被视为已发布的产品产物名。
+
+- 环境变量：将 `OO_TELEMETRY_DISABLED` 设为真值（`1`、`true`、`yes`、`on`，
+  大小写不敏感）会关闭当前 invocation 的 telemetry。
+- 环境变量：将 `DO_NOT_TRACK` 设为真值（`1`、`true`、`yes`、`on`，
+  大小写不敏感）也会关闭当前 invocation 的 telemetry。
+- 持久化：`oo telemetry disable` 和 `oo config set telemetry.enabled false` 会在
+  `settings.toml` 中持久化 telemetry 关闭状态。
+- 边界：关闭 telemetry 会阻止后续发送，并立即尝试清空本地待发送 telemetry 事件。
+  如果本地 telemetry store 暂时不可用，关闭状态仍会在未来发送前生效；但无法撤回已经通过
+  活跃 TCP 连接发出的字节。
+
+### `oo telemetry status`
+
+显示 telemetry 的实际开关状态、已存在的本地 device id 前缀、待发送事件数量和最后一次
+成功 flush 时间。
+
+- 输出：telemetry 启用时显示 `enabled: true`。
+- 输出：被 `OO_TELEMETRY_DISABLED` 或 `DO_NOT_TRACK` 关闭时显示
+  `enabled: false (env)`。
+- 输出：被持久化的 `telemetry.enabled = false` 关闭时显示
+  `enabled: false (config)`。
+- 输出：`device_id` 在 telemetry 创建本地 device id 前显示为 `none`。
+- 输出：`pending` 是本地待发送 telemetry 事件数量，包括已经开始发送但尚未确认发送成功
+  的事件。
+- 说明：`status` 不会创建 device id，也不会被记录为 telemetry。
+
+### `oo telemetry enable`
+
+持久化写入 `telemetry.enabled = true`。
+
+- 说明：开启 telemetry 不会清空 pending events，也不会被记录为 telemetry。
+
+### `oo telemetry disable`
+
+持久化写入 `telemetry.enabled = false`，并立即尝试删除本地全部待发送 telemetry 事件。
+
+- 说明：关闭 telemetry 不会被记录为 telemetry。
 
 ## 更新
 

--- a/src/adapters/commander/commander-cli-adapter.ts
+++ b/src/adapters/commander/commander-cli-adapter.ts
@@ -1,7 +1,13 @@
 import type { OptionValues } from "commander";
 import type { ZodError, ZodType } from "zod";
 
-import type { CliCatalog, CliCommandDefinition, CliExecutionContext } from "../../application/contracts/cli.ts";
+import type {
+    CliCatalog,
+    CliCommandDefinition,
+    CliCommandObserver,
+    CliExecutionContext,
+    CliParseErrorKind,
+} from "../../application/contracts/cli.ts";
 import type { Translator } from "../../application/contracts/translator.ts";
 import process from "node:process";
 import {
@@ -19,6 +25,7 @@ interface CommanderCliRunRequest {
     argv: readonly string[];
     catalog: CliCatalog;
     context: CliExecutionContext;
+    observer?: CliCommandObserver;
 }
 
 interface CommandOutputConfiguration {
@@ -51,20 +58,20 @@ class LocalizedCommand extends Command {
 export class CommanderCliAdapter {
     async run(request: CommanderCliRunRequest): Promise<number> {
         try {
-            const program = this.buildProgram(request.catalog, request.context);
+            const program = this.buildProgram(request);
 
             await program.parseAsync(request.argv, { from: "user" });
             return 0;
         }
         catch (error) {
-            return this.handleError(error, request.context);
+            return this.handleError(error, request.context, request.observer);
         }
     }
 
     private buildProgram(
-        catalog: CliCatalog,
-        context: CliExecutionContext,
+        request: CommanderCliRunRequest,
     ): Command {
+        const { catalog, context } = request;
         const program = new LocalizedCommand(context.translator, catalog.name);
 
         program
@@ -91,7 +98,7 @@ export class CommanderCliAdapter {
         }
 
         for (const command of catalog.commands) {
-            this.addCommand(program, command, context);
+            this.addCommand(program, command, request);
         }
 
         return program;
@@ -100,16 +107,16 @@ export class CommanderCliAdapter {
     private addCommand(
         parent: Command,
         definition: CliCommandDefinition,
-        context: CliExecutionContext,
+        request: CommanderCliRunRequest,
     ): void {
         const command = parent.command(
             definition.name,
             definition.hidden ? { hidden: true } : undefined,
         );
-        configureCommand(command, definition, context.translator);
+        configureCommand(command, definition, request.context.translator);
 
         for (const child of definition.children ?? []) {
-            this.addCommand(command, child, context);
+            this.addCommand(command, child, request);
         }
 
         const handler = definition.handler;
@@ -120,14 +127,19 @@ export class CommanderCliAdapter {
 
         const inputSchema = ensureCommandInputSchema(definition);
 
-        bindCommandHandler(command, definition, inputSchema, context);
+        bindCommandHandler(command, definition, inputSchema, request);
     }
 
     private handleError(
         error: unknown,
         context: CliExecutionContext,
+        observer?: CliCommandObserver,
     ): number {
         if (error instanceof CliUserError) {
+            observer?.onCommandFailed?.({
+                errorKey: error.key,
+                exitCode: error.exitCode,
+            });
             context.stderr.write(
                 `${context.translator.t(error.key, error.params)}\n`,
             );
@@ -136,11 +148,21 @@ export class CommanderCliAdapter {
         }
 
         if (error instanceof CommanderError) {
+            const parseErrorKind = resolveParseErrorKind(error);
+
+            if (parseErrorKind !== undefined) {
+                observer?.onParseError?.({
+                    commanderCode: error.code,
+                    parseErrorKind,
+                });
+            }
+
             if (
                 error.code === "commander.help"
                 || error.code === "commander.helpDisplayed"
                 || error.code === "commander.version"
             ) {
+                observer?.onCommandCompleted?.({ exitCode: 0 });
                 return 0;
             }
 
@@ -151,9 +173,18 @@ export class CommanderCliAdapter {
 
             context.stderr.write(`${localizedMessage}\n`);
 
+            observer?.onCommandFailed?.({
+                commanderCode: error.code,
+                exitCode: 2,
+                parseErrorKind,
+            });
+
             return 2;
         }
 
+        observer?.onCommandFailed?.({
+            exitCode: 1,
+        });
         context.stderr.write(
             `${context.translator.t("errors.unexpected", {
                 message: toErrorMessage(error),
@@ -224,24 +255,35 @@ function bindCommandHandler<TInput>(
     command: Command,
     definition: CliCommandDefinition<TInput>,
     inputSchema: ZodType<TInput>,
-    context: CliExecutionContext,
+    request: CommanderCliRunRequest,
 ): void {
     const handler = definition.handler!;
 
     command.action(async (...actionArguments) => {
         const commandInstance = actionArguments.at(-1) as Command;
+        const optionValues = commandInstance.optsWithGlobals<OptionValues>();
         const rawInput = collectRawInput(
             definition,
             actionArguments,
-            commandInstance.optsWithGlobals<OptionValues>(),
+            optionValues,
         );
+
+        request.observer?.onCommandResolved?.({
+            argCount: countRawPositionalArguments(rawInput, definition),
+            commandPath: resolveCommandPath(commandInstance),
+            excludeFromTelemetry: definition.excludeFromTelemetry === true,
+            flagsCount: countFlagArguments(request.argv),
+            outputFormat: resolveOutputFormat(optionValues),
+        });
+
         const parsedInput = parseInput(
             definition,
             inputSchema,
             rawInput,
         );
 
-        await handler(parsedInput, context);
+        await handler(parsedInput, request.context);
+        request.observer?.onCommandCompleted?.({ exitCode: 0 });
     });
 }
 
@@ -442,6 +484,77 @@ function localizeCommanderError(
     return `${message}\n${translator.t("errors.commander.suggestion", {
         value: suggestion,
     })}`;
+}
+
+function resolveCommandPath(command: Command): string[] {
+    const path: string[] = [];
+    let current: Command | null = command;
+
+    while (current.parent !== null) {
+        path.unshift(current.name());
+        current = current.parent;
+    }
+
+    return path;
+}
+
+function countRawPositionalArguments<TInput>(
+    rawInput: Record<string, unknown>,
+    definition: CliCommandDefinition<TInput>,
+): number {
+    let count = 0;
+
+    for (const argument of definition.arguments ?? []) {
+        const value = rawInput[argument.name];
+
+        if (Array.isArray(value)) {
+            count += value.length;
+            continue;
+        }
+
+        if (value !== undefined) {
+            count += 1;
+        }
+    }
+
+    return count;
+}
+
+function countFlagArguments(argv: readonly string[]): number {
+    return argv.filter(argument => argument.startsWith("-") && argument !== "--").length;
+}
+
+function resolveOutputFormat(optionValues: OptionValues): "json" | "text" {
+    return optionValues.format === "json" || optionValues.json === true
+        ? "json"
+        : "text";
+}
+
+function resolveParseErrorKind(
+    error: CommanderError,
+): CliParseErrorKind | undefined {
+    switch (error.code) {
+        case "commander.excessArguments":
+            return "excess_arguments";
+        case "commander.help":
+        case "commander.helpDisplayed":
+            return "help";
+        case "commander.invalidArgument":
+            return "invalid_argument";
+        case "commander.missingArgument":
+            return "missing_argument";
+        case "commander.missingMandatoryOptionValue":
+        case "commander.optionMissingArgument":
+            return "missing_option_value";
+        case "commander.unknownCommand":
+            return "unknown_command";
+        case "commander.unknownOption":
+            return "unknown_option";
+        case "commander.version":
+            return "version";
+        default:
+            return undefined;
+    }
 }
 
 function extractQuotedValue(message: string): string | undefined {

--- a/src/adapters/store/file-settings-store.test.ts
+++ b/src/adapters/store/file-settings-store.test.ts
@@ -90,6 +90,36 @@ describe("FileSettingsStore", () => {
         });
     });
 
+    test("writes and reads the persisted telemetry setting", async () => {
+        const root = await createTemporaryDirectory("store-telemetry-write");
+        const store = new FileSettingsStore({
+            appName: APP_NAME,
+            env: {
+                HOME: root,
+                XDG_CONFIG_HOME: root,
+            },
+            platform: "linux",
+        });
+
+        await store.write({
+            telemetry: {
+                enabled: false,
+            },
+        });
+
+        expect(await readFile(store.getFilePath(), "utf8")).toBe(
+            createExpectedSettingsFileContent([
+                "[telemetry]",
+                "enabled = false",
+            ]),
+        );
+        expect(await store.read()).toEqual({
+            telemetry: {
+                enabled: false,
+            },
+        });
+    });
+
     test("writes commented defaults when all persisted settings are removed", async () => {
         const root = await createTemporaryDirectory("store-empty-write");
         const store = new FileSettingsStore({

--- a/src/adapters/store/sqlite-utils.ts
+++ b/src/adapters/store/sqlite-utils.ts
@@ -19,14 +19,23 @@ export function openSqliteDatabase(
         create: true,
         strict: true,
     });
+    let configured = false;
 
-    if (options?.busyTimeoutMs !== undefined) {
-        database.run(`PRAGMA busy_timeout = ${options.busyTimeoutMs};`);
+    try {
+        if (options?.busyTimeoutMs !== undefined) {
+            database.run(`PRAGMA busy_timeout = ${options.busyTimeoutMs};`);
+        }
+
+        database.run("PRAGMA journal_mode = WAL;");
+        configured = true;
+
+        return database;
     }
-
-    database.run("PRAGMA journal_mode = WAL;");
-
-    return database;
+    finally {
+        if (!configured) {
+            database.close();
+        }
+    }
 }
 
 export function closeSqliteDatabase(

--- a/src/adapters/store/store-path.test.ts
+++ b/src/adapters/store/store-path.test.ts
@@ -30,6 +30,7 @@ describe("resolveStorePaths", () => {
             logDirectoryPath: join("/tmp/xdg-state", APP_NAME, "logs"),
             rootDirectory: join("/tmp/xdg", APP_NAME),
             settingsFilePath: join("/tmp/xdg", APP_NAME, "settings.toml"),
+            telemetryDirectory: join("/tmp/xdg", APP_NAME, "telemetry"),
             uploadsFilePath: join("/tmp/xdg", APP_NAME, "data", "uploads.sqlite"),
         });
     });

--- a/src/adapters/store/store-path.ts
+++ b/src/adapters/store/store-path.ts
@@ -8,6 +8,7 @@ const defaultDownloadSessionsFileName = "download-sessions.sqlite";
 const defaultUploadsFileName = "uploads.sqlite";
 const defaultLogDirectoryName = "logs";
 const defaultWindowsLogDirectoryName = "Logs";
+const defaultTelemetryDirectoryName = "telemetry";
 
 export interface FileStoreLocationOptions {
     appName: string;
@@ -24,6 +25,7 @@ export interface StorePaths {
     logDirectoryPath: string;
     rootDirectory: string;
     settingsFilePath: string;
+    telemetryDirectory: string;
     uploadsFilePath: string;
 }
 
@@ -91,6 +93,7 @@ export function resolveStorePaths(
         logDirectoryPath: resolveLogDirectory(options),
         rootDirectory,
         settingsFilePath: join(rootDirectory, defaultSettingsFileName),
+        telemetryDirectory: join(rootDirectory, defaultTelemetryDirectoryName),
         uploadsFilePath: join(dataDirectory, defaultUploadsFileName),
     };
 }

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -53,6 +53,7 @@ Commands:
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
+  telemetry                 Manage CLI telemetry
   update|upgrade [options]  Update the CLI
   help [command]            Show help for a command
 "
@@ -87,6 +88,7 @@ Commands:
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
+  telemetry                 Manage CLI telemetry
   update|upgrade [options]  Update the CLI
   help [command]            Show help for a command
 "
@@ -124,6 +126,7 @@ Commands:
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
+  telemetry                 Manage CLI telemetry
   update|upgrade [options]  Update the CLI
   help [command]            Show help for a command
 "
@@ -159,6 +162,7 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
   log                       管理持久化 debug 日志
   search [options] <text>   搜索 package 与 connector action
   packages                  包相关工具
+  telemetry                 管理 CLI telemetry
   update|upgrade [options]  更新 CLI
   help [command]            显示命令帮助
 "
@@ -190,6 +194,7 @@ Commands:
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
+  telemetry                 Manage CLI telemetry
   update|upgrade [options]  Update the CLI
   help [command]            Show help for a command
 "
@@ -225,6 +230,7 @@ Commands:
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
+  telemetry                 Manage CLI telemetry
   update|upgrade [options]  Update the CLI
   help [command]            Show help for a command
 "

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -4,7 +4,7 @@ import type { FileUploadRecordStore } from "../contracts/file-upload-store.ts";
 import type { SettingsStore } from "../contracts/settings-store.ts";
 
 import { mkdir, readdir, readFile, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { describe, expect, test } from "bun:test";
 import {
@@ -21,6 +21,16 @@ import { resolveStorePaths } from "../../adapters/store/store-path.ts";
 import { resolveCodexHomeDirectory } from "../commands/skills/bundled-skill-paths.ts";
 import { APP_NAME } from "../config/app-config.ts";
 import { CliUserError } from "../contracts/cli.ts";
+import { createTelemetryItemForTest } from "../telemetry/__tests__/helpers.ts";
+import {
+    telemetryInternalCommand,
+    telemetryInternalEnvKey,
+} from "../telemetry/constants.ts";
+import {
+    enqueueTelemetryBatchItem,
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../telemetry/outbox.ts";
 import { createTerminalColors } from "../terminal-colors.ts";
 import { createLazyInput, executeCli } from "./run-cli.ts";
 
@@ -285,6 +295,102 @@ describe("runCli bootstrap", () => {
         }
     });
 
+    test("records telemetry for invalid global inputs before store initialization", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const invalidLang = await sandbox.run(["--lang", "fr", "--help"]);
+            const rows = readTelemetryRowsForTest(
+                resolveSandboxTelemetryDirectory(sandbox),
+            );
+            const payload = parseTelemetryRowPayload(rows[0]!);
+
+            expect(invalidLang.exitCode).toBe(2);
+            expect(rows).toHaveLength(1);
+            expect(payload).toMatchObject({
+                properties: {
+                    command_action: "invalid_argument",
+                    command_full: "__parse__.invalid_argument",
+                    command_group: "__parse__",
+                    error_category: "user_error",
+                    exit_code: 2,
+                    parse_error_kind: "invalid_argument",
+                    success: false,
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("runs the internal telemetry flusher without recursive telemetry", async () => {
+        const sandbox = await createCliSandbox();
+        const stdout = createTextBuffer();
+        const stderr = createTextBuffer();
+        const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+        let requestCount = 0;
+
+        try {
+            enqueueTelemetryBatchItem({
+                directoryPath: telemetryDirectoryPath,
+                item: createTelemetryItemForTest(1),
+                nowMs: Date.now(),
+            });
+
+            const exitCode = await executeCli({
+                argv: [telemetryInternalCommand],
+                cwd: sandbox.cwd,
+                env: {
+                    ...sandbox.env,
+                    [telemetryInternalEnvKey]: "1",
+                },
+                fetcher: async () => {
+                    requestCount += 1;
+                    return new Response("");
+                },
+                stderr: stderr.writer,
+                stdout: stdout.writer,
+                systemLocale: "en-US",
+            });
+
+            expect(exitCode).toBe(0);
+            expect(requestCount).toBe(1);
+            expect(stdout.read()).toBe("");
+            expect(stderr.read()).toBe("");
+            expect(readTelemetryRowsForTest(telemetryDirectoryPath)).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not treat the telemetry internal env alone as a flusher invocation", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            sandbox.env[telemetryInternalEnvKey] = "1";
+
+            const result = await sandbox.run(["config", "list"]);
+            const rows = readTelemetryRowsForTest(
+                resolveSandboxTelemetryDirectory(sandbox),
+            );
+            const payload = parseTelemetryRowPayload(rows[0]!);
+
+            expect(result.exitCode).toBe(0);
+            expect(rows).toHaveLength(1);
+            expect(payload).toMatchObject({
+                properties: {
+                    command_full: "config.list",
+                    success: true,
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("tags bootstrap user errors with the user_error category", async () => {
         const sandbox = await createCliSandbox();
         const stdout = createTextBuffer();
@@ -356,6 +462,10 @@ describe("runCli bootstrap", () => {
                 stdout: stdout.writer,
                 systemLocale: "en-US",
             });
+            const rows = readTelemetryRowsForTest(
+                resolveSandboxTelemetryDirectory(sandbox),
+            );
+            const payload = parseTelemetryRowPayload(rows[0]!);
 
             expect(exitCode).toBe(1);
             expect(closeOrder).toEqual([
@@ -366,6 +476,50 @@ describe("runCli bootstrap", () => {
             expect(stderr.read()).toBe(
                 "Unexpected error: settings read failed\n",
             );
+            expect(rows).toHaveLength(1);
+            expect(payload).toMatchObject({
+                properties: {
+                    command_full: "__parse__.__root__",
+                    command_group: "__parse__",
+                    error_category: "system_error",
+                    exit_code: 1,
+                    success: false,
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("honors telemetry opt-out when unrelated settings are invalid", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const settingsFilePath = resolveStorePaths({
+                appName: APP_NAME,
+                env: sandbox.env,
+                platform: process.platform,
+            }).settingsFilePath;
+
+            await mkdir(dirname(settingsFilePath), { recursive: true });
+            await Bun.write(
+                settingsFilePath,
+                [
+                    "lang = 1",
+                    "",
+                    "[telemetry]",
+                    "enabled = false",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["config", "list"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(readTelemetryRowsForTest(
+                resolveSandboxTelemetryDirectory(sandbox),
+            )).toEqual([]);
         }
         finally {
             await sandbox.cleanup();
@@ -629,6 +783,12 @@ function createFailingSettingsStore(error: Error): SettingsStore {
             throw new Error("write should not be called");
         },
     };
+}
+
+function resolveSandboxTelemetryDirectory(sandbox: {
+    env: Record<string, string | undefined>;
+}): string {
+    return join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry");
 }
 
 describe("createLazyInput", () => {

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -330,23 +330,34 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
             "CLI invocation completed.",
         );
 
-        await emitCliCommandTelemetry({
-            authStore,
-            buildCommit: buildInfo.commitHash ?? "unknown",
-            env: invocation.env,
-            execPath: currentExecPath,
-            exitCode,
-            invocation,
-            logger,
-            recorder: telemetryRecorder,
-            sessionId,
-            settings: settingsForTelemetry,
-            settingsFilePath: storePaths.settingsFilePath,
-            startTimeMs,
-            telemetryDirectoryPath: storePaths.telemetryDirectory,
-            translatorLocale: translator.locale,
-            version,
-        });
+        try {
+            await emitCliCommandTelemetry({
+                authStore,
+                buildCommit: buildInfo.commitHash ?? "unknown",
+                env: invocation.env,
+                execPath: currentExecPath,
+                exitCode,
+                invocation,
+                logger,
+                recorder: telemetryRecorder,
+                sessionId,
+                settings: settingsForTelemetry,
+                settingsFilePath: storePaths.settingsFilePath,
+                startTimeMs,
+                telemetryDirectoryPath: storePaths.telemetryDirectory,
+                translatorLocale: translator.locale,
+                version,
+            });
+        }
+        catch (error) {
+            logger.warn(
+                {
+                    ...withCategory(logCategory.systemError),
+                    err: error,
+                },
+                "Failed to emit CLI command telemetry.",
+            );
+        }
 
         loggerHandle.close();
 

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -4,6 +4,7 @@ import type { CacheStore } from "../contracts/cache.ts";
 
 import type {
     CliExecutionContext,
+    CliTelemetryPropertyValue,
     Fetcher,
     InteractiveInput,
     Writer,
@@ -12,6 +13,7 @@ import type { FileDownloadSessionStore } from "../contracts/file-download-sessio
 import type { FileUploadRecordStore } from "../contracts/file-upload-store.ts";
 import type { SettingsStore } from "../contracts/settings-store.ts";
 import type { LogCategory } from "../logging/log-categories.ts";
+import type { AppSettings } from "../schemas/settings.ts";
 import process from "node:process";
 import packageManifest from "../../../package.json" with { type: "json" };
 import { SqliteCacheStore } from "../../adapters/cache/sqlite-cache.ts";
@@ -41,6 +43,13 @@ import { logCategory } from "../logging/log-categories.ts";
 import { withCategory, withErrorKey } from "../logging/log-fields.ts";
 import { initializeCurrentVersionProcessLock } from "../self-update/core.ts";
 import { createRetryingFetcher } from "../shared/retrying-fetcher.ts";
+import {
+    telemetryInternalCommand,
+    telemetryInternalEnvKey,
+} from "../telemetry/constants.ts";
+import { emitCliCommandTelemetry } from "../telemetry/emitter.ts";
+import { flushTelemetryOutbox } from "../telemetry/flusher.ts";
+import { createTelemetryInvocationRecorder } from "../telemetry/invocation.ts";
 
 export interface CliInvocation {
     argv: readonly string[];
@@ -83,7 +92,12 @@ interface CreateCliExecutionContextOptions {
     logger: Logger;
     logFilePath: string;
     packageName: string;
+    recordTelemetryProperties: (
+        properties: Record<string, CliTelemetryPropertyValue>,
+    ) => void;
     settingsStore: SettingsStore;
+    suppressTelemetry: () => void;
+    telemetryDirectoryPath: string;
     translator: ReturnType<typeof createTranslator>;
     version: string;
 }
@@ -111,6 +125,9 @@ export async function runCli(argv: string[]): Promise<number> {
 }
 
 export async function executeCli(invocation: CliInvocation): Promise<number> {
+    const startTimeMs = Date.now();
+    const sessionId = Bun.randomUUIDv7();
+    const telemetryRecorder = createTelemetryInvocationRecorder();
     const debugPathEnabled = hasCliDebugFlag(invocation.argv);
     const rawCliLanguage = detectCliLanguageFlag(invocation.argv);
     const parsedCliLanguage = parseExplicitLocale(rawCliLanguage);
@@ -119,6 +136,19 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
         env: invocation.env,
         platform: process.platform,
     });
+
+    if (isTelemetryFlushInvocation(invocation)) {
+        await flushTelemetryOutbox({
+            directoryPath: storePaths.telemetryDirectory,
+            env: invocation.env,
+            fetcher: invocation.fetcher,
+            settingsFilePath: storePaths.settingsFilePath,
+        });
+        return 0;
+    }
+
+    const buildInfo = resolveCliBuildInfo(packageManifest.version);
+    const version = invocation.version ?? buildInfo.version;
     const bootstrapTranslator = createTranslator(
         resolvePreferredLocale({
             cliFlag: parsedCliLanguage,
@@ -128,9 +158,11 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
     );
     let translator = bootstrapTranslator;
     let exitCode = 0;
+    let authStore: AuthStore | undefined;
     let cacheStore: CacheStore | undefined;
     let fileDownloadSessionStore: FileDownloadSessionStore | undefined;
     let fileUploadStore: FileUploadRecordStore | undefined;
+    let settingsForTelemetry: AppSettings | undefined;
     let currentVersionLockResource:
         | Awaited<ReturnType<typeof initializeCurrentVersionProcessLock>>
         | undefined;
@@ -160,6 +192,11 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
             );
 
             exitCode = 2;
+            telemetryRecorder.observer.onCommandFailed?.({
+                errorKey: "errors.lang.invalidFlag",
+                exitCode,
+                parseErrorKind: "invalid_argument",
+            });
             return exitCode;
         }
 
@@ -169,10 +206,12 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
             storePaths,
         );
 
+        authStore = initializedStores.authStore;
         cacheStore = initializedStores.cacheStore;
         fileUploadStore = initializedStores.fileUploadStore;
         fileDownloadSessionStore = initializedStores.fileDownloadSessionStore;
         const settings = await initializedStores.settingsStore.read();
+        settingsForTelemetry = settings;
 
         translator = createTranslator(
             resolvePreferredLocale({
@@ -185,8 +224,6 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
         const catalog = createCliCatalog();
         const completionRenderer = new StaticCompletionRenderer(translator);
         const packageName = invocation.packageName ?? packageManifest.name;
-        const buildInfo = resolveCliBuildInfo(packageManifest.version);
-        const version = invocation.version ?? buildInfo.version;
 
         logger.debug(
             {
@@ -225,7 +262,10 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
             logger,
             logFilePath,
             packageName,
+            recordTelemetryProperties: telemetryRecorder.recordProperties,
             settingsStore: initializedStores.settingsStore,
+            suppressTelemetry: telemetryRecorder.suppress,
+            telemetryDirectoryPath: storePaths.telemetryDirectory,
             translator,
             version,
         });
@@ -238,6 +278,7 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
             argv: invocation.argv,
             catalog,
             context,
+            observer: telemetryRecorder.observer,
         });
     }
     catch (error) {
@@ -263,6 +304,10 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
         }
 
         exitCode = writeBootstrapError(error, translator, invocation.stderr);
+        telemetryRecorder.observer.onCommandFailed?.({
+            errorKey: error instanceof CliUserError ? error.key : "errors.unexpected",
+            exitCode,
+        });
     }
     finally {
         exitCode = await closeCleanupResources(
@@ -284,6 +329,25 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
             },
             "CLI invocation completed.",
         );
+
+        await emitCliCommandTelemetry({
+            authStore,
+            buildCommit: buildInfo.commitHash ?? "unknown",
+            env: invocation.env,
+            execPath: currentExecPath,
+            exitCode,
+            invocation,
+            logger,
+            recorder: telemetryRecorder,
+            sessionId,
+            settings: settingsForTelemetry,
+            settingsFilePath: storePaths.settingsFilePath,
+            startTimeMs,
+            telemetryDirectoryPath: storePaths.telemetryDirectory,
+            translatorLocale: translator.locale,
+            version,
+        });
+
         loggerHandle.close();
 
         if (debugPathEnabled) {
@@ -348,6 +412,11 @@ function createCliExecutionContext(
         translator: options.translator,
         completionRenderer: options.completionRenderer,
         catalog: options.catalog,
+        telemetry: {
+            recordProperties: options.recordTelemetryProperties,
+            directoryPath: options.telemetryDirectoryPath,
+            suppressCurrentInvocation: options.suppressTelemetry,
+        },
         version: options.version,
         versionText: formatCliVersionText(
             {
@@ -357,6 +426,11 @@ function createCliExecutionContext(
             options.translator,
         ),
     };
+}
+
+function isTelemetryFlushInvocation(invocation: CliInvocation): boolean {
+    return invocation.argv[0] === telemetryInternalCommand
+        && invocation.env[telemetryInternalEnvKey] === "1";
 }
 
 function hasCliDebugFlag(argv: readonly string[]): boolean {

--- a/src/application/commands/auth/login.ts
+++ b/src/application/commands/auth/login.ts
@@ -11,6 +11,7 @@ import {
 } from "../../auth/login-flow.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { upsertAuthAccount } from "../../schemas/auth.ts";
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { writeLine } from "../shared/output.ts";
 import {
@@ -46,6 +47,9 @@ export const authLoginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
         const loginMethod = input.sessionToken === undefined
             ? "device_login" as const
             : "session_token" as const;
+
+        context.telemetry?.recordProperties({ auth_method: loginMethod });
+
         const account = loginMethod === "device_login"
             ? await runDeviceLogin(authEndpoint, context)
             : await requestAuthAccountWithSessionToken({
@@ -56,9 +60,12 @@ export const authLoginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
                     translator: context.translator,
                 });
 
-        await context.authStore.update(authFile =>
+        const nextAuthFile = await context.authStore.update(authFile =>
             upsertAuthAccount(authFile, account),
         );
+        context.telemetry?.recordProperties({
+            account_count_bucket: bucketTelemetryCount(nextAuthFile.auth.length),
+        });
         context.logger.info(
             {
                 accountId: account.id,

--- a/src/application/commands/auth/logout.ts
+++ b/src/application/commands/auth/logout.ts
@@ -1,6 +1,7 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { removeCurrentAuthAccount } from "../../schemas/auth.ts";
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { writeLine } from "../shared/output.ts";
 import { emptyAuthCommandInputSchema } from "./shared.ts";
 
@@ -28,6 +29,9 @@ export const authLogoutCommand: CliCommandDefinition = {
             },
             "Current auth account was removed.",
         );
+        context.telemetry?.recordProperties({
+            account_count_bucket: bucketTelemetryCount(remainingSavedAccounts),
+        });
 
         writeLine(
             context.stdout,

--- a/src/application/commands/auth/status.ts
+++ b/src/application/commands/auth/status.ts
@@ -1,6 +1,7 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 
 import type { AuthAccount } from "../../schemas/auth.ts";
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { isNetworkRestrictedSandboxError } from "../shared/request.ts";
 import {
     emptyAuthCommandInputSchema,
@@ -28,6 +29,10 @@ export const authStatusCommand: CliCommandDefinition = {
     inputSchema: emptyAuthCommandInputSchema,
     handler: async (_, context) => {
         const { authFile, currentAccount } = await readCurrentAuth(context);
+
+        context.telemetry?.recordProperties({
+            account_count_bucket: bucketTelemetryCount(authFile.auth.length),
+        });
 
         if (!currentAccount) {
             const hasStaleId = authFile.id !== "";

--- a/src/application/commands/auth/switch.ts
+++ b/src/application/commands/auth/switch.ts
@@ -2,6 +2,7 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { CliUserError } from "../../contracts/cli.ts";
 import { getNextAuthAccount, setCurrentAuthId } from "../../schemas/auth.ts";
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import {
     emptyAuthCommandInputSchema,
     formatAuthStrong,
@@ -15,6 +16,11 @@ export const authSwitchCommand: CliCommandDefinition = {
     inputSchema: emptyAuthCommandInputSchema,
     handler: async (_, context) => {
         const authFile = await context.authStore.read();
+
+        context.telemetry?.recordProperties({
+            account_count_bucket: bucketTelemetryCount(authFile.auth.length),
+        });
+
         const account = getNextAuthAccount(authFile);
 
         if (account === undefined) {

--- a/src/application/commands/catalog.ts
+++ b/src/application/commands/catalog.ts
@@ -15,6 +15,7 @@ import { logoutCommand } from "./logout.ts";
 import { packageCommand } from "./package/index.ts";
 import { mixedSearchCommand } from "./search.ts";
 import { skillsCommand } from "./skills/index.ts";
+import { telemetryCommand } from "./telemetry/index.ts";
 import { updateCommand } from "./update.ts";
 
 const globalOptions = [
@@ -53,6 +54,7 @@ export function createCliCatalog(): CliCatalog {
             logCommand,
             mixedSearchCommand,
             packageCommand,
+            telemetryCommand,
             updateCommand,
         ],
     };

--- a/src/application/commands/check-update.cli.test.ts
+++ b/src/application/commands/check-update.cli.test.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import { describe, expect, test } from "bun:test";
 
 import {
@@ -5,6 +7,11 @@ import {
     createCliSnapshot,
     readLatestLogContent,
 } from "../../../__tests__/helpers.ts";
+import { APP_NAME } from "../config/app-config.ts";
+import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../telemetry/outbox.ts";
 
 describe("checkUpdateCommand CLI", () => {
     test("writes update-check lifecycle logs when check-update finds a newer release", async () => {
@@ -24,6 +31,11 @@ describe("checkUpdateCommand CLI", () => {
                 },
             );
             const content = await readLatestLogContent(sandbox);
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
 
             expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(content).toContain(`"msg":"CLI update check started."`);
@@ -35,6 +47,13 @@ describe("checkUpdateCommand CLI", () => {
             );
             expect(content).toContain(`"msg":"CLI update notice emitted."`);
             expect(content).toContain(`"latestVersion":"1.2.0"`);
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    command_full: "check-update",
+                    update_available: true,
+                    version_kind: "stable",
+                },
+            });
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/check-update.ts
+++ b/src/application/commands/check-update.ts
@@ -7,6 +7,7 @@ import {
     cliUpdateCommand,
     renderCliUpdateNotice,
 } from "../update/update-notifier.ts";
+import { classifyTelemetryVersionKind } from "./self-update-telemetry.ts";
 
 export const checkUpdateCommand: CliCommandDefinition = {
     name: "check-update",
@@ -14,10 +15,15 @@ export const checkUpdateCommand: CliCommandDefinition = {
     descriptionKey: "commands.checkUpdate.description",
     inputSchema: z.object({}),
     handler: async (_, context) => {
+        context.telemetry?.recordProperties({
+            version_kind: classifyTelemetryVersionKind(context.version),
+        });
+
         const result = await checkForCliUpdate(context);
 
         switch (result.status) {
             case "failed":
+                context.telemetry?.recordProperties({ update_available: false });
                 switch (result.reason) {
                     case "invalid-current-version":
                         context.stdout.write(
@@ -36,6 +42,7 @@ export const checkUpdateCommand: CliCommandDefinition = {
                 }
                 return;
             case "up-to-date":
+                context.telemetry?.recordProperties({ update_available: false });
                 context.stdout.write(
                     `${context.translator.t("checkUpdate.upToDate", {
                         version: context.version,
@@ -43,6 +50,7 @@ export const checkUpdateCommand: CliCommandDefinition = {
                 );
                 return;
             case "update-available":
+                context.telemetry?.recordProperties({ update_available: true });
                 context.stdout.write(
                     renderCliUpdateNotice({
                         context,

--- a/src/application/commands/cloud-task/index.cli.test.ts
+++ b/src/application/commands/cloud-task/index.cli.test.ts
@@ -9,6 +9,10 @@ import {
     toRequest,
 } from "../../../../__tests__/helpers.ts";
 import { APP_NAME } from "../../config/app-config.ts";
+import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../../telemetry/outbox.ts";
 import { createTerminalColors } from "../../terminal-colors.ts";
 
 const searchDisplayNameColor = "#59F78D";
@@ -156,6 +160,11 @@ describe("cloudTaskCommand CLI", () => {
                     },
                 },
             );
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
 
             expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(JSON.parse(result.stdout)).toEqual({
@@ -180,6 +189,18 @@ describe("cloudTaskCommand CLI", () => {
                 packageVersion: "1.0.4",
                 type: "serverless",
             });
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    block_id: "Exist",
+                    command_full: "cloud-task.run",
+                    dry_run: false,
+                    package_name: "qrcode",
+                    package_version: "1.0.4",
+                },
+            });
+            expect(telemetryPayload?.properties).not.toHaveProperty("data");
+            expect(telemetryPayload?.properties).not.toHaveProperty("input");
+            expect(telemetryPayload?.properties).not.toHaveProperty("taskID");
         }
         finally {
             await sandbox.cleanup();
@@ -375,6 +396,9 @@ describe("cloudTaskCommand CLI", () => {
                     fetcher,
                 },
             );
+            const telemetryPayloads = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            ).map(row => parseTelemetryRowPayload(row));
 
             expect({
                 listResponse: createCliSnapshot(listResponse),
@@ -426,6 +450,34 @@ describe("cloudTaskCommand CLI", () => {
                 "https://cloud-task.oomol.com/v3/users/me/tasks/task-1/logs?page=2",
                 "https://cloud-task.oomol.com/v3/users/me/tasks?size=1&nextToken=eyJsYXN0SWQiOiIxMjMifQ%3D%3D&status=running&packageID=foo&blockName=main",
             ]);
+            expect(telemetryPayloads.find(
+                payload => payload?.properties.command_full === "cloud-task.result",
+            )).toMatchObject({
+                properties: {
+                    final_status: "success",
+                },
+            });
+            const logTelemetryPayload = telemetryPayloads.find(
+                payload => payload?.properties.command_full === "cloud-task.log",
+            );
+
+            expect(logTelemetryPayload).toMatchObject({
+                properties: {
+                    log_count_bucket: "1-5",
+                },
+            });
+            expect(logTelemetryPayload?.properties).not.toHaveProperty("task_id");
+            expect(logTelemetryPayload?.properties).not.toHaveProperty("taskID");
+            expect(logTelemetryPayload?.properties).not.toHaveProperty("logs");
+            expect(telemetryPayloads.find(
+                payload => payload?.properties.command_full === "cloud-task.list",
+            )).toMatchObject({
+                properties: {
+                    block_id: "main",
+                    package_name: "foo",
+                    result_count_bucket: "1-5",
+                },
+            });
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/cloud-task/index.cli.test.ts
+++ b/src/application/commands/cloud-task/index.cli.test.ts
@@ -201,6 +201,7 @@ describe("cloudTaskCommand CLI", () => {
             expect(telemetryPayload?.properties).not.toHaveProperty("data");
             expect(telemetryPayload?.properties).not.toHaveProperty("input");
             expect(telemetryPayload?.properties).not.toHaveProperty("taskID");
+            expect(telemetryPayload?.properties).not.toHaveProperty("task_id");
         }
         finally {
             await sandbox.cleanup();
@@ -469,9 +470,11 @@ describe("cloudTaskCommand CLI", () => {
             expect(logTelemetryPayload?.properties).not.toHaveProperty("task_id");
             expect(logTelemetryPayload?.properties).not.toHaveProperty("taskID");
             expect(logTelemetryPayload?.properties).not.toHaveProperty("logs");
-            expect(telemetryPayloads.find(
+            const listTelemetryPayload = telemetryPayloads.find(
                 payload => payload?.properties.command_full === "cloud-task.list",
-            )).toMatchObject({
+            );
+
+            expect(listTelemetryPayload).toMatchObject({
                 properties: {
                     block_id: "main",
                     package_name: "foo",

--- a/src/application/commands/cloud-task/list.ts
+++ b/src/application/commands/cloud-task/list.ts
@@ -2,6 +2,7 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import {
@@ -108,6 +109,17 @@ export const cloudTaskListCommand: CliCommandDefinition<CloudTaskListInput> = {
             primaryValue: input.blockId,
             secondaryOption: "--block-name",
         });
+        const telemetryProperties: Record<string, string> = {};
+
+        if (packageId !== undefined) {
+            telemetryProperties.package_name = packageId;
+        }
+
+        if (blockId !== undefined) {
+            telemetryProperties.block_id = blockId;
+        }
+
+        context.telemetry?.recordProperties(telemetryProperties);
 
         if (blockId !== undefined && packageId === undefined) {
             throw new CliUserError("errors.cloudTaskList.blockIdRequiresPackageId", 2);
@@ -139,6 +151,10 @@ export const cloudTaskListCommand: CliCommandDefinition<CloudTaskListInput> = {
         const response = parseCloudTaskListResponse(
             await requestCloudTask(requestUrl, account.apiKey, context),
         );
+
+        context.telemetry?.recordProperties({
+            result_count_bucket: bucketTelemetryCount(response.tasks.length),
+        });
 
         if (format === "json") {
             writeJsonOutput(context.stdout, response);

--- a/src/application/commands/cloud-task/log.ts
+++ b/src/application/commands/cloud-task/log.ts
@@ -1,6 +1,7 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import {
@@ -67,6 +68,10 @@ export const cloudTaskLogCommand: CliCommandDefinition<CloudTaskLogInput> = {
         const response = parseCloudTaskLogResponse(
             await requestCloudTask(requestUrl, account.apiKey, context),
         );
+
+        context.telemetry?.recordProperties({
+            log_count_bucket: bucketTelemetryCount(response.logs.length),
+        });
 
         if (format === "json") {
             writeJsonOutput(context.stdout, response);

--- a/src/application/commands/cloud-task/result.ts
+++ b/src/application/commands/cloud-task/result.ts
@@ -44,6 +44,10 @@ export const cloudTaskResultCommand: CliCommandDefinition<CloudTaskResultInput> 
             ),
         );
 
+        context.telemetry?.recordProperties({
+            final_status: response.status,
+        });
+
         if (format === "json") {
             writeJsonOutput(context.stdout, response);
             return;

--- a/src/application/commands/cloud-task/run.ts
+++ b/src/application/commands/cloud-task/run.ts
@@ -110,6 +110,13 @@ export const cloudTaskRunCommand: CliCommandDefinition<CloudTaskRunInput> = {
             });
         }
 
+        context.telemetry?.recordProperties({
+            block_id: block.blockName,
+            dry_run: input.dryRun === true,
+            package_name: packageInfo.packageName,
+            package_version: packageInfo.packageVersion,
+        });
+
         validateCloudTaskInputValues(inputValues, block, context.translator);
 
         if (input.dryRun === true) {

--- a/src/application/commands/cloud-task/wait.test.ts
+++ b/src/application/commands/cloud-task/wait.test.ts
@@ -1,6 +1,7 @@
 import type {
     CliCatalog,
     CliExecutionContext,
+    CliTelemetryPropertyValue,
     Fetcher,
     InteractiveInput,
 } from "../../contracts/cli.ts";
@@ -129,7 +130,11 @@ describe("cloudTaskWaitCommand", () => {
                 status: "success",
             },
         ]);
-        const { context, stdout } = createWaitContext({ fetcher });
+        const telemetryProperties: Record<string, CliTelemetryPropertyValue> = {};
+        const { context, stdout } = createWaitContext({
+            fetcher,
+            telemetryProperties,
+        });
         const handler = createCloudTaskWaitHandler({
             now: () => now,
             sleep: async (durationMs) => {
@@ -148,6 +153,10 @@ describe("cloudTaskWaitCommand", () => {
 
         expect(fetcher.requestCount).toBe(4);
         expect(sleepCalls).toEqual([3_000, 3_000, 3_000]);
+        expect(telemetryProperties).toMatchObject({
+            final_status: "success",
+            polled_count_bucket: "1-5",
+        });
         expect(stdout.read()).toBe(
             [
                 "Waiting for completion after 0s.",
@@ -174,7 +183,11 @@ describe("cloudTaskWaitCommand", () => {
                 status: "failed",
             },
         ]);
-        const { context, stdout } = createWaitContext({ fetcher });
+        const telemetryProperties: Record<string, CliTelemetryPropertyValue> = {};
+        const { context, stdout } = createWaitContext({
+            fetcher,
+            telemetryProperties,
+        });
         const handler = createCloudTaskWaitHandler({
             now: () => now,
             sleep: async (durationMs) => {
@@ -195,6 +208,10 @@ describe("cloudTaskWaitCommand", () => {
         });
 
         expect(fetcher.requestCount).toBe(2);
+        expect(telemetryProperties).toMatchObject({
+            final_status: "failed",
+            polled_count_bucket: "1-5",
+        });
         expect(stdout.read()).toBe(
             [
                 "Waiting for completion after 0s.",
@@ -231,7 +248,11 @@ describe("cloudTaskWaitCommand", () => {
                 status: "running",
             },
         ]);
-        const { context, stdout } = createWaitContext({ fetcher });
+        const telemetryProperties: Record<string, CliTelemetryPropertyValue> = {};
+        const { context, stdout } = createWaitContext({
+            fetcher,
+            telemetryProperties,
+        });
         const handler = createCloudTaskWaitHandler({
             now: () => now,
             sleep: async (durationMs) => {
@@ -254,6 +275,10 @@ describe("cloudTaskWaitCommand", () => {
 
         expect(fetcher.requestCount).toBe(4);
         expect(sleepCalls).toEqual([3_000, 3_000, 3_000, 1_000]);
+        expect(telemetryProperties).toMatchObject({
+            final_status: "timeout",
+            polled_count_bucket: "1-5",
+        });
         expect(stdout.read()).toBe(
             [
                 "Waiting for completion after 0s.",
@@ -268,6 +293,7 @@ describe("cloudTaskWaitCommand", () => {
 
 function createWaitContext(options: {
     fetcher: Fetcher;
+    telemetryProperties?: Record<string, CliTelemetryPropertyValue>;
 }): {
     context: CliExecutionContext;
     stderr: ReturnType<typeof createTextBuffer>;
@@ -295,6 +321,15 @@ function createWaitContext(options: {
             settingsStore: createSettingsStore({}),
             stdout: stdout.writer,
             stderr: stderr.writer,
+            telemetry: options.telemetryProperties === undefined
+                ? undefined
+                : {
+                        directoryPath: "",
+                        recordProperties(properties) {
+                            Object.assign(options.telemetryProperties!, properties);
+                        },
+                        suppressCurrentInvocation() {},
+                    },
             translator,
             completionRenderer: {
                 render: () => "",

--- a/src/application/commands/cloud-task/wait.ts
+++ b/src/application/commands/cloud-task/wait.ts
@@ -5,6 +5,7 @@ import type {
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import {
     createCloudTaskTaskUrl,
@@ -84,12 +85,18 @@ export function createCloudTaskWaitHandler(
         );
         const startedAt = dependencies.now();
         let lastPrintedElapsedMs: number | undefined;
+        let pollCount = 0;
 
         while (true) {
             const elapsedMs = dependencies.now() - startedAt;
             const remainingMs = timeoutMs - elapsedMs;
 
             if (remainingMs <= 0) {
+                context.telemetry?.recordProperties({
+                    final_status: "timeout",
+                    polled_count_bucket: bucketTelemetryCount(pollCount),
+                });
+
                 throw new CliUserError("errors.cloudTaskWait.timedOut", 1, {
                     taskId: input.taskId,
                     timeout: formatCloudTaskDuration(timeoutMs),
@@ -99,8 +106,14 @@ export function createCloudTaskWaitHandler(
             const response = parseCloudTaskResultResponse(
                 await requestCloudTask(requestUrl, account.apiKey, context),
             );
+            pollCount += 1;
 
             if (response.status === "success" || response.status === "failed") {
+                context.telemetry?.recordProperties({
+                    final_status: response.status,
+                    polled_count_bucket: bucketTelemetryCount(pollCount),
+                });
+
                 context.stdout.write(
                     `${formatCloudTaskResultAsText(input.taskId, response, context)}\n`,
                 );

--- a/src/application/commands/completion.ts
+++ b/src/application/commands/completion.ts
@@ -25,6 +25,8 @@ export const completionCommand: CliCommandDefinition<CompletionInput> = {
     }),
     mapInputError: (_, rawInput) => createInvalidShellError(rawInput),
     handler: (input, context) => {
+        context.telemetry?.recordProperties({ shell: input.shell });
+
         context.stdout.write(
             context.completionRenderer.render(input.shell, context.catalog),
         );

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -39,6 +39,7 @@ Commands:
   log                       Manage persisted debug logs
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
+  telemetry                 Manage CLI telemetry
   update|upgrade [options]  Update the CLI
   help [command]            Show help for a command
 "
@@ -70,6 +71,7 @@ Commands:
   log                       管理持久化 debug 日志
   search [options] <text>   搜索 package 与 connector action
   packages                  包相关工具
+  telemetry                 管理 CLI telemetry
   update|upgrade [options]  更新 CLI
   help [command]            显示命令帮助
 "

--- a/src/application/commands/config/get.ts
+++ b/src/application/commands/config/get.ts
@@ -27,6 +27,8 @@ export const configGetCommand: CliCommandDefinition<ConfigKeyInput> = {
     }),
     mapInputError: (_, rawInput) => createInvalidConfigKeyError(rawInput),
     handler: async (input, context) => {
+        context.telemetry?.recordProperties({ config_key: input.key });
+
         const settings = await context.settingsStore.read();
         const value = getConfigValue(settings, input.key);
 

--- a/src/application/commands/config/set.ts
+++ b/src/application/commands/config/set.ts
@@ -1,8 +1,7 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
-import type { AppSettings } from "../../schemas/settings.ts";
-
 import type { ConfigKey } from "./shared.ts";
 import { z } from "zod";
+import { disableTelemetryForCurrentInvocation } from "../../telemetry/control.ts";
 import { writeLine } from "../shared/output.ts";
 import {
     configDefinitions,
@@ -10,12 +9,10 @@ import {
     configKeySchema,
     createInvalidConfigKeyError,
     isConfigKey,
+    telemetryEnabledConfigKey,
 } from "./shared.ts";
 
 interface ResolvedConfigSetInput {
-    definition: {
-        setValue: (settings: AppSettings, value: string) => AppSettings;
-    };
     key: ConfigKey;
     value: string;
 }
@@ -23,25 +20,6 @@ interface ResolvedConfigSetInput {
 const configSetInputSchema = z.object({
     key: configKeySchema,
     value: z.string(),
-}).transform((input, ctx) => {
-    const definition = configDefinitions[input.key];
-    const valueResult = definition.valueSchema.safeParse(input.value);
-
-    if (!valueResult.success) {
-        ctx.addIssue({
-            code: "custom",
-            message: valueResult.error.message,
-            path: ["value"],
-        });
-
-        return z.NEVER;
-    }
-
-    return {
-        definition,
-        key: input.key,
-        value: valueResult.data,
-    } as ResolvedConfigSetInput;
 });
 
 export const configSetCommand: CliCommandDefinition<ResolvedConfigSetInput> = {
@@ -63,23 +41,40 @@ export const configSetCommand: CliCommandDefinition<ResolvedConfigSetInput> = {
     ],
     inputSchema: configSetInputSchema,
     mapInputError: (_, rawInput) => {
-        const definition = isConfigKey(rawInput.key) ? configDefinitions[rawInput.key] : undefined;
-
-        if (!definition) {
-            return createInvalidConfigKeyError(rawInput);
-        }
-
-        return definition.createInvalidValueError(rawInput.value);
+        return createInvalidConfigKeyError(rawInput);
     },
     handler: async (input, context) => {
+        context.telemetry?.recordProperties({ config_key: input.key });
+
+        const definition = isConfigKey(input.key)
+            ? configDefinitions[input.key]
+            : undefined;
+
+        if (!definition) {
+            throw createInvalidConfigKeyError({ key: input.key });
+        }
+
+        const parsedValue = definition.parseRawValue(input.value);
+
+        if (!parsedValue) {
+            throw definition.createInvalidValueError(input.value);
+        }
+
         await context.settingsStore.update(
-            settings => input.definition.setValue(settings, input.value),
+            settings => parsedValue.apply(settings),
         );
+
+        if (
+            input.key === telemetryEnabledConfigKey
+            && parsedValue.renderedValue === "false"
+        ) {
+            disableTelemetryForCurrentInvocation(context);
+        }
 
         context.logger.info(
             {
                 key: input.key,
-                value: input.value,
+                value: parsedValue.renderedValue,
             },
             "Config value persisted.",
         );
@@ -87,7 +82,7 @@ export const configSetCommand: CliCommandDefinition<ResolvedConfigSetInput> = {
             context.stdout,
             context.translator.t("config.set.success", {
                 key: input.key,
-                value: input.value,
+                value: parsedValue.renderedValue,
             }),
         );
     },

--- a/src/application/commands/config/shared.ts
+++ b/src/application/commands/config/shared.ts
@@ -1,24 +1,28 @@
-import type { ZodType } from "zod";
-import type { SupportedLocale } from "../../contracts/cli.ts";
 import type { AppSettings } from "../../schemas/settings.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import {
-    fileDownloadOutDirConfigValueSchema,
     getConfiguredFileDownloadOutDir,
+    getConfiguredTelemetryEnabled,
     localeSchema,
     setFileDownloadOutDir,
+    setTelemetryEnabled,
     unsetFileDownloadOutDir,
+    unsetTelemetryEnabled,
 } from "../../schemas/settings.ts";
 
-interface ConfigDefinition<TValue extends string> {
+interface ParsedConfigValue {
+    readonly apply: (settings: AppSettings) => AppSettings;
+    readonly renderedValue: string;
+}
+
+interface ConfigDefinition {
     createInvalidValueError: (rawValue: unknown) => CliUserError;
-    getValue: (settings: AppSettings) => TValue | undefined;
-    setValue: (settings: AppSettings, value: TValue) => AppSettings;
+    getValue: (settings: AppSettings) => string | undefined;
+    parseRawValue: (rawValue: string) => ParsedConfigValue | undefined;
     unsetValue: (settings: AppSettings) => AppSettings;
-    valueChoices: readonly TValue[];
-    valueSchema: ZodType<TValue>;
+    valueChoices: readonly string[];
 }
 
 function createValueErrorFactory(translationKey: string) {
@@ -30,17 +34,27 @@ function createValueErrorFactory(translationKey: string) {
 }
 
 export const fileDownloadOutDirConfigKey = "file.download.out_dir" as const;
+export const telemetryEnabledConfigKey = "telemetry.enabled" as const;
 
 export const configDefinitions = {
     lang: {
         createInvalidValueError: createValueErrorFactory("errors.config.invalidLangValue"),
-        getValue(settings: AppSettings): SupportedLocale | undefined {
+        getValue(settings: AppSettings): string | undefined {
             return settings.lang;
         },
-        setValue(settings: AppSettings, value: SupportedLocale): AppSettings {
+        parseRawValue(rawValue: string): ParsedConfigValue | undefined {
+            const result = localeSchema.safeParse(rawValue);
+
+            if (!result.success) {
+                return undefined;
+            }
+
             return {
-                ...settings,
-                lang: value,
+                apply: settings => ({
+                    ...settings,
+                    lang: result.data,
+                }),
+                renderedValue: result.data,
             };
         },
         unsetValue(settings: AppSettings): AppSettings {
@@ -51,22 +65,57 @@ export const configDefinitions = {
             return nextSettings;
         },
         valueChoices: localeSchema.options,
-        valueSchema: localeSchema,
-    } satisfies ConfigDefinition<SupportedLocale>,
+    } satisfies ConfigDefinition,
     [fileDownloadOutDirConfigKey]: {
         createInvalidValueError: createValueErrorFactory("errors.config.invalidFileDownloadOutDirValue"),
         getValue(settings: AppSettings): string | undefined {
             return getConfiguredFileDownloadOutDir(settings);
         },
-        setValue(settings: AppSettings, value: string): AppSettings {
-            return setFileDownloadOutDir(settings, value);
+        parseRawValue(rawValue: string): ParsedConfigValue | undefined {
+            const value = rawValue.trim();
+
+            if (value === "") {
+                return undefined;
+            }
+
+            return {
+                apply: settings => setFileDownloadOutDir(settings, value),
+                renderedValue: value,
+            };
         },
         unsetValue(settings: AppSettings): AppSettings {
             return unsetFileDownloadOutDir(settings);
         },
         valueChoices: [],
-        valueSchema: fileDownloadOutDirConfigValueSchema,
-    } satisfies ConfigDefinition<string>,
+    } satisfies ConfigDefinition,
+    [telemetryEnabledConfigKey]: {
+        createInvalidValueError: createValueErrorFactory("errors.config.invalidTelemetryEnabledValue"),
+        getValue(settings: AppSettings): string | undefined {
+            const value = getConfiguredTelemetryEnabled(settings);
+
+            return value === undefined ? undefined : String(value);
+        },
+        parseRawValue(rawValue: string): ParsedConfigValue | undefined {
+            switch (rawValue) {
+                case "false":
+                    return {
+                        apply: settings => setTelemetryEnabled(settings, false),
+                        renderedValue: "false",
+                    };
+                case "true":
+                    return {
+                        apply: settings => setTelemetryEnabled(settings, true),
+                        renderedValue: "true",
+                    };
+                default:
+                    return undefined;
+            }
+        },
+        unsetValue(settings: AppSettings): AppSettings {
+            return unsetTelemetryEnabled(settings);
+        },
+        valueChoices: ["true", "false"],
+    } satisfies ConfigDefinition,
 } as const;
 
 export type ConfigKey = keyof typeof configDefinitions;

--- a/src/application/commands/config/unset.ts
+++ b/src/application/commands/config/unset.ts
@@ -27,6 +27,8 @@ export const configUnsetCommand: CliCommandDefinition<ConfigKeyInput> = {
     }),
     mapInputError: (_, rawInput) => createInvalidConfigKeyError(rawInput),
     handler: async (input, context) => {
+        context.telemetry?.recordProperties({ config_key: input.key });
+
         await context.settingsStore.update(settings =>
             configDefinitions[input.key].unsetValue(settings),
         );

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -11,6 +11,10 @@ import {
     writeAuthFile,
 } from "../../../../__tests__/helpers.ts";
 import { APP_NAME } from "../../config/app-config.ts";
+import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../../telemetry/outbox.ts";
 import { createTerminalColors } from "../../terminal-colors.ts";
 import {
     renderConnectorActionSchemaCache,
@@ -351,6 +355,11 @@ describe("connectorCommand CLI", () => {
                     },
                 },
             );
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
 
             expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(JSON.parse(result.stdout)).toEqual({
@@ -373,6 +382,17 @@ describe("connectorCommand CLI", () => {
                     to: "foo@bar.com",
                 },
             });
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    action: "send_mail",
+                    command_full: "connector.run",
+                    data_size_bucket: "<1KB",
+                    dry_run: false,
+                    service: "gmail",
+                },
+            });
+            expect(telemetryPayload?.properties).not.toHaveProperty("data");
+            expect(telemetryPayload?.properties).not.toHaveProperty("input");
         }
         finally {
             await sandbox.cleanup();
@@ -721,6 +741,11 @@ describe("connectorCommand CLI", () => {
                     }),
                 },
             );
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
             const content = await readLatestLogContent(sandbox);
 
             expect(result.exitCode).toBe(1);
@@ -735,6 +760,17 @@ describe("connectorCommand CLI", () => {
             expect(content).toContain("\"errorCode\":\"invalid_input\"");
             expect(content).toContain("\"executionId\":\"exec-1\"");
             expect(content).not.toContain("\"responseBody\":");
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    action: "get_message",
+                    command_full: "connector.run",
+                    data_size_bucket: "<1KB",
+                    dry_run: false,
+                    error_code: "invalid_input",
+                    http_status: 400,
+                    service: "gmail",
+                },
+            });
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -1,7 +1,9 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 
+import { Buffer } from "node:buffer";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
+import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
@@ -88,6 +90,16 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             connectorRunDataErrorKeys,
             {},
         );
+
+        context.telemetry?.recordProperties({
+            action: actionName,
+            data_size_bucket: bucketTelemetryBytes(
+                Buffer.byteLength(JSON.stringify(inputData)),
+            ),
+            dry_run: input.dryRun === true,
+            service: input.serviceName,
+        });
+
         const actionReference = await ensureConnectorActionSchemaReference(
             {
                 actionName,
@@ -120,16 +132,24 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             return;
         }
 
-        const response = await runConnectorAction(
-            {
-                actionName,
-                apiKey: account.apiKey,
-                endpoint: account.endpoint,
-                inputData,
-                serviceName: input.serviceName,
-            },
-            context,
-        );
+        let response: Awaited<ReturnType<typeof runConnectorAction>>;
+
+        try {
+            response = await runConnectorAction(
+                {
+                    actionName,
+                    apiKey: account.apiKey,
+                    endpoint: account.endpoint,
+                    inputData,
+                    serviceName: input.serviceName,
+                },
+                context,
+            );
+        }
+        catch (error) {
+            recordConnectorRunFailureTelemetry(error, context.telemetry);
+            throw error;
+        }
 
         if (input.format === "json") {
             writeJsonOutput(context.stdout, response);
@@ -160,4 +180,27 @@ function formatConnectorRunResultData(
     colors: ReturnType<typeof createWriterColors>,
 ): string {
     return colors.cyan(JSON.stringify(value, null, 2) ?? "null");
+}
+
+function recordConnectorRunFailureTelemetry(
+    error: unknown,
+    telemetry: CliExecutionContext["telemetry"],
+): void {
+    if (!(error instanceof CliUserError)) {
+        return;
+    }
+
+    const status = error.params?.status;
+    if (typeof status === "number") {
+        telemetry?.recordProperties({
+            http_status: status,
+        });
+    }
+
+    const errorCode = error.params?.errorCode;
+    if (typeof errorCode === "string" && errorCode !== "") {
+        telemetry?.recordProperties({
+            error_code: errorCode,
+        });
+    }
 }

--- a/src/application/commands/connector/search.ts
+++ b/src/application/commands/connector/search.ts
@@ -1,6 +1,10 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
+import {
+    bucketTelemetryCount,
+    bucketTelemetryStringLength,
+} from "../../telemetry/buckets.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
@@ -45,8 +49,14 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        const account = await requireCurrentAccount(context);
         const keywords = parseCommaSeparatedKeywords(input.keywords);
+
+        context.telemetry?.recordProperties({
+            keyword_count_bucket: bucketTelemetryCount(keywords.length),
+            query_length_bucket: bucketTelemetryStringLength(input.text),
+        });
+
+        const account = await requireCurrentAccount(context);
         const results = await loadConnectorSearchResults(
             {
                 apiKey: account.apiKey,
@@ -56,6 +66,10 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
             },
             context,
         );
+
+        context.telemetry?.recordProperties({
+            result_count_bucket: bucketTelemetryCount(results.length),
+        });
 
         if (results.length === 0) {
             if (input.format === "json") {

--- a/src/application/commands/file/download.cli.test.ts
+++ b/src/application/commands/file/download.cli.test.ts
@@ -7,6 +7,11 @@ import {
     createCliSandbox,
     createCliSnapshot,
 } from "../../../../__tests__/helpers.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../../telemetry/outbox.ts";
 
 describe("file download CLI", () => {
     test("supports file download, creates missing directories, and prints the labeled saved path", async () => {
@@ -45,6 +50,11 @@ describe("file download CLI", () => {
                 },
             );
             const downloadedFilePath = join(outputDirectoryPath, "report.tar.gz");
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
 
             expect(createCliSnapshot(
                 result,
@@ -54,6 +64,16 @@ describe("file download CLI", () => {
                 },
             )).toMatchSnapshot();
             await expect(Bun.file(downloadedFilePath).text()).resolves.toBe("hello world");
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    bytes_total_bucket: "<1KB",
+                    command_full: "file.download",
+                    resumed: false,
+                    url_scheme: "https",
+                },
+            });
+            expect(telemetryPayload?.properties).not.toHaveProperty("url");
+            expect(telemetryPayload?.properties).not.toHaveProperty("host");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/file/download.ts
+++ b/src/application/commands/file/download.ts
@@ -9,6 +9,7 @@ import {
     defaultFileDownloadOutDir,
     getConfiguredFileDownloadOutDir,
 } from "../../schemas/settings.ts";
+import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
 import {
     finalizeDownloadedFile,
     openTemporaryDownloadFile,
@@ -72,6 +73,11 @@ export const fileDownloadCommand: CliCommandDefinition<FileDownloadInput> = {
     }),
     handler: async (input, context) => {
         const requestUrl = parseFileDownloadUrl(input.url);
+
+        context.telemetry?.recordProperties({
+            url_scheme: requestUrl.protocol.slice(0, -1),
+        });
+
         const requestedName = parseFileDownloadNameOption(input.name);
         const requestedExtension = parseFileDownloadExtensionOption(input.ext);
 
@@ -99,6 +105,21 @@ export const fileDownloadCommand: CliCommandDefinition<FileDownloadInput> = {
             sessionKey,
             context,
         );
+        const resumed = downloadPlan.kind === "write-response"
+            && downloadPlan.initialBytes > 0;
+
+        if (
+            downloadPlan.kind === "write-response"
+            && downloadPlan.totalBytes !== undefined
+        ) {
+            context.telemetry?.recordProperties({
+                bytes_total_bucket: bucketTelemetryBytes(downloadPlan.totalBytes),
+                resumed,
+            });
+        }
+        else {
+            context.telemetry?.recordProperties({ resumed });
+        }
 
         await executeDownloadPlan(downloadPlan, outputDirectoryPath, context);
     },

--- a/src/application/commands/file/upload.cli.test.ts
+++ b/src/application/commands/file/upload.cli.test.ts
@@ -1,5 +1,6 @@
-import { join } from "node:path";
+import { truncate } from "node:fs/promises";
 
+import { join } from "node:path";
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 
@@ -11,6 +12,11 @@ import {
 } from "../../../../__tests__/helpers.ts";
 import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../config/app-config.ts";
+import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../../telemetry/outbox.ts";
+import { maxFileUploadSizeBytes } from "./shared.ts";
 
 describe("file upload CLI", () => {
     test("supports file upload and persists the uploaded record", async () => {
@@ -71,6 +77,11 @@ describe("file upload CLI", () => {
             const database = new Database(uploadsFilePath, {
                 strict: true,
             });
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
 
             try {
                 expect(createFileUploadSnapshot(result)).toMatchSnapshot();
@@ -88,6 +99,15 @@ describe("file upload CLI", () => {
                     file_name: "sample",
                     size: 11,
                 });
+                expect(telemetryPayload).toMatchObject({
+                    properties: {
+                        bytes_total_bucket: "<1KB",
+                        command_full: "file.upload",
+                        rejected_too_large: false,
+                    },
+                });
+                expect(telemetryPayload?.properties).not.toHaveProperty("file_name");
+                expect(telemetryPayload?.properties).not.toHaveProperty("path");
                 expect(
                     database.query(
                         [
@@ -199,6 +219,40 @@ describe("file upload CLI", () => {
         finally {
             await Bun.file(firstFilePath).delete();
             await Bun.file(secondFilePath).delete();
+            await sandbox.cleanup();
+        }
+    });
+
+    test("records rejected too large telemetry without file identity", async () => {
+        const sandbox = await createCliSandbox();
+        const localFilePath = join(sandbox.env.HOME!, "large-upload.bin");
+
+        try {
+            await writeAuthFile(sandbox);
+            await Bun.write(localFilePath, "");
+            await truncate(localFilePath, maxFileUploadSizeBytes + 1);
+
+            const result = await sandbox.run(["file", "upload", localFilePath]);
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    bytes_total_bucket: "100MB+",
+                    command_full: "file.upload",
+                    error_category: "user_error",
+                    rejected_too_large: true,
+                },
+            });
+            expect(telemetryPayload?.properties).not.toHaveProperty("file_name");
+            expect(telemetryPayload?.properties).not.toHaveProperty("path");
+        }
+        finally {
+            await Bun.file(localFilePath).delete();
             await sandbox.cleanup();
         }
     });

--- a/src/application/commands/file/upload.ts
+++ b/src/application/commands/file/upload.ts
@@ -1,10 +1,14 @@
 import type { Stats } from "node:fs";
-import type { CliCommandDefinition } from "../../contracts/cli.ts";
+import type {
+    CliCommandDefinition,
+    CliExecutionContext,
+} from "../../contracts/cli.ts";
 
 import { stat } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
+import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import {
@@ -22,6 +26,10 @@ interface FileUploadInput {
     format?: string;
     filePath: string;
 }
+
+type RecordTelemetryProperties = NonNullable<
+    CliExecutionContext["telemetry"]
+>["recordProperties"];
 
 export const fileUploadCommand: CliCommandDefinition<FileUploadInput> = {
     name: "upload",
@@ -44,7 +52,17 @@ export const fileUploadCommand: CliCommandDefinition<FileUploadInput> = {
     handler: async (input, context) => {
         const format = parseFileFormat(input.format);
         const account = await requireCurrentAccount(context);
-        const sourceFile = await readSourceFile(input.filePath, context.cwd);
+        const sourceFile = await readSourceFile(
+            input.filePath,
+            context.cwd,
+            context.telemetry?.recordProperties,
+        );
+
+        context.telemetry?.recordProperties({
+            bytes_total_bucket: bucketTelemetryBytes(sourceFile.fileSize),
+            rejected_too_large: false,
+        });
+
         const uploadSession = await initFileUpload(
             account,
             sourceFile.fileName,
@@ -92,6 +110,7 @@ export const fileUploadCommand: CliCommandDefinition<FileUploadInput> = {
 async function readSourceFile(
     filePath: string,
     cwd: string,
+    recordTelemetryProperties: RecordTelemetryProperties | undefined,
 ): Promise<{
     file: {
         size: number;
@@ -120,6 +139,10 @@ async function readSourceFile(
     }
 
     if (metadata.size > maxFileUploadSizeBytes) {
+        recordTelemetryProperties?.({
+            bytes_total_bucket: bucketTelemetryBytes(metadata.size),
+            rejected_too_large: true,
+        });
         throw new CliUserError("errors.fileUpload.tooLarge", 2, {
             max: maxFileUploadSizeBytes,
             path: resolvedPath,

--- a/src/application/commands/install.ts
+++ b/src/application/commands/install.ts
@@ -14,6 +14,10 @@ import { resolveSelfUpdateShowPathShadowingWarning } from "../self-update/path-s
 import { isSemver } from "../semver.ts";
 import { writeSelfUpdatePathNoteIfNeeded } from "./self-update-output.ts";
 import { SelfUpdateProgressReporter } from "./self-update-progress.ts";
+import {
+    classifyTelemetryVersionKind,
+    recordSelfUpdatePathTelemetry,
+} from "./self-update-telemetry.ts";
 import { writeLine } from "./shared/output.ts";
 
 const installCommandInputSchema = z.object({
@@ -50,6 +54,14 @@ export const installCommand: CliCommandDefinition<
     ],
     inputSchema: installCommandInputSchema,
     handler: async (input, context) => {
+        context.telemetry?.recordProperties({
+            force: input.force,
+            path_modified: false,
+            version_kind: classifyTelemetryVersionKind(
+                input.version ?? context.version,
+            ),
+        });
+
         if (context.version === selfUpdateDevelopmentVersion) {
             writeLine(
                 context.stdout,
@@ -85,6 +97,11 @@ export const installCommand: CliCommandDefinition<
                     fetcher: context.fetcher,
                     logger: context.logger,
                 });
+
+            context.telemetry?.recordProperties({
+                update_available: targetVersion !== context.version,
+                version_kind: classifyTelemetryVersionKind(targetVersion),
+            });
 
             if (input.version === undefined) {
                 progressReporter?.setStage("resolve", {
@@ -124,6 +141,11 @@ export const installCommand: CliCommandDefinition<
                 );
                 return;
             }
+
+            recordSelfUpdatePathTelemetry(
+                context.telemetry,
+                result.pathConfiguration,
+            );
 
             progressReporter?.finish();
 

--- a/src/application/commands/package/info.test.ts
+++ b/src/application/commands/package/info.test.ts
@@ -5,6 +5,7 @@ import type {
 import type {
     CliCatalog,
     CliExecutionContext,
+    CliTelemetryPropertyValue,
     Fetcher,
     InteractiveInput,
     SupportedLocale,
@@ -144,12 +145,35 @@ describe("packageInfoCommand", () => {
 
         expect(fetchCount).toBe(2);
     });
+
+    test("records package identity as command telemetry properties", async () => {
+        const telemetryProperties: Record<string, CliTelemetryPropertyValue> = {};
+        const context = createPackageInfoContext({
+            cacheStore: createCacheStore(),
+            fetcher: async () => new Response(JSON.stringify({
+                packageName: "pdf",
+                packageVersion: "1.0.0",
+                title: "PDF Toolkit",
+                description: "Inspect PDF files",
+                blocks: [],
+            })),
+            telemetryProperties,
+        });
+
+        await packageInfoHandler({ packageSpecifier: "pdf@1.0.0" }, context);
+
+        expect(telemetryProperties).toEqual({
+            package_name: "pdf",
+            package_version: "1.0.0",
+        });
+    });
 });
 
 function createPackageInfoContext(options: {
     cacheStore: CacheStore;
     fetcher: Fetcher;
     locale?: SupportedLocale;
+    telemetryProperties?: Record<string, CliTelemetryPropertyValue>;
 }): CliExecutionContext {
     const stdout = createTextBuffer();
     const stderr = createTextBuffer();
@@ -178,6 +202,15 @@ function createPackageInfoContext(options: {
         settingsStore: createSettingsStore({}),
         stdout: stdout.writer,
         stderr: stderr.writer,
+        telemetry: options.telemetryProperties === undefined
+            ? undefined
+            : {
+                    directoryPath: "",
+                    recordProperties(properties) {
+                        Object.assign(options.telemetryProperties!, properties);
+                    },
+                    suppressCurrentInvocation() {},
+                },
         translator,
         completionRenderer: {
             render: () => "",

--- a/src/application/commands/package/info.ts
+++ b/src/application/commands/package/info.ts
@@ -45,8 +45,14 @@ export const packageInfoCommand: CliCommandDefinition<PackageInfoInput> = {
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        const account = await requireCurrentAccount(context);
         const packageSpecifier = parsePackageSpecifier(input.packageSpecifier);
+
+        context.telemetry?.recordProperties({
+            package_name: packageSpecifier.packageName,
+            package_version: packageSpecifier.packageVersion,
+        });
+
+        const account = await requireCurrentAccount(context);
         const response = await loadPackageInfo(
             packageSpecifier,
             account,

--- a/src/application/commands/package/search.test.ts
+++ b/src/application/commands/package/search.test.ts
@@ -5,6 +5,7 @@ import type {
 import type {
     CliCatalog,
     CliExecutionContext,
+    CliTelemetryPropertyValue,
     Fetcher,
     InteractiveInput,
 } from "../../contracts/cli.ts";
@@ -182,11 +183,38 @@ describe("packageSearchCommand", () => {
         expect(fetchCount).toBe(2);
         expect(setCount).toBe(0);
     });
+
+    test("records search telemetry buckets without the query text", async () => {
+        const telemetryProperties: Record<string, CliTelemetryPropertyValue> = {};
+        const context = createSearchContext({
+            cacheStore: createCacheStore(),
+            fetcher: async () => new Response(JSON.stringify({
+                packages: [
+                    {
+                        displayName: "Image Tools",
+                        name: "@oomol/image-tools",
+                        version: "1.2.3",
+                    },
+                ],
+            })),
+            telemetryProperties,
+        });
+
+        await searchHandler({ text: "image processing" }, context);
+
+        expect(telemetryProperties).toEqual({
+            query_length_bucket: "6-20",
+            result_count_bucket: "1-5",
+        });
+        expect(telemetryProperties).not.toHaveProperty("query");
+        expect(telemetryProperties).not.toHaveProperty("text");
+    });
 });
 
 function createSearchContext(options: {
     cacheStore: CacheStore;
     fetcher: Fetcher;
+    telemetryProperties?: Record<string, CliTelemetryPropertyValue>;
 }): CliExecutionContext {
     const stdout = createTextBuffer();
     const stderr = createTextBuffer();
@@ -209,6 +237,15 @@ function createSearchContext(options: {
         settingsStore: createSettingsStore({}),
         stdout: stdout.writer,
         stderr: stderr.writer,
+        telemetry: options.telemetryProperties === undefined
+            ? undefined
+            : {
+                    directoryPath: "",
+                    recordProperties(properties) {
+                        Object.assign(options.telemetryProperties!, properties);
+                    },
+                    suppressCurrentInvocation() {},
+                },
         translator,
         completionRenderer: {
             render: () => "",

--- a/src/application/commands/package/search.ts
+++ b/src/application/commands/package/search.ts
@@ -1,6 +1,10 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
+import {
+    bucketTelemetryCount,
+    bucketTelemetryStringLength,
+} from "../../telemetry/buckets.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
@@ -45,6 +49,10 @@ export const packageSearchCommand: CliCommandDefinition<SearchInput> = {
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
+        context.telemetry?.recordProperties({
+            query_length_bucket: bucketTelemetryStringLength(input.text),
+        });
+
         const account = await requireCurrentAccount(context);
         const response = await loadPackageSearchResponse(
             {
@@ -54,6 +62,10 @@ export const packageSearchCommand: CliCommandDefinition<SearchInput> = {
             },
             context,
         );
+
+        context.telemetry?.recordProperties({
+            result_count_bucket: bucketTelemetryCount(response.packages.length),
+        });
 
         if (input.onlyPackageId === true) {
             const packageIds = readPackageSearchIds(response.packages);

--- a/src/application/commands/search.cli.test.ts
+++ b/src/application/commands/search.cli.test.ts
@@ -10,6 +10,10 @@ import {
     writeAuthFile,
 } from "../../../__tests__/helpers.ts";
 import { APP_NAME } from "../config/app-config.ts";
+import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../telemetry/outbox.ts";
 import { createTerminalColors } from "../terminal-colors.ts";
 import { resolveConnectorActionSchemaPath } from "./connector/schema-cache.ts";
 import { mixedSearchKindColor } from "./search.ts";
@@ -78,6 +82,11 @@ describe("mixedSearchCommand CLI", () => {
                 },
             );
             const logContent = await readLatestLogContent(sandbox);
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
 
             expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             expect(requests.map(request => request.url).sort()).toEqual([
@@ -86,6 +95,16 @@ describe("mixedSearchCommand CLI", () => {
                 "https://search.oomol.com/v1/packages/-/intent-search?q=send+mail&lang=en&excludeScopes=connector&excludePackages=llm",
             ]);
             expect(logContent).toContain(`"path":"/v1/packages/-/intent-search"`);
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    command_full: "search",
+                    keyword_count_bucket: "1-5",
+                    query_length_bucket: "6-20",
+                    result_count_bucket: "1-5",
+                },
+            });
+            expect(telemetryPayload?.properties).not.toHaveProperty("query");
+            expect(telemetryPayload?.properties).not.toHaveProperty("text");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/search.ts
+++ b/src/application/commands/search.ts
@@ -8,6 +8,10 @@ import type {
 
 import { z } from "zod";
 
+import {
+    bucketTelemetryCount,
+    bucketTelemetryStringLength,
+} from "../telemetry/buckets.ts";
 import { createWriterColors } from "../terminal-colors.ts";
 import {
     formatConnectorSearchResultAsText,
@@ -84,8 +88,14 @@ export const mixedSearchCommand: CliCommandDefinition<MixedSearchInput> = {
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        const account = await requireCurrentAccount(context);
         const keywords = parseCommaSeparatedKeywords(input.keywords);
+
+        context.telemetry?.recordProperties({
+            keyword_count_bucket: bucketTelemetryCount(keywords.length),
+            query_length_bucket: bucketTelemetryStringLength(input.text),
+        });
+
+        const account = await requireCurrentAccount(context);
         const [packageResponse, connectorResults] = await Promise.all([
             loadPackageSearchResponse(
                 {
@@ -105,6 +115,11 @@ export const mixedSearchCommand: CliCommandDefinition<MixedSearchInput> = {
                 context,
             ),
         ]);
+        context.telemetry?.recordProperties({
+            result_count_bucket: bucketTelemetryCount(
+                packageResponse.packages.length + connectorResults.length,
+            ),
+        });
 
         if (input.format === "json") {
             writeJsonOutput(

--- a/src/application/commands/self-update-telemetry.ts
+++ b/src/application/commands/self-update-telemetry.ts
@@ -1,0 +1,26 @@
+import type { CliExecutionContext } from "../contracts/cli.ts";
+import type { SelfUpdatePathConfigurationResult } from "../contracts/self-update.ts";
+
+import { isSemver } from "../semver.ts";
+
+export function classifyTelemetryVersionKind(
+    version: string,
+): "invalid" | "prerelease" | "stable" {
+    if (!isSemver(version)) {
+        return "invalid";
+    }
+
+    const versionWithoutBuild = version.split("+")[0]!;
+
+    return versionWithoutBuild.includes("-") ? "prerelease" : "stable";
+}
+
+export function recordSelfUpdatePathTelemetry(
+    telemetry: CliExecutionContext["telemetry"],
+    pathConfiguration: SelfUpdatePathConfigurationResult,
+): void {
+    telemetry?.recordProperties({
+        path_modified: pathConfiguration.status === "configured"
+            || pathConfiguration.status === "partial-configured",
+    });
+}

--- a/src/application/commands/self-update.cli.test.ts
+++ b/src/application/commands/self-update.cli.test.ts
@@ -13,6 +13,7 @@ import {
     joinPathEntries,
     toRequest,
 } from "../../../__tests__/helpers.ts";
+import { APP_NAME } from "../config/app-config.ts";
 import { selfUpdateHidePathShadowingWarningEnvName } from "../self-update/path-shadowing-warning-preference.ts";
 import {
     resolveSelfUpdatePaths,
@@ -20,6 +21,10 @@ import {
     resolveSelfUpdateVersionExecutablePath,
 } from "../self-update/paths.ts";
 import { detectSelfUpdateReleasePlatform } from "../self-update/platform.ts";
+import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../telemetry/outbox.ts";
 
 describe("self-update commands", () => {
     test("install prints the development-version guard and exits successfully", async () => {
@@ -104,9 +109,23 @@ describe("self-update commands", () => {
                 selfUpdateRuntime: selfUpdateRuntime.runtime,
                 version: "1.0.0",
             });
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
 
             expect(createSelfUpdateInstallSnapshot(result, sandbox)).toMatchSnapshot();
             expect(latestRequestCount).toBe(0);
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    command_full: "install",
+                    force: false,
+                    path_modified: true,
+                    update_available: true,
+                    version_kind: "stable",
+                },
+            });
         }
         finally {
             await sandbox.cleanup();
@@ -425,6 +444,19 @@ describe("self-update commands", () => {
                 exitCode: 0,
                 stderr: "",
                 stdout: "Updated oo from 1.0.0 to 2.0.0.\nAdded <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.\n",
+            });
+            expect(parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            )).toMatchObject({
+                properties: {
+                    command_full: "update",
+                    force: true,
+                    path_modified: true,
+                    update_available: true,
+                    version_kind: "stable",
+                },
             });
             expect(selfUpdateRuntime.commands).toEqual([
                 {

--- a/src/application/commands/skills/__tests__/helpers.ts
+++ b/src/application/commands/skills/__tests__/helpers.ts
@@ -2,9 +2,13 @@ import type {
     BundledSkillAgentName,
     BundledSkillName,
 } from "../embedded-assets.ts";
+import { mkdir, symlink } from "node:fs/promises";
+import { join } from "node:path";
 import {
     getBundledSkillFiles,
 } from "../embedded-assets.ts";
+
+export type SymbolicLinkKindForTest = "directory" | "file";
 
 export function getBundledSkillSourcePath(
     skillName: BundledSkillName,
@@ -22,4 +26,27 @@ export function getBundledSkillSourcePath(
     }
 
     return file.sourcePath;
+}
+
+export async function createSymbolicLinkForTest(
+    targetPath: string,
+    linkPath: string,
+    kind: SymbolicLinkKindForTest,
+): Promise<void> {
+    if (kind === "file" && process.platform !== "win32") {
+        await Bun.write(targetPath, "secret\n");
+        await symlink(targetPath, linkPath);
+        return;
+    }
+
+    // Windows CI does not grant file symlink privileges. Junctions still report
+    // as symbolic links through lstat(), which is the branch these tests cover.
+    await mkdir(targetPath, { recursive: true });
+    await Bun.write(join(targetPath, "secret.txt"), "secret\n");
+
+    await symlink(
+        targetPath,
+        linkPath,
+        process.platform === "win32" ? "junction" : "dir",
+    );
 }

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -1769,9 +1769,11 @@ describe("skills commands", () => {
             expect(requests).toHaveLength(2);
             expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
             expect(requests[1]!.headers.get("Authorization")).toBe("secret-1");
-            expect(parseTelemetryRowPayload(
+            const telemetryPayload = parseTelemetryRowPayload(
                 readTelemetryRowsForTest(storePaths.telemetryDirectory)[0]!,
-            )).toMatchObject({
+            );
+
+            expect(telemetryPayload).toMatchObject({
                 properties: {
                     command_full: "skills.install",
                     package_kind: "registry",

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -17,6 +17,10 @@ import {
 import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { executeCli } from "../../bootstrap/run-cli.ts";
 import { APP_NAME } from "../../config/app-config.ts";
+import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../../telemetry/outbox.ts";
 import { getBundledSkillSourcePath } from "./__tests__/helpers.ts";
 import { bundledSkillDevelopmentVersion } from "./bundled-skill-model.ts";
 import {
@@ -107,6 +111,23 @@ describe("skills commands", () => {
                 ].join("\n"),
             );
             expect(result.stderr).toBe("");
+            expect(parseTelemetryRowPayload(
+                readTelemetryRowsForTest(storePaths.telemetryDirectory)[0]!,
+            )).toMatchObject({
+                properties: {
+                    bundled_skill: "__all__",
+                    command_full: "skills.install",
+                    package_kind: "bundled",
+                    skill_ids_count_bucket: "1-5",
+                    skill_ids_sample: [
+                        "oo",
+                        "oo-find-skills",
+                        "oo-create-skill",
+                        "oo-publish-skill",
+                    ],
+                    skill_ids_truncated: false,
+                },
+            });
             expect(await realpath(ooSkillDirectoryPath)).toBe(
                 await realpath(ooCanonicalSkillDirectoryPath),
             );
@@ -1748,6 +1769,18 @@ describe("skills commands", () => {
             expect(requests).toHaveLength(2);
             expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
             expect(requests[1]!.headers.get("Authorization")).toBe("secret-1");
+            expect(parseTelemetryRowPayload(
+                readTelemetryRowsForTest(storePaths.telemetryDirectory)[0]!,
+            )).toMatchObject({
+                properties: {
+                    command_full: "skills.install",
+                    package_kind: "registry",
+                    package_name: "openai",
+                    skill_ids_count_bucket: "1-5",
+                    skill_ids_sample: ["chatgpt"],
+                    skill_ids_truncated: false,
+                },
+            });
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -8,6 +8,7 @@ import { writeManagedSkillInstallSummary } from "./install-output.ts";
 import { migrateLegacyCanonicalSkillLayout } from "./legacy-canonical-migration.ts";
 import { installRegistrySkills } from "./registry-skill-install.ts";
 import { installBundledSkill, isBundledSkillName } from "./shared.ts";
+import { createSkillIdsTelemetryProperties } from "./telemetry.ts";
 
 interface SkillsInstallInput {
     all?: boolean;
@@ -58,6 +59,12 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         await migrateLegacyCanonicalSkillLayout(context);
 
         if (input.packageName === undefined) {
+            context.telemetry?.recordProperties({
+                bundled_skill: "__all__",
+                package_kind: "bundled",
+                ...createSkillIdsTelemetryProperties(availableBundledSkillNames),
+            });
+
             const summaries: ManagedSkillInstallSummary[] = [];
 
             for (const skillName of availableBundledSkillNames) {
@@ -69,6 +76,12 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         }
 
         if (isBundledSkillName(input.packageName)) {
+            context.telemetry?.recordProperties({
+                bundled_skill: input.packageName,
+                package_kind: "bundled",
+                ...createSkillIdsTelemetryProperties([input.packageName]),
+            });
+
             const summary = await installBundledSkill(
                 input.packageName as BundledSkillName,
                 context,

--- a/src/application/commands/skills/package-conversion.test.ts
+++ b/src/application/commands/skills/package-conversion.test.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
-import { mkdir, readFile, stat, symlink } from "node:fs/promises";
+import { mkdir, readFile, stat } from "node:fs/promises";
 import { join, posix } from "node:path";
 import { gunzipSync } from "node:zlib";
 import { describe, expect, test } from "bun:test";
@@ -15,6 +15,7 @@ import {
     useTemporaryDirectoryCleanup,
 } from "../../../../__tests__/helpers.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
+import { createSymbolicLinkForTest } from "./__tests__/helpers.ts";
 import {
     convertSkillDirectoryToPackage,
     publishConvertedSkillPackage,
@@ -444,21 +445,14 @@ describe("skill package conversion", () => {
     test("rejects symlinks while creating publish tarballs", async () => {
         const cases = [
             {
-                createLinkedPath: async (targetPath: string, linkPath: string) => {
-                    await Bun.write(targetPath, "secret\n");
-                    await symlink(targetPath, linkPath);
-                },
                 expectedPath: posix.join("package", "skills", "demo-skill", "linked-secret.txt"),
+                linkKind: "file",
                 linkName: "linked-secret.txt",
                 name: "file",
             },
             {
-                createLinkedPath: async (targetPath: string, linkPath: string) => {
-                    await mkdir(targetPath, { recursive: true });
-                    await Bun.write(join(targetPath, "secret.txt"), "secret\n");
-                    await symlink(targetPath, linkPath, "dir");
-                },
                 expectedPath: posix.join("package", "skills", "demo-skill", "linked-secret"),
+                linkKind: "directory",
                 linkName: "linked-secret",
                 name: "directory",
             },
@@ -496,7 +490,7 @@ describe("skill package conversion", () => {
                 version: "0.0.2",
             });
 
-            await testCase.createLinkedPath(
+            await createSymbolicLinkForTest(
                 join(externalPath, "secret"),
                 join(
                     packageRootDirectoryPath,
@@ -505,6 +499,7 @@ describe("skill package conversion", () => {
                     "demo-skill",
                     testCase.linkName,
                 ),
+                testCase.linkKind,
             );
 
             const error = await expectCliUserError(publishConvertedSkillPackage({

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -25,6 +25,10 @@ import { createTranslator } from "../../../i18n/translator.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import { defaultSettings } from "../../schemas/settings.ts";
 import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../../telemetry/outbox.ts";
+import {
     resolveClaudeHomeDirectory,
     resolveCodexHomeDirectory,
 } from "./bundled-skill-paths.ts";
@@ -102,6 +106,20 @@ describe("skills publish command", () => {
             expect(parsed.data.metadata).toMatchObject({
                 packageName: "@alice/demo-skill",
                 version: "0.0.1",
+            });
+            expect(parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            )).toMatchObject({
+                properties: {
+                    adopted: false,
+                    command_full: "skills.publish",
+                    package_name: "@alice/demo-skill",
+                    skill_id: "demo-skill",
+                    source_kind: "local",
+                    visibility: "private",
+                },
             });
         }
         finally {
@@ -426,6 +444,20 @@ describe("skills publish command", () => {
                 version: "0.3.0",
             });
             expect((await lstat(agentSkillDirectoryPath)).isSymbolicLink()).toBeTrue();
+            expect(parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            )).toMatchObject({
+                properties: {
+                    adopted: true,
+                    command_full: "skills.publish",
+                    package_name: "@alice/agent-skill",
+                    skill_id: "agent-skill",
+                    source_kind: "adoptable",
+                    visibility: "private",
+                },
+            });
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -108,11 +108,13 @@ describe("skills publish command", () => {
                 packageName: "@alice/demo-skill",
                 version: "0.0.1",
             });
-            expect(parseTelemetryRowPayload(
+            const telemetryPayload = parseTelemetryRowPayload(
                 readTelemetryRowsForTest(
                     join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
                 )[0]!,
-            )).toMatchObject({
+            );
+
+            expect(telemetryPayload).toMatchObject({
                 properties: {
                     adopted: false,
                     command_full: "skills.publish",
@@ -445,11 +447,13 @@ describe("skills publish command", () => {
                 version: "0.3.0",
             });
             expect((await lstat(agentSkillDirectoryPath)).isSymbolicLink()).toBeTrue();
-            expect(parseTelemetryRowPayload(
+            const telemetryPayload = parseTelemetryRowPayload(
                 readTelemetryRowsForTest(
                     join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
                 )[0]!,
-            )).toMatchObject({
+            );
+
+            expect(telemetryPayload).toMatchObject({
                 properties: {
                     adopted: true,
                     command_full: "skills.publish",

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -1,6 +1,6 @@
 import type { CliCatalog, CliExecutionContext, Fetcher } from "../../contracts/cli.ts";
 
-import { lstat, mkdir, readFile, stat, symlink } from "node:fs/promises";
+import { lstat, mkdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
@@ -28,6 +28,7 @@ import {
     parseTelemetryRowPayload,
     readTelemetryRowsForTest,
 } from "../../telemetry/outbox.ts";
+import { createSymbolicLinkForTest } from "./__tests__/helpers.ts";
 import {
     resolveClaudeHomeDirectory,
     resolveCodexHomeDirectory,
@@ -532,19 +533,12 @@ describe("skills publish command", () => {
     test("rejects adopting a skill directory that contains symlinks", async () => {
         const cases = [
             {
-                createLinkedPath: async (targetPath: string, linkPath: string) => {
-                    await Bun.write(targetPath, "secret\n");
-                    await symlink(targetPath, linkPath);
-                },
+                linkKind: "file",
                 linkPath: join("nested", "linked-secret.txt"),
                 name: "file",
             },
             {
-                createLinkedPath: async (targetPath: string, linkPath: string) => {
-                    await mkdir(targetPath, { recursive: true });
-                    await Bun.write(join(targetPath, "secret.txt"), "secret\n");
-                    await symlink(targetPath, linkPath, "dir");
-                },
+                linkKind: "directory",
                 linkPath: join("nested", "linked-secret"),
                 name: "directory",
             },
@@ -593,9 +587,10 @@ describe("skills publish command", () => {
                 "",
             ].join("\n"));
             await mkdir(join(sourceSkillDirectoryPath, "nested"), { recursive: true });
-            await testCase.createLinkedPath(
+            await createSymbolicLinkForTest(
                 join(externalPath, "secret"),
                 join(sourceSkillDirectoryPath, testCase.linkPath),
+                testCase.linkKind,
             );
 
             stdin.feed("yes\n");

--- a/src/application/commands/skills/publish.ts
+++ b/src/application/commands/skills/publish.ts
@@ -168,6 +168,11 @@ export const skillsPublishCommand: CliCommandDefinition<SkillsPublishInput> = {
         const agentName = parseSkillPublishAgent(input.agent);
         const visibility = parseSkillPublishVisibility(input.visibility)
             ?? defaultSkillPublishVisibility;
+
+        context.telemetry?.recordProperties({
+            visibility,
+        });
+
         const result = await publishSkillPackage(
             input.skill,
             context,
@@ -219,6 +224,13 @@ export async function publishLocalSkillPackage(
 
     const account = await requireAccount(context);
     const packageName = resolveCanonicalSkillPackageName(account.name, skillId);
+    context.telemetry?.recordProperties({
+        adopted: false,
+        package_name: packageName,
+        skill_id: skillId,
+        source_kind: "local",
+        visibility,
+    });
 
     return await publishResolvedSkillPackage(
         {
@@ -253,6 +265,14 @@ export async function publishSkillPackage(
 
     const account = await requireAccount(context);
     const packageName = resolveCanonicalSkillPackageName(account.name, source.skillId);
+    context.telemetry?.recordProperties({
+        adopted: source.kind === "adoptable",
+        package_name: packageName,
+        skill_id: source.skillId,
+        source_kind: source.kind,
+        visibility,
+    });
+
     const publishSource = await confirmAndPrepareSkillPublishSource(
         {
             packageName,

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -43,6 +43,7 @@ import {
     downloadRegistryPackageTarball,
     loadRegistryPackageSkillInfo,
 } from "./registry-skill-source.ts";
+import { createSkillIdsTelemetryProperties } from "./telemetry.ts";
 
 interface ManagedSkillPathState {
     exists: boolean;
@@ -93,6 +94,11 @@ export async function installRegistrySkills(
         context,
         request.packageVersion,
     );
+    context.telemetry?.recordProperties({
+        package_kind: "registry",
+        package_name: packageInfo.packageName,
+        ...createSkillIdsTelemetryProperties([]),
+    });
 
     if (packageInfo.skills.length === 0) {
         throw new CliUserError("errors.skills.install.noPublishedSkills", 1, {
@@ -110,6 +116,12 @@ export async function installRegistrySkills(
     if (selectionActions.actions.length === 0) {
         return;
     }
+
+    context.telemetry?.recordProperties(createSkillIdsTelemetryProperties(
+        selectionActions.actions
+            .filter(action => action.type === "install")
+            .map(action => action.skillName),
+    ));
 
     const settingsFilePath = context.settingsStore.getFilePath();
 

--- a/src/application/commands/skills/search.test.ts
+++ b/src/application/commands/skills/search.test.ts
@@ -1,6 +1,7 @@
 import type {
     CliCatalog,
     CliExecutionContext,
+    CliTelemetryPropertyValue,
     Fetcher,
     InteractiveInput,
 } from "../../contracts/cli.ts";
@@ -153,10 +154,35 @@ describe("skillsSearchCommand", () => {
             key: "errors.skillsSearch.invalidResponse",
         });
     });
+
+    test("records search telemetry buckets without the query text", async () => {
+        const telemetryProperties: Record<string, CliTelemetryPropertyValue> = {};
+        const context = createSearchContext({
+            fetcher: async () => new Response(JSON.stringify(fullServerResponse)),
+            telemetryProperties,
+        });
+
+        await searchHandler(
+            {
+                text: "text generation",
+                keywords: "  bar, baz , ,bar  ",
+            },
+            context,
+        );
+
+        expect(telemetryProperties).toEqual({
+            keyword_count_bucket: "1-5",
+            query_length_bucket: "6-20",
+            result_count_bucket: "1-5",
+        });
+        expect(telemetryProperties).not.toHaveProperty("query");
+        expect(telemetryProperties).not.toHaveProperty("text");
+    });
 });
 
 function createSearchContext(options: {
     fetcher: Fetcher;
+    telemetryProperties?: Record<string, CliTelemetryPropertyValue>;
 }): CliExecutionContext & {
     stdoutBuffer: ReturnType<typeof createTextBuffer>;
 } {
@@ -188,6 +214,15 @@ function createSearchContext(options: {
         stdout: stdoutBuffer.writer,
         stdoutBuffer,
         stderr: stderr.writer,
+        telemetry: options.telemetryProperties === undefined
+            ? undefined
+            : {
+                    directoryPath: "",
+                    recordProperties(properties) {
+                        Object.assign(options.telemetryProperties!, properties);
+                    },
+                    suppressCurrentInvocation() {},
+                },
         translator,
         completionRenderer: {
             render: () => "",

--- a/src/application/commands/skills/search.ts
+++ b/src/application/commands/skills/search.ts
@@ -3,6 +3,10 @@ import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/
 import type { TerminalColors } from "../../terminal-colors.ts";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
+import {
+    bucketTelemetryCount,
+    bucketTelemetryStringLength,
+} from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
@@ -73,15 +77,26 @@ export const skillsSearchCommand: CliCommandDefinition<SkillsSearchInput> = {
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
+        const keywords = parseCommaSeparatedKeywords(input.keywords);
+
+        context.telemetry?.recordProperties({
+            keyword_count_bucket: bucketTelemetryCount(keywords.length),
+            query_length_bucket: bucketTelemetryStringLength(input.text),
+        });
+
         const account = await requireCurrentAccount(context);
         const requestUrl = createSkillsSearchRequestUrl(
             account.endpoint,
             input.text,
-            parseCommaSeparatedKeywords(input.keywords),
+            keywords,
         );
         const response = parseSkillsSearchResponse(
             await requestSkillsSearch(requestUrl, account.apiKey, context),
         );
+
+        context.telemetry?.recordProperties({
+            result_count_bucket: bucketTelemetryCount(response.data.length),
+        });
 
         if (input.format === "json") {
             writeJsonOutput(context.stdout, response.data);

--- a/src/application/commands/skills/telemetry.ts
+++ b/src/application/commands/skills/telemetry.ts
@@ -1,0 +1,30 @@
+import type {
+    CliTelemetryPropertyValue,
+} from "../../contracts/cli.ts";
+
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
+
+const telemetrySampleSize = 5;
+
+export function createSkillIdsTelemetryProperties(
+    skillIds: readonly string[],
+): Record<string, CliTelemetryPropertyValue> {
+    return createArrayTelemetryProperties("skill_ids", skillIds);
+}
+
+export function createPackageNamesTelemetryProperties(
+    packageNames: readonly string[],
+): Record<string, CliTelemetryPropertyValue> {
+    return createArrayTelemetryProperties("package_names", packageNames);
+}
+
+function createArrayTelemetryProperties(
+    prefix: string,
+    values: readonly string[],
+): Record<string, CliTelemetryPropertyValue> {
+    return {
+        [`${prefix}_count_bucket`]: bucketTelemetryCount(values.length),
+        [`${prefix}_sample`]: values.slice(0, telemetrySampleSize),
+        [`${prefix}_truncated`]: values.length > telemetrySampleSize,
+    };
+}

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -17,6 +17,10 @@ import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { executeCli } from "../../bootstrap/run-cli.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../../telemetry/outbox.ts";
+import {
     resolveClaudeHomeDirectory,
     resolveCodexHomeDirectory,
     resolveHermesHomeDirectory,
@@ -229,6 +233,21 @@ describe("skills update command", () => {
                     "",
                 ].join("\n"),
             );
+            expect(parseTelemetryRowPayload(
+                readTelemetryRowsForTest(storePaths.telemetryDirectory)[0]!,
+            )).toMatchObject({
+                properties: {
+                    command_full: "skills.update",
+                    package_kind: "registry",
+                    package_name: "openai",
+                    package_names_count_bucket: "1-5",
+                    package_names_sample: ["openai"],
+                    package_names_truncated: false,
+                    skill_ids_count_bucket: "1-5",
+                    skill_ids_sample: ["chatgpt"],
+                    skill_ids_truncated: false,
+                },
+            });
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(codexInstalledSkillDirectoryPath),
                 "utf8",

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -40,6 +40,10 @@ import {
     loadRegistryPackageSkillInfo,
 } from "./registry-skill-source.ts";
 import { isBundledSkillName } from "./shared.ts";
+import {
+    createPackageNamesTelemetryProperties,
+    createSkillIdsTelemetryProperties,
+} from "./telemetry.ts";
 import { SkillsUpdateProgressReporter } from "./update-progress.ts";
 
 interface SkillsUpdateInput {
@@ -143,6 +147,19 @@ export async function updateManagedSkills(
     const unresolvedSkills = selectedSkills.filter(skill =>
         !isBundledSkillName(skill.name) && skill.metadata?.packageName === undefined,
     );
+    const packageNames = registrySkillGroups.map(group => group.packageName);
+    context.telemetry?.recordProperties({
+        package_kind: registrySkillGroups.length > 0 ? "registry" : "unknown",
+        ...createSkillIdsTelemetryProperties(selectedSkills.map(skill => skill.name)),
+        ...createPackageNamesTelemetryProperties(packageNames),
+    });
+
+    if (packageNames.length === 1) {
+        context.telemetry?.recordProperties({
+            package_name: packageNames[0]!,
+        });
+    }
+
     const failures: Error[] = [];
 
     progressReporter?.start();

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -1,0 +1,511 @@
+import type { CliCommandDefinition } from "../contracts/cli.ts";
+
+import { describe, expect, test } from "bun:test";
+import { createCliCommandTelemetryPayload } from "../telemetry/payload.ts";
+import { createCliCatalog } from "./catalog.ts";
+
+type TelemetryDecision
+    = | {
+        kind: "excluded";
+        reason: string;
+    }
+    | {
+        kind: "generic";
+        reason: string;
+    }
+    | {
+        kind: "properties";
+        properties: readonly string[];
+        reason: string;
+    };
+
+const forbiddenTelemetryDecisionProperties = [
+    "$identify",
+    "$set",
+    "$set_once",
+    "account_id",
+    "account_name",
+    "cwd",
+    "email",
+    "error_message",
+    "file_name",
+    "filename",
+    "host",
+    "hostname",
+    "path",
+    "stack",
+    "stack_trace",
+    "url",
+    "url_host",
+    "user_id",
+    "user_name",
+    "username",
+] as const;
+
+const forbiddenTelemetryDecisionPropertySuffixes = [
+    "_account_id",
+    "_account_name",
+    "_api_key",
+    "_cwd",
+    "_email",
+    "_error_message",
+    "_file_name",
+    "_filename",
+    "_host",
+    "_hostname",
+    "_path",
+    "_secret",
+    "_stack",
+    "_stack_trace",
+    "_token",
+    "_url",
+    "_url_host",
+    "_user_id",
+    "_user_name",
+    "_username",
+] as const;
+
+const commandTelemetryDecisions = {
+    "auth": {
+        kind: "generic",
+        reason: "Command group; child commands record command-specific auth dimensions.",
+    },
+    "auth.login": {
+        kind: "properties",
+        properties: ["auth_method", "account_count_bucket"],
+        reason: "Records login method and bounded saved-account count.",
+    },
+    "auth.logout": {
+        kind: "properties",
+        properties: ["account_count_bucket"],
+        reason: "Records bounded saved-account count after logout.",
+    },
+    "auth.status": {
+        kind: "properties",
+        properties: ["account_count_bucket"],
+        reason: "Records bounded saved-account count without account identity.",
+    },
+    "auth.switch": {
+        kind: "properties",
+        properties: ["account_count_bucket"],
+        reason: "Records bounded saved-account count without account identity.",
+    },
+    "check-update": {
+        kind: "properties",
+        properties: ["version_kind", "update_available"],
+        reason: "Records update availability without raw version strings.",
+    },
+    "cloud-task": {
+        kind: "generic",
+        reason: "Command group; child commands record cloud-task dimensions.",
+    },
+    "cloud-task.run": {
+        kind: "properties",
+        properties: ["block_id", "dry_run", "package_name", "package_version"],
+        reason: "Records published artifact identity and execution mode.",
+    },
+    "cloud-task.wait": {
+        kind: "properties",
+        properties: ["final_status", "polled_count_bucket"],
+        reason: "Records terminal status and bounded polling count.",
+    },
+    "cloud-task.result": {
+        kind: "properties",
+        properties: ["final_status"],
+        reason: "Records terminal cloud-task status.",
+    },
+    "cloud-task.log": {
+        kind: "properties",
+        properties: ["log_count_bucket"],
+        reason: "Records bounded returned-log count without task logs.",
+    },
+    "cloud-task.list": {
+        kind: "properties",
+        properties: ["block_id", "package_name", "result_count_bucket"],
+        reason: "Records safe filters and bounded result count.",
+    },
+    "completion": {
+        kind: "properties",
+        properties: ["shell"],
+        reason: "Records selected shell enum.",
+    },
+    "config": {
+        kind: "generic",
+        reason: "Command group; child commands record safe config dimensions where useful.",
+    },
+    "config.get": {
+        kind: "properties",
+        properties: ["config_key"],
+        reason: "Records config key enum without config value.",
+    },
+    "config.list": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; no config values are recorded.",
+    },
+    "config.path": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; no filesystem path is recorded.",
+    },
+    "config.set": {
+        kind: "properties",
+        properties: ["config_key"],
+        reason: "Records config key enum without config value.",
+    },
+    "config.unset": {
+        kind: "properties",
+        properties: ["config_key"],
+        reason: "Records config key enum without config value.",
+    },
+    "connector": {
+        kind: "generic",
+        reason: "Command group; child commands record connector dimensions.",
+    },
+    "connector.run": {
+        kind: "properties",
+        properties: [
+            "action",
+            "data_size_bucket",
+            "dry_run",
+            "error_code",
+            "http_status",
+            "service",
+        ],
+        reason: "Records connector identity and bucketed payload size without payload content.",
+    },
+    "connector.search": {
+        kind: "properties",
+        properties: [
+            "keyword_count_bucket",
+            "query_length_bucket",
+            "result_count_bucket",
+        ],
+        reason: "Records query and result buckets without query text.",
+    },
+    "file": {
+        kind: "generic",
+        reason: "Command group; child commands record file dimensions where safe.",
+    },
+    "file.cleanup": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; file identities are not recorded.",
+    },
+    "file.download": {
+        kind: "properties",
+        properties: ["bytes_total_bucket", "resumed", "url_scheme"],
+        reason: "Records scheme and byte bucket without URL host, path, or filename.",
+    },
+    "file.list": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; file identities are not recorded.",
+    },
+    "file.upload": {
+        kind: "properties",
+        properties: ["bytes_total_bucket", "rejected_too_large"],
+        reason: "Records upload size bucket and rejection state without path or filename.",
+    },
+    "install": {
+        kind: "properties",
+        properties: [
+            "force",
+            "path_modified",
+            "update_available",
+            "version_kind",
+        ],
+        reason: "Records self-update state without raw version strings.",
+    },
+    "log": {
+        kind: "generic",
+        reason: "Command group; log paths and log contents must not be recorded.",
+    },
+    "log.path": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; log path output is not recorded.",
+    },
+    "log.print": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; log contents are not recorded.",
+    },
+    "login": {
+        kind: "properties",
+        properties: ["auth_method", "account_count_bucket"],
+        reason: "Top-level auth alias records the same safe auth dimensions as auth.login.",
+    },
+    "logout": {
+        kind: "properties",
+        properties: ["account_count_bucket"],
+        reason: "Top-level auth alias records the same safe auth dimensions as auth.logout.",
+    },
+    "packages": {
+        kind: "generic",
+        reason: "Command group; child commands record package dimensions.",
+    },
+    "packages.info": {
+        kind: "properties",
+        properties: ["package_name", "package_version"],
+        reason: "Records published package artifact identity.",
+    },
+    "packages.search": {
+        kind: "properties",
+        properties: ["query_length_bucket", "result_count_bucket"],
+        reason: "Records query and result buckets without query text.",
+    },
+    "search": {
+        kind: "properties",
+        properties: [
+            "keyword_count_bucket",
+            "query_length_bucket",
+            "result_count_bucket",
+        ],
+        reason: "Records query and result buckets without query text.",
+    },
+    "skills": {
+        kind: "generic",
+        reason: "Command group; child commands record skill dimensions where safe.",
+    },
+    "skills.init": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; local skill content is not recorded.",
+    },
+    "skills.install": {
+        kind: "properties",
+        properties: [
+            "bundled_skill",
+            "package_kind",
+            "package_name",
+            "skill_ids_count_bucket",
+            "skill_ids_sample",
+            "skill_ids_truncated",
+        ],
+        reason: "Records artifact identity and bounded skill samples.",
+    },
+    "skills.list": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; installed skill inventory is not recorded.",
+    },
+    "skills.preflight": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; local paths are not recorded.",
+    },
+    "skills.publish": {
+        kind: "properties",
+        properties: [
+            "adopted",
+            "package_name",
+            "skill_id",
+            "source_kind",
+            "visibility",
+        ],
+        reason: "Records published skill artifact identity and publication mode.",
+    },
+    "skills.search": {
+        kind: "properties",
+        properties: [
+            "keyword_count_bucket",
+            "query_length_bucket",
+            "result_count_bucket",
+        ],
+        reason: "Records query and result buckets without query text.",
+    },
+    "skills.sync": {
+        kind: "generic",
+        reason: "Command group; sync children do not record local file paths.",
+    },
+    "skills.sync.apply": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; sync source paths are not recorded.",
+    },
+    "skills.sync.upload": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; sync source paths are not recorded.",
+    },
+    "skills.uninstall": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; local uninstall paths are not recorded.",
+    },
+    "skills.update": {
+        kind: "properties",
+        properties: [
+            "package_kind",
+            "package_name",
+            "package_names_count_bucket",
+            "package_names_sample",
+            "package_names_truncated",
+            "skill_ids_count_bucket",
+            "skill_ids_sample",
+            "skill_ids_truncated",
+        ],
+        reason: "Records artifact identity and bounded skill/package samples.",
+    },
+    "skills.validate": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; local validation path is not recorded.",
+    },
+    "telemetry": {
+        kind: "excluded",
+        reason: "Telemetry control commands must not observe themselves.",
+    },
+    "telemetry.disable": {
+        kind: "excluded",
+        reason: "Disabling telemetry must not emit a farewell event.",
+    },
+    "telemetry.enable": {
+        kind: "excluded",
+        reason: "Telemetry control commands must not observe themselves.",
+    },
+    "telemetry.status": {
+        kind: "excluded",
+        reason: "Status must not change pending telemetry counts.",
+    },
+    "update": {
+        kind: "properties",
+        properties: [
+            "force",
+            "path_modified",
+            "update_available",
+            "version_kind",
+        ],
+        reason: "Records self-update state without raw version strings.",
+    },
+} as const satisfies Record<string, TelemetryDecision>;
+
+describe("command telemetry decisions", () => {
+    test("covers every registered command with an explicit telemetry decision", () => {
+        const commandPaths = collectCommandPaths(createCliCatalog().commands);
+        const actualPaths = commandPaths.map(command => command.path).sort();
+        const decisionPaths = Object.keys(commandTelemetryDecisions).sort();
+
+        expect(decisionPaths).toEqual(actualPaths);
+    });
+
+    test("keeps exclusion metadata aligned with telemetry decisions", () => {
+        const commandPaths = collectCommandPaths(createCliCatalog().commands);
+
+        for (const command of commandPaths) {
+            const decision = commandTelemetryDecisions[command.path];
+
+            expect(decision).toBeDefined();
+            expect(command.definition.excludeFromTelemetry === true).toBe(
+                decision?.kind === "excluded",
+            );
+        }
+    });
+
+    test("documents command-specific telemetry properties when a command needs them", () => {
+        for (const [path, decision] of Object.entries(commandTelemetryDecisions)) {
+            if (decision.kind !== "properties") {
+                continue;
+            }
+
+            expect(
+                decision.properties.length,
+                `${path} should document at least one telemetry property.`,
+            ).toBeGreaterThan(0);
+        }
+    });
+
+    test("keeps command telemetry decision properties privacy-safe", () => {
+        const baseTelemetryPropertyNames = createBaseTelemetryPropertyNames();
+
+        for (const [path, decision] of Object.entries(commandTelemetryDecisions)) {
+            if (decision.kind !== "properties") {
+                continue;
+            }
+
+            for (const property of decision.properties) {
+                const forbiddenReason = readForbiddenTelemetryDecisionPropertyReason(
+                    property,
+                    baseTelemetryPropertyNames,
+                );
+
+                expect(
+                    forbiddenReason,
+                    `${path} must not document unsafe telemetry property ${property}.`,
+                ).toBeUndefined();
+            }
+        }
+    });
+});
+
+function collectCommandPaths(
+    commands: readonly CliCommandDefinition[],
+    parentPath: readonly string[] = [],
+): { definition: CliCommandDefinition; path: keyof typeof commandTelemetryDecisions }[] {
+    const paths: { definition: CliCommandDefinition; path: keyof typeof commandTelemetryDecisions }[] = [];
+
+    for (const command of commands) {
+        const commandPath = [...parentPath, command.name];
+        const path = commandPath.join(".") as keyof typeof commandTelemetryDecisions;
+
+        paths.push({
+            definition: command,
+            path,
+        });
+        paths.push(...collectCommandPaths(command.children ?? [], commandPath));
+    }
+
+    return paths;
+}
+
+function readForbiddenTelemetryDecisionPropertyReason(
+    property: string,
+    baseTelemetryPropertyNames: ReadonlySet<string>,
+): string | undefined {
+    if (baseTelemetryPropertyNames.has(property)) {
+        return "base telemetry property";
+    }
+
+    if (
+        forbiddenTelemetryDecisionProperties.includes(
+            property as typeof forbiddenTelemetryDecisionProperties[number],
+        )
+    ) {
+        return "forbidden telemetry property";
+    }
+
+    for (const suffix of forbiddenTelemetryDecisionPropertySuffixes) {
+        if (property.endsWith(suffix)) {
+            return `forbidden telemetry property suffix ${suffix}`;
+        }
+    }
+
+    return undefined;
+}
+
+function createBaseTelemetryPropertyNames(): ReadonlySet<string> {
+    const item = createCliCommandTelemetryPayload({
+        accountState: "authenticated",
+        arch: "arm64",
+        ciName: "github_actions",
+        cliCommit: "test-commit",
+        cliInstallMethod: "native",
+        cliVersion: "1.0.0",
+        command: {
+            argCount: 1,
+            commandAction: "list",
+            commandFull: "config.list",
+            commandGroup: "config",
+            flagsCount: 1,
+            outputFormat: "json",
+            parseErrorKind: "unknown_option",
+        },
+        distinctId: "019a0cca-0000-7000-8000-000000000001",
+        durationMs: 12,
+        isCi: true,
+        isFirstRun: false,
+        isTtyStderr: false,
+        isTtyStdout: false,
+        lang: "en",
+        os: "darwin",
+        osVersion: "25.0.0",
+        outcome: {
+            errorKey: "errors.fileDownload.requestFailed",
+            exitCode: 1,
+        },
+        runtimeVersion: "1.2.3",
+        sessionId: "019a0ccb-1111-7222-8333-444444444444",
+        timestamp: new Date("2026-01-01T00:00:00.000Z"),
+        uuid: "019a0ccb-408c-728a-9df9-1ef51b742b36",
+    });
+
+    return new Set(Object.keys(item.properties));
+}

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -102,7 +102,7 @@ const commandTelemetryDecisions = {
     "cloud-task.run": {
         kind: "properties",
         properties: ["block_id", "dry_run", "package_name", "package_version"],
-        reason: "Records published artifact identity and execution mode.",
+        reason: "Records product-domain package, version, and block dimensions for usage analytics.",
     },
     "cloud-task.wait": {
         kind: "properties",
@@ -122,7 +122,7 @@ const commandTelemetryDecisions = {
     "cloud-task.list": {
         kind: "properties",
         properties: ["block_id", "package_name", "result_count_bucket"],
-        reason: "Records safe filters and bounded result count.",
+        reason: "Records product-domain filter dimensions and bounded result count.",
     },
     "completion": {
         kind: "properties",
@@ -170,7 +170,7 @@ const commandTelemetryDecisions = {
             "http_status",
             "service",
         ],
-        reason: "Records connector identity and bucketed payload size without payload content.",
+        reason: "Records connector product dimensions, bucketed payload size, and stable error code.",
     },
     "connector.search": {
         kind: "properties",
@@ -242,7 +242,7 @@ const commandTelemetryDecisions = {
     "packages.info": {
         kind: "properties",
         properties: ["package_name", "package_version"],
-        reason: "Records published package artifact identity.",
+        reason: "Records product-domain package and version dimensions for usage analytics.",
     },
     "packages.search": {
         kind: "properties",
@@ -276,7 +276,7 @@ const commandTelemetryDecisions = {
             "skill_ids_sample",
             "skill_ids_truncated",
         ],
-        reason: "Records artifact identity and bounded skill samples.",
+        reason: "Records install source, product-domain package dimension, and bounded skill samples.",
     },
     "skills.list": {
         kind: "generic",
@@ -295,7 +295,7 @@ const commandTelemetryDecisions = {
             "source_kind",
             "visibility",
         ],
-        reason: "Records published skill artifact identity and publication mode.",
+        reason: "Records publication mode plus product-domain package and skill dimensions.",
     },
     "skills.search": {
         kind: "properties",

--- a/src/application/commands/telemetry/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/telemetry/__snapshots__/index.cli.test.ts.snap
@@ -1,0 +1,103 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`telemetry CLI shows default status without creating a device id or telemetry event 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"enabled: true
+device_id: none
+pending: 0
+last_flush: none
+"
+,
+}
+`;
+
+exports[`telemetry CLI supports telemetry enable and disable commands 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Telemetry disabled.
+"
+,
+}
+`;
+
+exports[`telemetry CLI supports telemetry enable and disable commands 2`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Telemetry enabled.
+"
+,
+}
+`;
+
+exports[`telemetry CLI supports telemetry.enabled through config commands 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Set telemetry.enabled to false.
+"
+,
+}
+`;
+
+exports[`telemetry CLI supports telemetry.enabled through config commands 2`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"false
+"
+,
+}
+`;
+
+exports[`telemetry CLI supports telemetry.enabled through config commands 3`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"telemetry.enabled=false
+"
+,
+}
+`;
+
+exports[`telemetry CLI supports telemetry.enabled through config commands 4`] = `
+{
+  "exitCode": 2,
+  "stderr": 
+"Invalid telemetry.enabled value: True. Use true or false.
+"
+,
+  "stdout": "",
+}
+`;
+
+exports[`telemetry CLI supports telemetry.enabled through config commands 5`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Set telemetry.enabled to true.
+"
+,
+}
+`;
+
+exports[`telemetry CLI supports telemetry.enabled through config commands 6`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Removed telemetry.enabled.
+"
+,
+}
+`;

--- a/src/application/commands/telemetry/disable.ts
+++ b/src/application/commands/telemetry/disable.ts
@@ -1,0 +1,25 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import { setTelemetryEnabled } from "../../schemas/settings.ts";
+import { disableTelemetryForCurrentInvocation } from "../../telemetry/control.ts";
+import { writeLine } from "../shared/output.ts";
+
+export const telemetryDisableCommand: CliCommandDefinition = {
+    name: "disable",
+    excludeFromTelemetry: true,
+    summaryKey: "commands.telemetry.disable.summary",
+    descriptionKey: "commands.telemetry.disable.description",
+    inputSchema: z.object({}),
+    handler: async (_, context) => {
+        await context.settingsStore.update(
+            settings => setTelemetryEnabled(settings, false),
+        );
+        disableTelemetryForCurrentInvocation(context);
+
+        writeLine(
+            context.stdout,
+            context.translator.t("telemetry.disable.success"),
+        );
+    },
+};

--- a/src/application/commands/telemetry/enable.ts
+++ b/src/application/commands/telemetry/enable.ts
@@ -1,0 +1,23 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import { setTelemetryEnabled } from "../../schemas/settings.ts";
+import { writeLine } from "../shared/output.ts";
+
+export const telemetryEnableCommand: CliCommandDefinition = {
+    name: "enable",
+    excludeFromTelemetry: true,
+    summaryKey: "commands.telemetry.enable.summary",
+    descriptionKey: "commands.telemetry.enable.description",
+    inputSchema: z.object({}),
+    handler: async (_, context) => {
+        await context.settingsStore.update(
+            settings => setTelemetryEnabled(settings, true),
+        );
+
+        writeLine(
+            context.stdout,
+            context.translator.t("telemetry.enable.success"),
+        );
+    },
+};

--- a/src/application/commands/telemetry/index.cli.test.ts
+++ b/src/application/commands/telemetry/index.cli.test.ts
@@ -1,0 +1,934 @@
+import { chmod, mkdir, truncate } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+import {
+    createCliSandbox,
+    createCliSnapshot,
+    writeAuthFile,
+} from "../../../../__tests__/helpers.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import { createTelemetryItemForTest } from "../../telemetry/__tests__/helpers.ts";
+import {
+    telemetryDatabaseMaxBytes,
+    telemetrySpawnIntervalMs,
+    telemetrySpawnThresholdEvents,
+} from "../../telemetry/constants.ts";
+import {
+    closeTelemetryDatabase,
+    enqueueTelemetryBatchItem,
+    leaseReadyTelemetryRows,
+    openTelemetryDatabase,
+    parseTelemetryRowPayload,
+    readOrCreateTelemetryDeviceId,
+    readTelemetryDeviceIdIfExists,
+    readTelemetryRowsForTest,
+    readTelemetryStateNumber,
+    resolveTelemetryDatabaseFilePath,
+    writeTelemetryStateNumber,
+} from "../../telemetry/outbox.ts";
+
+const posixTest = process.platform === "win32" ? test.skip : test;
+
+describe("telemetry CLI", () => {
+    test("shows default status without creating a device id or telemetry event", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["telemetry", "status"]);
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+            expect(result.stdout).toContain("enabled: true");
+            expect(result.stdout).toContain("device_id: none");
+            expect(result.stdout).toContain("pending: 0");
+            expect(readTelemetryRowsForTest(telemetryDirectoryPath)).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("shows the last successful flush timestamp", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+            const lastFlushAtMs = Date.UTC(2026, 0, 2, 3, 4, 5, 678);
+            const database = openTelemetryDatabase(telemetryDirectoryPath);
+
+            try {
+                writeTelemetryStateNumber(
+                    database,
+                    "last_flush_at_ms",
+                    lastFlushAtMs,
+                );
+            }
+            finally {
+                closeTelemetryDatabase(database);
+            }
+
+            const status = await sandbox.run(["telemetry", "status"]);
+
+            expect(status.exitCode).toBe(0);
+            expect(status.stdout).toContain("pending: 0");
+            expect(status.stdout).toContain("last_flush: 2026-01-02T03:04:05.678Z");
+            expect(readTelemetryRowsForTest(telemetryDirectoryPath)).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("records generic command telemetry in the outbox", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["config", "list"]);
+            const rows = readTelemetryRowsForTest(
+                resolveSandboxTelemetryDirectory(sandbox),
+            );
+            const payload = parseTelemetryRowPayload(rows[0]!);
+
+            expect(result.exitCode).toBe(0);
+            expect(rows).toHaveLength(1);
+            expect(payload).toMatchObject({
+                event: "cli_command_executed",
+                properties: {
+                    $geoip_disable: true,
+                    $ip: "",
+                    $process_person_profile: false,
+                    account_state: "anonymous",
+                    ci_name: "none",
+                    command_action: "list",
+                    command_full: "config.list",
+                    command_group: "config",
+                    distinct_id: expect.any(String),
+                    exit_code: 0,
+                    is_ci: false,
+                    success: true,
+                },
+            });
+            expect(payload).not.toHaveProperty("distinct_id");
+            expect(payload?.properties).not.toHaveProperty("$set");
+            expect(payload?.properties).not.toHaveProperty("$identify");
+            expect(payload?.properties).not.toHaveProperty("user_id");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("records CI environment without changing device-level identity", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            sandbox.env.GITHUB_ACTIONS = "true";
+
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+            const command = await sandbox.run(["config", "list"]);
+            const rows = readTelemetryRowsForTest(telemetryDirectoryPath);
+            const payload = parseTelemetryRowPayload(rows[0]!);
+            const deviceId = await readTelemetryDeviceIdIfExists(
+                telemetryDirectoryPath,
+            );
+
+            expect(command.exitCode).toBe(0);
+            expect(payload).toMatchObject({
+                properties: {
+                    ci_name: "github_actions",
+                    is_ci: true,
+                },
+            });
+            expect(payload?.properties.distinct_id).toBe(deviceId);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("records authenticated account state without account identity", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox, {
+                accounts: [
+                    {
+                        apiKey: "private-auth-token",
+                        endpoint: "private.example.internal",
+                        id: "private-account-id",
+                        name: "Private Account Name",
+                    },
+                ],
+            });
+
+            const command = await sandbox.run(["config", "list"]);
+            const rows = readTelemetryRowsForTest(
+                resolveSandboxTelemetryDirectory(sandbox),
+            );
+            const payload = parseTelemetryRowPayload(rows[0]!);
+            const serializedPayload = JSON.stringify(payload);
+
+            expect(command.exitCode).toBe(0);
+            expect(payload).toMatchObject({
+                properties: {
+                    account_state: "authenticated",
+                },
+            });
+            expect(payload?.properties).not.toHaveProperty("account_id");
+            expect(payload?.properties).not.toHaveProperty("account_name");
+            expect(payload?.properties).not.toHaveProperty("user_id");
+            expect(serializedPayload).not.toContain("private-account-id");
+            expect(serializedPayload).not.toContain("Private Account Name");
+            expect(serializedPayload).not.toContain("private-auth-token");
+            expect(serializedPayload).not.toContain("private.example.internal");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("records safe command-specific telemetry properties", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+
+            const config = await sandbox.run(["config", "set", "lang", "en"]);
+            const completion = await sandbox.run(["completion", "bash"]);
+            const rows = readTelemetryRowsForTest(telemetryDirectoryPath);
+            const payloads = rows.map(row => parseTelemetryRowPayload(row));
+
+            expect(config.exitCode).toBe(0);
+            expect(completion.exitCode).toBe(0);
+            expect(payloads).toMatchObject([
+                {
+                    properties: {
+                        command_full: "config.set",
+                        config_key: "lang",
+                    },
+                },
+                {
+                    properties: {
+                        command_full: "completion",
+                        shell: "bash",
+                    },
+                },
+            ]);
+            expect(payloads[0]?.properties).not.toHaveProperty("value");
+            expect(payloads[0]?.properties).not.toHaveProperty("config_value");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("records safe auth telemetry properties without account identity", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+
+            const authStatus = await sandbox.run(["auth", "status"]);
+            const rows = readTelemetryRowsForTest(telemetryDirectoryPath);
+            const payload = parseTelemetryRowPayload(rows[0]!);
+
+            expect(authStatus.exitCode).toBe(0);
+            expect(payload).toMatchObject({
+                properties: {
+                    account_count_bucket: "0",
+                    command_full: "auth.status",
+                },
+            });
+            expect(payload?.properties).not.toHaveProperty("account_id");
+            expect(payload?.properties).not.toHaveProperty("account_name");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not record telemetry commands themselves", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+
+            await sandbox.run(["config", "list"]);
+            const beforeRows = readTelemetryRowsForTest(telemetryDirectoryPath);
+            const status = await sandbox.run(["telemetry", "status"]);
+            const afterRows = readTelemetryRowsForTest(telemetryDirectoryPath);
+
+            expect(status.stdout).toContain(`pending: ${beforeRows.length}`);
+            expect(afterRows).toHaveLength(beforeRows.length);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports telemetry enable and disable commands", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+            const deviceId = await readOrCreateTelemetryDeviceId(
+                telemetryDirectoryPath,
+            );
+
+            await sandbox.run(["config", "list"]);
+            expect(readTelemetryRowsForTest(telemetryDirectoryPath)).toHaveLength(1);
+
+            const disable = await sandbox.run(["telemetry", "disable"]);
+            const disabledStatus = await sandbox.run(["telemetry", "status"]);
+            const enable = await sandbox.run(["telemetry", "enable"]);
+            const enabledStatus = await sandbox.run(["telemetry", "status"]);
+
+            expect(createCliSnapshot(disable)).toMatchSnapshot();
+            expect(createCliSnapshot(enable)).toMatchSnapshot();
+            expect(readTelemetryRowsForTest(telemetryDirectoryPath)).toEqual([]);
+            expect(await readTelemetryDeviceIdIfExists(telemetryDirectoryPath)).toBe(
+                deviceId.deviceId,
+            );
+            expect(disabledStatus.stdout).toContain("enabled: false (config)");
+            expect(enabledStatus.stdout).toContain("enabled: true");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports telemetry.enabled through config commands", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+
+            await sandbox.run(["config", "list"]);
+            const setFalse = await sandbox.run([
+                "config",
+                "set",
+                "telemetry.enabled",
+                "false",
+            ]);
+            const rowsAfterSetFalse = readTelemetryRowsForTest(
+                telemetryDirectoryPath,
+            );
+            const getFalse = await sandbox.run([
+                "config",
+                "get",
+                "telemetry.enabled",
+            ]);
+            const listFalse = await sandbox.run(["config", "list"]);
+            const invalid = await sandbox.run([
+                "config",
+                "set",
+                "telemetry.enabled",
+                "True",
+            ]);
+            const invalidNumber = await sandbox.run([
+                "config",
+                "set",
+                "telemetry.enabled",
+                "1",
+            ]);
+            const invalidWord = await sandbox.run([
+                "config",
+                "set",
+                "telemetry.enabled",
+                "yes",
+            ]);
+            const setTrue = await sandbox.run([
+                "config",
+                "set",
+                "telemetry.enabled",
+                "true",
+            ]);
+            const unset = await sandbox.run([
+                "config",
+                "unset",
+                "telemetry.enabled",
+            ]);
+            const getUnset = await sandbox.run([
+                "config",
+                "get",
+                "telemetry.enabled",
+            ]);
+            const listUnset = await sandbox.run(["config", "list"]);
+
+            expect(createCliSnapshot(setFalse)).toMatchSnapshot();
+            expect(createCliSnapshot(getFalse)).toMatchSnapshot();
+            expect(createCliSnapshot(listFalse)).toMatchSnapshot();
+            expect(createCliSnapshot(invalid)).toMatchSnapshot();
+            expect(createCliSnapshot(setTrue)).toMatchSnapshot();
+            expect(createCliSnapshot(unset)).toMatchSnapshot();
+            expect(rowsAfterSetFalse).toEqual([]);
+            expect(getFalse.stdout).toBe("false\n");
+            expect(getUnset.stdout).toBe("");
+            expect(listUnset.stdout).not.toContain("telemetry.enabled=");
+            expect(listFalse.stdout).toContain("telemetry.enabled=false");
+            expect(invalid.stderr).toContain("Invalid telemetry.enabled value");
+            expect(invalidNumber.stderr).toContain("Invalid telemetry.enabled value");
+            expect(invalidWord.stderr).toContain("Invalid telemetry.enabled value");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not purge pending telemetry when telemetry is enabled or unset", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+
+            enqueueTelemetryBatchItem({
+                directoryPath: telemetryDirectoryPath,
+                item: createTelemetryItemForTest(1),
+                nowMs: 1,
+            });
+            const initialRowId = readTelemetryRowsForTest(telemetryDirectoryPath)[0]!
+                .id;
+
+            const enable = await sandbox.run(["telemetry", "enable"]);
+            const rowsAfterEnable = readTelemetryRowsForTest(telemetryDirectoryPath);
+            const setTrue = await sandbox.run([
+                "config",
+                "set",
+                "telemetry.enabled",
+                "true",
+            ]);
+            const rowsAfterSetTrue = readTelemetryRowsForTest(telemetryDirectoryPath);
+            const unset = await sandbox.run([
+                "config",
+                "unset",
+                "telemetry.enabled",
+            ]);
+            const rowsAfterUnset = readTelemetryRowsForTest(telemetryDirectoryPath);
+
+            expect(enable.exitCode).toBe(0);
+            expect(setTrue.exitCode).toBe(0);
+            expect(unset.exitCode).toBe(0);
+            expect(rowsAfterEnable.map(row => row.id)).toContain(initialRowId);
+            expect(rowsAfterSetTrue.map(row => row.id)).toContain(initialRowId);
+            expect(rowsAfterUnset.map(row => row.id)).toContain(initialRowId);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("purges leased pending telemetry when disabled through config", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+
+            enqueueTelemetryBatchItem({
+                directoryPath: telemetryDirectoryPath,
+                item: createTelemetryItemForTest(1),
+                nowMs: 1,
+            });
+
+            const database = openTelemetryDatabase(telemetryDirectoryPath);
+
+            try {
+                expect(leaseReadyTelemetryRows(database, Date.now())).toHaveLength(1);
+            }
+            finally {
+                closeTelemetryDatabase(database);
+            }
+
+            const disable = await sandbox.run([
+                "config",
+                "set",
+                "telemetry.enabled",
+                "false",
+            ]);
+
+            expect(disable.exitCode).toBe(0);
+            expect(readTelemetryRowsForTest(telemetryDirectoryPath)).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("keeps disable commands successful when the telemetry outbox is locked", async () => {
+        const cases = [
+            ["telemetry", "disable"],
+            ["config", "set", "telemetry.enabled", "false"],
+        ] as const;
+
+        for (const argv of cases) {
+            const sandbox = await createCliSandbox();
+
+            try {
+                const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+
+                enqueueTelemetryBatchItem({
+                    directoryPath: telemetryDirectoryPath,
+                    item: createTelemetryItemForTest(1),
+                    nowMs: 1,
+                });
+
+                const database = openTelemetryDatabase(telemetryDirectoryPath);
+
+                try {
+                    database.run("BEGIN IMMEDIATE");
+
+                    const disable = await sandbox.run([...argv]);
+
+                    expect(disable.exitCode).toBe(0);
+                    expect(disable.stderr).toBe("");
+                }
+                finally {
+                    database.run("ROLLBACK");
+                    closeTelemetryDatabase(database);
+                }
+
+                const status = await sandbox.run(["telemetry", "status"]);
+
+                expect(status.stdout).toContain("enabled: false (config)");
+                expect(status.stdout).toContain("pending: 1");
+                expect(readTelemetryRowsForTest(telemetryDirectoryPath)).toHaveLength(1);
+            }
+            finally {
+                await sandbox.cleanup();
+            }
+        }
+    });
+
+    test("honors environment opt-out", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            sandbox.env.OO_TELEMETRY_DISABLED = "1";
+
+            const command = await sandbox.run(["config", "list"]);
+            const status = await sandbox.run(["telemetry", "status"]);
+
+            expect(command.exitCode).toBe(0);
+            expect(status.stdout).toContain("enabled: false (env)");
+            expect(readTelemetryRowsForTest(
+                resolveSandboxTelemetryDirectory(sandbox),
+            )).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("honors do-not-track opt-out", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            sandbox.env.DO_NOT_TRACK = "1";
+
+            const command = await sandbox.run(["config", "list"]);
+            const status = await sandbox.run(["telemetry", "status"]);
+
+            expect(command.exitCode).toBe(0);
+            expect(status.stdout).toContain("enabled: false (env)");
+            expect(readTelemetryRowsForTest(
+                resolveSandboxTelemetryDirectory(sandbox),
+            )).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("honors documented telemetry opt-out truthy values", async () => {
+        const cases = [
+            {
+                envKey: "OO_TELEMETRY_DISABLED",
+                envValue: "true",
+            },
+            {
+                envKey: "OO_TELEMETRY_DISABLED",
+                envValue: "ON",
+            },
+            {
+                envKey: "DO_NOT_TRACK",
+                envValue: " yes ",
+            },
+        ] as const;
+
+        for (const testCase of cases) {
+            const sandbox = await createCliSandbox();
+
+            try {
+                sandbox.env[testCase.envKey] = testCase.envValue;
+
+                const command = await sandbox.run(["config", "list"]);
+                const status = await sandbox.run(["telemetry", "status"]);
+
+                expect(command.exitCode).toBe(0);
+                expect(status.stdout).toContain("enabled: false (env)");
+                expect(readTelemetryRowsForTest(
+                    resolveSandboxTelemetryDirectory(sandbox),
+                )).toEqual([]);
+            }
+            finally {
+                await sandbox.cleanup();
+            }
+        }
+    });
+
+    test("counts leased rows as pending telemetry", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+
+            await sandbox.run(["config", "list"]);
+
+            const database = openTelemetryDatabase(telemetryDirectoryPath);
+
+            try {
+                expect(leaseReadyTelemetryRows(database, Date.now())).toHaveLength(1);
+            }
+            finally {
+                closeTelemetryDatabase(database);
+            }
+
+            const status = await sandbox.run(["telemetry", "status"]);
+
+            expect(status.stdout).toContain("pending: 1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("keeps commands successful when the telemetry database is locked", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+            const database = openTelemetryDatabase(telemetryDirectoryPath);
+
+            try {
+                database.run("BEGIN IMMEDIATE");
+
+                const command = await sandbox.run(["config", "list"]);
+
+                expect(command.exitCode).toBe(0);
+                expect(command.stderr).toBe("");
+            }
+            finally {
+                database.run("ROLLBACK");
+                closeTelemetryDatabase(database);
+            }
+
+            expect(readTelemetryRowsForTest(telemetryDirectoryPath)).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("keeps commands successful when the telemetry database is corrupt", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+
+            await mkdir(telemetryDirectoryPath, { recursive: true });
+            await Bun.write(
+                resolveTelemetryDatabaseFilePath(telemetryDirectoryPath),
+                "not sqlite",
+            );
+
+            const command = await sandbox.run(["config", "list"]);
+
+            expect(command.exitCode).toBe(0);
+            expect(command.stderr).toBe("");
+            expect(readTelemetryRowsForTest(telemetryDirectoryPath)).toHaveLength(1);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("drops telemetry without affecting commands when the outbox is over the hard limit", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+            const databaseFilePath = resolveTelemetryDatabaseFilePath(
+                telemetryDirectoryPath,
+            );
+
+            await mkdir(telemetryDirectoryPath, { recursive: true });
+            await Bun.write(databaseFilePath, "");
+            await truncate(databaseFilePath, telemetryDatabaseMaxBytes);
+
+            const command = await sandbox.run(["config", "list"]);
+
+            expect(command.exitCode).toBe(0);
+            expect(command.stderr).toBe("");
+            expect(readTelemetryRowsForTest(telemetryDirectoryPath)).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    posixTest("defers flusher spawn while the outbox is below threshold", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+            const markerPath = join(sandbox.cwd, "spawn-marker");
+            const execPath = join(sandbox.cwd, "spawn-recorder");
+
+            await writeTelemetrySpawnRecorder(execPath);
+            sandbox.env.OO_TEST_TELEMETRY_SPAWN_MARKER = markerPath;
+
+            const command = await sandbox.run(["config", "list"], { execPath });
+            const database = openTelemetryDatabase(telemetryDirectoryPath);
+
+            try {
+                expect(command.exitCode).toBe(0);
+                expect(readTelemetryStateNumber(
+                    database,
+                    "next_spawn_after_ms",
+                )).toBeUndefined();
+            }
+            finally {
+                closeTelemetryDatabase(database);
+            }
+
+            await Bun.sleep(50);
+            expect(await Bun.file(markerPath).exists()).toBeFalse();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    posixTest("spawns the flusher when the outbox crosses the threshold after a deferred command", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+            const markerPath = join(sandbox.cwd, "spawn-marker");
+            const execPath = join(sandbox.cwd, "spawn-recorder");
+
+            await writeTelemetrySpawnRecorder(execPath);
+            sandbox.env.OO_TEST_TELEMETRY_SPAWN_MARKER = markerPath;
+
+            const deferredCommand = await sandbox.run(["config", "list"], { execPath });
+
+            await Bun.sleep(50);
+            expect(deferredCommand.exitCode).toBe(0);
+            expect(await Bun.file(markerPath).exists()).toBeFalse();
+
+            for (let index = 0; index < telemetrySpawnThresholdEvents - 1; index += 1) {
+                enqueueTelemetryBatchItem({
+                    directoryPath: telemetryDirectoryPath,
+                    item: createTelemetryItemForTest(index),
+                    nowMs: index + 1,
+                });
+            }
+
+            const thresholdCommand = await sandbox.run(["config", "path"], { execPath });
+            const nextDatabase = openTelemetryDatabase(telemetryDirectoryPath);
+
+            try {
+                expect(thresholdCommand.exitCode).toBe(0);
+                expect(readTelemetryStateNumber(
+                    nextDatabase,
+                    "next_spawn_after_ms",
+                )).toBeDefined();
+                expect(await waitForFile(markerPath)).toBeTrue();
+            }
+            finally {
+                closeTelemetryDatabase(nextDatabase);
+            }
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    posixTest("spawns the flusher when the outbox reaches threshold", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+            const markerPath = join(sandbox.cwd, "spawn-marker");
+            const execPath = join(sandbox.cwd, "spawn-recorder");
+
+            await writeTelemetrySpawnRecorder(execPath);
+            sandbox.env.OO_TEST_TELEMETRY_SPAWN_MARKER = markerPath;
+
+            for (let index = 0; index < telemetrySpawnThresholdEvents - 1; index += 1) {
+                enqueueTelemetryBatchItem({
+                    directoryPath: telemetryDirectoryPath,
+                    item: createTelemetryItemForTest(index),
+                    nowMs: index + 1,
+                });
+            }
+
+            const startedAtMs = Date.now();
+            const command = await sandbox.run(["config", "list"], { execPath });
+            const nextDatabase = openTelemetryDatabase(telemetryDirectoryPath);
+
+            try {
+                const nextSpawnAfterMs = readTelemetryStateNumber(
+                    nextDatabase,
+                    "next_spawn_after_ms",
+                );
+
+                expect(command.exitCode).toBe(0);
+                expect(nextSpawnAfterMs).toBeGreaterThanOrEqual(
+                    startedAtMs + telemetrySpawnIntervalMs,
+                );
+                expect(nextSpawnAfterMs).toBeLessThanOrEqual(
+                    Date.now() + telemetrySpawnIntervalMs,
+                );
+                expect(await waitForFile(markerPath)).toBeTrue();
+            }
+            finally {
+                closeTelemetryDatabase(nextDatabase);
+            }
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    posixTest("does not repeatedly spawn the flusher across one hundred instant version commands", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+            const markerPath = join(sandbox.cwd, "spawn-marker");
+            const execPath = join(sandbox.cwd, "spawn-recorder");
+
+            await writeTelemetrySpawnCountingRecorder(execPath);
+            sandbox.env.OO_TEST_TELEMETRY_SPAWN_MARKER = markerPath;
+
+            for (let index = 0; index < 100; index += 1) {
+                const command = await sandbox.run(["--version"], { execPath });
+
+                expect(command.exitCode).toBe(0);
+            }
+
+            await Bun.sleep(50);
+
+            expect(readTelemetryRowsForTest(telemetryDirectoryPath)).toHaveLength(100);
+            expect(await readSpawnRecordCount(markerPath)).toBeLessThanOrEqual(1);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("respects flusher spawn backoff even when the outbox is over threshold", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const telemetryDirectoryPath = resolveSandboxTelemetryDirectory(sandbox);
+            const futureSpawnAfterMs = Date.now() + 24 * 60 * 60 * 1000;
+
+            for (let index = 0; index < telemetrySpawnThresholdEvents; index += 1) {
+                enqueueTelemetryBatchItem({
+                    directoryPath: telemetryDirectoryPath,
+                    item: createTelemetryItemForTest(index),
+                    nowMs: index + 1,
+                });
+            }
+
+            const database = openTelemetryDatabase(telemetryDirectoryPath);
+
+            try {
+                writeTelemetryStateNumber(
+                    database,
+                    "next_spawn_after_ms",
+                    futureSpawnAfterMs,
+                );
+            }
+            finally {
+                closeTelemetryDatabase(database);
+            }
+
+            const command = await sandbox.run(["config", "list"]);
+            const nextDatabase = openTelemetryDatabase(telemetryDirectoryPath);
+
+            try {
+                expect(command.exitCode).toBe(0);
+                expect(readTelemetryStateNumber(
+                    nextDatabase,
+                    "next_spawn_after_ms",
+                )).toBe(futureSpawnAfterMs);
+            }
+            finally {
+                closeTelemetryDatabase(nextDatabase);
+            }
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});
+
+function resolveSandboxTelemetryDirectory(sandbox: {
+    env: Record<string, string | undefined>;
+}): string {
+    return join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry");
+}
+
+async function writeTelemetrySpawnRecorder(filePath: string): Promise<void> {
+    await Bun.write(
+        filePath,
+        [
+            "#!/bin/sh",
+            "printf spawned > \"$OO_TEST_TELEMETRY_SPAWN_MARKER\"",
+            "",
+        ].join("\n"),
+    );
+    await chmod(filePath, 0o755);
+}
+
+async function writeTelemetrySpawnCountingRecorder(filePath: string): Promise<void> {
+    await Bun.write(
+        filePath,
+        [
+            "#!/bin/sh",
+            "printf 'spawned\\n' >> \"$OO_TEST_TELEMETRY_SPAWN_MARKER\"",
+            "",
+        ].join("\n"),
+    );
+    await chmod(filePath, 0o755);
+}
+
+async function readSpawnRecordCount(filePath: string): Promise<number> {
+    const file = Bun.file(filePath);
+
+    if (!(await file.exists())) {
+        return 0;
+    }
+
+    return (await file.text())
+        .split("\n")
+        .filter(line => line !== "")
+        .length;
+}
+
+async function waitForFile(filePath: string): Promise<boolean> {
+    const deadlineMs = Date.now() + 2_000;
+
+    while (Date.now() < deadlineMs) {
+        if (await Bun.file(filePath).exists()) {
+            return true;
+        }
+
+        await Bun.sleep(10);
+    }
+
+    return await Bun.file(filePath).exists();
+}

--- a/src/application/commands/telemetry/index.cli.test.ts
+++ b/src/application/commands/telemetry/index.cli.test.ts
@@ -15,7 +15,6 @@ import {
     telemetrySpawnThresholdEvents,
 } from "../../telemetry/constants.ts";
 import {
-    closeTelemetryDatabase,
     enqueueTelemetryBatchItem,
     leaseReadyTelemetryRows,
     openTelemetryDatabase,
@@ -65,7 +64,7 @@ describe("telemetry CLI", () => {
                 );
             }
             finally {
-                closeTelemetryDatabase(database);
+                database.close();
             }
 
             const status = await sandbox.run(["telemetry", "status"]);
@@ -436,7 +435,7 @@ describe("telemetry CLI", () => {
                 expect(leaseReadyTelemetryRows(database, Date.now())).toHaveLength(1);
             }
             finally {
-                closeTelemetryDatabase(database);
+                database.close();
             }
 
             const disable = await sandbox.run([
@@ -484,7 +483,7 @@ describe("telemetry CLI", () => {
                 }
                 finally {
                     database.run("ROLLBACK");
-                    closeTelemetryDatabase(database);
+                    database.close();
                 }
 
                 const status = await sandbox.run(["telemetry", "status"]);
@@ -590,7 +589,7 @@ describe("telemetry CLI", () => {
                 expect(leaseReadyTelemetryRows(database, Date.now())).toHaveLength(1);
             }
             finally {
-                closeTelemetryDatabase(database);
+                database.close();
             }
 
             const status = await sandbox.run(["telemetry", "status"]);
@@ -619,7 +618,7 @@ describe("telemetry CLI", () => {
             }
             finally {
                 database.run("ROLLBACK");
-                closeTelemetryDatabase(database);
+                database.close();
             }
 
             expect(readTelemetryRowsForTest(telemetryDirectoryPath)).toEqual([]);
@@ -698,7 +697,7 @@ describe("telemetry CLI", () => {
                 )).toBeUndefined();
             }
             finally {
-                closeTelemetryDatabase(database);
+                database.close();
             }
 
             await Bun.sleep(50);
@@ -746,7 +745,7 @@ describe("telemetry CLI", () => {
                 expect(await waitForFile(markerPath)).toBeTrue();
             }
             finally {
-                closeTelemetryDatabase(nextDatabase);
+                nextDatabase.close();
             }
         }
         finally {
@@ -793,7 +792,7 @@ describe("telemetry CLI", () => {
                 expect(await waitForFile(markerPath)).toBeTrue();
             }
             finally {
-                closeTelemetryDatabase(nextDatabase);
+                nextDatabase.close();
             }
         }
         finally {
@@ -853,7 +852,7 @@ describe("telemetry CLI", () => {
                 );
             }
             finally {
-                closeTelemetryDatabase(database);
+                database.close();
             }
 
             const command = await sandbox.run(["config", "list"]);
@@ -867,7 +866,7 @@ describe("telemetry CLI", () => {
                 )).toBe(futureSpawnAfterMs);
             }
             finally {
-                closeTelemetryDatabase(nextDatabase);
+                nextDatabase.close();
             }
         }
         finally {

--- a/src/application/commands/telemetry/index.ts
+++ b/src/application/commands/telemetry/index.ts
@@ -1,0 +1,17 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { telemetryDisableCommand } from "./disable.ts";
+import { telemetryEnableCommand } from "./enable.ts";
+import { telemetryStatusCommand } from "./status.ts";
+
+export const telemetryCommand: CliCommandDefinition = {
+    name: "telemetry",
+    excludeFromTelemetry: true,
+    summaryKey: "commands.telemetry.summary",
+    descriptionKey: "commands.telemetry.description",
+    children: [
+        telemetryStatusCommand,
+        telemetryEnableCommand,
+        telemetryDisableCommand,
+    ],
+};

--- a/src/application/commands/telemetry/status.ts
+++ b/src/application/commands/telemetry/status.ts
@@ -1,0 +1,67 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import {
+    readTelemetryDeviceIdIfExists,
+    readTelemetryOutboxSummary,
+} from "../../telemetry/outbox.ts";
+import { resolveTelemetryEffectiveStatus } from "../../telemetry/status.ts";
+import { writeLine } from "../shared/output.ts";
+
+export const telemetryStatusCommand: CliCommandDefinition = {
+    name: "status",
+    excludeFromTelemetry: true,
+    summaryKey: "commands.telemetry.status.summary",
+    descriptionKey: "commands.telemetry.status.description",
+    inputSchema: z.object({}),
+    handler: async (_, context) => {
+        const settings = await context.settingsStore.read();
+        const status = resolveTelemetryEffectiveStatus({
+            env: context.env,
+            settings,
+        });
+        const summary = context.telemetry === undefined
+            ? { pendingCount: 0 }
+            : readTelemetryOutboxSummary(
+                    context.telemetry.directoryPath,
+                    context.logger,
+                );
+        const deviceId = context.telemetry === undefined
+            ? undefined
+            : await readTelemetryDeviceIdIfExists(context.telemetry.directoryPath);
+
+        writeLine(
+            context.stdout,
+            [
+                context.translator.t("telemetry.status.enabled", {
+                    value: formatTelemetryEnabledStatus(status),
+                }),
+                context.translator.t("telemetry.status.deviceId", {
+                    value: deviceId?.slice(0, 8)
+                        ?? context.translator.t("telemetry.status.none"),
+                }),
+                context.translator.t("telemetry.status.pending", {
+                    value: summary.pendingCount,
+                }),
+                context.translator.t("telemetry.status.lastFlush", {
+                    value: summary.lastFlushAtMs === undefined
+                        ? context.translator.t("telemetry.status.none")
+                        : new Date(summary.lastFlushAtMs).toISOString(),
+                }),
+            ].join("\n"),
+        );
+    },
+};
+
+function formatTelemetryEnabledStatus(status: {
+    disabledReason?: "config" | "env";
+    enabled: boolean;
+}): string {
+    if (status.enabled) {
+        return "true";
+    }
+
+    return status.disabledReason === "env"
+        ? "false (env)"
+        : "false (config)";
+}

--- a/src/application/commands/update.ts
+++ b/src/application/commands/update.ts
@@ -20,6 +20,10 @@ import { resolveSelfUpdateModifyPath } from "../self-update/modify-path-preferen
 import { resolveSelfUpdateShowPathShadowingWarning } from "../self-update/path-shadowing-warning-preference.ts";
 import { writeSelfUpdatePathNoteIfNeeded } from "./self-update-output.ts";
 import { SelfUpdateProgressReporter } from "./self-update-progress.ts";
+import {
+    classifyTelemetryVersionKind,
+    recordSelfUpdatePathTelemetry,
+} from "./self-update-telemetry.ts";
 import { writeLine } from "./shared/output.ts";
 
 const updateCommandInputSchema = z.object({
@@ -42,6 +46,12 @@ export const updateCommand: CliCommandDefinition<
     ],
     inputSchema: updateCommandInputSchema,
     handler: async (input, context) => {
+        context.telemetry?.recordProperties({
+            force: true,
+            path_modified: false,
+            version_kind: classifyTelemetryVersionKind(context.version),
+        });
+
         const effectiveModifyPath = resolveSelfUpdateModifyPath({
             env: context.env,
             modifyPathFlag: input.modifyPath,
@@ -91,6 +101,10 @@ export const updateCommand: CliCommandDefinition<
             progressReporter?.setStage("resolve", {
                 version: latestVersion,
             });
+            context.telemetry?.recordProperties({
+                update_available: latestVersion !== context.version,
+                version_kind: classifyTelemetryVersionKind(latestVersion),
+            });
 
             if (
                 latestVersion === context.version
@@ -127,6 +141,7 @@ export const updateCommand: CliCommandDefinition<
                             ...context.selfUpdateRuntime,
                         },
                     });
+                recordSelfUpdatePathTelemetry(context.telemetry, pathConfiguration);
                 progressReporter?.finish();
                 writeLine(
                     context.stdout,
@@ -171,6 +186,11 @@ export const updateCommand: CliCommandDefinition<
                 );
                 return;
             }
+
+            recordSelfUpdatePathTelemetry(
+                context.telemetry,
+                result.pathConfiguration,
+            );
 
             progressReporter?.finish();
 

--- a/src/application/contracts/cli.ts
+++ b/src/application/contracts/cli.ts
@@ -66,6 +66,7 @@ export type CliCommandHandler<TInput> = {
 export interface CliCommandDefinition<TInput = unknown> {
     name: string;
     aliases?: readonly string[];
+    excludeFromTelemetry?: boolean;
     hidden?: boolean;
     summaryKey: string;
     descriptionKey?: string;
@@ -88,6 +89,51 @@ export interface CliCatalog {
     commands: readonly CliCommandDefinition<any>[];
 }
 
+export type CliParseErrorKind
+    = | "excess_arguments"
+        | "help"
+        | "invalid_argument"
+        | "missing_argument"
+        | "missing_option_value"
+        | "unknown_command"
+        | "unknown_option"
+        | "version";
+
+export interface CliCommandResolvedEvent {
+    argCount: number;
+    commandPath: readonly string[];
+    excludeFromTelemetry: boolean;
+    flagsCount: number;
+    outputFormat: "json" | "text";
+}
+
+export interface CliCommandCompletedEvent {
+    exitCode: number;
+}
+
+export interface CliCommandFailedEvent {
+    commanderCode?: string;
+    errorKey?: string;
+    exitCode: number;
+    parseErrorKind?: CliParseErrorKind;
+}
+
+export interface CliCommandObserver {
+    onCommandCompleted?: (event: CliCommandCompletedEvent) => void;
+    onCommandFailed?: (event: CliCommandFailedEvent) => void;
+    onCommandResolved?: (event: CliCommandResolvedEvent) => void;
+    onParseError?: (event: {
+        commanderCode?: string;
+        parseErrorKind: CliParseErrorKind;
+    }) => void;
+}
+
+export type CliTelemetryPropertyValue
+    = | boolean
+        | number
+        | readonly string[]
+        | string;
+
 export interface CompletionRenderer {
     render: (shell: SupportedShell, catalog: CliCatalog) => string;
 }
@@ -109,6 +155,13 @@ export interface CliExecutionContext {
     selfUpdateRuntime?: SelfUpdateRuntimeOverrides;
     stdout: Writer;
     stderr: Writer;
+    telemetry?: {
+        recordProperties: (
+            properties: Record<string, CliTelemetryPropertyValue>,
+        ) => void;
+        directoryPath: string;
+        suppressCurrentInvocation: () => void;
+    };
     translator: Translator;
     completionRenderer: CompletionRenderer;
     catalog: CliCatalog;

--- a/src/application/schemas/settings.ts
+++ b/src/application/schemas/settings.ts
@@ -25,14 +25,23 @@ const fileSettingsSchema = z.object({
     download: fileDownloadSettingsSchema.optional(),
 }).strict();
 
+const telemetrySettingsShape = {
+    enabled: z.boolean().optional(),
+};
+
+const telemetrySettingsReadSchema = z.object(telemetrySettingsShape);
+const telemetrySettingsSchema = z.object(telemetrySettingsShape).strict();
+
 export const settingsFileReadSchema = z.object({
     file: fileSettingsReadSchema.optional(),
     lang: localeSchema.optional(),
+    telemetry: telemetrySettingsReadSchema.optional(),
 });
 
 export const settingsFileSchema = z.object({
     file: fileSettingsSchema.optional(),
     lang: localeSchema.optional(),
+    telemetry: telemetrySettingsSchema.optional(),
 }).strict();
 
 export type AppSettings = z.output<typeof settingsFileSchema>;
@@ -56,6 +65,13 @@ const defaultSettingsCommentBlocks = [
         "# [file.download]",
         `# out_dir = "${defaultFileDownloadOutDir}"`,
     ],
+    [
+        "# telemetry.enabled controls whether oo records privacy-constrained usage telemetry.",
+        "# Default: true.",
+        "# Supported values: true or false.",
+        "# [telemetry]",
+        "# enabled = true",
+    ],
 ] as const;
 
 export function renderSettingsFile(settings: AppSettings): string {
@@ -73,6 +89,12 @@ export function renderSettingsFile(settings: AppSettings): string {
     if (parsedSettings.file?.download?.out_dir !== undefined) {
         persistedSettings.file = {
             download: { out_dir: parsedSettings.file.download.out_dir },
+        };
+    }
+
+    if (parsedSettings.telemetry?.enabled !== undefined) {
+        persistedSettings.telemetry = {
+            enabled: parsedSettings.telemetry.enabled,
         };
     }
 
@@ -122,6 +144,35 @@ export function unsetFileDownloadOutDir(
     }
 
     return deleteNestedProperty(settings, ["file", "download", "out_dir"]);
+}
+
+export function getConfiguredTelemetryEnabled(
+    settings: AppSettings,
+): boolean | undefined {
+    return settings.telemetry?.enabled;
+}
+
+export function setTelemetryEnabled(
+    settings: AppSettings,
+    value: boolean,
+): AppSettings {
+    return {
+        ...settings,
+        telemetry: {
+            ...settings.telemetry,
+            enabled: value,
+        },
+    };
+}
+
+export function unsetTelemetryEnabled(
+    settings: AppSettings,
+): AppSettings {
+    if (settings.telemetry?.enabled === undefined) {
+        return settings;
+    }
+
+    return deleteNestedProperty(settings, ["telemetry", "enabled"]);
 }
 
 // Shallow-clones each level of a nested object along the given path,

--- a/src/application/telemetry/__tests__/helpers.ts
+++ b/src/application/telemetry/__tests__/helpers.ts
@@ -1,0 +1,38 @@
+import { createCliCommandTelemetryPayload } from "../payload.ts";
+
+export function createTelemetryItemForTest(index: number) {
+    const uuidSuffix = index.toString(16).padStart(12, "0").slice(-12);
+
+    return createCliCommandTelemetryPayload({
+        accountState: "anonymous",
+        arch: "arm64",
+        ciName: "none",
+        cliCommit: "unknown",
+        cliInstallMethod: "unknown",
+        cliVersion: "0.0.0",
+        command: {
+            argCount: 0,
+            commandAction: "list",
+            commandFull: "config.list",
+            commandGroup: "config",
+            flagsCount: 0,
+            outputFormat: "text",
+        },
+        distinctId: "019a0cca-0000-7000-8000-000000000001",
+        durationMs: 1,
+        isCi: false,
+        isFirstRun: false,
+        isTtyStderr: false,
+        isTtyStdout: false,
+        lang: "en",
+        os: "linux",
+        osVersion: "1",
+        outcome: {
+            exitCode: 0,
+        },
+        runtimeVersion: "1",
+        sessionId: "019a0ccb-1111-7222-8333-444444444444",
+        timestamp: new Date("2026-05-07T12:34:56.789Z"),
+        uuid: `019a0ccb-408c-728a-9df9-${uuidSuffix}`,
+    });
+}

--- a/src/application/telemetry/buckets.test.ts
+++ b/src/application/telemetry/buckets.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import {
+    bucketTelemetryBytes,
+    bucketTelemetryCount,
+    bucketTelemetryStringLength,
+} from "./buckets.ts";
+
+describe("telemetry buckets", () => {
+    test("buckets counts into bounded cardinality ranges", () => {
+        expect([
+            bucketTelemetryCount(0),
+            bucketTelemetryCount(1),
+            bucketTelemetryCount(5),
+            bucketTelemetryCount(6),
+            bucketTelemetryCount(20),
+            bucketTelemetryCount(21),
+            bucketTelemetryCount(100),
+            bucketTelemetryCount(101),
+        ]).toEqual([
+            "0",
+            "1-5",
+            "1-5",
+            "6-20",
+            "6-20",
+            "21-100",
+            "21-100",
+            "100+",
+        ]);
+    });
+
+    test("buckets string length by Unicode code points", () => {
+        expect(bucketTelemetryStringLength("")).toBe("0");
+        expect(bucketTelemetryStringLength("hello")).toBe("1-5");
+        expect(bucketTelemetryStringLength("你好世界好")).toBe("1-5");
+        expect(bucketTelemetryStringLength("你好世界你好")).toBe("6-20");
+    });
+
+    test("buckets bytes into bounded size ranges", () => {
+        expect([
+            bucketTelemetryBytes(0),
+            bucketTelemetryBytes(1),
+            bucketTelemetryBytes(1023),
+            bucketTelemetryBytes(1024),
+            bucketTelemetryBytes(1024 * 1024),
+            bucketTelemetryBytes(10 * 1024 * 1024),
+            bucketTelemetryBytes(100 * 1024 * 1024),
+        ]).toEqual([
+            "0",
+            "<1KB",
+            "<1KB",
+            "<1MB",
+            "<10MB",
+            "<100MB",
+            "100MB+",
+        ]);
+    });
+});

--- a/src/application/telemetry/buckets.ts
+++ b/src/application/telemetry/buckets.ts
@@ -1,0 +1,59 @@
+export type TelemetryCountBucket = "0" | "1-5" | "6-20" | "21-100" | "100+";
+export type TelemetryByteBucket
+    = | "0"
+        | "100MB+"
+        | "<100MB"
+        | "<10MB"
+        | "<1KB"
+        | "<1MB";
+export type TelemetryStringLengthBucket = TelemetryCountBucket;
+
+export function bucketTelemetryCount(count: number): TelemetryCountBucket {
+    if (count <= 0) {
+        return "0";
+    }
+
+    if (count <= 5) {
+        return "1-5";
+    }
+
+    if (count <= 20) {
+        return "6-20";
+    }
+
+    if (count <= 100) {
+        return "21-100";
+    }
+
+    return "100+";
+}
+
+export function bucketTelemetryStringLength(
+    value: string,
+): TelemetryStringLengthBucket {
+    return bucketTelemetryCount(Array.from(value).length);
+}
+
+export function bucketTelemetryBytes(bytes: number): TelemetryByteBucket {
+    if (bytes <= 0) {
+        return "0";
+    }
+
+    if (bytes < 1024) {
+        return "<1KB";
+    }
+
+    if (bytes < 1024 * 1024) {
+        return "<1MB";
+    }
+
+    if (bytes < 10 * 1024 * 1024) {
+        return "<10MB";
+    }
+
+    if (bytes < 100 * 1024 * 1024) {
+        return "<100MB";
+    }
+
+    return "100MB+";
+}

--- a/src/application/telemetry/constants.ts
+++ b/src/application/telemetry/constants.ts
@@ -1,0 +1,27 @@
+export const telemetryInternalCommand = "__flush_telemetry";
+export const telemetryInternalEnvKey = "OO_TELEMETRY_INTERNAL";
+export const telemetryDisabledEnvKey = "OO_TELEMETRY_DISABLED";
+export const doNotTrackEnvKey = "DO_NOT_TRACK";
+
+export const telemetryDatabaseFileName = "telemetry.sqlite";
+export const telemetryDeviceIdFileName = "device-id";
+
+export const telemetryEndpoint = "https://t.oomol.com/batch";
+export const telemetryPostHogApiKey = "phc_AQhAZ9VYPH9JqgeMtYHc67aZedcQG2zGFTCSJAYrzB7X";
+export const telemetrySchemaVersion = 1;
+
+export const telemetryEventName = "cli_command_executed";
+export const telemetryMaxEventBytes = 4096;
+export const telemetryDatabaseMaxBytes = 50 * 1024 * 1024;
+export const telemetrySqliteBusyTimeoutMs = 20;
+export const telemetryLeaseTtlMs = 3 * 60 * 1000;
+export const telemetryMaxAttempts = 2;
+export const telemetryMaxEventAgeMs = 7 * 24 * 60 * 60 * 1000;
+export const telemetryChunkMaxEvents = 100;
+export const telemetryChunkMaxBytes = 1024 * 1024;
+export const telemetryLeaseMaxEvents = 500;
+export const telemetryRequestTimeoutMs = 10_000;
+export const telemetrySpawnIntervalMs = 60 * 1000;
+export const telemetrySpawnThresholdEvents = 20;
+export const telemetryBaseBackoffMs = 60 * 1000;
+export const telemetryMaxBackoffMs = 24 * 60 * 60 * 1000;

--- a/src/application/telemetry/control.test.ts
+++ b/src/application/telemetry/control.test.ts
@@ -1,0 +1,39 @@
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+import { createTemporaryDirectory } from "../../../__tests__/helpers.ts";
+import {
+    readTelemetrySettingsFile,
+    resolveTelemetryStatusFromSettingsFile,
+} from "./control.ts";
+
+describe("telemetry control", () => {
+    test("preserves telemetry opt-out when unrelated settings are invalid", async () => {
+        const root = await createTemporaryDirectory("telemetry-control");
+        const settingsFilePath = join(root, "settings.toml");
+
+        await Bun.write(
+            settingsFilePath,
+            [
+                "lang = 1",
+                "",
+                "[telemetry]",
+                "enabled = false",
+                "",
+            ].join("\n"),
+        );
+
+        await expect(readTelemetrySettingsFile(settingsFilePath)).resolves.toEqual({
+            telemetry: {
+                enabled: false,
+            },
+        });
+        await expect(resolveTelemetryStatusFromSettingsFile({
+            env: {},
+            settingsFilePath,
+        })).resolves.toEqual({
+            disabledReason: "config",
+            enabled: false,
+        });
+    });
+});

--- a/src/application/telemetry/control.ts
+++ b/src/application/telemetry/control.ts
@@ -1,0 +1,123 @@
+import type { Logger } from "pino";
+
+import type { CliExecutionContext } from "../contracts/cli.ts";
+import type { AppSettings } from "../schemas/settings.ts";
+import type { TelemetryEffectiveStatus } from "./status.ts";
+import { readFile } from "node:fs/promises";
+import { parse as parseToml } from "smol-toml";
+import { settingsFileReadSchema } from "../schemas/settings.ts";
+import { purgeTelemetryOutboxIfExists } from "./outbox.ts";
+import { resolveTelemetryEffectiveStatus } from "./status.ts";
+
+export function disableTelemetryForCurrentInvocation(
+    context: CliExecutionContext,
+): void {
+    context.telemetry?.suppressCurrentInvocation();
+
+    if (context.telemetry === undefined) {
+        return;
+    }
+
+    try {
+        purgeTelemetryOutboxIfExists(
+            context.telemetry.directoryPath,
+            context.logger,
+        );
+    }
+    catch (error) {
+        context.logger.debug(
+            {
+                err: error,
+            },
+            "Telemetry outbox purge failed silently after telemetry was disabled.",
+        );
+    }
+}
+
+export async function resolveTelemetryStatusFromSettingsFile(options: {
+    env: Record<string, string | undefined>;
+    logger?: Logger;
+    settings?: AppSettings;
+    settingsFilePath: string;
+}): Promise<TelemetryEffectiveStatus> {
+    const settings = options.settings
+        ?? await readTelemetrySettingsFile(options.settingsFilePath, options.logger);
+
+    return resolveTelemetryEffectiveStatus({
+        env: options.env,
+        settings,
+    });
+}
+
+export async function readTelemetrySettingsFile(
+    settingsFilePath: string,
+    logger?: Logger,
+): Promise<AppSettings> {
+    try {
+        const content = await readFile(settingsFilePath, "utf8");
+        const rawSettings = parseToml(content);
+        const parsed = settingsFileReadSchema.safeParse(rawSettings);
+
+        if (parsed.success) {
+            return parsed.data;
+        }
+
+        const telemetryEnabled = readRawTelemetryEnabled(rawSettings);
+
+        if (telemetryEnabled !== undefined) {
+            logger?.debug(
+                {
+                    issueCount: parsed.error.issues.length,
+                    path: settingsFilePath,
+                },
+                "Telemetry settings read preserved telemetry.enabled from an unsupported settings shape.",
+            );
+            return {
+                telemetry: {
+                    enabled: telemetryEnabled,
+                },
+            };
+        }
+
+        logger?.debug(
+            {
+                issueCount: parsed.error.issues.length,
+                path: settingsFilePath,
+            },
+            "Telemetry settings read ignored an unsupported settings shape.",
+        );
+        return {};
+    }
+    catch (error) {
+        logger?.debug(
+            {
+                err: error,
+                path: settingsFilePath,
+            },
+            "Telemetry settings read fell back to the default enabled state.",
+        );
+        return {};
+    }
+}
+
+function readRawTelemetryEnabled(rawSettings: unknown): boolean | undefined {
+    if (!isPlainObjectRecord(rawSettings)) {
+        return undefined;
+    }
+
+    const telemetry = rawSettings.telemetry;
+
+    if (!isPlainObjectRecord(telemetry)) {
+        return undefined;
+    }
+
+    return typeof telemetry.enabled === "boolean"
+        ? telemetry.enabled
+        : undefined;
+}
+
+function isPlainObjectRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null
+        && typeof value === "object"
+        && !Array.isArray(value);
+}

--- a/src/application/telemetry/emitter.ts
+++ b/src/application/telemetry/emitter.ts
@@ -1,0 +1,257 @@
+import type { Logger } from "pino";
+
+import type { CliInvocation } from "../bootstrap/run-cli.ts";
+import type { AuthStore } from "../contracts/auth-store.ts";
+import type { AppSettings } from "../schemas/settings.ts";
+import type { TelemetryInvocationRecorder } from "./invocation.ts";
+import type { TelemetryAccountState } from "./payload.ts";
+import { readFile } from "node:fs/promises";
+import { arch, release } from "node:os";
+import process from "node:process";
+import { parse as parseToml } from "smol-toml";
+import { authTomlFileSchema, getCurrentAuthAccount } from "../schemas/auth.ts";
+import { detectInstallationMethodFromExecPath } from "../self-update/installation.ts";
+import {
+    telemetryInternalCommand,
+    telemetryInternalEnvKey,
+    telemetrySpawnIntervalMs,
+    telemetrySpawnThresholdEvents,
+} from "./constants.ts";
+import { resolveTelemetryStatusFromSettingsFile } from "./control.ts";
+import {
+    closeTelemetryDatabase,
+    countTelemetryEvents,
+    enqueueTelemetryBatchItem,
+    openTelemetryDatabase,
+    readOrCreateTelemetryDeviceId,
+    readTelemetryStateNumber,
+    writeTelemetryStateNumber,
+} from "./outbox.ts";
+import { createCliCommandTelemetryPayload } from "./payload.ts";
+
+export interface EmitCliTelemetryOptions {
+    authStore?: AuthStore;
+    buildCommit: string;
+    env: Record<string, string | undefined>;
+    execPath: string;
+    exitCode: number;
+    invocation: CliInvocation;
+    logger: Logger;
+    recorder: TelemetryInvocationRecorder;
+    sessionId: string;
+    settings?: AppSettings;
+    settingsFilePath: string;
+    startTimeMs: number;
+    telemetryDirectoryPath: string;
+    translatorLocale: string;
+    version: string;
+}
+
+const ciEnvironmentDetectors = [
+    { envKey: "GITHUB_ACTIONS", name: "github_actions" },
+    { envKey: "GITLAB_CI", name: "gitlab_ci" },
+    { envKey: "BUILDKITE", name: "buildkite" },
+    { envKey: "CIRCLECI", name: "circleci" },
+    { envKey: "CI", name: "ci" },
+] as const;
+
+export async function emitCliCommandTelemetry(
+    options: EmitCliTelemetryOptions,
+): Promise<void> {
+    try {
+        if (options.recorder.shouldSuppress()) {
+            return;
+        }
+
+        const command = options.recorder.readCommand();
+
+        if (command.excludeFromTelemetry === true) {
+            return;
+        }
+
+        const status = await resolveTelemetryStatusFromSettingsFile({
+            env: options.env,
+            logger: options.logger,
+            settings: options.settings,
+            settingsFilePath: options.settingsFilePath,
+        });
+
+        if (!status.enabled) {
+            return;
+        }
+
+        const nowMs = Date.now();
+        const deviceId = await readOrCreateTelemetryDeviceId(
+            options.telemetryDirectoryPath,
+        );
+        const ci = detectCiEnvironment(options.env);
+        const uuid = Bun.randomUUIDv7();
+        const payload = createCliCommandTelemetryPayload({
+            accountState: await resolveTelemetryAccountState(options.authStore),
+            arch: arch(),
+            ciName: ci.name,
+            cliCommit: options.buildCommit,
+            cliInstallMethod: detectInstallationMethodFromExecPath({
+                env: options.env,
+                execPath: options.execPath,
+                platform: process.platform,
+            }).method,
+            cliVersion: options.version,
+            command,
+            distinctId: deviceId.deviceId,
+            durationMs: Math.max(0, nowMs - options.startTimeMs),
+            isCi: ci.isCi,
+            isFirstRun: deviceId.isFirstRun,
+            isTtyStderr: options.invocation.stderr.isTTY === true,
+            isTtyStdout: options.invocation.stdout.isTTY === true,
+            lang: options.translatorLocale,
+            os: process.platform,
+            osVersion: release(),
+            outcome: options.recorder.readOutcome(options.exitCode),
+            runtimeVersion: Bun.version,
+            sessionId: options.sessionId,
+            timestamp: new Date(nowMs),
+            uuid,
+        });
+        const inserted = enqueueTelemetryBatchItem({
+            directoryPath: options.telemetryDirectoryPath,
+            item: payload,
+            logger: options.logger,
+            nowMs,
+        });
+
+        if (inserted) {
+            spawnTelemetryFlusherIfDue(options, nowMs);
+        }
+    }
+    catch (error) {
+        options.logger.debug(
+            {
+                err: error,
+            },
+            "Telemetry emit failed silently.",
+        );
+    }
+}
+
+function spawnTelemetryFlusherIfDue(
+    options: EmitCliTelemetryOptions,
+    nowMs: number,
+): void {
+    const database = openTelemetryDatabase(
+        options.telemetryDirectoryPath,
+        options.logger,
+    );
+    let shouldSpawn = false;
+
+    try {
+        const nextSpawnAfterMs = readTelemetryStateNumber(
+            database,
+            "next_spawn_after_ms",
+        );
+
+        if (nextSpawnAfterMs !== undefined && nextSpawnAfterMs > nowMs) {
+            return;
+        }
+
+        const eventCount = countTelemetryEvents(database);
+
+        shouldSpawn = eventCount >= telemetrySpawnThresholdEvents
+            || nextSpawnAfterMs !== undefined;
+
+        if (!shouldSpawn) {
+            return;
+        }
+
+        writeTelemetryStateNumber(
+            database,
+            "next_spawn_after_ms",
+            nowMs + telemetrySpawnIntervalMs,
+        );
+    }
+    finally {
+        closeTelemetryDatabase(database);
+    }
+
+    if (!shouldSpawn) {
+        return;
+    }
+
+    try {
+        const subprocess = Bun.spawn({
+            cmd: [options.execPath, telemetryInternalCommand],
+            detached: true,
+            env: {
+                ...options.env,
+                [telemetryInternalEnvKey]: "1",
+            },
+            stderr: "ignore",
+            stdin: "ignore",
+            stdout: "ignore",
+            windowsHide: true,
+        });
+
+        subprocess.unref();
+    }
+    catch (error) {
+        options.logger.debug(
+            {
+                err: error,
+            },
+            "Telemetry flusher spawn failed silently.",
+        );
+    }
+}
+
+async function resolveTelemetryAccountState(
+    authStore: AuthStore | undefined,
+): Promise<TelemetryAccountState> {
+    if (authStore === undefined) {
+        return "unknown";
+    }
+
+    try {
+        const content = await readFile(authStore.getFilePath(), "utf8");
+        const parsed = authTomlFileSchema.safeParse(parseToml(content));
+
+        if (!parsed.success) {
+            return "unknown";
+        }
+
+        return getCurrentAuthAccount(parsed.data) === undefined
+            ? "anonymous"
+            : "authenticated";
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return "anonymous";
+        }
+
+        return "unknown";
+    }
+}
+
+function detectCiEnvironment(
+    env: Record<string, string | undefined>,
+): { isCi: boolean; name: string } {
+    for (const detector of ciEnvironmentDetectors) {
+        if (env[detector.envKey] !== undefined && env[detector.envKey] !== "") {
+            return {
+                isCi: true,
+                name: detector.name,
+            };
+        }
+    }
+
+    return {
+        isCi: false,
+        name: "none",
+    };
+}
+
+function isNodeNotFoundError(error: unknown): boolean {
+    return error !== null
+        && typeof error === "object"
+        && "code" in error
+        && error.code === "ENOENT";
+}

--- a/src/application/telemetry/emitter.ts
+++ b/src/application/telemetry/emitter.ts
@@ -19,7 +19,6 @@ import {
 } from "./constants.ts";
 import { resolveTelemetryStatusFromSettingsFile } from "./control.ts";
 import {
-    closeTelemetryDatabase,
     countTelemetryEvents,
     enqueueTelemetryBatchItem,
     openTelemetryDatabase,
@@ -170,11 +169,7 @@ function spawnTelemetryFlusherIfDue(
         );
     }
     finally {
-        closeTelemetryDatabase(database);
-    }
-
-    if (!shouldSpawn) {
-        return;
+        database.close();
     }
 
     try {

--- a/src/application/telemetry/flusher.test.ts
+++ b/src/application/telemetry/flusher.test.ts
@@ -1,0 +1,445 @@
+import { Buffer } from "node:buffer";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+import {
+    createTemporaryDirectory,
+    useTemporaryDirectoryCleanup,
+} from "../../../__tests__/helpers.ts";
+import { renderSettingsFile } from "../schemas/settings.ts";
+import { createTelemetryItemForTest } from "./__tests__/helpers.ts";
+import {
+    telemetryChunkMaxBytes,
+    telemetryLeaseMaxEvents,
+    telemetryLeaseTtlMs,
+    telemetryMaxEventAgeMs,
+} from "./constants.ts";
+import { flushTelemetryOutbox } from "./flusher.ts";
+import {
+    closeTelemetryDatabase,
+    enqueueTelemetryBatchItem,
+    leaseReadyTelemetryRows,
+    openTelemetryDatabase,
+    readTelemetryRowsForTest,
+} from "./outbox.ts";
+
+describe("telemetry flusher", () => {
+    const temporaryDirectories = useTemporaryDirectoryCleanup();
+
+    test("deletes successful chunks and keeps failed plus later chunks", async () => {
+        const root = await createTemporaryDirectory("telemetry-flush-partial");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+        const settingsFilePath = join(root, "settings.toml");
+        let requestCount = 0;
+
+        for (let index = 0; index < 201; index += 1) {
+            enqueueTelemetryBatchItem({
+                directoryPath,
+                item: createTelemetryItemForTest(index),
+                nowMs: 1000 + index,
+            });
+        }
+
+        await flushTelemetryOutbox({
+            directoryPath,
+            env: {},
+            fetcher: async () => {
+                requestCount += 1;
+                return new Response("", {
+                    status: requestCount === 1 ? 200 : 503,
+                });
+            },
+            now: () => 10_000,
+            random: () => 0,
+            settingsFilePath,
+        });
+
+        const rows = readTelemetryRowsForTest(directoryPath);
+        const attemptedRows = rows.filter(row => row.attempts === 1);
+        const unsentRows = rows.filter(row => row.attempts === 0);
+
+        expect(requestCount).toBe(2);
+        expect(rows).toHaveLength(101);
+        expect(attemptedRows).toHaveLength(100);
+        expect(unsentRows).toHaveLength(1);
+    });
+
+    test("flushes large outboxes as bounded request chunks", async () => {
+        const root = await createTemporaryDirectory("telemetry-flush-large-outbox");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+        const settingsFilePath = join(root, "settings.toml");
+        const eventCount = 1500;
+        const requestSizes: number[] = [];
+
+        for (let index = 0; index < eventCount; index += 1) {
+            const item = createTelemetryItemForTest(index);
+
+            item.properties.large_value = "x".repeat(3000);
+
+            expect(enqueueTelemetryBatchItem({
+                directoryPath,
+                item,
+                nowMs: 1000 + index,
+            })).toBeTrue();
+        }
+
+        const rowsBefore = readTelemetryRowsForTest(directoryPath);
+        const totalPayloadBytes = rowsBefore.reduce(
+            (total, row) => total + row.payloadBytes,
+            0,
+        );
+
+        expect(rowsBefore).toHaveLength(eventCount);
+        expect(totalPayloadBytes).toBeGreaterThan(5 * 1024 * 1024);
+
+        await flushTelemetryOutbox({
+            directoryPath,
+            env: {},
+            fetcher: async (_, init) => {
+                requestSizes.push(Buffer.byteLength(String(init?.body ?? ""), "utf8"));
+                return new Response("");
+            },
+            now: () => 10_000,
+            settingsFilePath,
+        });
+
+        expect(Math.max(...requestSizes)).toBeLessThanOrEqual(telemetryChunkMaxBytes);
+        expect(readTelemetryRowsForTest(directoryPath)).toHaveLength(
+            eventCount - telemetryLeaseMaxEvents,
+        );
+    });
+
+    test("drops rows after the second failed post attempt", async () => {
+        const root = await createTemporaryDirectory("telemetry-flush-attempts");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+        const settingsFilePath = join(root, "settings.toml");
+
+        enqueueTelemetryBatchItem({
+            directoryPath,
+            item: createTelemetryItemForTest(1),
+            nowMs: 1000,
+        });
+
+        await flushTelemetryOutbox({
+            directoryPath,
+            env: {},
+            fetcher: async () => new Response("", { status: 503 }),
+            now: () => 10_000,
+            random: () => 0,
+            settingsFilePath,
+        });
+        expect(readTelemetryRowsForTest(directoryPath)).toMatchObject([
+            { attempts: 1 },
+        ]);
+
+        await flushTelemetryOutbox({
+            directoryPath,
+            env: {},
+            fetcher: async () => new Response("", { status: 503 }),
+            now: () => 80_000,
+            random: () => 0,
+            settingsFilePath,
+        });
+
+        expect(readTelemetryRowsForTest(directoryPath)).toEqual([]);
+    });
+
+    test("treats timed out post requests as retryable failures", async () => {
+        const root = await createTemporaryDirectory("telemetry-flush-timeout");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+        const settingsFilePath = join(root, "settings.toml");
+        let signalSeen = false;
+
+        enqueueTelemetryBatchItem({
+            directoryPath,
+            item: createTelemetryItemForTest(1),
+            nowMs: 1000,
+        });
+
+        await flushTelemetryOutbox({
+            directoryPath,
+            env: {},
+            fetcher: async (_, init) => {
+                const signal = init?.signal;
+
+                expect(signal).toBeInstanceOf(AbortSignal);
+                signalSeen = true;
+
+                return await new Promise<Response>((_, reject) => {
+                    signal?.addEventListener(
+                        "abort",
+                        () => reject(new Error("aborted")),
+                        { once: true },
+                    );
+                });
+            },
+            now: () => 10_000,
+            random: () => 0,
+            requestTimeoutMs: 1,
+            settingsFilePath,
+        });
+
+        expect(signalSeen).toBe(true);
+        expect(readTelemetryRowsForTest(directoryPath)).toMatchObject([
+            {
+                attempts: 1,
+                leaseUntilMs: null,
+            },
+        ]);
+    });
+
+    test("drops expired rows before posting", async () => {
+        const root = await createTemporaryDirectory("telemetry-flush-expired");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+        const settingsFilePath = join(root, "settings.toml");
+        let requestCount = 0;
+
+        enqueueTelemetryBatchItem({
+            directoryPath,
+            item: createTelemetryItemForTest(1),
+            nowMs: 1000,
+        });
+
+        await flushTelemetryOutbox({
+            directoryPath,
+            env: {},
+            fetcher: async () => {
+                requestCount += 1;
+                return new Response("");
+            },
+            now: () => 1000 + telemetryMaxEventAgeMs + 1,
+            settingsFilePath,
+        });
+
+        expect(requestCount).toBe(0);
+        expect(readTelemetryRowsForTest(directoryPath)).toEqual([]);
+    });
+
+    test("rechecks opt-out before posting", async () => {
+        const root = await createTemporaryDirectory("telemetry-flush-opt-out");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+        const settingsFilePath = join(root, "settings.toml");
+        let requestCount = 0;
+
+        await Bun.write(
+            settingsFilePath,
+            renderSettingsFile({
+                telemetry: {
+                    enabled: false,
+                },
+            }),
+        );
+        enqueueTelemetryBatchItem({
+            directoryPath,
+            item: createTelemetryItemForTest(1),
+            nowMs: 1000,
+        });
+
+        await flushTelemetryOutbox({
+            directoryPath,
+            env: {},
+            fetcher: async () => {
+                requestCount += 1;
+                return new Response("");
+            },
+            now: () => 10_000,
+            settingsFilePath,
+        });
+
+        expect(requestCount).toBe(0);
+        expect(readTelemetryRowsForTest(directoryPath)).toMatchObject([
+            {
+                attempts: 0,
+                leaseUntilMs: null,
+            },
+        ]);
+    });
+
+    test("drops poison rows without blocking later valid rows", async () => {
+        const root = await createTemporaryDirectory("telemetry-flush-poison");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+        const settingsFilePath = join(root, "settings.toml");
+        let requestBody: string | undefined;
+        const poisonItem = createTelemetryItemForTest(1);
+        const validItem = createTelemetryItemForTest(2);
+
+        enqueueTelemetryBatchItem({
+            directoryPath,
+            item: poisonItem,
+            nowMs: 1000,
+        });
+        enqueueTelemetryBatchItem({
+            directoryPath,
+            item: validItem,
+            nowMs: 1001,
+        });
+
+        const database = openTelemetryDatabase(directoryPath);
+
+        try {
+            database.query(
+                "UPDATE telemetry_events SET payload_json = $payloadJson WHERE id = $id",
+            ).run({
+                id: poisonItem.uuid,
+                payloadJson: JSON.stringify({ event: "invalid" }),
+            });
+        }
+        finally {
+            closeTelemetryDatabase(database);
+        }
+
+        await flushTelemetryOutbox({
+            directoryPath,
+            env: {},
+            fetcher: async (_, init) => {
+                requestBody = String(init?.body ?? "");
+                return new Response("");
+            },
+            now: () => 10_000,
+            settingsFilePath,
+        });
+
+        expect(readTelemetryRowsForTest(directoryPath)).toEqual([]);
+        expect(JSON.parse(requestBody ?? "{}")).toMatchObject({
+            batch: [
+                {
+                    uuid: validItem.uuid,
+                },
+            ],
+        });
+    });
+
+    test("splits multi-row payload-too-large chunks before deleting rows", async () => {
+        const root = await createTemporaryDirectory("telemetry-flush-split-413");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+        const settingsFilePath = join(root, "settings.toml");
+        const requestBatches: string[][] = [];
+        const items = [1, 2, 3].map(index => createTelemetryItemForTest(index));
+
+        for (const [index, item] of items.entries()) {
+            enqueueTelemetryBatchItem({
+                directoryPath,
+                item,
+                nowMs: 1000 + index,
+            });
+        }
+
+        await flushTelemetryOutbox({
+            directoryPath,
+            env: {},
+            fetcher: async (_, init) => {
+                const request = JSON.parse(String(init?.body ?? "{}")) as {
+                    batch: { uuid: string }[];
+                };
+
+                requestBatches.push(request.batch.map(item => item.uuid));
+
+                return new Response("", {
+                    status: requestBatches.length === 1 ? 413 : 200,
+                });
+            },
+            now: () => 10_000,
+            settingsFilePath,
+        });
+
+        expect(requestBatches).toEqual([
+            items.map(item => item.uuid),
+            [items[0]!.uuid],
+            [items[1]!.uuid, items[2]!.uuid],
+        ]);
+        expect(readTelemetryRowsForTest(directoryPath)).toEqual([]);
+    });
+
+    test("drops single-row payload-too-large chunks", async () => {
+        const root = await createTemporaryDirectory("telemetry-flush-single-413");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+        const settingsFilePath = join(root, "settings.toml");
+        let requestCount = 0;
+
+        enqueueTelemetryBatchItem({
+            directoryPath,
+            item: createTelemetryItemForTest(1),
+            nowMs: 1000,
+        });
+
+        await flushTelemetryOutbox({
+            directoryPath,
+            env: {},
+            fetcher: async () => {
+                requestCount += 1;
+                return new Response("", { status: 413 });
+            },
+            now: () => 10_000,
+            settingsFilePath,
+        });
+
+        expect(requestCount).toBe(1);
+        expect(readTelemetryRowsForTest(directoryPath)).toEqual([]);
+    });
+
+    test("does not count a leased row as attempted before posting starts", async () => {
+        const root = await createTemporaryDirectory("telemetry-flush-crash-before-post");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+        const settingsFilePath = join(root, "settings.toml");
+        const leasedAtMs = 10_000;
+        let requestCount = 0;
+
+        enqueueTelemetryBatchItem({
+            directoryPath,
+            item: createTelemetryItemForTest(1),
+            nowMs: 1000,
+        });
+
+        const database = openTelemetryDatabase(directoryPath);
+
+        try {
+            expect(leaseReadyTelemetryRows(database, leasedAtMs)).toHaveLength(1);
+        }
+        finally {
+            closeTelemetryDatabase(database);
+        }
+
+        await flushTelemetryOutbox({
+            directoryPath,
+            env: {},
+            fetcher: async () => {
+                requestCount += 1;
+                return new Response("");
+            },
+            now: () => leasedAtMs + telemetryLeaseTtlMs - 1,
+            settingsFilePath,
+        });
+
+        expect(requestCount).toBe(0);
+        expect(readTelemetryRowsForTest(directoryPath)).toMatchObject([
+            {
+                attempts: 0,
+                leaseUntilMs: leasedAtMs + telemetryLeaseTtlMs,
+            },
+        ]);
+
+        await flushTelemetryOutbox({
+            directoryPath,
+            env: {},
+            fetcher: async () => {
+                requestCount += 1;
+                return new Response("");
+            },
+            now: () => leasedAtMs + telemetryLeaseTtlMs,
+            settingsFilePath,
+        });
+
+        expect(requestCount).toBe(1);
+        expect(readTelemetryRowsForTest(directoryPath)).toEqual([]);
+    });
+});

--- a/src/application/telemetry/flusher.test.ts
+++ b/src/application/telemetry/flusher.test.ts
@@ -16,7 +16,6 @@ import {
 } from "./constants.ts";
 import { flushTelemetryOutbox } from "./flusher.ts";
 import {
-    closeTelemetryDatabase,
     enqueueTelemetryBatchItem,
     leaseReadyTelemetryRows,
     openTelemetryDatabase,
@@ -292,7 +291,7 @@ describe("telemetry flusher", () => {
             });
         }
         finally {
-            closeTelemetryDatabase(database);
+            database.close();
         }
 
         await flushTelemetryOutbox({
@@ -406,7 +405,7 @@ describe("telemetry flusher", () => {
             expect(leaseReadyTelemetryRows(database, leasedAtMs)).toHaveLength(1);
         }
         finally {
-            closeTelemetryDatabase(database);
+            database.close();
         }
 
         await flushTelemetryOutbox({

--- a/src/application/telemetry/flusher.ts
+++ b/src/application/telemetry/flusher.ts
@@ -16,7 +16,6 @@ import {
 } from "./constants.ts";
 import { resolveTelemetryStatusFromSettingsFile } from "./control.ts";
 import {
-    closeTelemetryDatabase,
     deleteExpiredTelemetryEvents,
     deleteTelemetryRows,
     leaseReadyTelemetryRows,
@@ -134,7 +133,7 @@ export async function flushTelemetryOutbox(
         }
     }
     finally {
-        closeTelemetryDatabase(database);
+        database.close();
     }
 }
 

--- a/src/application/telemetry/flusher.ts
+++ b/src/application/telemetry/flusher.ts
@@ -1,0 +1,287 @@
+import type { Logger } from "pino";
+import type { Fetcher } from "../contracts/cli.ts";
+import type { TelemetryEventRow } from "./outbox.ts";
+import type {
+    TelemetryBatchItem,
+} from "./payload.ts";
+import { Buffer } from "node:buffer";
+import {
+    telemetryBaseBackoffMs,
+    telemetryChunkMaxBytes,
+    telemetryChunkMaxEvents,
+    telemetryEndpoint,
+    telemetryMaxAttempts,
+    telemetryMaxBackoffMs,
+    telemetryRequestTimeoutMs,
+} from "./constants.ts";
+import { resolveTelemetryStatusFromSettingsFile } from "./control.ts";
+import {
+    closeTelemetryDatabase,
+    deleteExpiredTelemetryEvents,
+    deleteTelemetryRows,
+    leaseReadyTelemetryRows,
+    openTelemetryDatabase,
+    parseTelemetryRowPayload,
+    reclaimExpiredTelemetryLeases,
+    recordTelemetryRowsAttempted,
+    releaseTelemetryRowsWithoutAttempt,
+    writeTelemetryStateNumber,
+} from "./outbox.ts";
+import { createTelemetryBatchRequestBody } from "./payload.ts";
+
+export interface FlushTelemetryOutboxOptions {
+    directoryPath: string;
+    env: Record<string, string | undefined>;
+    fetcher?: Fetcher;
+    logger?: Logger;
+    now?: () => number;
+    random?: () => number;
+    requestTimeoutMs?: number;
+    settingsFilePath: string;
+}
+
+interface TelemetryChunk {
+    body: string;
+    rows: TelemetryEventRow[];
+}
+
+export async function flushTelemetryOutbox(
+    options: FlushTelemetryOutboxOptions,
+): Promise<void> {
+    const now = options.now ?? Date.now;
+    const random = options.random ?? Math.random;
+    const fetcher = options.fetcher ?? fetch;
+    const requestTimeoutMs = options.requestTimeoutMs ?? telemetryRequestTimeoutMs;
+    const database = openTelemetryDatabase(options.directoryPath, options.logger);
+
+    try {
+        const nowMs = now();
+
+        reclaimExpiredTelemetryLeases(database, nowMs);
+        deleteExpiredTelemetryEvents(database, nowMs);
+
+        const leasedRows = leaseReadyTelemetryRows(database, nowMs);
+
+        if (leasedRows.length === 0) {
+            return;
+        }
+
+        const status = await resolveTelemetryStatusFromSettingsFile({
+            env: options.env,
+            logger: options.logger,
+            settingsFilePath: options.settingsFilePath,
+        });
+
+        if (!status.enabled) {
+            releaseTelemetryRowsWithoutAttempt(database, leasedRows, nowMs);
+            return;
+        }
+
+        const { chunks, poisonRows } = createTelemetryChunks(leasedRows);
+
+        deleteTelemetryRows(database, poisonRows);
+
+        for (let chunkIndex = 0; chunkIndex < chunks.length;) {
+            const chunk = chunks[chunkIndex]!;
+            const response = await postTelemetryChunk(
+                fetcher,
+                chunk.body,
+                requestTimeoutMs,
+            );
+
+            if (response.kind === "success") {
+                deleteTelemetryRows(database, chunk.rows);
+                writeTelemetryStateNumber(database, "last_flush_at_ms", now());
+                chunkIndex += 1;
+                continue;
+            }
+
+            if (
+                response.kind === "payload_too_large"
+                && chunk.rows.length > 1
+            ) {
+                chunks.splice(chunkIndex, 1, ...splitTelemetryChunk(chunk));
+                continue;
+            }
+
+            if (
+                response.kind === "permanent"
+                || response.kind === "payload_too_large"
+            ) {
+                deleteTelemetryRows(database, chunk.rows);
+                chunkIndex += 1;
+                continue;
+            }
+
+            const failedAtMs = now();
+            const availableAtMs = failedAtMs
+                + calculateTelemetryBackoffMs(chunk.rows, random);
+            const laterRows = chunks
+                .slice(chunkIndex + 1)
+                .flatMap(laterChunk => laterChunk.rows);
+
+            recordTelemetryRowsAttempted(database, chunk.rows, {
+                availableAtMs,
+                maxAttempts: telemetryMaxAttempts,
+            });
+            releaseTelemetryRowsWithoutAttempt(database, laterRows, availableAtMs);
+            writeTelemetryStateNumber(
+                database,
+                "next_spawn_after_ms",
+                availableAtMs,
+            );
+            return;
+        }
+    }
+    finally {
+        closeTelemetryDatabase(database);
+    }
+}
+
+function createTelemetryChunks(rows: readonly TelemetryEventRow[]): {
+    chunks: TelemetryChunk[];
+    poisonRows: TelemetryEventRow[];
+} {
+    const chunks: TelemetryChunk[] = [];
+    const poisonRows: TelemetryEventRow[] = [];
+    let currentRows: TelemetryEventRow[] = [];
+    let currentItems: TelemetryBatchItem[] = [];
+
+    for (const row of rows) {
+        const item = parseTelemetryRowPayload(row);
+
+        if (item === undefined) {
+            poisonRows.push(row);
+            continue;
+        }
+
+        const nextItems = [...currentItems, item];
+        const nextBody = createTelemetryBatchRequestBody(nextItems);
+
+        if (
+            currentRows.length > 0
+            && (
+                currentRows.length >= telemetryChunkMaxEvents
+                || Buffer.byteLength(nextBody, "utf8") > telemetryChunkMaxBytes
+            )
+        ) {
+            chunks.push({
+                body: createTelemetryBatchRequestBody(currentItems),
+                rows: currentRows,
+            });
+            currentRows = [row];
+            currentItems = [item];
+            continue;
+        }
+
+        currentRows.push(row);
+        currentItems.push(item);
+    }
+
+    if (currentRows.length > 0) {
+        chunks.push({
+            body: createTelemetryBatchRequestBody(currentItems),
+            rows: currentRows,
+        });
+    }
+
+    return {
+        chunks,
+        poisonRows,
+    };
+}
+
+async function postTelemetryChunk(
+    fetcher: Fetcher,
+    body: string,
+    timeoutMs: number,
+): Promise<{
+    kind: "payload_too_large" | "permanent" | "retriable" | "success";
+}> {
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(() => abortController.abort(), timeoutMs);
+
+    try {
+        const response = await fetcher(telemetryEndpoint, {
+            body,
+            headers: {
+                "content-type": "application/json",
+            },
+            method: "POST",
+            signal: abortController.signal,
+        });
+
+        if (response.ok) {
+            return { kind: "success" };
+        }
+
+        if (response.status === 413) {
+            return { kind: "payload_too_large" };
+        }
+
+        if (response.status === 400) {
+            return { kind: "permanent" };
+        }
+
+        if (
+            response.status === 408
+            || response.status === 429
+            || response.status >= 500
+        ) {
+            return { kind: "retriable" };
+        }
+
+        return { kind: "permanent" };
+    }
+    catch {
+        return { kind: "retriable" };
+    }
+    finally {
+        clearTimeout(timeoutId);
+    }
+}
+
+function splitTelemetryChunk(chunk: TelemetryChunk): [TelemetryChunk, TelemetryChunk] {
+    const splitIndex = Math.max(1, Math.floor(chunk.rows.length / 2));
+
+    return [
+        createTelemetryChunkFromRows(chunk.rows.slice(0, splitIndex)),
+        createTelemetryChunkFromRows(chunk.rows.slice(splitIndex)),
+    ];
+}
+
+function createTelemetryChunkFromRows(rows: TelemetryEventRow[]): TelemetryChunk {
+    return {
+        body: createTelemetryBatchRequestBody(
+            rows.map(readTelemetryBatchItem),
+        ),
+        rows,
+    };
+}
+
+function readTelemetryBatchItem(row: TelemetryEventRow): TelemetryBatchItem {
+    const item = parseTelemetryRowPayload(row);
+
+    if (item === undefined) {
+        throw new TypeError("Telemetry chunk row became invalid during split.");
+    }
+
+    return item;
+}
+
+function calculateTelemetryBackoffMs(
+    rows: readonly TelemetryEventRow[],
+    random: () => number,
+): number {
+    const nextAttempts = Math.max(
+        1,
+        ...rows.map(row => row.attempts + 1),
+    );
+    const exponentialBackoff = Math.min(
+        telemetryBaseBackoffMs * 2 ** (nextAttempts - 1),
+        telemetryMaxBackoffMs,
+    );
+    const jitter = Math.floor(exponentialBackoff * 0.2 * random());
+
+    return Math.min(exponentialBackoff + jitter, telemetryMaxBackoffMs);
+}

--- a/src/application/telemetry/invocation.ts
+++ b/src/application/telemetry/invocation.ts
@@ -1,0 +1,150 @@
+import type {
+    CliCommandFailedEvent,
+    CliCommandObserver,
+    CliParseErrorKind,
+    CliTelemetryPropertyValue,
+} from "../contracts/cli.ts";
+import type {
+    TelemetryCommandOutcome,
+    TelemetryCommandSnapshot,
+} from "./payload.ts";
+
+export interface TelemetryInvocationRecorder {
+    observer: CliCommandObserver;
+    recordProperties: (
+        properties: Record<string, CliTelemetryPropertyValue>,
+    ) => void;
+    readCommand: () => TelemetryCommandSnapshot;
+    readOutcome: (fallbackExitCode: number) => TelemetryCommandOutcome;
+    shouldSuppress: () => boolean;
+    suppress: () => void;
+}
+
+interface MutableTelemetryInvocationState {
+    command?: TelemetryCommandSnapshot;
+    commanderCode?: string;
+    errorKey?: string;
+    exitCode?: number;
+    parseErrorKind?: CliParseErrorKind;
+    properties: Record<string, CliTelemetryPropertyValue>;
+    suppress: boolean;
+}
+
+export function createTelemetryInvocationRecorder(): TelemetryInvocationRecorder {
+    const state: MutableTelemetryInvocationState = {
+        properties: {},
+        suppress: false,
+    };
+
+    return {
+        observer: {
+            onCommandCompleted(event) {
+                state.exitCode = event.exitCode;
+            },
+            onCommandFailed(event) {
+                applyFailedEvent(state, event);
+            },
+            onCommandResolved(event) {
+                state.command = {
+                    ...resolveTelemetryCommandPath(event.commandPath),
+                    argCount: event.argCount,
+                    excludeFromTelemetry: event.excludeFromTelemetry,
+                    flagsCount: event.flagsCount,
+                    outputFormat: event.outputFormat,
+                };
+            },
+            onParseError(event) {
+                state.commanderCode = event.commanderCode;
+                state.parseErrorKind = event.parseErrorKind;
+
+                if (state.command === undefined) {
+                    state.command = resolveParseTelemetryCommand(event.parseErrorKind);
+                }
+                else {
+                    state.command = {
+                        ...state.command,
+                        parseErrorKind: event.parseErrorKind,
+                    };
+                }
+            },
+        },
+        readCommand() {
+            return {
+                ...(state.command ?? resolveParseTelemetryCommand(state.parseErrorKind)),
+                properties: state.properties,
+            };
+        },
+        readOutcome(fallbackExitCode) {
+            return {
+                commanderCode: state.commanderCode,
+                errorKey: state.errorKey,
+                exitCode: state.exitCode ?? fallbackExitCode,
+                parseErrorKind: state.parseErrorKind,
+            };
+        },
+        shouldSuppress() {
+            return state.suppress;
+        },
+        recordProperties(properties) {
+            state.properties = {
+                ...state.properties,
+                ...properties,
+            };
+        },
+        suppress() {
+            state.suppress = true;
+        },
+    };
+}
+
+function applyFailedEvent(
+    state: MutableTelemetryInvocationState,
+    event: CliCommandFailedEvent,
+): void {
+    state.commanderCode = event.commanderCode;
+    state.errorKey = event.errorKey;
+    state.exitCode = event.exitCode;
+
+    if (event.parseErrorKind !== undefined) {
+        state.parseErrorKind = event.parseErrorKind;
+
+        if (state.command === undefined) {
+            state.command = resolveParseTelemetryCommand(event.parseErrorKind);
+        }
+    }
+}
+
+function resolveTelemetryCommandPath(
+    commandPath: readonly string[],
+): TelemetryCommandSnapshot {
+    const commandGroup = commandPath[0] ?? "__parse__";
+
+    if (commandPath.length <= 1) {
+        return {
+            commandAction: "__root__",
+            commandFull: commandGroup,
+            commandGroup,
+        };
+    }
+
+    const commandAction = commandPath.at(-1) ?? "__root__";
+
+    return {
+        commandAction,
+        commandFull: commandPath.join("."),
+        commandGroup,
+    };
+}
+
+function resolveParseTelemetryCommand(
+    parseErrorKind: CliParseErrorKind | undefined,
+): TelemetryCommandSnapshot {
+    const commandAction = parseErrorKind ?? "__root__";
+
+    return {
+        commandAction,
+        commandFull: `__parse__.${commandAction}`,
+        commandGroup: "__parse__",
+        parseErrorKind,
+    };
+}

--- a/src/application/telemetry/outbox.test.ts
+++ b/src/application/telemetry/outbox.test.ts
@@ -16,6 +16,7 @@ import {
     resolveTelemetryDatabaseFilePath,
     resolveTelemetryDeviceIdFilePath,
 } from "./outbox.ts";
+import { isUuidV7 } from "./uuid.ts";
 
 describe("telemetry outbox", () => {
     const temporaryDirectories = useTemporaryDirectoryCleanup();
@@ -89,7 +90,7 @@ describe("telemetry outbox", () => {
         const next = await readOrCreateTelemetryDeviceId(directoryPath);
 
         expect(created.isFirstRun).toBe(true);
-        expect(isUuidV7ForTest(created.deviceId)).toBe(true);
+        expect(isUuidV7(created.deviceId)).toBe(true);
         expect(await readTelemetryDeviceIdIfExists(directoryPath)).toBe(
             created.deviceId,
         );
@@ -99,16 +100,3 @@ describe("telemetry outbox", () => {
         });
     });
 });
-
-function isUuidV7ForTest(value: string): boolean {
-    const parts = value.split("-");
-
-    return parts.length === 5
-        && parts[0]?.length === 8
-        && parts[1]?.length === 4
-        && parts[2]?.length === 4
-        && parts[2]?.[0] === "7"
-        && parts[3]?.length === 4
-        && ["8", "9", "a", "b"].includes(parts[3]?.[0] ?? "")
-        && parts[4]?.length === 12;
-}

--- a/src/application/telemetry/outbox.test.ts
+++ b/src/application/telemetry/outbox.test.ts
@@ -1,0 +1,114 @@
+import { mkdir, truncate } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+import {
+    createTemporaryDirectory,
+    useTemporaryDirectoryCleanup,
+} from "../../../__tests__/helpers.ts";
+import { createTelemetryItemForTest } from "./__tests__/helpers.ts";
+import { telemetryDatabaseMaxBytes } from "./constants.ts";
+import {
+    enqueueTelemetryBatchItem,
+    readOrCreateTelemetryDeviceId,
+    readTelemetryDeviceIdIfExists,
+    readTelemetryRowsForTest,
+    resolveTelemetryDatabaseFilePath,
+    resolveTelemetryDeviceIdFilePath,
+} from "./outbox.ts";
+
+describe("telemetry outbox", () => {
+    const temporaryDirectories = useTemporaryDirectoryCleanup();
+
+    test("resets a corrupt database without failing enqueue", async () => {
+        const root = await createTemporaryDirectory("telemetry-outbox-corrupt");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+
+        await mkdir(directoryPath, { recursive: true });
+        await Bun.write(resolveTelemetryDatabaseFilePath(directoryPath), "not sqlite");
+
+        const inserted = enqueueTelemetryBatchItem({
+            directoryPath,
+            item: createTelemetryItemForTest(1),
+            nowMs: 1000,
+        });
+
+        expect(inserted).toBe(true);
+        expect(readTelemetryRowsForTest(directoryPath)).toHaveLength(1);
+    });
+
+    test("drops new rows when the database file is over the hard limit", async () => {
+        const root = await createTemporaryDirectory("telemetry-outbox-hard-limit");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+        const databaseFilePath = resolveTelemetryDatabaseFilePath(directoryPath);
+
+        await mkdir(directoryPath, { recursive: true });
+        await Bun.write(databaseFilePath, "");
+        await truncate(databaseFilePath, telemetryDatabaseMaxBytes);
+
+        const inserted = enqueueTelemetryBatchItem({
+            directoryPath,
+            item: createTelemetryItemForTest(1),
+            nowMs: 1000,
+        });
+
+        expect(inserted).toBe(false);
+    });
+
+    test("includes sqlite sidecar files in the hard limit", async () => {
+        const root = await createTemporaryDirectory("telemetry-outbox-sidecar-limit");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+        const databaseFilePath = resolveTelemetryDatabaseFilePath(directoryPath);
+
+        await mkdir(directoryPath, { recursive: true });
+        await Bun.write(databaseFilePath, "");
+        await Bun.write(`${databaseFilePath}-wal`, "");
+        await truncate(`${databaseFilePath}-wal`, telemetryDatabaseMaxBytes);
+
+        const inserted = enqueueTelemetryBatchItem({
+            directoryPath,
+            item: createTelemetryItemForTest(1),
+            nowMs: 1000,
+        });
+
+        expect(inserted).toBe(false);
+    });
+
+    test("repairs invalid persisted device ids with a stable uuid v7", async () => {
+        const root = await createTemporaryDirectory("telemetry-outbox-device-id");
+        temporaryDirectories.track(root);
+        const directoryPath = join(root, "telemetry");
+
+        await mkdir(directoryPath, { recursive: true });
+        await Bun.write(resolveTelemetryDeviceIdFilePath(directoryPath), "");
+
+        const created = await readOrCreateTelemetryDeviceId(directoryPath);
+        const next = await readOrCreateTelemetryDeviceId(directoryPath);
+
+        expect(created.isFirstRun).toBe(true);
+        expect(isUuidV7ForTest(created.deviceId)).toBe(true);
+        expect(await readTelemetryDeviceIdIfExists(directoryPath)).toBe(
+            created.deviceId,
+        );
+        expect(next).toEqual({
+            deviceId: created.deviceId,
+            isFirstRun: false,
+        });
+    });
+});
+
+function isUuidV7ForTest(value: string): boolean {
+    const parts = value.split("-");
+
+    return parts.length === 5
+        && parts[0]?.length === 8
+        && parts[1]?.length === 4
+        && parts[2]?.length === 4
+        && parts[2]?.[0] === "7"
+        && parts[3]?.length === 4
+        && ["8", "9", "a", "b"].includes(parts[3]?.[0] ?? "")
+        && parts[4]?.length === 12;
+}

--- a/src/application/telemetry/outbox.ts
+++ b/src/application/telemetry/outbox.ts
@@ -172,7 +172,7 @@ export function enqueueTelemetryBatchItem(options: {
         return true;
     }
     finally {
-        closeTelemetryDatabase(database);
+        database.close();
     }
 }
 
@@ -193,7 +193,7 @@ export function readTelemetryOutboxSummary(
         };
     }
     finally {
-        closeTelemetryDatabase(database);
+        database.close();
     }
 }
 
@@ -211,7 +211,7 @@ export function purgeTelemetryOutboxIfExists(
         database.run(`DELETE FROM ${telemetryEventsTableName}`);
     }
     finally {
-        closeTelemetryDatabase(database);
+        database.close();
     }
 }
 
@@ -315,6 +315,7 @@ export function leaseReadyTelemetryRows(
     const leasedRows: TelemetryEventRow[] = [];
 
     database.run("BEGIN IMMEDIATE");
+    let committed = false;
 
     try {
         const rows = database.query<TelemetryEventRow, {
@@ -365,10 +366,12 @@ export function leaseReadyTelemetryRows(
         }
 
         database.run("COMMIT");
+        committed = true;
     }
-    catch (error) {
-        database.run("ROLLBACK");
-        throw error;
+    finally {
+        if (!committed) {
+            database.run("ROLLBACK");
+        }
     }
 
     return leasedRows;
@@ -468,7 +471,7 @@ export function readTelemetryRowsForTest(
         ).all(null);
     }
     finally {
-        closeTelemetryDatabase(database);
+        database.close();
     }
 }
 
@@ -484,10 +487,6 @@ export function countTelemetryEvents(database: Database): number {
     ).get(null);
 
     return row?.count ?? 0;
-}
-
-export function closeTelemetryDatabase(database: Database): void {
-    database.close();
 }
 
 function initializeTelemetryDatabase(database: Database): void {
@@ -540,7 +539,7 @@ function openInitializedTelemetryDatabase(filePath: string): Database {
     }
     finally {
         if (!initialized) {
-            closeTelemetryDatabase(database);
+            database.close();
         }
     }
 }

--- a/src/application/telemetry/outbox.ts
+++ b/src/application/telemetry/outbox.ts
@@ -256,13 +256,7 @@ export function openTelemetryDatabase(
     const filePath = resolveTelemetryDatabaseFilePath(directoryPath);
 
     try {
-        const database = openSqliteDatabase(filePath, {
-            busyTimeoutMs: telemetrySqliteBusyTimeoutMs,
-        });
-
-        initializeTelemetryDatabase(database);
-
-        return database;
+        return openInitializedTelemetryDatabase(filePath);
     }
     catch (error) {
         if (!isRecoverableTelemetrySqliteError(error)) {
@@ -279,13 +273,7 @@ export function openTelemetryDatabase(
         );
         resetTelemetryDatabaseFiles(filePath);
 
-        const database = openSqliteDatabase(filePath, {
-            busyTimeoutMs: telemetrySqliteBusyTimeoutMs,
-        });
-
-        initializeTelemetryDatabase(database);
-
-        return database;
+        return openInitializedTelemetryDatabase(filePath);
     }
 }
 
@@ -536,6 +524,25 @@ function initializeTelemetryDatabase(database: Database): void {
             ")",
         ].join(" "),
     );
+}
+
+function openInitializedTelemetryDatabase(filePath: string): Database {
+    const database = openSqliteDatabase(filePath, {
+        busyTimeoutMs: telemetrySqliteBusyTimeoutMs,
+    });
+    let initialized = false;
+
+    try {
+        initializeTelemetryDatabase(database);
+        initialized = true;
+
+        return database;
+    }
+    finally {
+        if (!initialized) {
+            closeTelemetryDatabase(database);
+        }
+    }
 }
 
 function isTelemetryDatabaseOverHardLimit(directoryPath: string): boolean {

--- a/src/application/telemetry/outbox.ts
+++ b/src/application/telemetry/outbox.ts
@@ -1,0 +1,619 @@
+import type { Database } from "bun:sqlite";
+import type { Logger } from "pino";
+
+import type { TelemetryBatchItem } from "./payload.ts";
+import { Buffer } from "node:buffer";
+import { mkdirSync, rmSync, statSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { openSqliteDatabase } from "../../adapters/store/sqlite-utils.ts";
+import { logCategory } from "../logging/log-categories.ts";
+import { withCategory, withStorePath } from "../logging/log-fields.ts";
+import {
+    telemetryDatabaseFileName,
+    telemetryDatabaseMaxBytes,
+    telemetryDeviceIdFileName,
+    telemetryLeaseMaxEvents,
+    telemetryLeaseTtlMs,
+    telemetryMaxAttempts,
+    telemetryMaxEventAgeMs,
+    telemetrySqliteBusyTimeoutMs,
+} from "./constants.ts";
+import {
+    parseTelemetryBatchItemJson,
+    serializeTelemetryBatchItem,
+} from "./payload.ts";
+import { isUuidV7 } from "./uuid.ts";
+
+export interface TelemetryDeviceIdResult {
+    deviceId: string;
+    isFirstRun: boolean;
+}
+
+export interface TelemetryEventRow {
+    attempts: number;
+    availableAtMs: number;
+    createdAtMs: number;
+    id: string;
+    leaseUntilMs: number | null;
+    payloadBytes: number;
+    payloadJson: string;
+}
+
+export interface TelemetryOutboxSummary {
+    lastFlushAtMs?: number;
+    pendingCount: number;
+}
+
+const telemetryEventsTableName = "telemetry_events";
+const telemetryStateTableName = "telemetry_state";
+
+export function resolveTelemetryDatabaseFilePath(directoryPath: string): string {
+    return join(directoryPath, telemetryDatabaseFileName);
+}
+
+export function resolveTelemetryDeviceIdFilePath(directoryPath: string): string {
+    return join(directoryPath, telemetryDeviceIdFileName);
+}
+
+export async function readTelemetryDeviceIdIfExists(
+    directoryPath: string,
+): Promise<string | undefined> {
+    try {
+        const content = await readFile(
+            resolveTelemetryDeviceIdFilePath(directoryPath),
+            "utf8",
+        );
+        const deviceId = content.trim();
+
+        return isUuidV7(deviceId) ? deviceId : undefined;
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
+}
+
+export async function readOrCreateTelemetryDeviceId(
+    directoryPath: string,
+): Promise<TelemetryDeviceIdResult> {
+    const existingDeviceId = await readTelemetryDeviceIdIfExists(directoryPath);
+
+    if (existingDeviceId !== undefined) {
+        return {
+            deviceId: existingDeviceId,
+            isFirstRun: false,
+        };
+    }
+
+    const deviceId = Bun.randomUUIDv7();
+
+    await mkdir(directoryPath, { recursive: true });
+    await writeFile(
+        resolveTelemetryDeviceIdFilePath(directoryPath),
+        `${deviceId}\n`,
+        {
+            encoding: "utf8",
+            flag: "wx",
+        },
+    ).catch(async (error) => {
+        if (!isNodeAlreadyExistsError(error)) {
+            throw error;
+        }
+
+        const racedDeviceId = await readTelemetryDeviceIdIfExists(directoryPath);
+
+        if (racedDeviceId !== undefined) {
+            return;
+        }
+
+        await writeFile(
+            resolveTelemetryDeviceIdFilePath(directoryPath),
+            `${deviceId}\n`,
+            "utf8",
+        );
+    });
+
+    const persistedDeviceId = await readTelemetryDeviceIdIfExists(directoryPath);
+
+    return persistedDeviceId === undefined
+        ? {
+                deviceId,
+                isFirstRun: true,
+            }
+        : {
+                deviceId: persistedDeviceId,
+                isFirstRun: persistedDeviceId === deviceId,
+            };
+}
+
+export function enqueueTelemetryBatchItem(options: {
+    directoryPath: string;
+    item: TelemetryBatchItem;
+    logger?: Logger;
+    nowMs: number;
+}): boolean {
+    const payloadJson = serializeTelemetryBatchItem(options.item);
+
+    if (payloadJson === undefined || isTelemetryDatabaseOverHardLimit(options.directoryPath)) {
+        return false;
+    }
+
+    const database = openTelemetryDatabase(options.directoryPath, options.logger);
+
+    try {
+        database.query(
+            [
+                `INSERT INTO ${telemetryEventsTableName} (`,
+                "id,",
+                "created_at_ms,",
+                "available_at_ms,",
+                "payload_json,",
+                "payload_bytes",
+                ") VALUES (",
+                "$id,",
+                "$createdAtMs,",
+                "$availableAtMs,",
+                "$payloadJson,",
+                "$payloadBytes",
+                ")",
+            ].join(" "),
+        ).run({
+            availableAtMs: options.nowMs,
+            createdAtMs: options.nowMs,
+            id: options.item.uuid,
+            payloadBytes: Buffer.byteLength(payloadJson, "utf8"),
+            payloadJson,
+        });
+
+        return true;
+    }
+    finally {
+        closeTelemetryDatabase(database);
+    }
+}
+
+export function readTelemetryOutboxSummary(
+    directoryPath: string,
+    logger?: Logger,
+): TelemetryOutboxSummary {
+    if (!telemetryDatabaseFileExists(directoryPath)) {
+        return { pendingCount: 0 };
+    }
+
+    const database = openTelemetryDatabase(directoryPath, logger);
+
+    try {
+        return {
+            lastFlushAtMs: readTelemetryStateNumber(database, "last_flush_at_ms"),
+            pendingCount: countTelemetryEvents(database),
+        };
+    }
+    finally {
+        closeTelemetryDatabase(database);
+    }
+}
+
+export function purgeTelemetryOutboxIfExists(
+    directoryPath: string,
+    logger?: Logger,
+): void {
+    if (!telemetryDatabaseFileExists(directoryPath)) {
+        return;
+    }
+
+    const database = openTelemetryDatabase(directoryPath, logger);
+
+    try {
+        database.run(`DELETE FROM ${telemetryEventsTableName}`);
+    }
+    finally {
+        closeTelemetryDatabase(database);
+    }
+}
+
+export function readTelemetryStateNumber(
+    database: Database,
+    key: string,
+): number | undefined {
+    const row = database.query<{ value: string }, { key: string }>(
+        `SELECT value FROM ${telemetryStateTableName} WHERE key = $key LIMIT 1`,
+    ).get({ key });
+
+    if (row === null) {
+        return undefined;
+    }
+
+    const parsed = Number(row.value);
+
+    return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+export function writeTelemetryStateNumber(
+    database: Database,
+    key: string,
+    value: number,
+): void {
+    database.query(
+        [
+            `INSERT INTO ${telemetryStateTableName} (key, value)`,
+            "VALUES ($key, $value)",
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        ].join(" "),
+    ).run({
+        key,
+        value: String(value),
+    });
+}
+
+export function openTelemetryDatabase(
+    directoryPath: string,
+    logger?: Logger,
+): Database {
+    const filePath = resolveTelemetryDatabaseFilePath(directoryPath);
+
+    try {
+        const database = openSqliteDatabase(filePath, {
+            busyTimeoutMs: telemetrySqliteBusyTimeoutMs,
+        });
+
+        initializeTelemetryDatabase(database);
+
+        return database;
+    }
+    catch (error) {
+        if (!isRecoverableTelemetrySqliteError(error)) {
+            throw error;
+        }
+
+        logger?.warn(
+            {
+                ...withCategory(logCategory.systemError),
+                err: error,
+                ...withStorePath(filePath),
+            },
+            "Telemetry sqlite database was reset after a recoverable open failure.",
+        );
+        resetTelemetryDatabaseFiles(filePath);
+
+        const database = openSqliteDatabase(filePath, {
+            busyTimeoutMs: telemetrySqliteBusyTimeoutMs,
+        });
+
+        initializeTelemetryDatabase(database);
+
+        return database;
+    }
+}
+
+export function reclaimExpiredTelemetryLeases(
+    database: Database,
+    nowMs: number,
+): void {
+    database.query(
+        [
+            `UPDATE ${telemetryEventsTableName}`,
+            "SET lease_until_ms = NULL",
+            "WHERE lease_until_ms IS NOT NULL",
+            "AND lease_until_ms <= $nowMs",
+        ].join(" "),
+    ).run({ nowMs });
+}
+
+export function deleteExpiredTelemetryEvents(
+    database: Database,
+    nowMs: number,
+): void {
+    database.query(
+        [
+            `DELETE FROM ${telemetryEventsTableName}`,
+            "WHERE attempts >= $maxAttempts",
+            "OR created_at_ms <= $oldestAllowedMs",
+        ].join(" "),
+    ).run({
+        maxAttempts: telemetryMaxAttempts,
+        oldestAllowedMs: nowMs - telemetryMaxEventAgeMs,
+    });
+}
+
+export function leaseReadyTelemetryRows(
+    database: Database,
+    nowMs: number,
+): TelemetryEventRow[] {
+    const leaseUntilMs = nowMs + telemetryLeaseTtlMs;
+    const leasedRows: TelemetryEventRow[] = [];
+
+    database.run("BEGIN IMMEDIATE");
+
+    try {
+        const rows = database.query<TelemetryEventRow, {
+            limit: number;
+            nowMs: number;
+        }>(
+            [
+                "SELECT",
+                "id AS id,",
+                "created_at_ms AS createdAtMs,",
+                "available_at_ms AS availableAtMs,",
+                "lease_until_ms AS leaseUntilMs,",
+                "attempts AS attempts,",
+                "payload_json AS payloadJson,",
+                "payload_bytes AS payloadBytes",
+                `FROM ${telemetryEventsTableName}`,
+                "WHERE available_at_ms <= $nowMs",
+                "AND (lease_until_ms IS NULL OR lease_until_ms <= $nowMs)",
+                "ORDER BY created_at_ms ASC",
+                "LIMIT $limit",
+            ].join(" "),
+        ).all({
+            limit: telemetryLeaseMaxEvents,
+            nowMs,
+        });
+        const leaseStatement = database.query(
+            [
+                `UPDATE ${telemetryEventsTableName}`,
+                "SET lease_until_ms = $leaseUntilMs",
+                "WHERE id = $id",
+                "AND (lease_until_ms IS NULL OR lease_until_ms <= $nowMs)",
+            ].join(" "),
+        );
+
+        for (const row of rows) {
+            const result = leaseStatement.run({
+                id: row.id,
+                leaseUntilMs,
+                nowMs,
+            });
+
+            if (result.changes > 0) {
+                leasedRows.push({
+                    ...row,
+                    leaseUntilMs,
+                });
+            }
+        }
+
+        database.run("COMMIT");
+    }
+    catch (error) {
+        database.run("ROLLBACK");
+        throw error;
+    }
+
+    return leasedRows;
+}
+
+export function deleteTelemetryRows(
+    database: Database,
+    rows: readonly Pick<TelemetryEventRow, "id">[],
+): void {
+    const statement = database.query(
+        `DELETE FROM ${telemetryEventsTableName} WHERE id = $id`,
+    );
+
+    for (const row of rows) {
+        statement.run({ id: row.id });
+    }
+}
+
+export function recordTelemetryRowsAttempted(
+    database: Database,
+    rows: readonly Pick<TelemetryEventRow, "id">[],
+    options: {
+        availableAtMs: number;
+        maxAttempts: number;
+    },
+): void {
+    const statement = database.query(
+        [
+            `UPDATE ${telemetryEventsTableName}`,
+            "SET attempts = attempts + 1,",
+            "available_at_ms = $availableAtMs,",
+            "lease_until_ms = NULL",
+            "WHERE id = $id",
+        ].join(" "),
+    );
+
+    for (const row of rows) {
+        statement.run({
+            availableAtMs: options.availableAtMs,
+            id: row.id,
+        });
+    }
+
+    database.query(
+        [
+            `DELETE FROM ${telemetryEventsTableName}`,
+            "WHERE attempts >= $maxAttempts",
+        ].join(" "),
+    ).run({ maxAttempts: options.maxAttempts });
+}
+
+export function releaseTelemetryRowsWithoutAttempt(
+    database: Database,
+    rows: readonly Pick<TelemetryEventRow, "id">[],
+    availableAtMs: number,
+): void {
+    const statement = database.query(
+        [
+            `UPDATE ${telemetryEventsTableName}`,
+            "SET available_at_ms = $availableAtMs,",
+            "lease_until_ms = NULL",
+            "WHERE id = $id",
+        ].join(" "),
+    );
+
+    for (const row of rows) {
+        statement.run({
+            availableAtMs,
+            id: row.id,
+        });
+    }
+}
+
+export function readTelemetryRowsForTest(
+    directoryPath: string,
+): TelemetryEventRow[] {
+    if (!telemetryDatabaseFileExists(directoryPath)) {
+        return [];
+    }
+
+    const database = openTelemetryDatabase(directoryPath);
+
+    try {
+        return database.query<TelemetryEventRow, null>(
+            [
+                "SELECT",
+                "id AS id,",
+                "created_at_ms AS createdAtMs,",
+                "available_at_ms AS availableAtMs,",
+                "lease_until_ms AS leaseUntilMs,",
+                "attempts AS attempts,",
+                "payload_json AS payloadJson,",
+                "payload_bytes AS payloadBytes",
+                `FROM ${telemetryEventsTableName}`,
+                "ORDER BY created_at_ms ASC",
+            ].join(" "),
+        ).all(null);
+    }
+    finally {
+        closeTelemetryDatabase(database);
+    }
+}
+
+export function parseTelemetryRowPayload(
+    row: Pick<TelemetryEventRow, "payloadJson">,
+): TelemetryBatchItem | undefined {
+    return parseTelemetryBatchItemJson(row.payloadJson);
+}
+
+export function countTelemetryEvents(database: Database): number {
+    const row = database.query<{ count: number }, null>(
+        `SELECT COUNT(*) AS count FROM ${telemetryEventsTableName}`,
+    ).get(null);
+
+    return row?.count ?? 0;
+}
+
+export function closeTelemetryDatabase(database: Database): void {
+    database.close();
+}
+
+function initializeTelemetryDatabase(database: Database): void {
+    database.run(
+        [
+            `CREATE TABLE IF NOT EXISTS ${telemetryEventsTableName} (`,
+            "id TEXT PRIMARY KEY,",
+            "created_at_ms INTEGER NOT NULL,",
+            "available_at_ms INTEGER NOT NULL,",
+            "lease_until_ms INTEGER,",
+            "attempts INTEGER NOT NULL DEFAULT 0,",
+            "payload_json TEXT NOT NULL,",
+            "payload_bytes INTEGER NOT NULL",
+            ")",
+        ].join(" "),
+    );
+    database.run(
+        [
+            `CREATE INDEX IF NOT EXISTS ${telemetryEventsTableName}_ready_idx`,
+            `ON ${telemetryEventsTableName}(available_at_ms, created_at_ms)`,
+        ].join(" "),
+    );
+    database.run(
+        [
+            `CREATE INDEX IF NOT EXISTS ${telemetryEventsTableName}_lease_idx`,
+            `ON ${telemetryEventsTableName}(lease_until_ms)`,
+        ].join(" "),
+    );
+    database.run(
+        [
+            `CREATE TABLE IF NOT EXISTS ${telemetryStateTableName} (`,
+            "key TEXT PRIMARY KEY,",
+            "value TEXT NOT NULL",
+            ")",
+        ].join(" "),
+    );
+}
+
+function isTelemetryDatabaseOverHardLimit(directoryPath: string): boolean {
+    return readTelemetryDatabaseFileSetBytes(
+        resolveTelemetryDatabaseFilePath(directoryPath),
+    ) >= telemetryDatabaseMaxBytes;
+}
+
+function readTelemetryDatabaseFileSetBytes(filePath: string): number {
+    let totalBytes = 0;
+
+    for (const suffix of ["", "-wal", "-shm"]) {
+        try {
+            const stats = statSync(`${filePath}${suffix}`);
+
+            if (stats.isFile()) {
+                totalBytes += stats.size;
+            }
+        }
+        catch (error) {
+            if (isNodeNotFoundError(error)) {
+                continue;
+            }
+
+            throw error;
+        }
+    }
+
+    return totalBytes;
+}
+
+function telemetryDatabaseFileExists(directoryPath: string): boolean {
+    try {
+        return statSync(resolveTelemetryDatabaseFilePath(directoryPath)).isFile();
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}
+
+function resetTelemetryDatabaseFiles(filePath: string): void {
+    mkdirSync(dirname(filePath), { recursive: true });
+
+    for (const suffix of ["", "-shm", "-wal"]) {
+        rmSync(`${filePath}${suffix}`, {
+            force: true,
+        });
+    }
+}
+
+function isRecoverableTelemetrySqliteError(error: unknown): boolean {
+    if (error === null || typeof error !== "object" || !("code" in error)) {
+        return false;
+    }
+
+    return [
+        "SQLITE_CANTOPEN",
+        "SQLITE_CORRUPT",
+        "SQLITE_IOERR",
+        "SQLITE_NOTADB",
+    ].includes(String(error.code));
+}
+
+function isNodeNotFoundError(error: unknown): boolean {
+    return isNodeErrorWithCode(error, "ENOENT");
+}
+
+function isNodeAlreadyExistsError(error: unknown): boolean {
+    return isNodeErrorWithCode(error, "EEXIST");
+}
+
+function isNodeErrorWithCode(error: unknown, code: string): boolean {
+    return error !== null
+        && typeof error === "object"
+        && "code" in error
+        && error.code === code;
+}

--- a/src/application/telemetry/payload.test.ts
+++ b/src/application/telemetry/payload.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, test } from "bun:test";
+import {
+    classifyTelemetryError,
+    createCliCommandTelemetryPayload,
+    createTelemetryBatchRequestBody,
+    parseTelemetryBatchItemJson,
+    serializeTelemetryBatchItem,
+} from "./payload.ts";
+
+describe("telemetry payload", () => {
+    test("renders the canonical PostHog batch shape", () => {
+        const item = createCanonicalTelemetryItem();
+        const request = JSON.parse(createTelemetryBatchRequestBody([item]));
+        const storedItem = JSON.parse(serializeTelemetryBatchItem(item)!);
+        const postHogSetPropertyName = createPostHogPropertyName("set");
+        const postHogIdentifyPropertyName = createPostHogPropertyName("identify");
+
+        expect(request).toEqual({
+            api_key: "phc_AQhAZ9VYPH9JqgeMtYHc67aZedcQG2zGFTCSJAYrzB7X",
+            batch: [item],
+            historical_migration: false,
+        });
+        expect(request.batch[0]).not.toHaveProperty("distinct_id");
+        expect(request.batch[0].uuid).toBe(
+            "019a0ccb-408c-728a-9df9-1ef51b742b36",
+        );
+        expect(request.batch[0].properties.session_id).toBe(
+            "019a0ccb-1111-7222-8333-444444444444",
+        );
+        expect(request.batch[0].properties.session_id).not.toBe(
+            request.batch[0].uuid,
+        );
+        expect(request.batch[0].properties.distinct_id).toBe(
+            "019a0cca-0000-7000-8000-000000000001",
+        );
+        expect(request.batch[0].properties.$ip).toBe("");
+        expect(request.batch[0].properties.$geoip_disable).toBe(true);
+        expect(request.batch[0].properties.$process_person_profile).toBe(false);
+        expect(request.batch[0].properties).not.toHaveProperty(
+            postHogSetPropertyName,
+        );
+        expect(request.batch[0].properties).not.toHaveProperty(
+            postHogIdentifyPropertyName,
+        );
+        expect(storedItem).not.toHaveProperty("api_key");
+        expect(storedItem).not.toHaveProperty("batch");
+        expect(serializeTelemetryBatchItem(item)).toBe(JSON.stringify(item));
+    });
+
+    test("rejects malformed batch items before they enter the outbox", () => {
+        const item = createCanonicalTelemetryItem();
+        const itemRecord = item as unknown as Record<string, unknown>;
+        const properties = item.properties as Record<string, unknown>;
+        const postHogSetPropertyName = createPostHogPropertyName("set");
+        const postHogSetOncePropertyName = createPostHogPropertyName("set_once");
+
+        const invalidItems = [
+            removeProperty(itemRecord, "event"),
+            removeProperty(itemRecord, "uuid"),
+            {
+                ...itemRecord,
+                uuid: "not-a-uuid-v7",
+            },
+            {
+                ...itemRecord,
+                uuid: "",
+            },
+            removeProperty(itemRecord, "properties"),
+            {
+                ...itemRecord,
+                distinct_id: "must-not-be-top-level",
+            },
+            {
+                ...itemRecord,
+                properties: removeProperty(properties, "distinct_id"),
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    distinct_id: "not-a-uuid-v7",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    distinct_id: "",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: removeProperty(properties, "$process_person_profile"),
+            },
+            {
+                ...itemRecord,
+                properties: removeProperty(properties, "$geoip_disable"),
+            },
+            {
+                ...itemRecord,
+                $ip: "",
+                properties: removeProperty(properties, "$ip"),
+            },
+            {
+                ...itemRecord,
+                $geoip_disable: true,
+                properties: removeProperty(properties, "$geoip_disable"),
+            },
+            {
+                ...itemRecord,
+                $process_person_profile: false,
+                properties: removeProperty(properties, "$process_person_profile"),
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    $geoip_disable: false,
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    $process_person_profile: true,
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    $ip: "127.0.0.1",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    [postHogSetPropertyName]: {
+                        account_id: "forbidden",
+                    },
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    [postHogSetOncePropertyName]: {
+                        user_id: "forbidden",
+                    },
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    account_id: "forbidden",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    account_name: "forbidden",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    hostname: "forbidden",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    path: "/private/path",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    cwd: "/private/workspace",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    file_name: "secret.txt",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    filename: "secret.txt",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    url: "https://internal.example/path",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    url_host: "internal.example",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    email: "user@example.com",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    error_message: "full error text",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
+                    stack_trace: "full stack trace",
+                },
+            },
+        ];
+
+        for (const invalidItem of invalidItems) {
+            expect(
+                parseTelemetryBatchItemJson(JSON.stringify(invalidItem)),
+            ).toBeUndefined();
+        }
+    });
+
+    test("adds command-specific properties", () => {
+        const options = createCanonicalTelemetryOptions();
+        const item = createCliCommandTelemetryPayload({
+            ...options,
+            command: {
+                ...options.command,
+                properties: {
+                    config_key: "lang",
+                },
+            },
+        });
+
+        expect(item.properties.command_full).toBe("config.list");
+        expect(item.properties.distinct_id).toBe(
+            "019a0cca-0000-7000-8000-000000000001",
+        );
+        expect(item.properties.config_key).toBe("lang");
+    });
+
+    test("rejects command-specific telemetry properties that override base properties", () => {
+        const reservedProperties: Record<string, string>[] = [
+            { command_full: "malicious.override" },
+            { distinct_id: "019a0cca-0000-7000-8000-000000000002" },
+            { schema_version: "2" },
+        ];
+
+        for (const properties of reservedProperties) {
+            const options = createCanonicalTelemetryOptions();
+
+            expect(() => createCliCommandTelemetryPayload({
+                ...options,
+                command: {
+                    ...options.command,
+                    properties,
+                },
+            })).toThrow();
+        }
+    });
+
+    test("rejects forbidden command-specific telemetry properties during payload creation", () => {
+        const forbiddenProperties: Record<string, string>[] = [
+            { [createPostHogPropertyName("identify")]: "forbidden" },
+            { [createPostHogPropertyName("set")]: "forbidden" },
+            { [createPostHogPropertyName("set_once")]: "forbidden" },
+            { account_id: "forbidden" },
+            { account_name: "forbidden" },
+            { cwd: "/private/workspace" },
+            { email: "user@example.com" },
+            { error_message: "full error text" },
+            { file_name: "secret.txt" },
+            { filename: "secret.txt" },
+            { host: "internal.example" },
+            { hostname: "workstation.local" },
+            { path: "/private/path" },
+            { stack: "full stack trace" },
+            { stack_trace: "full stack trace" },
+            { url: "https://internal.example/path" },
+            { url_host: "internal.example" },
+            { user_id: "forbidden" },
+            { user_name: "forbidden" },
+            { username: "forbidden" },
+        ];
+
+        for (const properties of forbiddenProperties) {
+            const options = createCanonicalTelemetryOptions();
+
+            expect(() => createCliCommandTelemetryPayload({
+                ...options,
+                command: {
+                    ...options.command,
+                    properties,
+                },
+            })).toThrow();
+        }
+    });
+
+    test("rejects oversized event payloads before they enter the outbox", () => {
+        const item = createCanonicalTelemetryItem();
+
+        item.properties.large_value = "x".repeat(4096);
+
+        expect(serializeTelemetryBatchItem(item)).toBeUndefined();
+    });
+
+    test("measures event size by bytes instead of string length", () => {
+        const item = createCanonicalTelemetryItem();
+
+        item.properties.large_value = "界".repeat(1400);
+
+        expect(serializeTelemetryBatchItem(item)).toBeUndefined();
+    });
+
+    test("classifies failed command outcomes by structured error keys", () => {
+        expect(classifyTelemetryError({
+            errorKey: "errors.fileDownload.requestFailed",
+            exitCode: 1,
+        })).toBe("network_error");
+        expect(classifyTelemetryError({
+            errorKey: "errors.auth.required",
+            exitCode: 1,
+        })).toBe("auth_error");
+        expect(classifyTelemetryError({
+            errorKey: "errors.store.readFailed",
+            exitCode: 1,
+        })).toBe("system_error");
+        expect(classifyTelemetryError({
+            errorKey: "errors.config.invalidKey",
+            exitCode: 2,
+        })).toBe("user_error");
+        expect(classifyTelemetryError({
+            exitCode: 1,
+        })).toBe("user_error");
+        expect(classifyTelemetryError({
+            errorKey: "errors.fileDownload.requestFailed",
+            exitCode: 0,
+        })).toBeUndefined();
+    });
+});
+
+function createCanonicalTelemetryItem() {
+    return createCliCommandTelemetryPayload(createCanonicalTelemetryOptions());
+}
+
+function createCanonicalTelemetryOptions() {
+    return {
+        accountState: "authenticated",
+        arch: "arm64",
+        ciName: "none",
+        cliCommit: "abcdef0",
+        cliInstallMethod: "native",
+        cliVersion: "1.2.3",
+        command: {
+            argCount: 0,
+            commandAction: "list",
+            commandFull: "config.list",
+            commandGroup: "config",
+            flagsCount: 0,
+            outputFormat: "text",
+        },
+        distinctId: "019a0cca-0000-7000-8000-000000000001",
+        durationMs: 42,
+        isCi: false,
+        isFirstRun: false,
+        isTtyStderr: true,
+        isTtyStdout: true,
+        lang: "zh",
+        os: "darwin",
+        osVersion: "15.4.0",
+        outcome: {
+            exitCode: 0,
+        },
+        runtimeVersion: "1.2.10",
+        sessionId: "019a0ccb-1111-7222-8333-444444444444",
+        timestamp: new Date("2026-05-07T12:34:56.789Z"),
+        uuid: "019a0ccb-408c-728a-9df9-1ef51b742b36",
+    } as const;
+}
+
+function removeProperty(
+    source: Record<string, unknown>,
+    propertyName: string,
+): Record<string, unknown> {
+    const next = { ...source };
+
+    delete next[propertyName];
+
+    return next;
+}
+
+function createPostHogPropertyName(name: string): string {
+    return `$${name}`;
+}

--- a/src/application/telemetry/payload.ts
+++ b/src/application/telemetry/payload.ts
@@ -1,0 +1,334 @@
+import type { CliTelemetryPropertyValue } from "../contracts/cli.ts";
+import { Buffer } from "node:buffer";
+import { z } from "zod";
+import {
+    telemetryEventName,
+    telemetryMaxEventBytes,
+    telemetryPostHogApiKey,
+    telemetrySchemaVersion,
+} from "./constants.ts";
+import { isUuidV7 } from "./uuid.ts";
+
+export type TelemetryAccountState = "anonymous" | "authenticated" | "unknown";
+export type TelemetryErrorCategory
+    = | "auth_error"
+        | "network_error"
+        | "system_error"
+        | "user_error";
+export type TelemetryOutputFormat = "json" | "text";
+export type TelemetryPropertyValue
+    = CliTelemetryPropertyValue;
+
+export interface TelemetryCommandSnapshot {
+    argCount?: number;
+    commandAction?: string;
+    commandFull?: string;
+    commandGroup?: string;
+    excludeFromTelemetry?: boolean;
+    flagsCount?: number;
+    outputFormat?: TelemetryOutputFormat;
+    parseErrorKind?: string;
+    properties?: Record<string, TelemetryPropertyValue>;
+}
+
+export interface TelemetryCommandOutcome {
+    commanderCode?: string;
+    errorKey?: string;
+    exitCode: number;
+    parseErrorKind?: string;
+}
+
+export interface CreateCliCommandTelemetryPayloadOptions {
+    accountState: TelemetryAccountState;
+    arch: string;
+    cliCommit: string;
+    cliInstallMethod: string;
+    cliVersion: string;
+    command: TelemetryCommandSnapshot;
+    durationMs: number;
+    isCi: boolean;
+    isFirstRun: boolean;
+    isTtyStderr: boolean;
+    isTtyStdout: boolean;
+    lang: string;
+    os: string;
+    osVersion: string;
+    outcome: TelemetryCommandOutcome;
+    runtimeVersion: string;
+    sessionId: string;
+    timestamp: Date;
+    uuid: string;
+    distinctId: string;
+    ciName: string;
+}
+
+export interface TelemetryBatchItem {
+    event: string;
+    properties: Record<string, TelemetryPropertyValue>;
+    timestamp: string;
+    uuid: string;
+}
+
+const telemetryPropertyValueSchema = z.union([
+    z.boolean(),
+    z.number(),
+    z.string(),
+    z.array(z.string()),
+]);
+const uuidV7Schema = z.string().refine(isUuidV7);
+
+const telemetryPropertiesSchema = z.object({
+    $geoip_disable: z.literal(true),
+    $ip: z.literal(""),
+    $process_person_profile: z.literal(false),
+    account_state: z.enum(["authenticated", "anonymous", "unknown"]),
+    arch: z.string().min(1),
+    arg_count: z.number().int().nonnegative(),
+    ci_name: z.string().min(1),
+    cli_commit: z.string().min(1),
+    cli_install_method: z.enum(["bun", "native", "npm", "pnpm", "unknown", "yarn"]),
+    cli_version: z.string().min(1),
+    command_action: z.string().min(1),
+    command_full: z.string().min(1),
+    command_group: z.string().min(1),
+    distinct_id: uuidV7Schema,
+    duration_ms: z.number().int().nonnegative(),
+    exit_code: z.number().int(),
+    flags_count: z.number().int().nonnegative(),
+    is_ci: z.boolean(),
+    is_first_run: z.boolean(),
+    is_tty_stderr: z.boolean(),
+    is_tty_stdout: z.boolean(),
+    lang: z.string().min(1),
+    os: z.string().min(1),
+    os_version: z.string().min(1),
+    output_format: z.enum(["json", "text"]),
+    runtime: z.literal("bun"),
+    runtime_version: z.string().min(1),
+    schema_version: z.literal(telemetrySchemaVersion),
+    session_id: uuidV7Schema,
+    success: z.boolean(),
+}).catchall(telemetryPropertyValueSchema);
+const forbiddenTelemetryPropertyKeys = [
+    createPostHogPropertyName("identify"),
+    createPostHogPropertyName("set"),
+    createPostHogPropertyName(["set", "once"].join("_")),
+    ["account", "id"].join("_"),
+    ["account", "name"].join("_"),
+    "cwd",
+    "email",
+    ["error", "message"].join("_"),
+    ["file", "name"].join("_"),
+    "filename",
+    "host",
+    ["host", "name"].join(""),
+    "path",
+    "stack",
+    ["stack", "trace"].join("_"),
+    "url",
+    ["url", "host"].join("_"),
+    ["user", "id"].join("_"),
+    ["user", "name"].join("_"),
+    "username",
+] as const;
+
+export const telemetryBatchItemSchema = z.object({
+    event: z.literal(telemetryEventName),
+    properties: telemetryPropertiesSchema,
+    timestamp: z.string().datetime(),
+    uuid: uuidV7Schema,
+}).strict().superRefine((item, ctx) => {
+    if (Object.hasOwn(item, "distinct_id")) {
+        ctx.addIssue({
+            code: "custom",
+            message: "distinct_id must be stored in properties.",
+            path: ["distinct_id"],
+        });
+    }
+
+    for (const forbiddenKey of forbiddenTelemetryPropertyKeys) {
+        if (Object.hasOwn(item.properties, forbiddenKey)) {
+            ctx.addIssue({
+                code: "custom",
+                message: `${forbiddenKey} is not allowed in telemetry properties.`,
+                path: ["properties", forbiddenKey],
+            });
+        }
+    }
+});
+
+function createPostHogPropertyName(name: string): string {
+    return `$${name}`;
+}
+
+export function createCliCommandTelemetryPayload(
+    options: CreateCliCommandTelemetryPayloadOptions,
+): TelemetryBatchItem {
+    const commandGroup = options.command.commandGroup ?? "__parse__";
+    const commandAction = options.command.commandAction ?? "__root__";
+    const commandFull = options.command.commandFull
+        ?? `${commandGroup}.${commandAction}`;
+    const parseErrorKind = options.command.parseErrorKind
+        ?? options.outcome.parseErrorKind;
+    const properties: Record<string, TelemetryPropertyValue> = {
+        $geoip_disable: true,
+        $ip: "",
+        $process_person_profile: false,
+        account_state: options.accountState,
+        arch: options.arch,
+        arg_count: options.command.argCount ?? 0,
+        ci_name: options.ciName,
+        cli_commit: options.cliCommit,
+        cli_install_method: options.cliInstallMethod,
+        cli_version: options.cliVersion,
+        command_action: commandAction,
+        command_full: commandFull,
+        command_group: commandGroup,
+        distinct_id: options.distinctId,
+        duration_ms: options.durationMs,
+        exit_code: options.outcome.exitCode,
+        flags_count: options.command.flagsCount ?? 0,
+        is_ci: options.isCi,
+        is_first_run: options.isFirstRun,
+        is_tty_stderr: options.isTtyStderr,
+        is_tty_stdout: options.isTtyStdout,
+        lang: options.lang,
+        os: options.os,
+        os_version: options.osVersion,
+        output_format: options.command.outputFormat ?? "text",
+        runtime: "bun",
+        runtime_version: options.runtimeVersion,
+        schema_version: telemetrySchemaVersion,
+        session_id: options.sessionId,
+        success: options.outcome.exitCode === 0,
+    };
+
+    if (parseErrorKind !== undefined) {
+        properties.parse_error_kind = parseErrorKind;
+    }
+
+    appendCommandSpecificProperties(properties, options.command.properties);
+
+    const errorCategory = classifyTelemetryError(options.outcome);
+
+    if (errorCategory !== undefined) {
+        properties.error_category = errorCategory;
+    }
+
+    return telemetryBatchItemSchema.parse({
+        event: telemetryEventName,
+        properties,
+        timestamp: options.timestamp.toISOString(),
+        uuid: options.uuid,
+    });
+}
+
+function appendCommandSpecificProperties(
+    target: Record<string, TelemetryPropertyValue>,
+    source: Record<string, TelemetryPropertyValue> | undefined,
+): void {
+    if (source === undefined) {
+        return;
+    }
+
+    for (const [key, value] of Object.entries(source)) {
+        if (Object.hasOwn(target, key)) {
+            throw new TypeError(
+                `Command telemetry property ${key} cannot override a base telemetry property.`,
+            );
+        }
+
+        target[key] = value;
+    }
+}
+
+export function serializeTelemetryBatchItem(item: TelemetryBatchItem): string | undefined {
+    const parsed = telemetryBatchItemSchema.safeParse(item);
+
+    if (!parsed.success) {
+        return undefined;
+    }
+
+    const payloadJson = JSON.stringify(parsed.data);
+
+    return Buffer.byteLength(payloadJson, "utf8") <= telemetryMaxEventBytes
+        ? payloadJson
+        : undefined;
+}
+
+export function parseTelemetryBatchItemJson(
+    payloadJson: string,
+): TelemetryBatchItem | undefined {
+    try {
+        const parsed = telemetryBatchItemSchema.safeParse(JSON.parse(payloadJson));
+
+        return parsed.success ? parsed.data : undefined;
+    }
+    catch {
+        return undefined;
+    }
+}
+
+export function createTelemetryBatchRequestBody(
+    items: readonly TelemetryBatchItem[],
+): string {
+    return JSON.stringify({
+        api_key: telemetryPostHogApiKey,
+        batch: items,
+        historical_migration: false,
+    });
+}
+
+export function classifyTelemetryError(
+    outcome: TelemetryCommandOutcome,
+): TelemetryErrorCategory | undefined {
+    if (outcome.exitCode === 0) {
+        return undefined;
+    }
+
+    const errorKey = outcome.errorKey;
+
+    if (errorKey === undefined) {
+        return "user_error";
+    }
+
+    if (
+        errorKey.endsWith(".downloadError")
+        || errorKey.endsWith(".downloadFailed")
+        || errorKey.endsWith(".downloadStalled")
+        || errorKey.endsWith(".downloadTimedOut")
+        || errorKey.endsWith(".invalidResponse")
+        || errorKey.endsWith(".packageDownloadError")
+        || errorKey.endsWith(".packageDownloadFailed")
+        || errorKey.endsWith(".packageInfoRequestError")
+        || errorKey.endsWith(".packageInfoRequestFailed")
+        || errorKey.endsWith(".requestError")
+        || errorKey.endsWith(".requestFailed")
+    ) {
+        return "network_error";
+    }
+
+    if (
+        errorKey === "errors.auth.noSavedAccounts"
+        || errorKey === "errors.auth.required"
+        || errorKey === "errors.auth.sessionTokenRequired"
+        || errorKey === "errors.auth.loginTimeout"
+    ) {
+        return "auth_error";
+    }
+
+    if (
+        errorKey === "errors.unexpected"
+        || errorKey.startsWith("errors.authStore.")
+        || errorKey.startsWith("errors.store.")
+        || errorKey.endsWith(".dataReadFailed")
+        || errorKey.endsWith(".outDirCreateFailed")
+        || errorKey.endsWith(".readFailed")
+        || errorKey.endsWith(".storageConflict")
+        || errorKey.endsWith(".writeFailed")
+    ) {
+        return "system_error";
+    }
+
+    return "user_error";
+}

--- a/src/application/telemetry/status.ts
+++ b/src/application/telemetry/status.ts
@@ -1,0 +1,42 @@
+import type { AppSettings } from "../schemas/settings.ts";
+
+import { readEnvBoolean } from "../shared/env-boolean.ts";
+import {
+    doNotTrackEnvKey,
+    telemetryDisabledEnvKey,
+} from "./constants.ts";
+
+export type TelemetryDisabledReason = "config" | "env";
+
+export interface TelemetryEffectiveStatus {
+    enabled: boolean;
+    disabledReason?: TelemetryDisabledReason;
+}
+
+export function resolveTelemetryEffectiveStatus(options: {
+    env: Record<string, string | undefined>;
+    settings: AppSettings;
+}): TelemetryEffectiveStatus {
+    if (isTelemetryDisabledByEnv(options.env)) {
+        return {
+            disabledReason: "env",
+            enabled: false,
+        };
+    }
+
+    if (options.settings.telemetry?.enabled === false) {
+        return {
+            disabledReason: "config",
+            enabled: false,
+        };
+    }
+
+    return { enabled: true };
+}
+
+export function isTelemetryDisabledByEnv(
+    env: Record<string, string | undefined>,
+): boolean {
+    return readEnvBoolean(env[telemetryDisabledEnvKey]) === true
+        || readEnvBoolean(env[doNotTrackEnvKey]) === true;
+}

--- a/src/application/telemetry/uuid.ts
+++ b/src/application/telemetry/uuid.ts
@@ -1,0 +1,44 @@
+export function isUuidV7(value: string): boolean {
+    const parts = value.split("-");
+    const expectedLengths = [8, 4, 4, 4, 12] as const;
+
+    if (parts.length !== expectedLengths.length) {
+        return false;
+    }
+
+    for (const [index, expectedLength] of expectedLengths.entries()) {
+        const part = parts[index]!;
+
+        if (part.length !== expectedLength || !isHexString(part)) {
+            return false;
+        }
+    }
+
+    return parts[2]![0] === "7" && isUuidVariant(parts[3]![0]!);
+}
+
+function isHexString(value: string): boolean {
+    for (const char of value) {
+        const lower = char.toLowerCase();
+
+        if (
+            !(
+                (lower >= "0" && lower <= "9")
+                || (lower >= "a" && lower <= "f")
+            )
+        ) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function isUuidVariant(char: string): boolean {
+    const lower = char.toLowerCase();
+
+    return lower === "8"
+        || lower === "9"
+        || lower === "a"
+        || lower === "b";
+}

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -73,6 +73,17 @@ export const enMessages = {
     "commands.config.set.summary": "Persist a configuration value",
     "commands.config.unset.description": "Remove a persisted configuration value.",
     "commands.config.unset.summary": "Remove a configuration value",
+    "commands.telemetry.description":
+        "Inspect and update privacy-constrained CLI telemetry settings.",
+    "commands.telemetry.summary": "Manage CLI telemetry",
+    "commands.telemetry.disable.description":
+        "Disable CLI telemetry and synchronously purge pending telemetry events.",
+    "commands.telemetry.disable.summary": "Disable CLI telemetry",
+    "commands.telemetry.enable.description": "Enable CLI telemetry.",
+    "commands.telemetry.enable.summary": "Enable CLI telemetry",
+    "commands.telemetry.status.description":
+        "Show the effective telemetry state, device id prefix, pending count, and last flush time.",
+    "commands.telemetry.status.summary": "Show telemetry status",
     "commands.file.cleanup.description":
         "Delete expired upload records from the local sqlite store.",
     "commands.file.cleanup.summary": "Clean expired upload records",
@@ -161,6 +172,13 @@ export const enMessages = {
     "commands.skills.uninstall.summary": "Remove a managed skill",
     "config.set.success": "Set {key} to {value}.",
     "config.unset.success": "Removed {key}.",
+    "telemetry.disable.success": "Telemetry disabled.",
+    "telemetry.enable.success": "Telemetry enabled.",
+    "telemetry.status.deviceId": "device_id: {value}",
+    "telemetry.status.enabled": "enabled: {value}",
+    "telemetry.status.lastFlush": "last_flush: {value}",
+    "telemetry.status.none": "none",
+    "telemetry.status.pending": "pending: {value}",
     "errors.commander.excessArguments": "Too many arguments were provided.",
     "errors.commander.invalidArgument": "Invalid argument: {value}.",
     "errors.commander.missingArgument": "Missing required argument: {value}.",
@@ -303,6 +321,8 @@ export const enMessages = {
         "Invalid lang value: {value}. Use en or zh.",
     "errors.config.invalidFileDownloadOutDirValue":
         "Invalid file.download.out_dir value: {value}. Use a non-empty path.",
+    "errors.config.invalidTelemetryEnabledValue":
+        "Invalid telemetry.enabled value: {value}. Use true or false.",
     "errors.skills.invalidName":
         "Unsupported skill: {value}. Use {choices}.",
     "errors.skills.invalidPath":
@@ -856,6 +876,17 @@ export const zhMessages = {
     "commands.config.set.summary": "持久化配置值",
     "commands.config.unset.description": "移除一个持久化配置值。",
     "commands.config.unset.summary": "移除配置值",
+    "commands.telemetry.description":
+        "查看并更新受隐私约束的 CLI telemetry 设置。",
+    "commands.telemetry.summary": "管理 CLI telemetry",
+    "commands.telemetry.disable.description":
+        "关闭 CLI telemetry，并同步清空待发送 telemetry 事件。",
+    "commands.telemetry.disable.summary": "关闭 CLI telemetry",
+    "commands.telemetry.enable.description": "开启 CLI telemetry。",
+    "commands.telemetry.enable.summary": "开启 CLI telemetry",
+    "commands.telemetry.status.description":
+        "显示 telemetry 的实际开关状态、device id 前缀、待发送数量和最后 flush 时间。",
+    "commands.telemetry.status.summary": "显示 telemetry 状态",
     "commands.file.cleanup.description": "删除本地 sqlite 中已过期的上传记录。",
     "commands.file.cleanup.summary": "清理已过期上传记录",
     "commands.file.description": "管理临时文件传输。",
@@ -931,6 +962,13 @@ export const zhMessages = {
     "commands.skills.uninstall.summary": "移除一个受管理的 skill",
     "config.set.success": "已将 {key} 设置为 {value}。",
     "config.unset.success": "已移除 {key}。",
+    "telemetry.disable.success": "已关闭 telemetry。",
+    "telemetry.enable.success": "已开启 telemetry。",
+    "telemetry.status.deviceId": "device_id: {value}",
+    "telemetry.status.enabled": "enabled: {value}",
+    "telemetry.status.lastFlush": "last_flush: {value}",
+    "telemetry.status.none": "none",
+    "telemetry.status.pending": "pending: {value}",
     "errors.commander.excessArguments": "提供了过多的参数。",
     "errors.commander.invalidArgument": "参数无效：{value}。",
     "errors.commander.missingArgument": "缺少必填参数：{value}。",
@@ -1062,6 +1100,8 @@ export const zhMessages = {
         "无效的 lang 值：{value}。请使用 en 或 zh。",
     "errors.config.invalidFileDownloadOutDirValue":
         "无效的 file.download.out_dir 值：{value}。请使用非空路径。",
+    "errors.config.invalidTelemetryEnabledValue":
+        "无效的 telemetry.enabled 值：{value}。请使用 true 或 false。",
     "errors.skills.invalidName":
         "不支持的 skill：{value}。请使用 {choices}。",
     "errors.skills.invalidPath":


### PR DESCRIPTION
Introduce an opt-out telemetry pipeline so we can understand command adoption, error rates, update health, and package or skill usage distribution without harvesting user content.

Events are emitted by the generic executeCli path and persisted to a local outbox before being flushed to PostHog Cloud (EU region) with person profile processing disabled and a random local device id. A telemetry-decisions architecture test forces every registered command to make an explicit telemetry decision and rejects forbidden, private, or sensitive property names at build time.

Add `oo telemetry status|enable|disable`, the `telemetry.enabled` config key, and `OO_TELEMETRY_DISABLED` / `DO_NOT_TRACK` env overrides. Disabling telemetry attempts to purge pending local events immediately and prevents future sends. Document the boundary in PRIVACY.md, PRIVACY-ZH_CN.md, README files, and docs/commands*.md so users can audit exactly what is and is not collected.