### PR TITLE
[codex] Tighten oo-create-skill authoring guidance

### DIFF
--- a/contrib/skills/claude/oo-create-skill/SKILL.md
+++ b/contrib/skills/claude/oo-create-skill/SKILL.md
@@ -35,11 +35,17 @@ this constitution, not a separate checklist.
    that metadata, schemas, or command output can answer: package/block
    references, connector service/action identifiers, payload field names,
    result field paths, command shape, authentication state, defaults, or schema
-   constraints.
-3. Resolve once, then shorten future executions. The generated skill must
-   contain concrete package/block references or connector service/action
-   identifiers, plus the minimum payload, result, and failure guidance needed
-   so future agents do not run discovery again.
+   constraints. Treat local `schemaPath` files as supporting metadata, not proof
+   that a connector action is currently exposed by `oo`; pin only actions whose
+   service/action identity is confirmed by current command output.
+3. Resolve and test before writing the runbook. Do not predesign the whole
+   execution process and then look for metadata that seems to fit it. Discover
+   the capability, inspect metadata, run the smallest safe test when command
+   shape or result shape matters, and then write the generated skill from those
+   observed facts. The generated skill must contain concrete package/block
+   references or connector service/action identifiers, plus the minimum payload,
+   result, and failure guidance needed so future agents do not run discovery
+   again.
 4. Choose the most direct capability for the user's outcome. Treat Fusion API,
    ordinary connectors, packages, and blocks as first-class candidates. Prefer
    domain fit over result ordering. When choices are otherwise equivalent,
@@ -124,6 +130,21 @@ Use `oo connector search "<goal>" --json` only to refine a shortlisted connector
 path, not to restart broad discovery. Do not force a package or block reference
 when the chosen reusable workflow is connector-backed.
 
+Do not write a connector action into a generated skill just because a local
+schema file exists. If command output does not expose the candidate action, or a
+non-destructive invocation reports `unknown action`, choose an exposed action
+that satisfies the workflow instead and document any important runtime shape
+change, such as async submission plus polling replacing a synchronous call.
+
+When result shape, status transitions, file return format, or envelope structure
+will affect the runbook, run a minimal representative invocation or status/result
+poll during authoring whenever it is safe and proportionate. Do not spend
+meaningful user money, mutate external state, disclose sensitive data, or trigger
+large jobs only to learn a response shape; ask the user or use documented dry-run
+or read-only paths when those risks are material. If a field path is inferred
+from schema rather than observed, label that uncertainty in the generated skill
+instead of presenting it as tested fact.
+
 Keep chosen packages, blocks, or connector actions concrete in the generated
 skill.
 
@@ -177,7 +198,9 @@ headings but include these execution facts when metadata provides them:
   to report on success and what not to treat as the final result. For generated
   files, images, documents, archives, media, or other artifacts, state how
   future agents should preview them or deliver them to the user instead of only
-  reporting a local path.
+  reporting a local path. For inline base64 or `data:` URI artifacts, tell
+  future agents to save and preview the artifact rather than printing the full
+  encoded payload.
 - Failure handling: action-specific stop conditions from schema or metadata,
   plus common auth, permission, billing, schema rejection, inaccessible file,
   timeout, and not-found branches.

--- a/contrib/skills/claude/oo-create-skill/SKILL.md
+++ b/contrib/skills/claude/oo-create-skill/SKILL.md
@@ -31,21 +31,21 @@ this constitution, not a separate checklist.
    metadata ambiguity with multiple user-visible outcomes. Prefer a short
    choice prompt with a recommended option when asking; add a free-form input
    option only when the decision cannot be covered by concrete choices.
-2. `oo` metadata defines execution facts. Do not ask the user to resolve facts
-   that metadata, schemas, or command output can answer: package/block
-   references, connector service/action identifiers, payload field names,
-   result field paths, command shape, authentication state, defaults, or schema
-   constraints. Treat local `schemaPath` files as supporting metadata, not proof
-   that a connector action is currently exposed by `oo`; pin only actions whose
-   service/action identity is confirmed by current command output.
+2. `oo` metadata and command output define execution facts. Do not ask the user
+   to resolve facts that metadata, schemas, or command output can answer:
+   package/block references, connector service/action identifiers, payload
+   field names, result field paths, command shape, authentication state,
+   defaults, or schema constraints. Treat local `schemaPath` files as supporting
+   metadata; current command output or a safe invocation must confirm connector
+   action availability and observed result paths.
 3. Resolve and test before writing the runbook. Do not predesign the whole
    execution process and then look for metadata that seems to fit it. Discover
-   the capability, inspect metadata, run the smallest safe test when command
-   shape or result shape matters, and then write the generated skill from those
-   observed facts. The generated skill must contain concrete package/block
-   references or connector service/action identifiers, plus the minimum payload,
-   result, and failure guidance needed so future agents do not run discovery
-   again.
+   the capability, inspect metadata, run the smallest safe test when command,
+   result, status, file, or envelope shape matters, and write from observed
+   facts. Mark schema-only inferences as untested. The generated skill must
+   contain concrete package/block references or connector service/action
+   identifiers plus the minimum payload, result, and failure guidance needed so
+   future agents do not run discovery again.
 4. Choose the most direct capability for the user's outcome. Treat Fusion API,
    ordinary connectors, packages, and blocks as first-class candidates. Prefer
    domain fit over result ordering. When choices are otherwise equivalent,
@@ -130,20 +130,19 @@ Use `oo connector search "<goal>" --json` only to refine a shortlisted connector
 path, not to restart broad discovery. Do not force a package or block reference
 when the chosen reusable workflow is connector-backed.
 
-Do not write a connector action into a generated skill just because a local
-schema file exists. If command output does not expose the candidate action, or a
-non-destructive invocation reports `unknown action`, choose an exposed action
-that satisfies the workflow instead and document any important runtime shape
-change, such as async submission plus polling replacing a synchronous call.
+Do not choose a connector action just because a local schema file exists. If
+command output does not expose the candidate action, or a non-destructive test
+reports `unknown action`, choose an exposed action and document any runtime
+shape change, such as async submission plus polling replacing a synchronous
+call.
 
 When result shape, status transitions, file return format, or envelope structure
 will affect the runbook, run a minimal representative invocation or status/result
-poll during authoring whenever it is safe and proportionate. Do not spend
-meaningful user money, mutate external state, disclose sensitive data, or trigger
-large jobs only to learn a response shape; ask the user or use documented dry-run
-or read-only paths when those risks are material. If a field path is inferred
-from schema rather than observed, label that uncertainty in the generated skill
-instead of presenting it as tested fact.
+poll during authoring when safe and proportionate. Do not spend meaningful user
+money, mutate external state, disclose sensitive data, or trigger large jobs
+only to learn a response shape; ask the user or use documented dry-run or
+read-only paths when those risks are material. If a field path is inferred from
+schema rather than observed, label it as untested.
 
 Keep chosen packages, blocks, or connector actions concrete in the generated
 skill.
@@ -223,22 +222,16 @@ Preserve `metadata.title` when it exists. If you change the displayed title or
 first heading, update `metadata.title` to match. If `metadata.title` or
 `metadata.icon` is absent, add a suitable value.
 
-The final skill must contain concrete package/block references or connector
-service/action identifiers. It must not instruct future agents to run `oo
-search`, `oo connector search`, or discover capabilities at execution time.
+The final skill must not instruct future agents to run `oo search`, `oo
+connector search`, or discover capabilities at execution time. Include only the
+selected package/block references or connector service/action identity, command
+shape, payload rules, result extraction, common stop conditions, and async or
+idempotency guidance that observed metadata, output shape, or documented oo
+workflow exposes.
 
-Do not duplicate broad oo execution mechanics. For connector-backed workflows,
-include only the selected service/action identity, the small connector command
-shape, payload rules, result extraction, and common stop conditions such as
-missing inputs, inaccessible files, schema rejection, auth, billing,
-permission, timeout, or not-found blockers. Include async polling, status
-checks, or idempotency guidance only when the selected action metadata, output
-shape, or documented oo workflow exposes those behaviors.
-
-Before finishing, check whether the generated skill will shorten future
-executions: a future agent should reach the selected capability without
-rediscovery, build a valid payload, read the useful result, and stop on common
-failures. If not, add only the missing execution guidance.
+Before finishing, check that a future agent can reach the selected capability
+without rediscovery, build a valid payload, read the useful result, and stop on
+common failures. If not, add only the missing execution guidance.
 
 Keep `SKILL.md` concise. Use `references/workflow.md` only when the workflow
 has several steps, decision rules, or examples. Use `references/packages.json`

--- a/contrib/skills/codebuddy/oo-create-skill/SKILL.md
+++ b/contrib/skills/codebuddy/oo-create-skill/SKILL.md
@@ -34,11 +34,17 @@ this constitution, not a separate checklist.
    that metadata, schemas, or command output can answer: package/block
    references, connector service/action identifiers, payload field names,
    result field paths, command shape, authentication state, defaults, or schema
-   constraints.
-3. Resolve once, then shorten future executions. The generated skill must
-   contain concrete package/block references or connector service/action
-   identifiers, plus the minimum payload, result, and failure guidance needed
-   so future agents do not run discovery again.
+   constraints. Treat local `schemaPath` files as supporting metadata, not proof
+   that a connector action is currently exposed by `oo`; pin only actions whose
+   service/action identity is confirmed by current command output.
+3. Resolve and test before writing the runbook. Do not predesign the whole
+   execution process and then look for metadata that seems to fit it. Discover
+   the capability, inspect metadata, run the smallest safe test when command
+   shape or result shape matters, and then write the generated skill from those
+   observed facts. The generated skill must contain concrete package/block
+   references or connector service/action identifiers, plus the minimum payload,
+   result, and failure guidance needed so future agents do not run discovery
+   again.
 4. Choose the most direct capability for the user's outcome. Treat Fusion API,
    ordinary connectors, packages, and blocks as first-class candidates. Prefer
    domain fit over result ordering. When choices are otherwise equivalent,
@@ -123,6 +129,21 @@ Use `oo connector search "<goal>" --json` only to refine a shortlisted connector
 path, not to restart broad discovery. Do not force a package or block reference
 when the chosen reusable workflow is connector-backed.
 
+Do not write a connector action into a generated skill just because a local
+schema file exists. If command output does not expose the candidate action, or a
+non-destructive invocation reports `unknown action`, choose an exposed action
+that satisfies the workflow instead and document any important runtime shape
+change, such as async submission plus polling replacing a synchronous call.
+
+When result shape, status transitions, file return format, or envelope structure
+will affect the runbook, run a minimal representative invocation or status/result
+poll during authoring whenever it is safe and proportionate. Do not spend
+meaningful user money, mutate external state, disclose sensitive data, or trigger
+large jobs only to learn a response shape; ask the user or use documented dry-run
+or read-only paths when those risks are material. If a field path is inferred
+from schema rather than observed, label that uncertainty in the generated skill
+instead of presenting it as tested fact.
+
 Keep chosen packages, blocks, or connector actions concrete in the generated
 skill.
 
@@ -176,7 +197,9 @@ headings but include these execution facts when metadata provides them:
   to report on success and what not to treat as the final result. For generated
   files, images, documents, archives, media, or other artifacts, state how
   future agents should preview them or deliver them to the user instead of only
-  reporting a local path.
+  reporting a local path. For inline base64 or `data:` URI artifacts, tell
+  future agents to save and preview the artifact rather than printing the full
+  encoded payload.
 - Failure handling: action-specific stop conditions from schema or metadata,
   plus common auth, permission, billing, schema rejection, inaccessible file,
   timeout, and not-found branches.

--- a/contrib/skills/codebuddy/oo-create-skill/SKILL.md
+++ b/contrib/skills/codebuddy/oo-create-skill/SKILL.md
@@ -30,21 +30,21 @@ this constitution, not a separate checklist.
    metadata ambiguity with multiple user-visible outcomes. Prefer a short
    choice prompt with a recommended option when asking; add a free-form input
    option only when the decision cannot be covered by concrete choices.
-2. `oo` metadata defines execution facts. Do not ask the user to resolve facts
-   that metadata, schemas, or command output can answer: package/block
-   references, connector service/action identifiers, payload field names,
-   result field paths, command shape, authentication state, defaults, or schema
-   constraints. Treat local `schemaPath` files as supporting metadata, not proof
-   that a connector action is currently exposed by `oo`; pin only actions whose
-   service/action identity is confirmed by current command output.
+2. `oo` metadata and command output define execution facts. Do not ask the user
+   to resolve facts that metadata, schemas, or command output can answer:
+   package/block references, connector service/action identifiers, payload
+   field names, result field paths, command shape, authentication state,
+   defaults, or schema constraints. Treat local `schemaPath` files as supporting
+   metadata; current command output or a safe invocation must confirm connector
+   action availability and observed result paths.
 3. Resolve and test before writing the runbook. Do not predesign the whole
    execution process and then look for metadata that seems to fit it. Discover
-   the capability, inspect metadata, run the smallest safe test when command
-   shape or result shape matters, and then write the generated skill from those
-   observed facts. The generated skill must contain concrete package/block
-   references or connector service/action identifiers, plus the minimum payload,
-   result, and failure guidance needed so future agents do not run discovery
-   again.
+   the capability, inspect metadata, run the smallest safe test when command,
+   result, status, file, or envelope shape matters, and write from observed
+   facts. Mark schema-only inferences as untested. The generated skill must
+   contain concrete package/block references or connector service/action
+   identifiers plus the minimum payload, result, and failure guidance needed so
+   future agents do not run discovery again.
 4. Choose the most direct capability for the user's outcome. Treat Fusion API,
    ordinary connectors, packages, and blocks as first-class candidates. Prefer
    domain fit over result ordering. When choices are otherwise equivalent,
@@ -129,20 +129,19 @@ Use `oo connector search "<goal>" --json` only to refine a shortlisted connector
 path, not to restart broad discovery. Do not force a package or block reference
 when the chosen reusable workflow is connector-backed.
 
-Do not write a connector action into a generated skill just because a local
-schema file exists. If command output does not expose the candidate action, or a
-non-destructive invocation reports `unknown action`, choose an exposed action
-that satisfies the workflow instead and document any important runtime shape
-change, such as async submission plus polling replacing a synchronous call.
+Do not choose a connector action just because a local schema file exists. If
+command output does not expose the candidate action, or a non-destructive test
+reports `unknown action`, choose an exposed action and document any runtime
+shape change, such as async submission plus polling replacing a synchronous
+call.
 
 When result shape, status transitions, file return format, or envelope structure
 will affect the runbook, run a minimal representative invocation or status/result
-poll during authoring whenever it is safe and proportionate. Do not spend
-meaningful user money, mutate external state, disclose sensitive data, or trigger
-large jobs only to learn a response shape; ask the user or use documented dry-run
-or read-only paths when those risks are material. If a field path is inferred
-from schema rather than observed, label that uncertainty in the generated skill
-instead of presenting it as tested fact.
+poll during authoring when safe and proportionate. Do not spend meaningful user
+money, mutate external state, disclose sensitive data, or trigger large jobs
+only to learn a response shape; ask the user or use documented dry-run or
+read-only paths when those risks are material. If a field path is inferred from
+schema rather than observed, label it as untested.
 
 Keep chosen packages, blocks, or connector actions concrete in the generated
 skill.
@@ -222,22 +221,16 @@ Preserve `metadata.title` when it exists. If you change the displayed title or
 first heading, update `metadata.title` to match. If `metadata.title` or
 `metadata.icon` is absent, add a suitable value.
 
-The final skill must contain concrete package/block references or connector
-service/action identifiers. It must not instruct future agents to run `oo
-search`, `oo connector search`, or discover capabilities at execution time.
+The final skill must not instruct future agents to run `oo search`, `oo
+connector search`, or discover capabilities at execution time. Include only the
+selected package/block references or connector service/action identity, command
+shape, payload rules, result extraction, common stop conditions, and async or
+idempotency guidance that observed metadata, output shape, or documented oo
+workflow exposes.
 
-Do not duplicate broad oo execution mechanics. For connector-backed workflows,
-include only the selected service/action identity, the small connector command
-shape, payload rules, result extraction, and common stop conditions such as
-missing inputs, inaccessible files, schema rejection, auth, billing,
-permission, timeout, or not-found blockers. Include async polling, status
-checks, or idempotency guidance only when the selected action metadata, output
-shape, or documented oo workflow exposes those behaviors.
-
-Before finishing, check whether the generated skill will shorten future
-executions: a future agent should reach the selected capability without
-rediscovery, build a valid payload, read the useful result, and stop on common
-failures. If not, add only the missing execution guidance.
+Before finishing, check that a future agent can reach the selected capability
+without rediscovery, build a valid payload, read the useful result, and stop on
+common failures. If not, add only the missing execution guidance.
 
 Keep `SKILL.md` concise. Use `references/workflow.md` only when the workflow
 has several steps, decision rules, or examples. Use `references/packages.json`

--- a/contrib/skills/codex/oo-create-skill/SKILL.md
+++ b/contrib/skills/codex/oo-create-skill/SKILL.md
@@ -30,21 +30,21 @@ this constitution, not a separate checklist.
    metadata ambiguity with multiple user-visible outcomes. Prefer a short
    choice prompt with a recommended option when asking; add a free-form input
    option only when the decision cannot be covered by concrete choices.
-2. `oo` metadata defines execution facts. Do not ask the user to resolve facts
-   that metadata, schemas, or command output can answer: package/block
-   references, connector service/action identifiers, payload field names,
-   result field paths, command shape, authentication state, defaults, or schema
-   constraints. Treat local `schemaPath` files as supporting metadata, not proof
-   that a connector action is currently exposed by `oo`; pin only actions whose
-   service/action identity is confirmed by current command output.
+2. `oo` metadata and command output define execution facts. Do not ask the user
+   to resolve facts that metadata, schemas, or command output can answer:
+   package/block references, connector service/action identifiers, payload
+   field names, result field paths, command shape, authentication state,
+   defaults, or schema constraints. Treat local `schemaPath` files as supporting
+   metadata; current command output or a safe invocation must confirm connector
+   action availability and observed result paths.
 3. Resolve and test before writing the runbook. Do not predesign the whole
    execution process and then look for metadata that seems to fit it. Discover
-   the capability, inspect metadata, run the smallest safe test when command
-   shape or result shape matters, and then write the generated skill from those
-   observed facts. The generated skill must contain concrete package/block
-   references or connector service/action identifiers, plus the minimum payload,
-   result, and failure guidance needed so future agents do not run discovery
-   again.
+   the capability, inspect metadata, run the smallest safe test when command,
+   result, status, file, or envelope shape matters, and write from observed
+   facts. Mark schema-only inferences as untested. The generated skill must
+   contain concrete package/block references or connector service/action
+   identifiers plus the minimum payload, result, and failure guidance needed so
+   future agents do not run discovery again.
 4. Choose the most direct capability for the user's outcome. Treat Fusion API,
    ordinary connectors, packages, and blocks as first-class candidates. Prefer
    domain fit over result ordering. When choices are otherwise equivalent,
@@ -156,20 +156,19 @@ Use `oo connector search "<goal>" --json` only to refine a shortlisted connector
 path, not to restart broad discovery. Do not force a package or block reference
 when the chosen reusable workflow is connector-backed.
 
-Do not write a connector action into a generated skill just because a local
-schema file exists. If command output does not expose the candidate action, or a
-non-destructive invocation reports `unknown action`, choose an exposed action
-that satisfies the workflow instead and document any important runtime shape
-change, such as async submission plus polling replacing a synchronous call.
+Do not choose a connector action just because a local schema file exists. If
+command output does not expose the candidate action, or a non-destructive test
+reports `unknown action`, choose an exposed action and document any runtime
+shape change, such as async submission plus polling replacing a synchronous
+call.
 
 When result shape, status transitions, file return format, or envelope structure
 will affect the runbook, run a minimal representative invocation or status/result
-poll during authoring whenever it is safe and proportionate. Do not spend
-meaningful user money, mutate external state, disclose sensitive data, or trigger
-large jobs only to learn a response shape; ask the user or use documented dry-run
-or read-only paths when those risks are material. If a field path is inferred
-from schema rather than observed, label that uncertainty in the generated skill
-instead of presenting it as tested fact.
+poll during authoring when safe and proportionate. Do not spend meaningful user
+money, mutate external state, disclose sensitive data, or trigger large jobs
+only to learn a response shape; ask the user or use documented dry-run or
+read-only paths when those risks are material. If a field path is inferred from
+schema rather than observed, label it as untested.
 
 Keep chosen packages, blocks, or connector actions concrete in the generated
 skill.
@@ -253,22 +252,16 @@ Preserve `metadata.title` when it exists. If you change the displayed title or
 first heading, update `metadata.title` to match. If `metadata.title` or
 `metadata.icon` is absent, add a suitable value.
 
-The final skill must contain concrete package/block references or connector
-service/action identifiers. It must not instruct future agents to run `oo
-search`, `oo connector search`, or discover capabilities at execution time.
+The final skill must not instruct future agents to run `oo search`, `oo
+connector search`, or discover capabilities at execution time. Include only the
+selected package/block references or connector service/action identity, command
+shape, payload rules, result extraction, common stop conditions, and async or
+idempotency guidance that observed metadata, output shape, or documented oo
+workflow exposes.
 
-Do not duplicate broad oo execution mechanics. For connector-backed workflows,
-include only the selected service/action identity, the small connector command
-shape, payload rules, result extraction, and common stop conditions such as
-missing inputs, inaccessible files, schema rejection, auth, billing,
-permission, timeout, or not-found blockers. Include async polling, status
-checks, or idempotency guidance only when the selected action metadata, output
-shape, or documented oo workflow exposes those behaviors.
-
-Before finishing, check whether the generated skill will shorten future
-executions: a future agent should reach the selected capability without
-rediscovery, build a valid payload, read the useful result, and stop on common
-failures. If not, add only the missing execution guidance.
+Before finishing, check that a future agent can reach the selected capability
+without rediscovery, build a valid payload, read the useful result, and stop on
+common failures. If not, add only the missing execution guidance.
 
 Keep `SKILL.md` concise. Use `references/workflow.md` only when the workflow
 has several steps, decision rules, or examples. Use `references/packages.json`

--- a/contrib/skills/codex/oo-create-skill/SKILL.md
+++ b/contrib/skills/codex/oo-create-skill/SKILL.md
@@ -34,11 +34,17 @@ this constitution, not a separate checklist.
    that metadata, schemas, or command output can answer: package/block
    references, connector service/action identifiers, payload field names,
    result field paths, command shape, authentication state, defaults, or schema
-   constraints.
-3. Resolve once, then shorten future executions. The generated skill must
-   contain concrete package/block references or connector service/action
-   identifiers, plus the minimum payload, result, and failure guidance needed
-   so future agents do not run discovery again.
+   constraints. Treat local `schemaPath` files as supporting metadata, not proof
+   that a connector action is currently exposed by `oo`; pin only actions whose
+   service/action identity is confirmed by current command output.
+3. Resolve and test before writing the runbook. Do not predesign the whole
+   execution process and then look for metadata that seems to fit it. Discover
+   the capability, inspect metadata, run the smallest safe test when command
+   shape or result shape matters, and then write the generated skill from those
+   observed facts. The generated skill must contain concrete package/block
+   references or connector service/action identifiers, plus the minimum payload,
+   result, and failure guidance needed so future agents do not run discovery
+   again.
 4. Choose the most direct capability for the user's outcome. Treat Fusion API,
    ordinary connectors, packages, and blocks as first-class candidates. Prefer
    domain fit over result ordering. When choices are otherwise equivalent,
@@ -150,6 +156,21 @@ Use `oo connector search "<goal>" --json` only to refine a shortlisted connector
 path, not to restart broad discovery. Do not force a package or block reference
 when the chosen reusable workflow is connector-backed.
 
+Do not write a connector action into a generated skill just because a local
+schema file exists. If command output does not expose the candidate action, or a
+non-destructive invocation reports `unknown action`, choose an exposed action
+that satisfies the workflow instead and document any important runtime shape
+change, such as async submission plus polling replacing a synchronous call.
+
+When result shape, status transitions, file return format, or envelope structure
+will affect the runbook, run a minimal representative invocation or status/result
+poll during authoring whenever it is safe and proportionate. Do not spend
+meaningful user money, mutate external state, disclose sensitive data, or trigger
+large jobs only to learn a response shape; ask the user or use documented dry-run
+or read-only paths when those risks are material. If a field path is inferred
+from schema rather than observed, label that uncertainty in the generated skill
+instead of presenting it as tested fact.
+
 Keep chosen packages, blocks, or connector actions concrete in the generated
 skill.
 
@@ -207,7 +228,9 @@ headings but include these execution facts when metadata provides them:
   to report on success and what not to treat as the final result. For generated
   files, images, documents, archives, media, or other artifacts, state how
   future agents should preview them or deliver them to the user instead of only
-  reporting a local path.
+  reporting a local path. For inline base64 or `data:` URI artifacts, tell
+  future agents to save and preview the artifact rather than printing the full
+  encoded payload.
 - Failure handling: action-specific stop conditions from schema or metadata,
   plus common auth, permission, billing, schema rejection, inaccessible file,
   timeout, and not-found branches.

--- a/contrib/skills/openclaw/oo-create-skill/SKILL.md
+++ b/contrib/skills/openclaw/oo-create-skill/SKILL.md
@@ -34,11 +34,17 @@ this constitution, not a separate checklist.
    that metadata, schemas, or command output can answer: package/block
    references, connector service/action identifiers, payload field names,
    result field paths, command shape, authentication state, defaults, or schema
-   constraints.
-3. Resolve once, then shorten future executions. The generated skill must
-   contain concrete package/block references or connector service/action
-   identifiers, plus the minimum payload, result, and failure guidance needed
-   so future agents do not run discovery again.
+   constraints. Treat local `schemaPath` files as supporting metadata, not proof
+   that a connector action is currently exposed by `oo`; pin only actions whose
+   service/action identity is confirmed by current command output.
+3. Resolve and test before writing the runbook. Do not predesign the whole
+   execution process and then look for metadata that seems to fit it. Discover
+   the capability, inspect metadata, run the smallest safe test when command
+   shape or result shape matters, and then write the generated skill from those
+   observed facts. The generated skill must contain concrete package/block
+   references or connector service/action identifiers, plus the minimum payload,
+   result, and failure guidance needed so future agents do not run discovery
+   again.
 4. Choose the most direct capability for the user's outcome. Treat Fusion API,
    ordinary connectors, packages, and blocks as first-class candidates. Prefer
    domain fit over result ordering. When choices are otherwise equivalent,
@@ -123,6 +129,21 @@ Use `oo connector search "<goal>" --json` only to refine a shortlisted connector
 path, not to restart broad discovery. Do not force a package or block reference
 when the chosen reusable workflow is connector-backed.
 
+Do not write a connector action into a generated skill just because a local
+schema file exists. If command output does not expose the candidate action, or a
+non-destructive invocation reports `unknown action`, choose an exposed action
+that satisfies the workflow instead and document any important runtime shape
+change, such as async submission plus polling replacing a synchronous call.
+
+When result shape, status transitions, file return format, or envelope structure
+will affect the runbook, run a minimal representative invocation or status/result
+poll during authoring whenever it is safe and proportionate. Do not spend
+meaningful user money, mutate external state, disclose sensitive data, or trigger
+large jobs only to learn a response shape; ask the user or use documented dry-run
+or read-only paths when those risks are material. If a field path is inferred
+from schema rather than observed, label that uncertainty in the generated skill
+instead of presenting it as tested fact.
+
 Keep chosen packages, blocks, or connector actions concrete in the generated
 skill.
 
@@ -176,7 +197,9 @@ headings but include these execution facts when metadata provides them:
   to report on success and what not to treat as the final result. For generated
   files, images, documents, archives, media, or other artifacts, state how
   future agents should preview them or deliver them to the user instead of only
-  reporting a local path.
+  reporting a local path. For inline base64 or `data:` URI artifacts, tell
+  future agents to save and preview the artifact rather than printing the full
+  encoded payload.
 - Failure handling: action-specific stop conditions from schema or metadata,
   plus common auth, permission, billing, schema rejection, inaccessible file,
   timeout, and not-found branches.

--- a/contrib/skills/openclaw/oo-create-skill/SKILL.md
+++ b/contrib/skills/openclaw/oo-create-skill/SKILL.md
@@ -30,21 +30,21 @@ this constitution, not a separate checklist.
    metadata ambiguity with multiple user-visible outcomes. Prefer a short
    choice prompt with a recommended option when asking; add a free-form input
    option only when the decision cannot be covered by concrete choices.
-2. `oo` metadata defines execution facts. Do not ask the user to resolve facts
-   that metadata, schemas, or command output can answer: package/block
-   references, connector service/action identifiers, payload field names,
-   result field paths, command shape, authentication state, defaults, or schema
-   constraints. Treat local `schemaPath` files as supporting metadata, not proof
-   that a connector action is currently exposed by `oo`; pin only actions whose
-   service/action identity is confirmed by current command output.
+2. `oo` metadata and command output define execution facts. Do not ask the user
+   to resolve facts that metadata, schemas, or command output can answer:
+   package/block references, connector service/action identifiers, payload
+   field names, result field paths, command shape, authentication state,
+   defaults, or schema constraints. Treat local `schemaPath` files as supporting
+   metadata; current command output or a safe invocation must confirm connector
+   action availability and observed result paths.
 3. Resolve and test before writing the runbook. Do not predesign the whole
    execution process and then look for metadata that seems to fit it. Discover
-   the capability, inspect metadata, run the smallest safe test when command
-   shape or result shape matters, and then write the generated skill from those
-   observed facts. The generated skill must contain concrete package/block
-   references or connector service/action identifiers, plus the minimum payload,
-   result, and failure guidance needed so future agents do not run discovery
-   again.
+   the capability, inspect metadata, run the smallest safe test when command,
+   result, status, file, or envelope shape matters, and write from observed
+   facts. Mark schema-only inferences as untested. The generated skill must
+   contain concrete package/block references or connector service/action
+   identifiers plus the minimum payload, result, and failure guidance needed so
+   future agents do not run discovery again.
 4. Choose the most direct capability for the user's outcome. Treat Fusion API,
    ordinary connectors, packages, and blocks as first-class candidates. Prefer
    domain fit over result ordering. When choices are otherwise equivalent,
@@ -129,20 +129,19 @@ Use `oo connector search "<goal>" --json` only to refine a shortlisted connector
 path, not to restart broad discovery. Do not force a package or block reference
 when the chosen reusable workflow is connector-backed.
 
-Do not write a connector action into a generated skill just because a local
-schema file exists. If command output does not expose the candidate action, or a
-non-destructive invocation reports `unknown action`, choose an exposed action
-that satisfies the workflow instead and document any important runtime shape
-change, such as async submission plus polling replacing a synchronous call.
+Do not choose a connector action just because a local schema file exists. If
+command output does not expose the candidate action, or a non-destructive test
+reports `unknown action`, choose an exposed action and document any runtime
+shape change, such as async submission plus polling replacing a synchronous
+call.
 
 When result shape, status transitions, file return format, or envelope structure
 will affect the runbook, run a minimal representative invocation or status/result
-poll during authoring whenever it is safe and proportionate. Do not spend
-meaningful user money, mutate external state, disclose sensitive data, or trigger
-large jobs only to learn a response shape; ask the user or use documented dry-run
-or read-only paths when those risks are material. If a field path is inferred
-from schema rather than observed, label that uncertainty in the generated skill
-instead of presenting it as tested fact.
+poll during authoring when safe and proportionate. Do not spend meaningful user
+money, mutate external state, disclose sensitive data, or trigger large jobs
+only to learn a response shape; ask the user or use documented dry-run or
+read-only paths when those risks are material. If a field path is inferred from
+schema rather than observed, label it as untested.
 
 Keep chosen packages, blocks, or connector actions concrete in the generated
 skill.
@@ -222,22 +221,16 @@ Preserve `metadata.title` when it exists. If you change the displayed title or
 first heading, update `metadata.title` to match. If `metadata.title` or
 `metadata.icon` is absent, add a suitable value.
 
-The final skill must contain concrete package/block references or connector
-service/action identifiers. It must not instruct future agents to run `oo
-search`, `oo connector search`, or discover capabilities at execution time.
+The final skill must not instruct future agents to run `oo search`, `oo
+connector search`, or discover capabilities at execution time. Include only the
+selected package/block references or connector service/action identity, command
+shape, payload rules, result extraction, common stop conditions, and async or
+idempotency guidance that observed metadata, output shape, or documented oo
+workflow exposes.
 
-Do not duplicate broad oo execution mechanics. For connector-backed workflows,
-include only the selected service/action identity, the small connector command
-shape, payload rules, result extraction, and common stop conditions such as
-missing inputs, inaccessible files, schema rejection, auth, billing,
-permission, timeout, or not-found blockers. Include async polling, status
-checks, or idempotency guidance only when the selected action metadata, output
-shape, or documented oo workflow exposes those behaviors.
-
-Before finishing, check whether the generated skill will shorten future
-executions: a future agent should reach the selected capability without
-rediscovery, build a valid payload, read the useful result, and stop on common
-failures. If not, add only the missing execution guidance.
+Before finishing, check that a future agent can reach the selected capability
+without rediscovery, build a valid payload, read the useful result, and stop on
+common failures. If not, add only the missing execution guidance.
 
 Keep `SKILL.md` concise. Use `references/workflow.md` only when the workflow
 has several steps, decision rules, or examples. Use `references/packages.json`

--- a/contrib/skills/qoderwork/oo-create-skill/SKILL.md
+++ b/contrib/skills/qoderwork/oo-create-skill/SKILL.md
@@ -34,11 +34,17 @@ this constitution, not a separate checklist.
    that metadata, schemas, or command output can answer: package/block
    references, connector service/action identifiers, payload field names,
    result field paths, command shape, authentication state, defaults, or schema
-   constraints.
-3. Resolve once, then shorten future executions. The generated skill must
-   contain concrete package/block references or connector service/action
-   identifiers, plus the minimum payload, result, and failure guidance needed
-   so future agents do not run discovery again.
+   constraints. Treat local `schemaPath` files as supporting metadata, not proof
+   that a connector action is currently exposed by `oo`; pin only actions whose
+   service/action identity is confirmed by current command output.
+3. Resolve and test before writing the runbook. Do not predesign the whole
+   execution process and then look for metadata that seems to fit it. Discover
+   the capability, inspect metadata, run the smallest safe test when command
+   shape or result shape matters, and then write the generated skill from those
+   observed facts. The generated skill must contain concrete package/block
+   references or connector service/action identifiers, plus the minimum payload,
+   result, and failure guidance needed so future agents do not run discovery
+   again.
 4. Choose the most direct capability for the user's outcome. Treat Fusion API,
    ordinary connectors, packages, and blocks as first-class candidates. Prefer
    domain fit over result ordering. When choices are otherwise equivalent,
@@ -123,6 +129,21 @@ Use `oo connector search "<goal>" --json` only to refine a shortlisted connector
 path, not to restart broad discovery. Do not force a package or block reference
 when the chosen reusable workflow is connector-backed.
 
+Do not write a connector action into a generated skill just because a local
+schema file exists. If command output does not expose the candidate action, or a
+non-destructive invocation reports `unknown action`, choose an exposed action
+that satisfies the workflow instead and document any important runtime shape
+change, such as async submission plus polling replacing a synchronous call.
+
+When result shape, status transitions, file return format, or envelope structure
+will affect the runbook, run a minimal representative invocation or status/result
+poll during authoring whenever it is safe and proportionate. Do not spend
+meaningful user money, mutate external state, disclose sensitive data, or trigger
+large jobs only to learn a response shape; ask the user or use documented dry-run
+or read-only paths when those risks are material. If a field path is inferred
+from schema rather than observed, label that uncertainty in the generated skill
+instead of presenting it as tested fact.
+
 Keep chosen packages, blocks, or connector actions concrete in the generated
 skill.
 
@@ -176,7 +197,9 @@ headings but include these execution facts when metadata provides them:
   to report on success and what not to treat as the final result. For generated
   files, images, documents, archives, media, or other artifacts, state how
   future agents should preview them or deliver them to the user instead of only
-  reporting a local path.
+  reporting a local path. For inline base64 or `data:` URI artifacts, tell
+  future agents to save and preview the artifact rather than printing the full
+  encoded payload.
 - Failure handling: action-specific stop conditions from schema or metadata,
   plus common auth, permission, billing, schema rejection, inaccessible file,
   timeout, and not-found branches.

--- a/contrib/skills/qoderwork/oo-create-skill/SKILL.md
+++ b/contrib/skills/qoderwork/oo-create-skill/SKILL.md
@@ -30,21 +30,21 @@ this constitution, not a separate checklist.
    metadata ambiguity with multiple user-visible outcomes. Prefer a short
    choice prompt with a recommended option when asking; add a free-form input
    option only when the decision cannot be covered by concrete choices.
-2. `oo` metadata defines execution facts. Do not ask the user to resolve facts
-   that metadata, schemas, or command output can answer: package/block
-   references, connector service/action identifiers, payload field names,
-   result field paths, command shape, authentication state, defaults, or schema
-   constraints. Treat local `schemaPath` files as supporting metadata, not proof
-   that a connector action is currently exposed by `oo`; pin only actions whose
-   service/action identity is confirmed by current command output.
+2. `oo` metadata and command output define execution facts. Do not ask the user
+   to resolve facts that metadata, schemas, or command output can answer:
+   package/block references, connector service/action identifiers, payload
+   field names, result field paths, command shape, authentication state,
+   defaults, or schema constraints. Treat local `schemaPath` files as supporting
+   metadata; current command output or a safe invocation must confirm connector
+   action availability and observed result paths.
 3. Resolve and test before writing the runbook. Do not predesign the whole
    execution process and then look for metadata that seems to fit it. Discover
-   the capability, inspect metadata, run the smallest safe test when command
-   shape or result shape matters, and then write the generated skill from those
-   observed facts. The generated skill must contain concrete package/block
-   references or connector service/action identifiers, plus the minimum payload,
-   result, and failure guidance needed so future agents do not run discovery
-   again.
+   the capability, inspect metadata, run the smallest safe test when command,
+   result, status, file, or envelope shape matters, and write from observed
+   facts. Mark schema-only inferences as untested. The generated skill must
+   contain concrete package/block references or connector service/action
+   identifiers plus the minimum payload, result, and failure guidance needed so
+   future agents do not run discovery again.
 4. Choose the most direct capability for the user's outcome. Treat Fusion API,
    ordinary connectors, packages, and blocks as first-class candidates. Prefer
    domain fit over result ordering. When choices are otherwise equivalent,
@@ -129,20 +129,19 @@ Use `oo connector search "<goal>" --json` only to refine a shortlisted connector
 path, not to restart broad discovery. Do not force a package or block reference
 when the chosen reusable workflow is connector-backed.
 
-Do not write a connector action into a generated skill just because a local
-schema file exists. If command output does not expose the candidate action, or a
-non-destructive invocation reports `unknown action`, choose an exposed action
-that satisfies the workflow instead and document any important runtime shape
-change, such as async submission plus polling replacing a synchronous call.
+Do not choose a connector action just because a local schema file exists. If
+command output does not expose the candidate action, or a non-destructive test
+reports `unknown action`, choose an exposed action and document any runtime
+shape change, such as async submission plus polling replacing a synchronous
+call.
 
 When result shape, status transitions, file return format, or envelope structure
 will affect the runbook, run a minimal representative invocation or status/result
-poll during authoring whenever it is safe and proportionate. Do not spend
-meaningful user money, mutate external state, disclose sensitive data, or trigger
-large jobs only to learn a response shape; ask the user or use documented dry-run
-or read-only paths when those risks are material. If a field path is inferred
-from schema rather than observed, label that uncertainty in the generated skill
-instead of presenting it as tested fact.
+poll during authoring when safe and proportionate. Do not spend meaningful user
+money, mutate external state, disclose sensitive data, or trigger large jobs
+only to learn a response shape; ask the user or use documented dry-run or
+read-only paths when those risks are material. If a field path is inferred from
+schema rather than observed, label it as untested.
 
 Keep chosen packages, blocks, or connector actions concrete in the generated
 skill.
@@ -222,22 +221,16 @@ Preserve `metadata.title` when it exists. If you change the displayed title or
 first heading, update `metadata.title` to match. If `metadata.title` or
 `metadata.icon` is absent, add a suitable value.
 
-The final skill must contain concrete package/block references or connector
-service/action identifiers. It must not instruct future agents to run `oo
-search`, `oo connector search`, or discover capabilities at execution time.
+The final skill must not instruct future agents to run `oo search`, `oo
+connector search`, or discover capabilities at execution time. Include only the
+selected package/block references or connector service/action identity, command
+shape, payload rules, result extraction, common stop conditions, and async or
+idempotency guidance that observed metadata, output shape, or documented oo
+workflow exposes.
 
-Do not duplicate broad oo execution mechanics. For connector-backed workflows,
-include only the selected service/action identity, the small connector command
-shape, payload rules, result extraction, and common stop conditions such as
-missing inputs, inaccessible files, schema rejection, auth, billing,
-permission, timeout, or not-found blockers. Include async polling, status
-checks, or idempotency guidance only when the selected action metadata, output
-shape, or documented oo workflow exposes those behaviors.
-
-Before finishing, check whether the generated skill will shorten future
-executions: a future agent should reach the selected capability without
-rediscovery, build a valid payload, read the useful result, and stop on common
-failures. If not, add only the missing execution guidance.
+Before finishing, check that a future agent can reach the selected capability
+without rediscovery, build a valid payload, read the useful result, and stop on
+common failures. If not, add only the missing execution guidance.
 
 Keep `SKILL.md` concise. Use `references/workflow.md` only when the workflow
 has several steps, decision rules, or examples. Use `references/packages.json`

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -398,10 +398,16 @@ describe("embedded skill assets", () => {
             expect(content).toContain("result field paths");
             expect(content).toContain("authentication state");
             expect(content).toContain("defaults");
-            expect(content).toContain("Resolve once, then shorten future executions");
+            expect(content).toContain("Resolve and test before writing the runbook");
+            expect(content).toContain("observed facts");
+            expect(content).toContain("future agents");
+            expect(content).toContain("do not run discovery");
+            expect(content).toContain("again");
             expect(content).toContain("do not ask only for cosmetic details");
             expect(content).toContain("facts that `oo` metadata can resolve");
-            expect(content).toContain("future agents do not run discovery again");
+            expect(content).toContain("future agents");
+            expect(content).toContain("do not run discovery");
+            expect(content).toContain("again");
             expect(content).not.toContain("Operating Principles");
             expect(content).not.toContain("Work like a confident authoring agent");
             expect(content).not.toContain("interrupt the user only for true blockers");
@@ -503,6 +509,13 @@ describe("embedded skill assets", () => {
             expect(content).toContain(
                 "Resolve concrete package, block, and connector references",
             );
+            expect(content).toContain("Resolve and test before writing the runbook");
+            expect(content).toContain("Do not predesign the whole");
+            expect(content).toContain("execution process");
+            expect(content).toContain("Discover");
+            expect(content).toContain("the capability");
+            expect(content).toContain("run the smallest safe test");
+            expect(content).toContain("observed facts");
             expect(content).toContain("Choose the most direct capability");
             expect(content).toContain("domain fit over result ordering");
             expect(content).toContain("Treat Fusion API, connector, and package/block results");
@@ -514,15 +527,44 @@ describe("embedded skill assets", () => {
             expect(content).toContain("choose Fusion API by default");
             expect(content).toContain("account, cost, compliance");
             expect(content).toContain("output-contract differences");
+            expect(content).toContain("Treat local `schemaPath` files as supporting metadata");
+            expect(content).toContain("not proof");
+            expect(content).toContain("currently exposed by `oo`");
+            expect(content).toContain("pin only actions");
+            expect(content).toContain("service/action identity is confirmed");
+            expect(content).toContain("current command output");
             expect(content).toContain("Apply the Constitution");
             expect(content).toContain("Blocks are flexible");
             expect(content).toContain("weaker performance and higher execution friction");
+            expect(content).toContain(
+                "Do not write a connector action into a generated skill just because a local schema file exists",
+            );
+            expect(content).toContain("unknown action");
+            expect(content).toContain("choose an exposed action");
+            expect(content).toContain("async submission plus polling replacing a synchronous call");
+            expect(content).toContain("When result shape");
+            expect(content).toContain("status transitions");
+            expect(content).toContain("file return format");
+            expect(content).toContain("envelope structure");
+            expect(content).toContain("minimal representative invocation");
+            expect(content).toContain("status/result poll");
+            expect(content).toContain("safe and proportionate");
+            expect(content).toContain("Do not spend");
+            expect(content).toContain("meaningful user money");
+            expect(content).toContain("mutate external state");
+            expect(content).toContain("disclose sensitive data");
+            expect(content).toContain("documented dry-run");
+            expect(content).toContain("read-only paths");
+            expect(content).toContain("inferred from schema rather than observed");
+            expect(content).toContain("presenting it as tested fact");
             expect(content).toContain("Do not force a package or block reference");
             expect(content).toContain("when the chosen reusable workflow is connector-backed.");
             expect(content).toContain(
                 "connector service/action identifiers",
             );
-            expect(content).toContain("future agents do not run discovery again");
+            expect(content).toContain("future agents");
+            expect(content).toContain("do not run discovery");
+            expect(content).toContain("again");
             expect(content).not.toContain("default preference order");
             expect(content).not.toContain("If Fusion API and an ordinary connector action both match");
             expect(content).not.toContain("Apply the capability principle above");
@@ -593,6 +635,10 @@ describe("embedded skill assets", () => {
             expect(content).toContain("files, images, documents");
             expect(content).toContain("preview them or deliver them to the user");
             expect(content).toContain("reporting a local path");
+            expect(content).toContain("inline base64 or `data:` URI artifacts");
+            expect(content).toContain("save and preview the artifact");
+            expect(content).toContain("printing the full");
+            expect(content).toContain("encoded payload");
             expect(content).toContain("Failure handling");
             expect(content).toContain("action-specific stop conditions");
             expect(content).toContain("schema rejection");

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -390,16 +390,21 @@ describe("embedded skill assets", () => {
             expect(content).toContain("recommended option");
             expect(content).toContain("free-form input");
             expect(content).toContain("concrete choices");
-            expect(content).toContain("`oo` metadata defines execution facts");
-            expect(content).toContain("Do not ask the user to resolve facts");
+            expect(content).toContain("`oo` metadata and command output define execution facts");
+            expect(content).toContain("Do not ask");
+            expect(content).toContain("resolve facts");
             expect(content).toContain("package/block references");
             expect(content).toContain("connector service/action identifiers");
             expect(content).toContain("field names");
             expect(content).toContain("result field paths");
             expect(content).toContain("authentication state");
             expect(content).toContain("defaults");
+            expect(content).toContain("current command output");
+            expect(content).toContain("safe invocation");
+            expect(content).toContain("observed result paths");
             expect(content).toContain("Resolve and test before writing the runbook");
-            expect(content).toContain("observed facts");
+            expect(content).toContain("observed");
+            expect(content).toContain("facts");
             expect(content).toContain("future agents");
             expect(content).toContain("do not run discovery");
             expect(content).toContain("again");
@@ -515,7 +520,8 @@ describe("embedded skill assets", () => {
             expect(content).toContain("Discover");
             expect(content).toContain("the capability");
             expect(content).toContain("run the smallest safe test");
-            expect(content).toContain("observed facts");
+            expect(content).toContain("observed");
+            expect(content).toContain("facts");
             expect(content).toContain("Choose the most direct capability");
             expect(content).toContain("domain fit over result ordering");
             expect(content).toContain("Treat Fusion API, connector, and package/block results");
@@ -527,18 +533,20 @@ describe("embedded skill assets", () => {
             expect(content).toContain("choose Fusion API by default");
             expect(content).toContain("account, cost, compliance");
             expect(content).toContain("output-contract differences");
-            expect(content).toContain("Treat local `schemaPath` files as supporting metadata");
-            expect(content).toContain("not proof");
-            expect(content).toContain("currently exposed by `oo`");
-            expect(content).toContain("pin only actions");
-            expect(content).toContain("service/action identity is confirmed");
+            expect(content).toContain("Treat local `schemaPath` files");
+            expect(content).toContain("supporting");
+            expect(content).toContain("metadata");
             expect(content).toContain("current command output");
+            expect(content).toContain("safe invocation");
+            expect(content).toContain("confirm connector");
+            expect(content).toContain("action availability");
             expect(content).toContain("Apply the Constitution");
             expect(content).toContain("Blocks are flexible");
             expect(content).toContain("weaker performance and higher execution friction");
             expect(content).toContain(
-                "Do not write a connector action into a generated skill just because a local schema file exists",
+                "Do not choose a connector action just because a local schema file exists",
             );
+            expect(content).toContain("non-destructive test");
             expect(content).toContain("unknown action");
             expect(content).toContain("choose an exposed action");
             expect(content).toContain("async submission plus polling replacing a synchronous call");
@@ -556,7 +564,7 @@ describe("embedded skill assets", () => {
             expect(content).toContain("documented dry-run");
             expect(content).toContain("read-only paths");
             expect(content).toContain("inferred from schema rather than observed");
-            expect(content).toContain("presenting it as tested fact");
+            expect(content).toContain("label it as untested");
             expect(content).toContain("Do not force a package or block reference");
             expect(content).toContain("when the chosen reusable workflow is connector-backed.");
             expect(content).toContain(
@@ -642,11 +650,13 @@ describe("embedded skill assets", () => {
             expect(content).toContain("Failure handling");
             expect(content).toContain("action-specific stop conditions");
             expect(content).toContain("schema rejection");
-            expect(content).toContain(
-                "only when the selected action metadata, output shape, or documented oo workflow exposes",
-            );
-            expect(content).toContain("shorten future executions");
-            expect(content).toContain("reach the selected capability without rediscovery");
+            expect(content).toContain("async or");
+            expect(content).toContain("idempotency guidance");
+            expect(content).toContain("observed metadata");
+            expect(content).toContain("documented oo");
+            expect(content).toContain("Before finishing");
+            expect(content).toContain("future agent can reach the selected capability");
+            expect(content).toContain("without rediscovery");
             expect(content).toContain("stop on common failures");
             expect(content).not.toContain("Use whatever structure fits the domain");
             expect(content).not.toContain("async polling/idempotency when needed");


### PR DESCRIPTION
## Summary
- teach oo-create-skill prompts to treat local schema metadata as supporting evidence instead of proof of runnable connector actions
- require authoring-time discovery plus safe representative tests for command/result/status/file/envelope shapes when they affect generated runbooks
- condense the added guidance across Codex, Claude, CodeBuddy, OpenClaw, and QoderWork variants and update embedded asset assertions

## Why
The GPT Image 2 workflow exposed a case where a local schema existed for a Fusion API action, but the action was not available through the connector run path. The skill authoring guidance now makes current command output and safe observed results the source of truth.

## Validation
- bun run lint:fix
- bun run ts-check
- bun run test src/application/commands/skills/embedded-assets.test.ts
- bun run test
- oo skills validate contrib/skills/codex/oo-create-skill
- oo skills validate contrib/skills/claude/oo-create-skill
- oo skills validate contrib/skills/codebuddy/oo-create-skill
- oo skills validate contrib/skills/openclaw/oo-create-skill
- oo skills validate contrib/skills/qoderwork/oo-create-skill
