### PR TITLE
chore: switch upload-release job to ubuntu-latest

### DIFF
--- a/.github/workflows/upload-release-binaries-to-oss.yaml
+++ b/.github/workflows/upload-release-binaries-to-oss.yaml
@@ -42,7 +42,7 @@ concurrency:
 
 jobs:
   upload_release_binaries:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       oss_uri: ${{ steps.prepare.outputs.oss_uri }}
       release_tag: ${{ steps.prepare.outputs.release_tag }}


### PR DESCRIPTION
Move the upload_release_binaries job off the Blacksmith runner and onto GitHub-hosted ubuntu-latest, mirroring the earlier publish job change in #164. This reduces CI latency for release uploads and keeps runner usage consistent across release-related workflows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/oomol-lab/codesmith/oo-cli/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->