### PR TITLE
ci(testbox): remove pull_request trigger from win32 workflow

### DIFF
--- a/.github/workflows/blacksmith-win32-testbox.yml
+++ b/.github/workflows/blacksmith-win32-testbox.yml
@@ -6,9 +6,6 @@ on:
         type: string
         description: Testbox session ID
         required: true
-  pull_request:
-    paths:
-      - ".github/workflows/**"
 permissions:
   contents: read
 concurrency:


### PR DESCRIPTION
The Blacksmith win32 testbox workflow requires an explicit testbox session ID provided via workflow_dispatch input, so triggering it on pull_request events would always fail or waste runner time. Drop the pull_request trigger and keep manual dispatch as the only entry point.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/oomol-lab/codesmith/oo-cli/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->