### PR TITLE
build(tsconfig): add bun types to compiler options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
 
+    "types": ["bun"],
     "allowImportingTsExtensions": true,
     "allowJs": true,
     // Best practices


### PR DESCRIPTION
Restrict TypeScript's ambient type inclusion to bun's type definitions to fix conflicts from auto-included @types packages. This makes the type resolution explicit and predictable.