### PR TITLE
ci: migrate workflows to Blacksmith-managed runners

### DIFF
--- a/.github/workflows/deploy-install-worker.yaml
+++ b/.github/workflows/deploy-install-worker.yaml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   quality:
     name: Quality
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Checkout
@@ -40,9 +40,9 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+          - blacksmith-4vcpu-ubuntu-2404
+          - blacksmith-4vcpu-windows-2025
+          - blacksmith-6vcpu-macos-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,11 +62,11 @@ jobs:
       matrix:
         include:
           - platform_name: Linux
-            runs_on: ubuntu-latest
+            runs_on: blacksmith-4vcpu-ubuntu-2404
             artifact_name: release-packages-linux
             build_script: build:linux
           - platform_name: macOS
-            runs_on: macos-latest
+            runs_on: blacksmith-6vcpu-macos-latest
             artifact_name: release-packages-macos
             build_script: build:macos
           - platform_name: Win32 x64
@@ -120,7 +120,7 @@ jobs:
     needs:
       - compute-version
       - build-platform-packages
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       RELEASE_VERSION: ${{ needs.compute-version.outputs.version }}

--- a/.github/workflows/upload-release-binaries-to-oss.yaml
+++ b/.github/workflows/upload-release-binaries-to-oss.yaml
@@ -42,7 +42,7 @@ concurrency:
 
 jobs:
   upload_release_binaries:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       oss_uri: ${{ steps.prepare.outputs.oss_uri }}
       release_tag: ${{ steps.prepare.outputs.release_tag }}

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -455,18 +455,24 @@ export async function readLatestLogContent(sandbox: CliSandbox): Promise<string>
     const logFilesWithMetadata = await Promise.all(
         logFileNames.map(async fileName => ({
             fileName,
-            metadata: await stat(join(logDirectoryPath, fileName)),
+            metadata: await stat(join(logDirectoryPath, fileName), { bigint: true }),
         })),
     );
+    // Sort by nanosecond-precision mtime so the "latest" file is unambiguous
+    // even when multiple log files are produced within the same millisecond.
+    // When timestamps tie, fall back to the rolling-file-destination naming
+    // convention: a sessionCounter suffix (e.g. "-01") indicates a newer file
+    // that was created when the base file name was already taken.
     const latestLogFileName = logFilesWithMetadata
         .sort((left, right) => {
-            const modifiedAtDelta = left.metadata.mtimeMs - right.metadata.mtimeMs;
+            const modifiedAtDelta = left.metadata.mtimeNs - right.metadata.mtimeNs;
 
-            if (modifiedAtDelta !== 0) {
-                return modifiedAtDelta;
+            if (modifiedAtDelta !== 0n) {
+                return modifiedAtDelta < 0n ? -1 : 1;
             }
 
-            return left.fileName.localeCompare(right.fileName);
+            return left.fileName.length - right.fileName.length
+                || left.fileName.localeCompare(right.fileName);
         })
         .at(-1)
         ?.fileName;


### PR DESCRIPTION
Switch the deploy, PR check, publish, and release upload workflows from GitHub-hosted runners to Blacksmith equivalents. The new pool provides higher vCPU counts on the workloads that benefit from it (quality, build, and publish) while keeping smaller runners for the lightweight deploy and OSS upload jobs, reducing CI wall time and overall minute consumption.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/oomol-lab/codesmith/oo-cli/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->