### PR TITLE
[codex] Fix oo-create-skill file transfer guidance

### DIFF
--- a/contrib/skills/claude/oo-create-skill/SKILL.md
+++ b/contrib/skills/claude/oo-create-skill/SKILL.md
@@ -53,11 +53,13 @@ this constitution, not a separate checklist.
    credentials. Ask the user to choose only when provider, account, cost,
    compliance, data-routing, or output-contract differences are material.
 5. Preserve the local/cloud boundary. Generated skills must tell future agents
-   to use the agent-provided `oo-upload` helper for local attachments sent to
-   cloud processing and `oo-download` for cloud artifacts saved locally. Do not
-   treat these helpers as capabilities to rediscover, do not hand-roll transfer
-   logic, and do not pass local filesystem paths to cloud actions unless the
-   schema explicitly supports local paths.
+   to upload local attachments with `oo file upload "<filePath>" --json`, pass
+   the returned `downloadUrl` into cloud payloads, and save remote artifacts
+   with `oo file download "<url>" [outDir] [--name "<name>"] [--ext "<ext>"]`.
+   `oo file download` prints `Saved to: <path>` and does not support `--json`.
+   Do not treat these file-transfer commands as capabilities to rediscover, do
+   not hand-roll transfer logic, and do not pass local filesystem paths to cloud
+   actions unless the schema explicitly supports local paths.
 6. Make file artifacts visible to the user. When a generated skill can produce
    images, documents, archives, media, or other files, it must tell future
    agents to preview the artifact when practical, or otherwise deliver it with
@@ -209,7 +211,7 @@ field paths; do not present the local `schemaPath` as a stable contract for
 future agents.
 
 When the workflow crosses the local/cloud file boundary, include the
-`oo-upload` and `oo-download` helper guidance from the Constitution in the
+`oo file upload` and `oo file download` guidance from the Constitution in the
 generated skill.
 
 Review the frontmatter `description` before finishing: user-visible outcome

--- a/contrib/skills/codebuddy/oo-create-skill/SKILL.md
+++ b/contrib/skills/codebuddy/oo-create-skill/SKILL.md
@@ -52,11 +52,13 @@ this constitution, not a separate checklist.
    credentials. Ask the user to choose only when provider, account, cost,
    compliance, data-routing, or output-contract differences are material.
 5. Preserve the local/cloud boundary. Generated skills must tell future agents
-   to use the agent-provided `oo-upload` helper for local attachments sent to
-   cloud processing and `oo-download` for cloud artifacts saved locally. Do not
-   treat these helpers as capabilities to rediscover, do not hand-roll transfer
-   logic, and do not pass local filesystem paths to cloud actions unless the
-   schema explicitly supports local paths.
+   to upload local attachments with `oo file upload "<filePath>" --json`, pass
+   the returned `downloadUrl` into cloud payloads, and save remote artifacts
+   with `oo file download "<url>" [outDir] [--name "<name>"] [--ext "<ext>"]`.
+   `oo file download` prints `Saved to: <path>` and does not support `--json`.
+   Do not treat these file-transfer commands as capabilities to rediscover, do
+   not hand-roll transfer logic, and do not pass local filesystem paths to cloud
+   actions unless the schema explicitly supports local paths.
 6. Make file artifacts visible to the user. When a generated skill can produce
    images, documents, archives, media, or other files, it must tell future
    agents to preview the artifact when practical, or otherwise deliver it with
@@ -208,7 +210,7 @@ field paths; do not present the local `schemaPath` as a stable contract for
 future agents.
 
 When the workflow crosses the local/cloud file boundary, include the
-`oo-upload` and `oo-download` helper guidance from the Constitution in the
+`oo file upload` and `oo file download` guidance from the Constitution in the
 generated skill.
 
 Review the frontmatter `description` before finishing: user-visible outcome

--- a/contrib/skills/codex/oo-create-skill/SKILL.md
+++ b/contrib/skills/codex/oo-create-skill/SKILL.md
@@ -52,11 +52,13 @@ this constitution, not a separate checklist.
    credentials. Ask the user to choose only when provider, account, cost,
    compliance, data-routing, or output-contract differences are material.
 5. Preserve the local/cloud boundary. Generated skills must tell future agents
-   to use the agent-provided `oo-upload` helper for local attachments sent to
-   cloud processing and `oo-download` for cloud artifacts saved locally. Do not
-   treat these helpers as capabilities to rediscover, do not hand-roll transfer
-   logic, and do not pass local filesystem paths to cloud actions unless the
-   schema explicitly supports local paths.
+   to upload local attachments with `oo file upload "<filePath>" --json`, pass
+   the returned `downloadUrl` into cloud payloads, and save remote artifacts
+   with `oo file download "<url>" [outDir] [--name "<name>"] [--ext "<ext>"]`.
+   `oo file download` prints `Saved to: <path>` and does not support `--json`.
+   Do not treat these file-transfer commands as capabilities to rediscover, do
+   not hand-roll transfer logic, and do not pass local filesystem paths to cloud
+   actions unless the schema explicitly supports local paths.
 6. Make file artifacts visible to the user. When a generated skill can produce
    images, documents, archives, media, or other files, it must tell future
    agents to preview the artifact when practical, or otherwise deliver it with
@@ -239,7 +241,7 @@ field paths; do not present the local `schemaPath` as a stable contract for
 future agents.
 
 When the workflow crosses the local/cloud file boundary, include the
-`oo-upload` and `oo-download` helper guidance from the Constitution in the
+`oo file upload` and `oo file download` guidance from the Constitution in the
 generated skill.
 
 Review the frontmatter `description` before finishing: user-visible outcome

--- a/contrib/skills/openclaw/oo-create-skill/SKILL.md
+++ b/contrib/skills/openclaw/oo-create-skill/SKILL.md
@@ -52,11 +52,13 @@ this constitution, not a separate checklist.
    credentials. Ask the user to choose only when provider, account, cost,
    compliance, data-routing, or output-contract differences are material.
 5. Preserve the local/cloud boundary. Generated skills must tell future agents
-   to use the agent-provided `oo-upload` helper for local attachments sent to
-   cloud processing and `oo-download` for cloud artifacts saved locally. Do not
-   treat these helpers as capabilities to rediscover, do not hand-roll transfer
-   logic, and do not pass local filesystem paths to cloud actions unless the
-   schema explicitly supports local paths.
+   to upload local attachments with `oo file upload "<filePath>" --json`, pass
+   the returned `downloadUrl` into cloud payloads, and save remote artifacts
+   with `oo file download "<url>" [outDir] [--name "<name>"] [--ext "<ext>"]`.
+   `oo file download` prints `Saved to: <path>` and does not support `--json`.
+   Do not treat these file-transfer commands as capabilities to rediscover, do
+   not hand-roll transfer logic, and do not pass local filesystem paths to cloud
+   actions unless the schema explicitly supports local paths.
 6. Make file artifacts visible to the user. When a generated skill can produce
    images, documents, archives, media, or other files, it must tell future
    agents to preview the artifact when practical, or otherwise deliver it with
@@ -208,7 +210,7 @@ field paths; do not present the local `schemaPath` as a stable contract for
 future agents.
 
 When the workflow crosses the local/cloud file boundary, include the
-`oo-upload` and `oo-download` helper guidance from the Constitution in the
+`oo file upload` and `oo file download` guidance from the Constitution in the
 generated skill.
 
 Review the frontmatter `description` before finishing: user-visible outcome

--- a/contrib/skills/qoderwork/oo-create-skill/SKILL.md
+++ b/contrib/skills/qoderwork/oo-create-skill/SKILL.md
@@ -52,11 +52,13 @@ this constitution, not a separate checklist.
    credentials. Ask the user to choose only when provider, account, cost,
    compliance, data-routing, or output-contract differences are material.
 5. Preserve the local/cloud boundary. Generated skills must tell future agents
-   to use the agent-provided `oo-upload` helper for local attachments sent to
-   cloud processing and `oo-download` for cloud artifacts saved locally. Do not
-   treat these helpers as capabilities to rediscover, do not hand-roll transfer
-   logic, and do not pass local filesystem paths to cloud actions unless the
-   schema explicitly supports local paths.
+   to upload local attachments with `oo file upload "<filePath>" --json`, pass
+   the returned `downloadUrl` into cloud payloads, and save remote artifacts
+   with `oo file download "<url>" [outDir] [--name "<name>"] [--ext "<ext>"]`.
+   `oo file download` prints `Saved to: <path>` and does not support `--json`.
+   Do not treat these file-transfer commands as capabilities to rediscover, do
+   not hand-roll transfer logic, and do not pass local filesystem paths to cloud
+   actions unless the schema explicitly supports local paths.
 6. Make file artifacts visible to the user. When a generated skill can produce
    images, documents, archives, media, or other files, it must tell future
    agents to preview the artifact when practical, or otherwise deliver it with
@@ -208,7 +210,7 @@ field paths; do not present the local `schemaPath` as a stable contract for
 future agents.
 
 When the workflow crosses the local/cloud file boundary, include the
-`oo-upload` and `oo-download` helper guidance from the Constitution in the
+`oo file upload` and `oo file download` guidance from the Constitution in the
 generated skill.
 
 Review the frontmatter `description` before finishing: user-visible outcome

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -579,7 +579,7 @@ describe("embedded skill assets", () => {
         }
     });
 
-    test("guides oo-create-skill generated workflows to use managed attachment transfer helpers", async () => {
+    test("guides oo-create-skill generated workflows to use oo file transfer commands", async () => {
         for (const agentName of availableBundledSkillAgentNames) {
             const skillFile = getBundledSkillFiles("oo-create-skill", agentName).find(
                 file => file.relativePath === "SKILL.md",
@@ -595,10 +595,12 @@ describe("embedded skill assets", () => {
 
             expect(content).toContain("Preserve the local/cloud boundary");
             expect(content).toContain("Make file artifacts visible to the user");
-            expect(content).toContain("agent-provided `oo-upload` helper");
-            expect(content).toContain("local attachments sent to");
-            expect(content).toContain("`oo-download` for cloud artifacts");
-            expect(content).toContain("treat these helpers as capabilities");
+            expect(content).toContain("`oo file upload \"<filePath>\" --json`");
+            expect(content).toContain("the returned `downloadUrl`");
+            expect(content).toContain("`oo file download \"<url>\" [outDir]");
+            expect(content).toContain("`Saved to: <path>`");
+            expect(content).toContain("does not support `--json`");
+            expect(content).toContain("file-transfer commands as capabilities");
             expect(content).toContain("hand-roll transfer");
             expect(content).toContain("logic");
             expect(content).toContain(
@@ -607,6 +609,8 @@ describe("embedded skill assets", () => {
             expect(content).toContain("A successful");
             expect(content).toContain("file path alone is not enough");
             expect(content).toContain("local/cloud file boundary");
+            expect(content).not.toContain("oo-upload");
+            expect(content).not.toContain("oo-download");
         }
     });
 


### PR DESCRIPTION
## Summary

- Replace stale `oo-upload` / `oo-download` guidance in bundled `oo-create-skill` assets with the current `oo file upload` and `oo file download` CLI contracts.
- Tell generated skills to pass uploaded files via the returned `downloadUrl` and to parse download output from `Saved to: <path>` because `oo file download` does not support `--json`.
- Update embedded asset tests to assert the current file transfer guidance and reject the old helper names.

## Why

The creator skill still taught future generated skills to use helper names that are not part of the current OO CLI. That could cause newly authored skills to fail when moving local attachments into cloud payloads or saving remote artifacts locally.

## Validation

- `bun run lint:fix`
- `bun run ts-check`
- `bun run test src/application/commands/skills/embedded-assets.test.ts`
