### PR TITLE
fix(ci): skip external-PR guard for same-repo pull requests

### DIFF
--- a/.github/workflows/blacksmith-win32-testbox.yml
+++ b/.github/workflows/blacksmith-win32-testbox.yml
@@ -4,11 +4,11 @@ on:
     inputs:
       testbox_id:
         type: string
-        description: "Testbox session ID"
+        description: Testbox session ID
         required: true
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
 permissions:
   contents: read
 concurrency:

--- a/contrib/ci/reject-large-external-pr.test.ts
+++ b/contrib/ci/reject-large-external-pr.test.ts
@@ -113,100 +113,133 @@ describe("reject-large-external-pr", () => {
     });
 
     test("allows same-repository pull requests before requiring a GitHub token", async () => {
-        const directory = await mkdtemp(join(tmpdir(), "oo-large-pr-"));
-        const eventPath = join(directory, "event.json");
-
-        try {
-            await writePullRequestEvent(eventPath, {
-                additions: 500,
-                authorAssociation: "NONE",
-                baseRepositoryFullName: "oomol-lab/oo-cli",
-                deletions: 500,
-                headRepositoryFullName: "oomol-lab/oo-cli",
-            });
-
+        await withTempPullRequestEvent({
+            additions: 500,
+            authorAssociation: "NONE",
+            baseRepositoryFullName: "oomol-lab/oo-cli",
+            deletions: 500,
+            headRepositoryFullName: "oomol-lab/oo-cli",
+        }, async (eventPath) => {
             await main({
                 GITHUB_EVENT_PATH: eventPath,
             });
-        }
-        finally {
-            await rm(directory, { force: true, recursive: true });
-        }
+        });
     });
 
-    test("comments and closes large external pull requests without a GET body", async () => {
-        const directory = await mkdtemp(join(tmpdir(), "oo-large-pr-"));
-        const eventPath = join(directory, "event.json");
-        const requests: Array<{ init: FetchInit; url: string }> = [];
-        // Bun's fetch type requires a `preconnect` property; preserve the original.
-        globalThis.fetch = Object.assign(async (
-            input: Parameters<typeof fetch>[0],
-            init?: FetchInit,
-        ): Promise<Response> => {
-            requests.push({
-                init,
-                url: String(input),
-            });
+    test("treats missing repository names as external when reading events", async () => {
+        const requests = installGitHubApiFetchStub();
 
-            if (init?.method === "GET") {
-                return Response.json([]);
-            }
-
-            return Response.json({});
-        }, {
-            preconnect: originalFetch.preconnect,
-        });
-
-        try {
-            await writePullRequestEvent(eventPath, {
-                additions: 120,
-                authorAssociation: "CONTRIBUTOR",
-                baseRepositoryFullName: "oomol-lab/oo-cli",
-                deletions: 80,
-                headRepositoryFullName: "external-user/oo-cli",
-            });
-
+        await withTempPullRequestEvent({
+            additions: 120,
+            authorAssociation: "CONTRIBUTOR",
+            baseRepositoryFullName: "oomol-lab/oo-cli",
+            deletions: 80,
+        }, async (eventPath) => {
             await main({
                 GITHUB_API_URL: "https://api.example.test/",
                 GITHUB_EVENT_PATH: eventPath,
                 GITHUB_TOKEN: "token",
             });
+        });
 
-            expect(requests).toHaveLength(3);
-            const commentListRequest = requests.find(request => request.init?.method === "GET");
-            const commentCreateRequest = requests.find(request => request.init?.method === "POST");
-            const closeRequest = requests.find(request => request.init?.method === "PATCH");
-            if (
-                commentListRequest === undefined
-                || commentCreateRequest === undefined
-                || closeRequest === undefined
-            ) {
-                throw new Error("Expected comment list, comment create, and close requests.");
-            }
+        expect(requests).toHaveLength(3);
+        expect(requests.some(request => request.init?.method === "PATCH")).toBeTrue();
+    });
 
-            expect(commentListRequest).toMatchObject({
-                url: "https://api.example.test/repos/oomol-lab/oo-cli/issues/157/comments?per_page=100",
+    test("comments and closes large external pull requests without a GET body", async () => {
+        const requests = installGitHubApiFetchStub();
+
+        await withTempPullRequestEvent({
+            additions: 120,
+            authorAssociation: "CONTRIBUTOR",
+            baseRepositoryFullName: "oomol-lab/oo-cli",
+            deletions: 80,
+            headRepositoryFullName: "external-user/oo-cli",
+        }, async (eventPath) => {
+            await main({
+                GITHUB_API_URL: "https://api.example.test/",
+                GITHUB_EVENT_PATH: eventPath,
+                GITHUB_TOKEN: "token",
             });
-            expect(commentListRequest.init?.body).toBeUndefined();
-            expect(JSON.parse(String(commentCreateRequest.init?.body))).toMatchObject({
-                body: expect.stringContaining("oo-cli-large-external-pr-guard"),
-            });
-            expect(JSON.parse(String(closeRequest.init?.body))).toEqual({
-                state: "closed",
-            });
+        });
+
+        expect(requests).toHaveLength(3);
+        const commentListRequest = requests.find(request => request.init?.method === "GET");
+        const commentCreateRequest = requests.find(request => request.init?.method === "POST");
+        const closeRequest = requests.find(request => request.init?.method === "PATCH");
+        if (
+            commentListRequest === undefined
+            || commentCreateRequest === undefined
+            || closeRequest === undefined
+        ) {
+            throw new Error("Expected comment list, comment create, and close requests.");
         }
-        finally {
-            await rm(directory, { force: true, recursive: true });
-        }
+
+        expect(commentListRequest).toMatchObject({
+            url: "https://api.example.test/repos/oomol-lab/oo-cli/issues/157/comments?per_page=100",
+        });
+        expect(commentListRequest.init?.body).toBeUndefined();
+        expect(JSON.parse(String(commentCreateRequest.init?.body))).toMatchObject({
+            body: expect.stringContaining("oo-cli-large-external-pr-guard"),
+        });
+        expect(JSON.parse(String(closeRequest.init?.body))).toEqual({
+            state: "closed",
+        });
     });
 });
 
 interface PullRequestEventOptions {
     additions: number;
     authorAssociation: string;
-    baseRepositoryFullName: string;
+    baseRepositoryFullName?: string;
     deletions: number;
-    headRepositoryFullName: string;
+    headRepositoryFullName?: string;
+}
+
+interface CapturedFetchRequest {
+    init: FetchInit;
+    url: string;
+}
+
+function installGitHubApiFetchStub(): CapturedFetchRequest[] {
+    const requests: CapturedFetchRequest[] = [];
+
+    // Bun's fetch type requires a `preconnect` property; preserve the original.
+    globalThis.fetch = Object.assign(async (
+        input: Parameters<typeof fetch>[0],
+        init?: FetchInit,
+    ): Promise<Response> => {
+        requests.push({
+            init,
+            url: String(input),
+        });
+
+        if (init?.method === "GET") {
+            return Response.json([]);
+        }
+
+        return Response.json({});
+    }, {
+        preconnect: originalFetch.preconnect,
+    });
+
+    return requests;
+}
+
+async function withTempPullRequestEvent(
+    options: PullRequestEventOptions,
+    run: (eventPath: string) => Promise<void>,
+): Promise<void> {
+    const directory = await mkdtemp(join(tmpdir(), "oo-large-pr-"));
+    const eventPath = join(directory, "event.json");
+
+    try {
+        await writePullRequestEvent(eventPath, options);
+        await run(eventPath);
+    }
+    finally {
+        await rm(directory, { force: true, recursive: true });
+    }
 }
 
 async function writePullRequestEvent(eventPath: string, options: PullRequestEventOptions): Promise<void> {
@@ -221,15 +254,11 @@ async function writePullRequestEvent(eventPath: string, options: PullRequestEven
             additions: options.additions,
             author_association: options.authorAssociation,
             base: {
-                repo: {
-                    full_name: options.baseRepositoryFullName,
-                },
+                repo: createPullRequestRepositoryPayload(options.baseRepositoryFullName),
             },
             deletions: options.deletions,
             head: {
-                repo: {
-                    full_name: options.headRepositoryFullName,
-                },
+                repo: createPullRequestRepositoryPayload(options.headRepositoryFullName),
             },
             number: 157,
             user: {
@@ -237,4 +266,14 @@ async function writePullRequestEvent(eventPath: string, options: PullRequestEven
             },
         },
     }));
+}
+
+function createPullRequestRepositoryPayload(
+    repositoryFullName: string | undefined,
+): Record<string, string> {
+    return repositoryFullName === undefined
+        ? {}
+        : {
+                full_name: repositoryFullName,
+            };
 }

--- a/contrib/ci/reject-large-external-pr.test.ts
+++ b/contrib/ci/reject-large-external-pr.test.ts
@@ -1,9 +1,20 @@
-import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import {
     buildLargeExternalPullRequestRejectionComment,
     evaluateLargeExternalPullRequest,
+    main,
 } from "./reject-large-external-pr.ts";
+
+const originalFetch = globalThis.fetch;
+type FetchInit = Parameters<typeof fetch>[1];
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
 
 describe("reject-large-external-pr", () => {
     test("rejects external pull requests at the diff limit", () => {
@@ -17,6 +28,7 @@ describe("reject-large-external-pr", () => {
             diffLimit: 200,
             diffSize: 200,
             shouldReject: true,
+            sourceIsExternal: true,
         });
     });
 
@@ -47,6 +59,20 @@ describe("reject-large-external-pr", () => {
             deletions: 500,
             authorAssociation: "OWNER",
         }).shouldReject).toBeFalse();
+    });
+
+    test("allows same-repository pull requests above the diff limit", () => {
+        expect(evaluateLargeExternalPullRequest({
+            additions: 500,
+            authorAssociation: "NONE",
+            baseRepositoryFullName: "oomol-lab/oo-cli",
+            deletions: 500,
+            headRepositoryFullName: "oomol-lab/oo-cli",
+        })).toMatchObject({
+            authorIsExternal: false,
+            shouldReject: false,
+            sourceIsExternal: false,
+        });
     });
 
     test("allows bots above the diff limit", () => {
@@ -85,4 +111,130 @@ describe("reject-large-external-pr", () => {
         expect(comment).toContain("This pull request changes 200 lines (120 additions and 80 deletions)");
         expect(comment).toContain("Please open an issue instead");
     });
+
+    test("allows same-repository pull requests before requiring a GitHub token", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "oo-large-pr-"));
+        const eventPath = join(directory, "event.json");
+
+        try {
+            await writePullRequestEvent(eventPath, {
+                additions: 500,
+                authorAssociation: "NONE",
+                baseRepositoryFullName: "oomol-lab/oo-cli",
+                deletions: 500,
+                headRepositoryFullName: "oomol-lab/oo-cli",
+            });
+
+            await main({
+                GITHUB_EVENT_PATH: eventPath,
+            });
+        }
+        finally {
+            await rm(directory, { force: true, recursive: true });
+        }
+    });
+
+    test("comments and closes large external pull requests without a GET body", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "oo-large-pr-"));
+        const eventPath = join(directory, "event.json");
+        const requests: Array<{ init: FetchInit; url: string }> = [];
+        // Bun's fetch type requires a `preconnect` property; preserve the original.
+        globalThis.fetch = Object.assign(async (
+            input: Parameters<typeof fetch>[0],
+            init?: FetchInit,
+        ): Promise<Response> => {
+            requests.push({
+                init,
+                url: String(input),
+            });
+
+            if (init?.method === "GET") {
+                return Response.json([]);
+            }
+
+            return Response.json({});
+        }, {
+            preconnect: originalFetch.preconnect,
+        });
+
+        try {
+            await writePullRequestEvent(eventPath, {
+                additions: 120,
+                authorAssociation: "CONTRIBUTOR",
+                baseRepositoryFullName: "oomol-lab/oo-cli",
+                deletions: 80,
+                headRepositoryFullName: "external-user/oo-cli",
+            });
+
+            await main({
+                GITHUB_API_URL: "https://api.example.test/",
+                GITHUB_EVENT_PATH: eventPath,
+                GITHUB_TOKEN: "token",
+            });
+
+            expect(requests).toHaveLength(3);
+            const commentListRequest = requests.find(request => request.init?.method === "GET");
+            const commentCreateRequest = requests.find(request => request.init?.method === "POST");
+            const closeRequest = requests.find(request => request.init?.method === "PATCH");
+            if (
+                commentListRequest === undefined
+                || commentCreateRequest === undefined
+                || closeRequest === undefined
+            ) {
+                throw new Error("Expected comment list, comment create, and close requests.");
+            }
+
+            expect(commentListRequest).toMatchObject({
+                url: "https://api.example.test/repos/oomol-lab/oo-cli/issues/157/comments?per_page=100",
+            });
+            expect(commentListRequest.init?.body).toBeUndefined();
+            expect(JSON.parse(String(commentCreateRequest.init?.body))).toMatchObject({
+                body: expect.stringContaining("oo-cli-large-external-pr-guard"),
+            });
+            expect(JSON.parse(String(closeRequest.init?.body))).toEqual({
+                state: "closed",
+            });
+        }
+        finally {
+            await rm(directory, { force: true, recursive: true });
+        }
+    });
 });
+
+interface PullRequestEventOptions {
+    additions: number;
+    authorAssociation: string;
+    baseRepositoryFullName: string;
+    deletions: number;
+    headRepositoryFullName: string;
+}
+
+async function writePullRequestEvent(eventPath: string, options: PullRequestEventOptions): Promise<void> {
+    await Bun.write(eventPath, JSON.stringify({
+        repository: {
+            name: "oo-cli",
+            owner: {
+                login: "oomol-lab",
+            },
+        },
+        pull_request: {
+            additions: options.additions,
+            author_association: options.authorAssociation,
+            base: {
+                repo: {
+                    full_name: options.baseRepositoryFullName,
+                },
+            },
+            deletions: options.deletions,
+            head: {
+                repo: {
+                    full_name: options.headRepositoryFullName,
+                },
+            },
+            number: 157,
+            user: {
+                type: "User",
+            },
+        },
+    }));
+}

--- a/contrib/ci/reject-large-external-pr.ts
+++ b/contrib/ci/reject-large-external-pr.ts
@@ -148,21 +148,44 @@ function parseNumber(value: unknown, fieldName: string): number {
 function parsePullRequestRepositoryFullName(
     pullRequest: Record<string, unknown>,
     refName: "base" | "head",
-): string {
-    const pullRequestRef = parseObject(pullRequest[refName], `pull_request.${refName}`);
-    const repository = parseObject(pullRequestRef.repo, `pull_request.${refName}.repo`);
+): string | undefined {
+    const pullRequestRef = parseOptionalObject(pullRequest[refName]);
+    if (pullRequestRef === undefined) {
+        return undefined;
+    }
 
-    return parseString(repository.full_name, `pull_request.${refName}.repo.full_name`);
+    const repository = parseOptionalObject(pullRequestRef.repo);
+    if (repository === undefined) {
+        return undefined;
+    }
+
+    const fullName = repository.full_name;
+    if (typeof fullName !== "string") {
+        return undefined;
+    }
+
+    const normalizedFullName = fullName.trim();
+    return normalizedFullName === "" ? undefined : normalizedFullName;
+}
+
+function parseOptionalObject(value: unknown): Record<string, unknown> | undefined {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : undefined;
 }
 
 function evaluateSourceIsExternal(input: PullRequestGuardInput): boolean {
-    // Fail closed when callers omit repo names: the rejection guard should err toward "external".
-    // readPullRequestEvent always populates both fields in production.
-    if (input.baseRepositoryFullName === undefined || input.headRepositoryFullName === undefined) {
+    const baseRepositoryFullName = input.baseRepositoryFullName?.trim();
+    const headRepositoryFullName = input.headRepositoryFullName?.trim();
+
+    if (baseRepositoryFullName === undefined || baseRepositoryFullName === "") {
+        return true;
+    }
+    if (headRepositoryFullName === undefined || headRepositoryFullName === "") {
         return true;
     }
 
-    return input.baseRepositoryFullName !== input.headRepositoryFullName;
+    return baseRepositoryFullName !== headRepositoryFullName;
 }
 
 function buildRepoPath(ref: PullRequestRef, suffix: string): string {

--- a/contrib/ci/reject-large-external-pr.ts
+++ b/contrib/ci/reject-large-external-pr.ts
@@ -9,8 +9,10 @@ interface PullRequestGuardInput {
     additions: number;
     authorAssociation: string;
     authorType?: string;
+    baseRepositoryFullName?: string;
     deletions: number;
     diffLimit?: number;
+    headRepositoryFullName?: string;
 }
 
 interface PullRequestGuardDecision {
@@ -19,6 +21,7 @@ interface PullRequestGuardDecision {
     diffSize: number;
     diffLimit: number;
     shouldReject: boolean;
+    sourceIsExternal: boolean;
 }
 
 interface RejectionCommentInput {
@@ -56,7 +59,10 @@ export function evaluateLargeExternalPullRequest(input: PullRequestGuardInput): 
     const diffLimit = input.diffLimit ?? DEFAULT_EXTERNAL_PR_DIFF_LIMIT;
     const diffSize = Math.abs(input.additions) + Math.abs(input.deletions);
     const authorIsBot = input.authorType === "Bot";
-    const authorIsExternal = !authorIsBot && !INTERNAL_AUTHOR_ASSOCIATIONS.has(input.authorAssociation);
+    const sourceIsExternal = evaluateSourceIsExternal(input);
+    const authorIsExternal = !authorIsBot
+        && sourceIsExternal
+        && !INTERNAL_AUTHOR_ASSOCIATIONS.has(input.authorAssociation);
 
     return {
         authorIsBot,
@@ -64,6 +70,7 @@ export function evaluateLargeExternalPullRequest(input: PullRequestGuardInput): 
         diffSize,
         diffLimit,
         shouldReject: authorIsExternal && diffSize >= diffLimit,
+        sourceIsExternal,
     };
 }
 
@@ -96,6 +103,8 @@ async function readPullRequestEvent(eventPath: string): Promise<PullRequestEvent
     const repositoryOwner = parseObject(repository.owner, "repository.owner");
     const pullRequest = parseObject(eventPayload.pull_request, "pull_request");
     const pullRequestAuthor = parseObject(pullRequest.user, "pull_request.user");
+    const baseRepositoryFullName = parsePullRequestRepositoryFullName(pullRequest, "base");
+    const headRepositoryFullName = parsePullRequestRepositoryFullName(pullRequest, "head");
 
     return {
         owner: parseString(repositoryOwner.login, "repository.owner.login"),
@@ -106,6 +115,8 @@ async function readPullRequestEvent(eventPath: string): Promise<PullRequestEvent
             deletions: parseNumber(pullRequest.deletions, "pull_request.deletions"),
             authorAssociation: parseString(pullRequest.author_association, "pull_request.author_association"),
             authorType: parseString(pullRequestAuthor.type, "pull_request.user.type"),
+            baseRepositoryFullName,
+            headRepositoryFullName,
         },
     };
 }
@@ -134,17 +145,38 @@ function parseNumber(value: unknown, fieldName: string): number {
     throw new TypeError(`${fieldName} must be a finite number.`);
 }
 
+function parsePullRequestRepositoryFullName(
+    pullRequest: Record<string, unknown>,
+    refName: "base" | "head",
+): string {
+    const pullRequestRef = parseObject(pullRequest[refName], `pull_request.${refName}`);
+    const repository = parseObject(pullRequestRef.repo, `pull_request.${refName}.repo`);
+
+    return parseString(repository.full_name, `pull_request.${refName}.repo.full_name`);
+}
+
+function evaluateSourceIsExternal(input: PullRequestGuardInput): boolean {
+    // Fail closed when callers omit repo names: the rejection guard should err toward "external".
+    // readPullRequestEvent always populates both fields in production.
+    if (input.baseRepositoryFullName === undefined || input.headRepositoryFullName === undefined) {
+        return true;
+    }
+
+    return input.baseRepositoryFullName !== input.headRepositoryFullName;
+}
+
 function buildRepoPath(ref: PullRequestRef, suffix: string): string {
     return `/repos/${encodeURIComponent(ref.owner)}/${encodeURIComponent(ref.repo)}/${suffix}`;
 }
 
 async function ensureRejectionComment(
-    options: GitHubApiClientOptions & PullRequestRef & { body: string },
+    options: GitHubApiClientOptions & PullRequestRef & { commentBody: string },
 ): Promise<void> {
+    const { commentBody, ...requestOptions } = options;
     const existingComments = await requestGitHubJson<GitHubIssueComment[]>({
-        ...options,
+        ...requestOptions,
         method: "GET",
-        path: buildRepoPath(options, `issues/${options.pullNumber}/comments?per_page=100`),
+        path: buildRepoPath(requestOptions, `issues/${requestOptions.pullNumber}/comments?per_page=100`),
     });
 
     if (existingComments.some(comment => comment.body?.includes(REJECTION_COMMENT_MARKER) === true)) {
@@ -152,11 +184,11 @@ async function ensureRejectionComment(
     }
 
     await requestGitHubJson({
-        ...options,
+        ...requestOptions,
         method: "POST",
-        path: buildRepoPath(options, `issues/${options.pullNumber}/comments`),
+        path: buildRepoPath(requestOptions, `issues/${requestOptions.pullNumber}/comments`),
         body: {
-            body: options.body,
+            body: commentBody,
         },
     });
 }
@@ -206,9 +238,10 @@ function trimTrailingSlash(value: string): string {
 export async function main(environment: NodeJS.ProcessEnv = process.env): Promise<void> {
     const event = await readPullRequestEvent(readRequiredEnv(environment, "GITHUB_EVENT_PATH"));
     const decision = evaluateLargeExternalPullRequest(event.pullRequest);
+    const decisionSummary = `association=${event.pullRequest.authorAssociation}, bot=${decision.authorIsBot}, sourceExternal=${decision.sourceIsExternal}, authorExternal=${decision.authorIsExternal}, diff=${decision.diffSize}, limit=${decision.diffLimit}`;
 
     if (!decision.shouldReject) {
-        process.stdout.write(`Pull request allowed: bot=${decision.authorIsBot}, external=${decision.authorIsExternal}, diff=${decision.diffSize}, limit=${decision.diffLimit}.\n`);
+        process.stdout.write(`Pull request allowed: ${decisionSummary}.\n`);
         return;
     }
 
@@ -222,20 +255,22 @@ export async function main(environment: NodeJS.ProcessEnv = process.env): Promis
         diffLimit: decision.diffLimit,
     });
 
-    await ensureRejectionComment({
-        ...apiClientOptions,
-        body: commentBody,
-        owner: event.owner,
-        pullNumber: event.pullNumber,
-        repo: event.repo,
-    });
-    await closePullRequest({
-        ...apiClientOptions,
-        owner: event.owner,
-        pullNumber: event.pullNumber,
-        repo: event.repo,
-    });
-    process.stdout.write(`Closed external pull request #${event.pullNumber}: diff=${decision.diffSize}, limit=${decision.diffLimit}.\n`);
+    await Promise.all([
+        ensureRejectionComment({
+            ...apiClientOptions,
+            commentBody,
+            owner: event.owner,
+            pullNumber: event.pullNumber,
+            repo: event.repo,
+        }),
+        closePullRequest({
+            ...apiClientOptions,
+            owner: event.owner,
+            pullNumber: event.pullNumber,
+            repo: event.repo,
+        }),
+    ]);
+    process.stdout.write(`Closed external pull request #${event.pullNumber}: ${decisionSummary}.\n`);
 }
 
 if (import.meta.main) {

--- a/src/application/telemetry/flusher.test.ts
+++ b/src/application/telemetry/flusher.test.ts
@@ -1,6 +1,7 @@
+import type { TelemetryBatchItem } from "./payload.ts";
 import { Buffer } from "node:buffer";
-import { join } from "node:path";
 
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import {
     createTemporaryDirectory,
@@ -21,6 +22,7 @@ import {
     openTelemetryDatabase,
     readTelemetryRowsForTest,
 } from "./outbox.ts";
+import { serializeTelemetryBatchItem } from "./payload.ts";
 
 describe("telemetry flusher", () => {
     const temporaryDirectories = useTemporaryDirectoryCleanup();
@@ -70,19 +72,17 @@ describe("telemetry flusher", () => {
         const directoryPath = join(root, "telemetry");
         const settingsFilePath = join(root, "settings.toml");
         const eventCount = 1500;
+        const items: TelemetryBatchItem[] = [];
         const requestSizes: number[] = [];
 
         for (let index = 0; index < eventCount; index += 1) {
             const item = createTelemetryItemForTest(index);
 
             item.properties.large_value = "x".repeat(3000);
-
-            expect(enqueueTelemetryBatchItem({
-                directoryPath,
-                item,
-                nowMs: 1000 + index,
-            })).toBeTrue();
+            items.push(item);
         }
+
+        writeTelemetryBatchItemsForTest(directoryPath, items, 1000);
 
         const rowsBefore = readTelemetryRowsForTest(directoryPath);
         const totalPayloadBytes = rowsBefore.reduce(
@@ -442,3 +442,63 @@ describe("telemetry flusher", () => {
         expect(readTelemetryRowsForTest(directoryPath)).toEqual([]);
     });
 });
+
+function writeTelemetryBatchItemsForTest(
+    directoryPath: string,
+    items: readonly TelemetryBatchItem[],
+    firstNowMs: number,
+): void {
+    const database = openTelemetryDatabase(directoryPath);
+
+    try {
+        database.run("BEGIN IMMEDIATE");
+        let committed = false;
+
+        try {
+            const statement = database.query(
+                [
+                    "INSERT INTO telemetry_events (",
+                    "id,",
+                    "created_at_ms,",
+                    "available_at_ms,",
+                    "payload_json,",
+                    "payload_bytes",
+                    ") VALUES (",
+                    "$id,",
+                    "$createdAtMs,",
+                    "$availableAtMs,",
+                    "$payloadJson,",
+                    "$payloadBytes",
+                    ")",
+                ].join(" "),
+            );
+
+            for (const [index, item] of items.entries()) {
+                const payloadJson = serializeTelemetryBatchItem(item);
+                if (payloadJson === undefined) {
+                    throw new Error("Expected telemetry test item to be serializable.");
+                }
+
+                const nowMs = firstNowMs + index;
+                statement.run({
+                    availableAtMs: nowMs,
+                    createdAtMs: nowMs,
+                    id: item.uuid,
+                    payloadBytes: Buffer.byteLength(payloadJson, "utf8"),
+                    payloadJson,
+                });
+            }
+
+            database.run("COMMIT");
+            committed = true;
+        }
+        finally {
+            if (!committed) {
+                database.run("ROLLBACK");
+            }
+        }
+    }
+    finally {
+        database.close();
+    }
+}


### PR DESCRIPTION
The large external PR guard rejected any non-INTERNAL author whose PR exceeded the diff limit, which incorrectly closed branches pushed directly to the upstream repository by contributors without write metadata. Detect same-repository PRs by comparing head and base `full_name`, treat them as internal regardless of association, and fail closed when repo names are missing. Also parallelize the comment and close API calls and enrich the decision log line.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/oomol-lab/codesmith/oo-cli/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->