### PR TITLE
fix(skills): reconcile managed skill publication form on sync

### DIFF
--- a/src/application/commands/skills/auto-sync.ts
+++ b/src/application/commands/skills/auto-sync.ts
@@ -39,7 +39,10 @@ import {
     isManagedSkillPathContained,
     resolveManagedSkillCanonicalRootDirectoryPath,
 } from "./managed-skill-paths.ts";
-import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
+import {
+    isManagedSkillPublicationCurrent,
+    resolveManagedSkillPublicationMode,
+} from "./managed-skill-publication.ts";
 import { publishManagedBundledSkill } from "./shared.ts";
 
 interface ManagedSkillTargetState<Metadata> {
@@ -272,6 +275,9 @@ async function synchronizeRegistrySkill(
             installation.installedSkillDirectoryPath,
             readManagedSkillMetadata,
         );
+        const publicationMode = resolveManagedSkillPublicationMode(
+            installation.agentName,
+        );
 
         if (targetState.kind === "unmanaged") {
             context.logger.warn(
@@ -287,33 +293,38 @@ async function synchronizeRegistrySkill(
 
         if (targetState.kind === "managed") {
             if (
-                targetState.metadata?.packageName === skill.metadata.packageName
-                && targetState.metadata.version === skill.metadata.version
+                targetState.metadata?.packageName !== skill.metadata.packageName
+                || targetState.metadata.version !== skill.metadata.version
             ) {
+                context.logger.warn(
+                    {
+                        agentName: installation.agentName,
+                        canonicalPackageName: skill.metadata.packageName,
+                        canonicalVersion: skill.metadata.version,
+                        path: installation.installedSkillDirectoryPath,
+                        skillName: skill.name,
+                        targetPackageName: targetState.metadata?.packageName,
+                        targetVersion: targetState.metadata?.version,
+                    },
+                    "Registry skill startup synchronization skipped because the target metadata does not match canonical metadata.",
+                );
                 return;
             }
 
-            context.logger.warn(
-                {
-                    agentName: installation.agentName,
-                    canonicalPackageName: skill.metadata.packageName,
-                    canonicalVersion: skill.metadata.version,
-                    path: installation.installedSkillDirectoryPath,
-                    skillName: skill.name,
-                    targetPackageName: targetState.metadata?.packageName,
-                    targetVersion: targetState.metadata?.version,
-                },
-                "Registry skill startup synchronization skipped because the target metadata does not match canonical metadata.",
-            );
-            return;
+            if (
+                await isManagedSkillPublicationCurrent(
+                    installation.installedSkillDirectoryPath,
+                    publicationMode,
+                )
+            ) {
+                return;
+            }
         }
 
         const publication = await publishBundledSkillInstallation({
             canonicalSkillDirectoryPath: skill.path,
             installedSkillDirectoryPath: installation.installedSkillDirectoryPath,
-            publicationMode: resolveManagedSkillPublicationMode(
-                installation.agentName,
-            ),
+            publicationMode,
         });
 
         context.logger.info(

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, stat } from "node:fs/promises";
+import { lstat, mkdir, readFile, realpath, stat, symlink } from "node:fs/promises";
 import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
@@ -15,6 +15,7 @@ import { bundledSkillDevelopmentVersion } from "./bundled-skill-model.ts";
 import {
     resolveBundledSkillMetadataFilePath,
     resolveClaudeHomeDirectory,
+    resolveCodeBuddyHomeDirectory,
     resolveCodexHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
@@ -234,6 +235,67 @@ describe("skills CLI", () => {
             expect(result.stdout).toContain("Options:");
             expect(result.stdout).not.toContain("Installed skill");
             expect(await readFile(join(claudeSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
+                "# ChatGPT\n",
+            );
+            expect(content).toContain(
+                `"msg":"Registry skill synchronized during CLI startup."`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("converts synchronized registry skill targets to copies for copy-only hosts", async () => {
+        const sandbox = await createCliSandbox();
+        const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
+        const codeBuddySkillsDirectory = join(codeBuddyHomeDirectory, "skills");
+        const codeBuddySkillDirectoryPath = join(codeBuddySkillsDirectory, "chatgpt");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+
+        try {
+            await mkdir(codeBuddySkillsDirectory, { recursive: true });
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(canonicalSkillDirectoryPath, "SKILL.md"),
+                "# ChatGPT\n",
+            );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath),
+                renderSkillMetadataJson({
+                    packageName: "openai",
+                    version: "0.0.3",
+                }),
+            );
+            await symlink(
+                canonicalSkillDirectoryPath,
+                codeBuddySkillDirectoryPath,
+                process.platform === "win32" ? "junction" : "dir",
+            );
+
+            const result = await sandbox.run(["--help"], {
+                fetcher: async () => {
+                    throw new Error("startup synchronization should not fetch");
+                },
+            });
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain("Options:");
+            expect(await realpath(codeBuddySkillDirectoryPath)).not.toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect((await lstat(codeBuddySkillDirectoryPath)).isSymbolicLink()).toBeFalse();
+            expect(await readFile(join(codeBuddySkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
                 "# ChatGPT\n",
             );
             expect(content).toContain(

--- a/src/application/commands/skills/managed-skill-publication.test.ts
+++ b/src/application/commands/skills/managed-skill-publication.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { availableBundledSkillAgentNames } from "./embedded-assets.ts";
-import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
+import {
+    isManagedSkillPublicationCurrent,
+    resolveManagedSkillPublicationMode,
+} from "./managed-skill-publication.ts";
 
 describe("managed skill publication policy", () => {
     test("allows symlink publication only for explicitly supported agents", () => {
@@ -23,5 +26,14 @@ describe("managed skill publication policy", () => {
             "trae-cn": "copy",
             "workbuddy": "copy",
         });
+    });
+
+    test("treats a missing copy-mode target as not current", async () => {
+        await expect(
+            isManagedSkillPublicationCurrent(
+                "/tmp/oo-missing-managed-skill-publication-target",
+                "copy",
+            ),
+        ).resolves.toBeFalse();
     });
 });

--- a/src/application/commands/skills/managed-skill-publication.test.ts
+++ b/src/application/commands/skills/managed-skill-publication.test.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import { availableBundledSkillAgentNames } from "./embedded-assets.ts";
@@ -29,9 +31,14 @@ describe("managed skill publication policy", () => {
     });
 
     test("treats a missing copy-mode target as not current", async () => {
+        const missingSkillDirectoryPath = join(
+            tmpdir(),
+            `oo-missing-managed-skill-publication-target-${Bun.randomUUIDv7()}`,
+        );
+
         await expect(
             isManagedSkillPublicationCurrent(
-                "/tmp/oo-missing-managed-skill-publication-target",
+                missingSkillDirectoryPath,
                 "copy",
             ),
         ).resolves.toBeFalse();

--- a/src/application/commands/skills/managed-skill-publication.ts
+++ b/src/application/commands/skills/managed-skill-publication.ts
@@ -2,6 +2,7 @@ import type { BundledSkillPublicationMode } from "./bundled-skill-filesystem.ts"
 import type { BundledSkillAgentName } from "./embedded-assets.ts";
 
 import { lstat } from "node:fs/promises";
+import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
 
 const symlinkCapableManagedSkillAgentNames: ReadonlySet<BundledSkillAgentName> = new Set([
     "claude",
@@ -23,7 +24,16 @@ export async function isManagedSkillPublicationCurrent(
 ): Promise<boolean> {
     switch (publicationMode) {
         case "copy":
-            return !(await lstat(skillDirectoryPath)).isSymbolicLink();
+            try {
+                return !(await lstat(skillDirectoryPath)).isSymbolicLink();
+            }
+            catch (error) {
+                if (isNodeNotFoundError(error)) {
+                    return false;
+                }
+
+                throw error;
+            }
         case "symlink-or-copy":
             return true;
     }

--- a/src/application/commands/skills/managed-skill-publication.ts
+++ b/src/application/commands/skills/managed-skill-publication.ts
@@ -1,6 +1,8 @@
 import type { BundledSkillPublicationMode } from "./bundled-skill-filesystem.ts";
 import type { BundledSkillAgentName } from "./embedded-assets.ts";
 
+import { lstat } from "node:fs/promises";
+
 const symlinkCapableManagedSkillAgentNames: ReadonlySet<BundledSkillAgentName> = new Set([
     "claude",
     "codex",
@@ -13,4 +15,16 @@ export function resolveManagedSkillPublicationMode(
     return symlinkCapableManagedSkillAgentNames.has(agentName)
         ? "symlink-or-copy"
         : "copy";
+}
+
+export async function isManagedSkillPublicationCurrent(
+    skillDirectoryPath: string,
+    publicationMode: BundledSkillPublicationMode,
+): Promise<boolean> {
+    switch (publicationMode) {
+        case "copy":
+            return !(await lstat(skillDirectoryPath)).isSymbolicLink();
+        case "symlink-or-copy":
+            return true;
+    }
 }

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -26,6 +26,10 @@ import {
     isManagedSkillPathContained,
     resolveManagedSkillCanonicalRootDirectoryPath,
 } from "./managed-skill-paths.ts";
+import {
+    isManagedSkillPublicationCurrent,
+    resolveManagedSkillPublicationMode,
+} from "./managed-skill-publication.ts";
 import { extractRegistryPackageArchive } from "./registry-skill-archive.ts";
 import {
     findPackageSkillOrThrow,
@@ -632,15 +636,22 @@ async function isRegistrySkillCurrentInAllHosts(
                 return undefined;
             }
 
-            return await readManagedSkillMetadata(
-                installation.installedSkillDirectoryPath,
-            );
+            return {
+                metadata: await readManagedSkillMetadata(
+                    installation.installedSkillDirectoryPath,
+                ),
+                publicationCurrent: await isManagedSkillPublicationCurrent(
+                    installation.installedSkillDirectoryPath,
+                    resolveManagedSkillPublicationMode(installation.agentName),
+                ),
+            };
         }),
     );
 
-    return targetStates.every(metadata =>
-        metadata?.packageName === packageName
-        && metadata.version === packageVersion,
+    return targetStates.every(state =>
+        state?.metadata?.packageName === packageName
+        && state.metadata.version === packageVersion
+        && state.publicationCurrent,
     );
 }
 


### PR DESCRIPTION
Registry skill startup synchronization and update currency checks previously compared only metadata, so a symlinked target on a copy-only host (e.g., CodeBuddy) was treated as up-to-date even though it violated the host's required publication mode.

Add `isManagedSkillPublicationCurrent` and consult it from both the startup sync and `isRegistrySkillCurrentInAllHosts` so a stale symlink triggers republication as a copy when the host requires it.