### PR TITLE
[codex] Refine skill publish and OO selection behavior

### DIFF
--- a/contrib/skills/claude/oo-create-skill/SKILL.md
+++ b/contrib/skills/claude/oo-create-skill/SKILL.md
@@ -64,6 +64,10 @@ this constitution, not a separate checklist.
    domain-focused. Include the facts needed to execute reliably; omit broad oo
    mechanics, full schema dumps, and implementation details that the managed OO
    notice already covers.
+8. Write generated skills in English regardless of the user's language,
+   including `--description`, `--title`, frontmatter, headings, examples, and
+   reference files. Preserve non-English only for literal runtime values,
+   product names, language-pair requirements, or necessary sample I/O.
 
 ## Workflow
 

--- a/contrib/skills/claude/oo-publish-skill/SKILL.md
+++ b/contrib/skills/claude/oo-publish-skill/SKILL.md
@@ -34,8 +34,8 @@ publishing by filesystem path, pass the path directly and omit `--agent`.
 The publish command performs its own environment, authentication, and account
 checks, so run it directly.
 
-Use the default private visibility unless the user explicitly asks for a public
-package. Add `--visibility public` only for that explicit public request.
+Let `oo skills publish` resolve visibility unless the user explicitly asks for
+`private` or `public`. Pass `--visibility` only for that explicit request.
 
 Do not ask whether to publish to the current account. `oo skills publish`
 resolves the account and asks any necessary ownership questions itself.

--- a/contrib/skills/claude/oo/references/search-and-selection.md
+++ b/contrib/skills/claude/oo/references/search-and-selection.md
@@ -136,9 +136,12 @@ Rank mixed results in this order:
 2. Whether the target service, destination, or output is explicitly named or
    strongly implied
 3. Whether the candidate is ready to run, especially authenticated connector
-   readiness
+   readiness. Treat authenticated connectors and Fusion API candidates as
+   out-of-box.
 4. How many required inputs and follow-up questions it adds
 5. How closely the documented output matches the user's desired outcome
+6. If the user did not name a model or product, prefer more capable, modern,
+   reputable candidates over older or obscure equivalents.
 
 Tie-breakers:
 

--- a/contrib/skills/codebuddy/oo-create-skill/SKILL.md
+++ b/contrib/skills/codebuddy/oo-create-skill/SKILL.md
@@ -63,6 +63,10 @@ this constitution, not a separate checklist.
    domain-focused. Include the facts needed to execute reliably; omit broad oo
    mechanics, full schema dumps, and implementation details that the managed OO
    notice already covers.
+8. Write generated skills in English regardless of the user's language,
+   including `--description`, `--title`, frontmatter, headings, examples, and
+   reference files. Preserve non-English only for literal runtime values,
+   product names, language-pair requirements, or necessary sample I/O.
 
 ## Workflow
 

--- a/contrib/skills/codebuddy/oo-publish-skill/SKILL.md
+++ b/contrib/skills/codebuddy/oo-publish-skill/SKILL.md
@@ -33,8 +33,8 @@ publishing by filesystem path, pass the path directly and omit `--agent`.
 The publish command performs its own environment, authentication, and account
 checks, so run it directly.
 
-Use the default private visibility unless the user explicitly asks for a public
-package. Add `--visibility public` only for that explicit public request.
+Let `oo skills publish` resolve visibility unless the user explicitly asks for
+`private` or `public`. Pass `--visibility` only for that explicit request.
 
 Do not ask whether to publish to the current account. `oo skills publish`
 resolves the account and asks any necessary ownership questions itself.

--- a/contrib/skills/codebuddy/oo/references/search-and-selection.md
+++ b/contrib/skills/codebuddy/oo/references/search-and-selection.md
@@ -136,9 +136,12 @@ Rank mixed results in this order:
 2. Whether the target service, destination, or output is explicitly named or
    strongly implied
 3. Whether the candidate is ready to run, especially authenticated connector
-   readiness
+   readiness. Treat authenticated connectors and Fusion API candidates as
+   out-of-box.
 4. How many required inputs and follow-up questions it adds
 5. How closely the documented output matches the user's desired outcome
+6. If the user did not name a model or product, prefer more capable, modern,
+   reputable candidates over older or obscure equivalents.
 
 Tie-breakers:
 

--- a/contrib/skills/codex/oo-create-skill/SKILL.md
+++ b/contrib/skills/codex/oo-create-skill/SKILL.md
@@ -63,6 +63,10 @@ this constitution, not a separate checklist.
    domain-focused. Include the facts needed to execute reliably; omit broad oo
    mechanics, full schema dumps, and implementation details that the managed OO
    notice already covers.
+8. Write generated skills in English regardless of the user's language,
+   including `--description`, `--title`, frontmatter, headings, examples, and
+   reference files. Preserve non-English only for literal runtime values,
+   product names, language-pair requirements, or necessary sample I/O.
 
 ## Workflow
 

--- a/contrib/skills/codex/oo-publish-skill/SKILL.md
+++ b/contrib/skills/codex/oo-publish-skill/SKILL.md
@@ -30,8 +30,8 @@ by filesystem path, pass the path directly and omit `--agent`.
 The publish command performs its own environment, authentication, and account
 checks, so run it directly.
 
-Use the default private visibility unless the user explicitly asks for a public
-package. Add `--visibility public` only for that explicit public request.
+Let `oo skills publish` resolve visibility unless the user explicitly asks for
+`private` or `public`. Pass `--visibility` only for that explicit request.
 
 Do not ask whether to publish to the current account. `oo skills publish`
 resolves the account and asks any necessary ownership questions itself.

--- a/contrib/skills/codex/oo/references/search-and-selection.md
+++ b/contrib/skills/codex/oo/references/search-and-selection.md
@@ -136,9 +136,12 @@ Rank mixed results in this order:
 2. Whether the target service, destination, or output is explicitly named or
    strongly implied
 3. Whether the candidate is ready to run, especially authenticated connector
-   readiness
+   readiness. Treat authenticated connectors and Fusion API candidates as
+   out-of-box.
 4. How many required inputs and follow-up questions it adds
 5. How closely the documented output matches the user's desired outcome
+6. If the user did not name a model or product, prefer more capable, modern,
+   reputable candidates over older or obscure equivalents.
 
 Tie-breakers:
 

--- a/contrib/skills/openclaw/oo-create-skill/SKILL.md
+++ b/contrib/skills/openclaw/oo-create-skill/SKILL.md
@@ -63,6 +63,10 @@ this constitution, not a separate checklist.
    domain-focused. Include the facts needed to execute reliably; omit broad oo
    mechanics, full schema dumps, and implementation details that the managed OO
    notice already covers.
+8. Write generated skills in English regardless of the user's language,
+   including `--description`, `--title`, frontmatter, headings, examples, and
+   reference files. Preserve non-English only for literal runtime values,
+   product names, language-pair requirements, or necessary sample I/O.
 
 ## Workflow
 

--- a/contrib/skills/openclaw/oo-publish-skill/SKILL.md
+++ b/contrib/skills/openclaw/oo-publish-skill/SKILL.md
@@ -33,8 +33,8 @@ publishing by filesystem path, pass the path directly and omit `--agent`.
 The publish command performs its own environment, authentication, and account
 checks, so run it directly.
 
-Use the default private visibility unless the user explicitly asks for a public
-package. Add `--visibility public` only for that explicit public request.
+Let `oo skills publish` resolve visibility unless the user explicitly asks for
+`private` or `public`. Pass `--visibility` only for that explicit request.
 
 Do not ask whether to publish to the current account. `oo skills publish`
 resolves the account and asks any necessary ownership questions itself.

--- a/contrib/skills/openclaw/oo/references/search-and-selection.md
+++ b/contrib/skills/openclaw/oo/references/search-and-selection.md
@@ -136,9 +136,12 @@ Rank mixed results in this order:
 2. Whether the target service, destination, or output is explicitly named or
    strongly implied
 3. Whether the candidate is ready to run, especially authenticated connector
-   readiness
+   readiness. Treat authenticated connectors and Fusion API candidates as
+   out-of-box.
 4. How many required inputs and follow-up questions it adds
 5. How closely the documented output matches the user's desired outcome
+6. If the user did not name a model or product, prefer more capable, modern,
+   reputable candidates over older or obscure equivalents.
 
 Tie-breakers:
 

--- a/contrib/skills/qoderwork/oo-create-skill/SKILL.md
+++ b/contrib/skills/qoderwork/oo-create-skill/SKILL.md
@@ -63,6 +63,10 @@ this constitution, not a separate checklist.
    domain-focused. Include the facts needed to execute reliably; omit broad oo
    mechanics, full schema dumps, and implementation details that the managed OO
    notice already covers.
+8. Write generated skills in English regardless of the user's language,
+   including `--description`, `--title`, frontmatter, headings, examples, and
+   reference files. Preserve non-English only for literal runtime values,
+   product names, language-pair requirements, or necessary sample I/O.
 
 ## Workflow
 

--- a/contrib/skills/qoderwork/oo-publish-skill/SKILL.md
+++ b/contrib/skills/qoderwork/oo-publish-skill/SKILL.md
@@ -33,8 +33,8 @@ publishing by filesystem path, pass the path directly and omit `--agent`.
 The publish command performs its own environment, authentication, and account
 checks, so run it directly.
 
-Use the default private visibility unless the user explicitly asks for a public
-package. Add `--visibility public` only for that explicit public request.
+Let `oo skills publish` resolve visibility unless the user explicitly asks for
+`private` or `public`. Pass `--visibility` only for that explicit request.
 
 Do not ask whether to publish to the current account. `oo skills publish`
 resolves the account and asks any necessary ownership questions itself.

--- a/contrib/skills/qoderwork/oo/references/search-and-selection.md
+++ b/contrib/skills/qoderwork/oo/references/search-and-selection.md
@@ -136,9 +136,12 @@ Rank mixed results in this order:
 2. Whether the target service, destination, or output is explicitly named or
    strongly implied
 3. Whether the candidate is ready to run, especially authenticated connector
-   readiness
+   readiness. Treat authenticated connectors and Fusion API candidates as
+   out-of-box.
 4. How many required inputs and follow-up questions it adds
 5. How closely the documented output matches the user's desired outcome
+6. If the user did not name a model or product, prefer more capable, modern,
+   reputable candidates over older or obscure equivalents.
 
 Tie-breakers:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -474,7 +474,9 @@ Convert one skill into an OOMOL package and run the publish step.
   it may also be a path to a skill directory containing `SKILL.md`. Relative
   paths resolve from the current working directory.
 - Options: `--visibility <visibility>` sets the registry package visibility.
-  Accepted values are `private` and `public`. The default is `private`.
+  Accepted values are `private` and `public`. When omitted, an existing package
+  keeps its current registry visibility. If no existing visibility can be read,
+  an interactive terminal prompts for `private` or `public`.
 - Options: `--agent <agent>` is a source hint used only when the skill is not
   found in local, bundled, or registry storage. Accepted values are `codex`,
   `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `trae-cn`,
@@ -521,6 +523,11 @@ Convert one skill into an OOMOL package and run the publish step.
   confirmation style unless `-y, --yes` is provided. Answering no, pressing
   Enter, or running without an interactive stdin stops before conversion, PUT,
   or local metadata writeback.
+- Visibility resolution: explicit `--visibility` is used as-is. Without it, the
+  command preserves a latest remote package marked `public` as public and a
+  private/restricted remote package as private. If the latest package metadata
+  is missing or does not include visibility, the command asks for `private` or
+  `public`; non-interactive runs must pass `--visibility`.
 - Version resolution: if the requested version is not greater than the latest
   remote package version, the command publishes the next patch version.
 - Writeback: after the publish step succeeds, `SKILL.md` frontmatter is updated

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -410,7 +410,8 @@ skills。
 - 参数：`<skill-id>` 通常是 skill id。当没有匹配到由 oo 管理的 skill 时，也可以
   是包含 `SKILL.md` 的 skill 目录路径。相对路径会从当前工作目录解析。
 - 选项：`--visibility <visibility>` 设置 registry 包可见性。可选值为
-  `private` 和 `public`，默认值为 `private`。
+  `private` 和 `public`。省略时，已有包会沿用当前 registry 可见性。如果无法读取
+  已有可见性，交互式终端会询问发布为 `private` 还是 `public`。
 - 选项：`--agent <agent>` 仅在 local、bundled 和 registry 存储中都没有匹配时
   作为来源提示。可选值为 `codex`、`claude`、`hermes`、`codebuddy`、
   `workbuddy`、`trae`、`trae-cn`、`openclaw` 和 `qoderwork`。
@@ -445,6 +446,10 @@ skills。
   包含 blocks，交互式终端会按既有 `[y/N]` 确认风格询问是否继续。回答 no、
   直接回车，或在没有交互式 stdin 的环境中运行，都会在转换、PUT 和本地 metadata
   回写前停止；提供 `-y, --yes` 时会跳过该确认。
+- 可见性解析：显式传入 `--visibility` 时使用该值。未传入时，如果 latest 远端包
+  是 `public`，继续以公开包发布；如果是 private/restricted，则继续以私有包发布。
+  如果 latest 包元数据不存在或不包含可见性，命令会询问 `private` 或 `public`；
+  非交互式运行必须传入 `--visibility`。
 - 版本解析：如果请求版本不大于远端 latest 包版本，命令会发布下一个 patch 版本。
 - 回写：发布步骤成功后，命令会把最终的 `metadata.packageName` 和
   `metadata.version` 写回 `SKILL.md` frontmatter。

--- a/src/application/commands/package/shared.ts
+++ b/src/application/commands/package/shared.ts
@@ -53,11 +53,13 @@ const packageInfoBlockSchema = z.object({
 }).passthrough();
 
 const packageInfoResponseSchema = z.object({
+    access: z.enum(["private", "public", "restricted"]).optional(),
     blocks: z.array(packageInfoBlockSchema).optional().default([]),
     description: z.string().optional().default(""),
     packageName: z.string().min(1),
     packageVersion: z.string().min(1),
     title: z.string().optional().default(""),
+    visibility: z.enum(["private", "public", "restricted"]).optional(),
 }).passthrough();
 
 const transformedInputHandleSchema = z.object({
@@ -83,6 +85,7 @@ const transformedBlockSchema = z.object({
 }).strict();
 
 const transformedPackageInfoResponseSchema = z.object({
+    access: z.enum(["private", "public", "restricted"]).optional(),
     blocks: z.array(transformedBlockSchema),
     description: z.string(),
     displayName: z.string(),
@@ -409,6 +412,7 @@ function parseRawPackageInfoResponse(rawResponse: string): PackageInfoResponse {
         );
 
         return transformedPackageInfoResponseSchema.parse({
+            access: parsedResponse.visibility ?? parsedResponse.access,
             packageName: parsedResponse.packageName,
             packageVersion: parsedResponse.packageVersion,
             description: parsedResponse.description,

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -330,6 +330,28 @@ describe("embedded skill assets", () => {
         }
     });
 
+    test("guides oo search selection toward ready and high-quality candidates", async () => {
+        for (const agentName of availableBundledSkillAgentNames) {
+            const searchGuide = getBundledSkillFiles("oo", agentName).find(
+                file => file.relativePath === "references/search-and-selection.md",
+            );
+
+            if (searchGuide === undefined) {
+                throw new Error(`Missing ${agentName} oo search-and-selection guide`);
+            }
+
+            const content = normalizeMarkdownWrappingForAssertion(
+                await Bun.file(searchGuide.sourcePath).text(),
+            );
+
+            expect(content).toContain("Treat authenticated connectors and Fusion API candidates");
+            expect(content).toContain("out-of-box");
+            expect(content).toContain("If the user did not name a model or product");
+            expect(content).toContain("prefer more capable, modern, reputable candidates");
+            expect(content).toContain("older or obscure equivalents");
+        }
+    });
+
     test("guides oo-create-skill agents to fill presentation metadata", async () => {
         for (const agentName of availableBundledSkillAgentNames) {
             const skillFile = getBundledSkillFiles("oo-create-skill", agentName).find(
@@ -494,6 +516,32 @@ describe("embedded skill assets", () => {
             );
             expect(content).not.toContain("one short positive trigger sentence");
             expect(content).not.toContain("Keep implementation plumbing out of the description");
+        }
+    });
+
+    test("guides oo-create-skill generated skills to stay in English", async () => {
+        for (const agentName of availableBundledSkillAgentNames) {
+            const skillFile = getBundledSkillFiles("oo-create-skill", agentName).find(
+                file => file.relativePath === "SKILL.md",
+            );
+
+            if (skillFile === undefined) {
+                throw new Error(`Missing ${agentName} oo-create-skill SKILL.md`);
+            }
+
+            const content = normalizeMarkdownWrappingForAssertion(
+                await Bun.file(skillFile.sourcePath).text(),
+            );
+
+            expect(content).toContain(
+                "Write generated skills in English regardless of the user's language",
+            );
+            expect(content).toContain("including `--description`, `--title`");
+            expect(content).toContain("frontmatter, headings, examples, and reference files");
+            expect(content).toContain("Preserve non-English only for literal runtime values");
+            expect(content).toContain("language-pair requirements");
+            expect(content).not.toContain("Write all generated prose in English");
+            expect(content).not.toContain("Do not mirror the user's language into the skill body");
         }
     });
 
@@ -690,7 +738,7 @@ describe("embedded skill assets", () => {
             expect(content).toContain("oo skills publish");
             expect(content).toContain("When publishing by skill id");
             expect(content).toContain("include `--agent");
-            expect(content).toContain("Add `--visibility public` only");
+            expect(content).toContain("Pass `--visibility` only");
             expect(content).toContain("The publish command performs its own");
             expect(content).toContain("Do not ask whether to publish to the current account");
             expect(content).toContain("Do not package manually");

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -777,7 +777,12 @@ function normalizeLineEndingsForAssertion(text: string): string {
 }
 
 function normalizeMarkdownWrappingForAssertion(text: string): string {
-    return normalizeLineEndingsForAssertion(text).replaceAll("\n", " ");
+    const lines = normalizeLineEndingsForAssertion(text).split("\n");
+    // Strip leading whitespace from continuation lines so soft-wrapped list
+    // items and indented prose match assertions written as flat sentences.
+    return lines
+        .map((line, index) => (index === 0 ? line : line.trimStart()))
+        .join(" ");
 }
 
 function readBundledSkillSourceAgentName(

--- a/src/application/commands/skills/interactive-prompts.ts
+++ b/src/application/commands/skills/interactive-prompts.ts
@@ -66,6 +66,26 @@ export async function confirmInteractiveValue(
     }
 }
 
+export async function selectInteractiveValue<Value extends string>(
+    context: InteractivePromptContext,
+    options: {
+        invalidMessage: string;
+        prompt: string;
+        values: readonly Value[];
+    },
+): Promise<Value> {
+    while (true) {
+        context.stdout.write(options.prompt);
+        const value = normalizePromptValue(await readPromptLine(context.stdin));
+
+        if (isInteractiveValueOption(value, options.values)) {
+            return value;
+        }
+
+        context.stdout.write(`${options.invalidMessage}\n`);
+    }
+}
+
 export async function selectInteractiveSkills(
     context: InteractivePromptContext,
     options: {
@@ -377,6 +397,13 @@ async function readPromptLine(stdin: InteractiveInput): Promise<string> {
 
 function normalizePromptValue(value: string): string {
     return value.trim().toLowerCase();
+}
+
+function isInteractiveValueOption<Value extends string>(
+    value: string,
+    values: readonly Value[],
+): value is Value {
+    return values.includes(value as Value);
 }
 
 function resolveLineBreakIndex(value: string): number {

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -68,7 +68,9 @@ describe("skills publish command", () => {
         );
 
         try {
+            const stdin = createInteractiveInput();
             const requests: Request[] = [];
+            stdin.feed("private\n");
             const result = await sandbox.run(
                 ["skills", "publish", "demo-skill"],
                 {
@@ -83,12 +85,13 @@ describe("skills publish command", () => {
 
                         return new Response("", { status: 201 });
                     },
+                    stdin,
                 },
             );
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
-                "Published skill demo-skill as private package @alice/demo-skill@0.0.1. View it at https://hub.oomol.com/package/@alice/demo-skill.\n",
+                "Publish skill demo-skill as package @alice/demo-skill with which visibility? [private/public] Published skill demo-skill as private package @alice/demo-skill@0.0.1. View it at https://hub.oomol.com/package/@alice/demo-skill.\n",
             );
             expect(result.stderr).toBe("");
             expect(requests.map(request => `${request.method} ${request.url}`)).toEqual([
@@ -186,6 +189,57 @@ describe("skills publish command", () => {
         }
     });
 
+    test("preserves public visibility from an existing package", async () => {
+        const { sandbox } = await createCliPublishSkillSandbox(
+            "existing-public-skill",
+            [
+                "---",
+                "name: existing-public-skill",
+                "description: Use a known package workflow.",
+                "---",
+                "",
+            ].join("\n"),
+        );
+
+        try {
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["skills", "publish", "existing-public-skill"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.url.includes("/-/oomol/package-info/")) {
+                            return new Response(JSON.stringify({
+                                access: "public",
+                                blocks: [],
+                                description: "Existing public skill package.",
+                                packageName: "@alice/existing-public-skill",
+                                packageVersion: "0.0.3",
+                                title: "Existing Public Skill",
+                            }));
+                        }
+
+                        return new Response("", { status: 201 });
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                "Published skill existing-public-skill as public package @alice/existing-public-skill@0.0.4. View it at https://hub.oomol.com/package/@alice/existing-public-skill.\n",
+            );
+            await expect(requests[1]!.json()).resolves.toMatchObject({
+                access: "public",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("publishes a registry skill when the installed package matches the target package", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -221,7 +275,7 @@ describe("skills publish command", () => {
 
             const requests: Request[] = [];
             const result = await sandbox.run(
-                ["skills", "publish", "registry-skill"],
+                ["skills", "publish", "registry-skill", "--visibility", "private"],
                 {
                     fetcher: async (input, init) => {
                         const request = toRequest(input, init);
@@ -346,7 +400,7 @@ describe("skills publish command", () => {
             );
 
             const result = await sandbox.run(
-                ["skills", "publish", "forked-skill", "--yes"],
+                ["skills", "publish", "forked-skill", "--yes", "--visibility", "private"],
                 {
                     fetcher: async (input, init) => {
                         const request = toRequest(input, init);
@@ -411,7 +465,7 @@ describe("skills publish command", () => {
             stdin.feed("yes\n");
 
             const result = await sandbox.run(
-                ["skills", "publish", "agent-skill", "--agent", "codex"],
+                ["skills", "publish", "agent-skill", "--agent", "codex", "--visibility", "private"],
                 {
                     fetcher: async (input, init) => {
                         const request = toRequest(input, init);
@@ -989,6 +1043,7 @@ describe("skills publish command", () => {
 
                         if (request.url.includes("/-/oomol/package-info/")) {
                             return new Response(JSON.stringify({
+                                access: "restricted",
                                 blocks: [
                                     {
                                         blockName: "main",

--- a/src/application/commands/skills/publish.ts
+++ b/src/application/commands/skills/publish.ts
@@ -1,5 +1,6 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
+import type { PackageInfoResponse } from "../package/shared.ts";
 import type { BundledSkillAgentName } from "./embedded-assets.ts";
 import type { LocalSkillHostPublicationTarget } from "./init.ts";
 
@@ -34,7 +35,10 @@ import {
     resolveLocalSkillPublicationTargets,
     resolveSkillInitPublicationMessageKey,
 } from "./init.ts";
-import { confirmInteractiveValue } from "./interactive-prompts.ts";
+import {
+    confirmInteractiveValue,
+    selectInteractiveValue,
+} from "./interactive-prompts.ts";
 import { createMissingManagedSkillHostError } from "./managed-skill-hosts.ts";
 import {
     parseManagedSkillMetadataContent,
@@ -50,7 +54,6 @@ import {
 import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
 import {
     convertSkillDirectoryToPackage,
-    defaultSkillPublishVisibility,
     publishConvertedSkillPackage,
     readLocalSkillPackageMetadata,
     skillPublishVisibilityValues,
@@ -70,6 +73,7 @@ interface PublishLocalSkillPackageResult {
     packageName: string;
     skillDirectoryPath: string;
     skillId: string;
+    visibility: SkillPublishVisibility;
     version: string;
 }
 
@@ -114,6 +118,15 @@ interface ResolveSkillPublishVersionRequest {
     yes: boolean;
 }
 
+interface ResolveSkillPublishPlanRequest extends ResolveSkillPublishVersionRequest {
+    requestedVisibility?: SkillPublishVisibility;
+}
+
+interface ResolvedSkillPublishPlan {
+    version: string;
+    visibility: SkillPublishVisibility;
+}
+
 interface PublishLocalSkillPackageDependencies {
     checkAuthoringEnvironment?: typeof checkLocalSkillAuthoringEnvironment;
     convertSkillDirectoryToPackage?: typeof convertSkillDirectoryToPackage;
@@ -124,6 +137,9 @@ interface PublishLocalSkillPackageDependencies {
     resolveFinalPublishVersion?: (
         request: ResolveSkillPublishVersionRequest,
     ) => Promise<string>;
+    resolveFinalPublishPlan?: (
+        request: ResolveSkillPublishPlanRequest,
+    ) => Promise<ResolvedSkillPublishPlan>;
     writePublishedSkillMetadata?: typeof writePublishedSkillMetadata;
 }
 
@@ -166,12 +182,7 @@ export const skillsPublishCommand: CliCommandDefinition<SkillsPublishInput> = {
     }),
     handler: async (input, context) => {
         const agentName = parseSkillPublishAgent(input.agent);
-        const visibility = parseSkillPublishVisibility(input.visibility)
-            ?? defaultSkillPublishVisibility;
-
-        context.telemetry?.recordProperties({
-            visibility,
-        });
+        const visibility = parseSkillPublishVisibility(input.visibility);
 
         const result = await publishSkillPackage(
             input.skill,
@@ -190,7 +201,7 @@ export const skillsPublishCommand: CliCommandDefinition<SkillsPublishInput> = {
                 name: result.skillId,
                 packageName: result.packageName,
                 visibility: context.translator.t(
-                    `skills.publish.visibility.${visibility}`,
+                    `skills.publish.visibility.${result.visibility}`,
                 ),
                 version: result.version,
             }),
@@ -201,7 +212,7 @@ export const skillsPublishCommand: CliCommandDefinition<SkillsPublishInput> = {
 export async function publishLocalSkillPackage(
     skillId: string,
     context: CliExecutionContext,
-    visibility: SkillPublishVisibility = defaultSkillPublishVisibility,
+    visibility?: SkillPublishVisibility,
     dependencies: PublishLocalSkillPackageDependencies = {},
 ): Promise<PublishLocalSkillPackageResult> {
     const checkAuthoringEnvironment
@@ -229,7 +240,6 @@ export async function publishLocalSkillPackage(
         package_name: packageName,
         skill_id: skillId,
         source_kind: "local",
-        visibility,
     });
 
     return await publishResolvedSkillPackage(
@@ -249,7 +259,7 @@ export async function publishLocalSkillPackage(
 export async function publishSkillPackage(
     skillReference: string,
     context: CliExecutionContext,
-    visibility: SkillPublishVisibility = defaultSkillPublishVisibility,
+    visibility?: SkillPublishVisibility,
     options: PublishSkillPackageOptions = {},
     dependencies: PublishLocalSkillPackageDependencies = {},
 ): Promise<PublishLocalSkillPackageResult> {
@@ -270,7 +280,6 @@ export async function publishSkillPackage(
         package_name: packageName,
         skill_id: source.skillId,
         source_kind: source.kind,
-        visibility,
     });
 
     const publishSource = await confirmAndPrepareSkillPublishSource(
@@ -305,11 +314,15 @@ async function publishResolvedSkillPackage(
         yes: boolean;
     },
     context: CliExecutionContext,
-    visibility: SkillPublishVisibility,
+    requestedVisibility: SkillPublishVisibility | undefined,
     dependencies: PublishLocalSkillPackageDependencies,
 ): Promise<PublishLocalSkillPackageResult> {
-    const resolveFinalPublishVersion = dependencies.resolveFinalPublishVersion
-        ?? resolveRequestedSkillPublishVersion;
+    const resolveFinalPublishPlan = dependencies.resolveFinalPublishPlan
+        ?? ((planRequest: ResolveSkillPublishPlanRequest) =>
+            resolveRequestedSkillPublishPlan(
+                planRequest,
+                dependencies.resolveFinalPublishVersion,
+            ));
     const createTemporaryPackageRoot = dependencies.createTemporaryPackageRoot
         ?? createDefaultTemporaryPackageRoot;
     const removeTemporaryPackageRoot = dependencies.removeTemporaryPackageRoot
@@ -328,13 +341,17 @@ async function publishResolvedSkillPackage(
         skillDirectoryPath: request.skillDirectoryPath,
         skillId: request.skillId,
     });
-    const version = await resolveFinalPublishVersion({
+    const publishPlan = await resolveFinalPublishPlan({
         account: request.account,
         context,
         packageName: request.packageName,
         requestedVersion: skillMetadata.requestedVersion,
+        requestedVisibility,
         skillId: request.skillId,
         yes: request.yes,
+    });
+    context.telemetry?.recordProperties({
+        visibility: publishPlan.visibility,
     });
     let packageRootDirectoryPath: string | undefined;
 
@@ -346,18 +363,18 @@ async function publishResolvedSkillPackage(
             packageRootDirectoryPath,
             skillDirectoryPath: request.skillDirectoryPath,
             skillId: request.skillId,
-            version,
+            version: publishPlan.version,
         });
         await publishPackage({
             account: request.account,
             context,
             packageRootDirectoryPath,
-            visibility,
+            visibility: publishPlan.visibility,
         });
         await writeMetadata({
             packageName: request.packageName,
             skillDirectoryPath: request.skillDirectoryPath,
-            version,
+            version: publishPlan.version,
         });
     }
     finally {
@@ -371,7 +388,8 @@ async function publishResolvedSkillPackage(
         packageName: request.packageName,
         skillDirectoryPath: request.skillDirectoryPath,
         skillId: request.skillId,
-        version,
+        visibility: publishPlan.visibility,
+        version: publishPlan.version,
     };
 }
 
@@ -1160,12 +1178,34 @@ function createSkillPublishSourceMissingError(skillReference: string): CliUserEr
     });
 }
 
+async function resolveRequestedSkillPublishPlan(
+    request: ResolveSkillPublishPlanRequest,
+    resolveFinalPublishVersion?: (
+        request: ResolveSkillPublishVersionRequest,
+    ) => Promise<string>,
+): Promise<ResolvedSkillPublishPlan> {
+    const packageSpecifier = parsePackageSpecifier(request.packageName);
+    const packageInfo = resolveFinalPublishVersion === undefined
+        ? await loadLatestPackageInfoOrUndefined(request, packageSpecifier)
+        : undefined;
+    const version = resolveFinalPublishVersion === undefined
+        ? await resolveRequestedSkillPublishVersion(request, packageInfo)
+        : await resolveFinalPublishVersion(request);
+    const visibility = await resolveRequestedSkillPublishVisibility(
+        request,
+        packageInfo,
+    );
+
+    return {
+        version,
+        visibility,
+    };
+}
+
 async function resolveRequestedSkillPublishVersion(
     request: ResolveSkillPublishVersionRequest,
+    packageInfo: PackageInfoResponse | undefined,
 ): Promise<string> {
-    const packageSpecifier = parsePackageSpecifier(request.packageName);
-    const packageInfo = await loadLatestPackageInfoOrUndefined(request);
-
     if (packageInfo === undefined) {
         return request.requestedVersion;
     }
@@ -1187,26 +1227,86 @@ async function resolveRequestedSkillPublishVersion(
     }
 
     return incrementSemverPatch(packageInfo.packageVersion);
+}
 
-    async function loadLatestPackageInfoOrUndefined(
-        versionRequest: ResolveSkillPublishVersionRequest,
-    ) {
-        try {
-            return await loadPackageInfo(
-                packageSpecifier,
-                versionRequest.account,
-                resolveRequestLanguage(versionRequest.context.translator.locale),
-                versionRequest.context,
-            );
-        }
-        catch (error) {
-            if (isPackageInfoNotFoundError(error)) {
-                return undefined;
-            }
-
-            throw error;
-        }
+async function loadLatestPackageInfoOrUndefined(
+    request: ResolveSkillPublishVersionRequest,
+    packageSpecifier: ReturnType<typeof parsePackageSpecifier>,
+): Promise<PackageInfoResponse | undefined> {
+    try {
+        return await loadPackageInfo(
+            packageSpecifier,
+            request.account,
+            resolveRequestLanguage(request.context.translator.locale),
+            request.context,
+        );
     }
+    catch (error) {
+        if (isPackageInfoNotFoundError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
+}
+
+async function resolveRequestedSkillPublishVisibility(
+    request: ResolveSkillPublishPlanRequest,
+    packageInfo: PackageInfoResponse | undefined,
+): Promise<SkillPublishVisibility> {
+    if (request.requestedVisibility !== undefined) {
+        return request.requestedVisibility;
+    }
+
+    const existingVisibility = readExistingSkillPublishVisibility(packageInfo);
+
+    if (existingVisibility !== undefined) {
+        return existingVisibility;
+    }
+
+    return await selectNewSkillPublishVisibility(request);
+}
+
+function readExistingSkillPublishVisibility(
+    packageInfo: PackageInfoResponse | undefined,
+): SkillPublishVisibility | undefined {
+    switch (packageInfo?.access) {
+        case "public":
+            return "public";
+        case "private":
+        case "restricted":
+            return "private";
+        case undefined:
+            return undefined;
+    }
+}
+
+async function selectNewSkillPublishVisibility(
+    request: ResolveSkillPublishPlanRequest,
+): Promise<SkillPublishVisibility> {
+    const params = {
+        name: request.skillId,
+        packageName: request.packageName,
+    };
+
+    if (request.context.stdin.isTTY !== true) {
+        throw new CliUserError(
+            "errors.skills.publish.visibilityRequired",
+            1,
+            params,
+        );
+    }
+
+    return await selectInteractiveValue(request.context, {
+        invalidMessage: request.context.translator.t(
+            "skills.publish.visibility.invalid",
+        ),
+        prompt: request.context.translator.t(
+            "skills.publish.visibility.prompt",
+            params,
+        ),
+        values: skillPublishVisibilityValues,
+    });
 }
 
 async function confirmRemotePackageBlocksPublish(

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -369,6 +369,8 @@ export const enMessages = {
         "The skill package publish request returned HTTP {status}: {message}",
     "errors.skills.publish.skillNotFound":
         "Cannot find skill {name} in local, bundled, registry, requested agent, or path sources.",
+    "errors.skills.publish.visibilityRequired":
+        "Package {packageName} does not have an existing visibility to preserve. Run in an interactive terminal or pass --visibility private or --visibility public.",
     "errors.fileDownload.downloadFailed":
         "Failed to download the file at {path}: {message}",
     "errors.fileDownload.invalidExt":
@@ -577,7 +579,7 @@ export const enMessages = {
     "options.icon": "Set the generated skill icon reference",
     "options.title": "Set the generated skill display title",
     "options.visibility":
-        "Set package visibility (private or public; default private)",
+        "Set package visibility (private or public)",
     "options.skill":
         "Specify skill names to install (use * for all skills)",
     "options.onlyPackageId": "Return only package ids",
@@ -670,7 +672,11 @@ export const enMessages = {
         "Skill {name} was found at {path}. Move it into local storage at {localPath} and publish it as {packageName}? [y/N] ",
     "skills.publish.confirm.invalid":
         "Invalid choice. Enter y/yes or n/no.",
+    "skills.publish.visibility.invalid":
+        "Invalid choice. Enter private or public.",
     "skills.publish.visibility.private": "private",
+    "skills.publish.visibility.prompt":
+        "Publish skill {name} as package {packageName} with which visibility? [private/public] ",
     "skills.publish.visibility.public": "public",
     "skills.publish.registryPackage.prompt":
         "Skill {name} is installed from {packageName}. Publish it as {targetPackageName}? [y/N] ",
@@ -1146,6 +1152,8 @@ export const zhMessages = {
         "skill 包发布请求失败：{message}",
     "errors.skills.publish.requestFailed":
         "skill 包发布请求返回了 HTTP {status}：{message}",
+    "errors.skills.publish.visibilityRequired":
+        "包 {packageName} 没有可沿用的已有可见性。请在交互式终端中运行，或传入 --visibility private / --visibility public。",
     "errors.skills.publish.skillNotFound":
         "无法在 local、bundled、registry、指定 Agent 或路径来源中找到 skill {name}。",
     "errors.fileDownload.downloadFailed":
@@ -1351,7 +1359,7 @@ export const zhMessages = {
     "options.icon": "设置生成的 skill icon 引用",
     "options.title": "设置生成的 skill 显示标题",
     "options.visibility":
-        "设置包可见性（private 或 public，默认 private）",
+        "设置包可见性（private 或 public）",
     "options.skill":
         "指定要安装的 skill 名称（使用 * 表示全部）",
     "options.onlyPackageId": "仅返回 package id",
@@ -1443,7 +1451,11 @@ export const zhMessages = {
         "在 {path} 找到 skill {name}。是否将它移入本地存储 {localPath} 并发布为 {packageName}？[y/N] ",
     "skills.publish.confirm.invalid":
         "输入无效。请输入 y/yes 或 n/no。",
+    "skills.publish.visibility.invalid":
+        "输入无效。请输入 private 或 public。",
     "skills.publish.visibility.private": "私有包",
+    "skills.publish.visibility.prompt":
+        "要以哪种可见性发布 skill {name} 为包 {packageName}？[private/public] ",
     "skills.publish.visibility.public": "公开包",
     "skills.publish.registryPackage.prompt":
         "skill {name} 安装自 {packageName}。是否发布为 {targetPackageName}？[y/N] ",


### PR DESCRIPTION
## Summary

- Resolve skill publish visibility from the latest remote package when `--visibility` is omitted.
- Preserve existing public packages as public and private/restricted packages as private.
- Prompt interactively for `private` or `public` when no existing visibility can be read, with a non-interactive error that asks callers to pass `--visibility`.
- Require bundled `oo-create-skill` creator instructions to generate or update skill metadata, headings, examples, and workflow prose in English regardless of the user language, using a compact single-rule prompt.
- Refine OO mixed search selection so ready-to-run candidates are preferred, treating authenticated connectors and Fusion API as out-of-box, and so unspecified model/product choices favor capable, modern, reputable options.
- Update command docs, bundled skill guidance, and embedded asset tests to match the new behavior.

## Why

`oo skills publish` previously defaulted omitted visibility to `private`, which could accidentally make an existing public skill package private on republish. The command now makes the publish visibility decision explicit: preserve what already exists when possible, otherwise ask.

`oo-create-skill` could mirror a Chinese user request into generated skill text. The creator instructions now state that generated skills must be English-only unless non-English text is a literal runtime value, product name, language-pair requirement, or necessary sample input/output.

OO mixed search selection now better matches user expectations when they ask for a result, not a specific provider: prefer out-of-box paths first and choose higher-quality, modern, reputable options when directness is comparable.

## Validation

- `bun run lint:fix`
- `bun run ts-check`
- `git diff --check`

Blacksmith Testbox validation was attempted, but `blacksmith testbox warmup blacksmith-win32-testbox.yml` is blocked because this machine is not authenticated with Blacksmith (`blacksmith auth login` required). Per repo instructions, I did not run `bun run test` locally outside Testbox.