### PR TITLE
refactor(skills): publish skills with copy mode only

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -352,10 +352,15 @@ supported host directory that already exists.
   Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, OpenClaw, and QoderWork host.
   Existing oo-managed bundled skill targets are refreshed to the current `oo`
   version, except that `0.0.0-development` startup runs do not refresh
-  existing bundled targets.
+  existing copied bundled targets.
 - Published skills: when a published skill already has a local canonical copy
   under `<config-dir>/skills/registry/<skill-id>`, `oo` publishes that copy to
   any newly detected supported host that is missing it.
+- Local skills: when a local skill already has a canonical copy under
+  `<config-dir>/skills/local/<skill-id>`, `oo` publishes that copy to any newly
+  detected supported host that is missing it.
+- Migration: existing oo-managed symlink targets from older releases are
+  replaced with copied directories during startup synchronization.
 - Safety: startup synchronization does not fetch registry data, does not
   require authentication, does not print additional command output, and does
   not overwrite same-name targets that are not managed by `oo`.
@@ -442,16 +447,12 @@ directory that already exists.
   `~/.trae-cn/skills/<skill-id>`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
   `~/.qoderwork/skills/<skill-id>`.
-- Publication mode: Codex, Claude Code, and QoderWork targets are
-  published as symlinks to the canonical directory when the current platform
-  and environment allow it. Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, and
-  OpenClaw targets are copied.
+- Publication mode: all target directories receive copied skill files.
 - Failure behavior: if no supported agent home exists, or if the canonical
   local directory or any target directory already exists, the command exits
   non-zero before writing the skill.
 - Output: text output first prints the canonical storage directory, then prints
-  one success line per target path with the actual publication mode
-  (`Linked` or `Copied`).
+  one copied-success line per target path.
 
 ### `oo skills validate <path>`
 
@@ -620,13 +621,10 @@ Install bundled or published skills into supported local skill directories.
   the command creates that root before publishing the selected skill.
 - Path rule: published skill names are accepted only when their resolved
   canonical and target directories remain under those local `skills` roots.
-- Installation mode: bundled and published Codex, Claude Code, and QoderWork
-  skills are published to the target directory as a symlink to the
-  canonical directory when the current platform and environment allow it. When
-  symlink creation fails, `oo` falls back to copying the canonical files into
-  the target skills directory.
-- Installation mode: bundled and published Hermes, CodeBuddy, WorkBuddy, Trae,
-  Trae CN, and OpenClaw skills are copied into the target skills directory.
+- Installation mode: bundled and published skills are copied into every target
+  skills directory. Existing oo-managed symlink targets from older releases are
+  replaced with copied directories when the skill is synchronized, installed,
+  or updated.
 - Metadata: bundled skills write a hidden `.oo-metadata.json` file whose
   `version` field matches the current `oo` version.
 - Metadata: published skills write a hidden `.oo-metadata.json` file whose

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -306,11 +306,15 @@ skills。
   CodeBuddy、WorkBuddy、Trae、Trae CN、OpenClaw 和 QoderWork Agent 都安装了 `oo`、
   `oo-find-skills`、`oo-create-skill` 与 `oo-publish-skill`。已经由 oo 管理的
   内置 skill 目标会刷新到当前 `oo` 版本；
-  但当启动中的当前版本为 `0.0.0-development` 时，不会刷新已存在的内置 skill
-  目标。
+  但当启动中的当前版本为 `0.0.0-development` 时，不会刷新已存在的复制版内置
+  skill 目标。
 - 已发布 skill：如果某个已发布 skill 已经有本地 canonical 副本
   `<config-dir>/skills/registry/<skill-id>`，`oo` 会把该副本发布到任何新检测
   到且尚未安装它的受支持 Agent。
+- 本地 skill：如果某个本地 skill 已经有 canonical 副本
+  `<config-dir>/skills/local/<skill-id>`，`oo` 会把该副本发布到任何新检测到且尚未
+  安装它的受支持 Agent。
+- 迁移：旧版本留下的 oo-managed 软链接目标，会在启动同步期间替换为复制目录。
 - 安全规则：启动同步不会请求 registry，不要求登录，不会产生额外命令输出，也
   不会覆盖不由 `oo` 管理的同名目标。
 
@@ -385,13 +389,10 @@ skills。
   `~/.trae-cn/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`，以及
   `~/.qoderwork/skills/<skill-id>`。
-- 发布方式：Codex、Claude Code 和 QoderWork 目标会在当前平台和环境允许时发布为
-  指向 canonical 目录的软连接；Hermes、CodeBuddy、WorkBuddy、Trae、Trae CN 和
-  OpenClaw 目标会复制。
+- 发布方式：所有目标目录都会收到复制后的 skill 文件。
 - 失败行为：如果没有受支持的 Agent home，或 canonical 本地目录、任意目标目录
   已存在，命令会在写入 skill 前以非零状态退出。
-- 输出：文本输出会先打印 canonical 存储目录，然后为每个目标路径打印一行带实际发布
-  方式（软链接或复制）的成功消息。
+- 输出：文本输出会先打印 canonical 存储目录，然后为每个目标路径打印一行复制成功消息。
 
 ### `oo skills validate <path>`
 
@@ -527,11 +528,8 @@ skills。
   `~/.qoderwork/skills/<skill-id>`。
 - 目标目录：当已存在的受支持 Agent 缺少 `skills` 根目录时，命令会先创建该目录，
   再发布所选 skill。
-- 安装方式：内置和已发布的 Codex / Claude Code / QoderWork skill 会优先把
-  目标目录发布为指向 canonical 目录的软连接。如果当前平台或环境下创建软连接失败，
-  则会回退为把 canonical 目录内容复制到目标 skills 目录。
-- 安装方式：内置和已发布的 Hermes / CodeBuddy / WorkBuddy / Trae / Trae CN /
-  OpenClaw skill 会直接复制到目标 skills 目录。
+- 安装方式：内置和已发布 skill 会复制到每个目标 skills 目录。旧版本留下的
+  oo-managed 软链接目标，会在同步、安装或更新该 skill 时替换为复制目录。
 - 元数据：内置 skill 会写入一个隐藏的 `.oo-metadata.json` 文件，其中
   `version` 字段记录当前 `oo` 版本。
 - 元数据：已发布 skill 也会写入一个隐藏的 `.oo-metadata.json` 文件，

--- a/src/application/commands/skills/auto-sync.ts
+++ b/src/application/commands/skills/auto-sync.ts
@@ -27,6 +27,7 @@ import {
 import {
     availableBundledSkillNames,
 } from "./embedded-assets.ts";
+import { readSkillFileContent } from "./local-skill-ownership.ts";
 import {
     resolveAvailableManagedSkillHosts,
     resolveManagedSkillHostInstallation,
@@ -36,12 +37,13 @@ import {
     readManagedSkillMetadata,
 } from "./managed-skill-metadata.ts";
 import {
+    isLocalSkillPathContained,
     isManagedSkillPathContained,
+    resolveLocalSkillCanonicalRootDirectoryPath,
     resolveManagedSkillCanonicalRootDirectoryPath,
 } from "./managed-skill-paths.ts";
 import {
     isManagedSkillPublicationCurrent,
-    resolveManagedSkillPublicationMode,
 } from "./managed-skill-publication.ts";
 import { publishManagedBundledSkill } from "./shared.ts";
 
@@ -54,6 +56,11 @@ interface CanonicalRegistrySkill {
     metadata: ManagedSkillMetadata & {
         packageName: string;
     };
+    name: string;
+    path: string;
+}
+
+interface CanonicalLocalSkill {
     name: string;
     path: string;
 }
@@ -77,6 +84,7 @@ export async function synchronizeManagedSkillsForAvailableHosts(
             synchronizeBundledSkills(hosts, context),
             synchronizeRegistrySkills(hosts, context),
         ]);
+        await synchronizeLocalSkills(hosts, context);
     }
     catch (error) {
         context.logger.warn(
@@ -127,9 +135,14 @@ async function synchronizeBundledSkill(
             return;
         }
 
+        const publicationCurrent = targetState.kind === "managed"
+            ? await isManagedSkillPublicationCurrent(installation.installedSkillDirectoryPath)
+            : false;
+
         if (
             targetState.kind === "managed"
             && targetState.metadata?.version === context.version
+            && publicationCurrent
         ) {
             return;
         }
@@ -137,6 +150,7 @@ async function synchronizeBundledSkill(
         if (
             targetState.kind === "managed"
             && context.version === bundledSkillDevelopmentVersion
+            && publicationCurrent
         ) {
             context.logger.info(
                 {
@@ -169,7 +183,7 @@ async function synchronizeBundledSkill(
             return;
         }
 
-        const publication = await publishManagedBundledSkill({
+        const installedSkillDirectoryPath = await publishManagedBundledSkill({
             agentName: host.agentName,
             homeDirectory: host.homeDirectory,
             settingsFilePath,
@@ -181,8 +195,7 @@ async function synchronizeBundledSkill(
             {
                 agentName: host.agentName,
                 canonicalPath: canonicalSkillDirectoryPath,
-                installMode: publication.mode,
-                path: publication.path,
+                path: installedSkillDirectoryPath,
                 previousVersion: targetState.metadata?.version,
                 skillName,
                 version: context.version,
@@ -275,10 +288,6 @@ async function synchronizeRegistrySkill(
             installation.installedSkillDirectoryPath,
             readManagedSkillMetadata,
         );
-        const publicationMode = resolveManagedSkillPublicationMode(
-            installation.agentName,
-        );
-
         if (targetState.kind === "unmanaged") {
             context.logger.warn(
                 {
@@ -314,26 +323,23 @@ async function synchronizeRegistrySkill(
             if (
                 await isManagedSkillPublicationCurrent(
                     installation.installedSkillDirectoryPath,
-                    publicationMode,
                 )
             ) {
                 return;
             }
         }
 
-        const publication = await publishBundledSkillInstallation({
+        await publishBundledSkillInstallation({
             canonicalSkillDirectoryPath: skill.path,
             installedSkillDirectoryPath: installation.installedSkillDirectoryPath,
-            publicationMode,
         });
 
         context.logger.info(
             {
                 agentName: installation.agentName,
                 canonicalPath: skill.path,
-                installMode: publication.mode,
                 packageName: skill.metadata.packageName,
-                path: publication.path,
+                path: installation.installedSkillDirectoryPath,
                 skillName: skill.name,
                 version: skill.metadata.version,
             },
@@ -353,17 +359,227 @@ async function synchronizeRegistrySkill(
     }
 }
 
+async function synchronizeLocalSkills(
+    hosts: readonly ManagedSkillHost[],
+    context: SkillSyncContext,
+): Promise<void> {
+    const skills = await listCanonicalLocalSkills(context);
+
+    await Promise.all(
+        skills.flatMap(skill =>
+            resolveManagedSkillHostInstallations(hosts, skill.name).map(
+                installation =>
+                    synchronizeLocalSkill(installation, skill, context),
+            ),
+        ),
+    );
+}
+
+async function synchronizeLocalSkill(
+    installation: ManagedSkillHostInstallation,
+    skill: CanonicalLocalSkill,
+    context: SkillSyncContext,
+): Promise<void> {
+    try {
+        if (
+            !isLocalSkillPathContained(
+                installation.homeDirectory,
+                context.settingsStore.getFilePath(),
+                skill.name,
+            )
+        ) {
+            context.logger.warn(
+                {
+                    agentName: installation.agentName,
+                    skillName: skill.name,
+                },
+                "Local skill startup synchronization skipped because the target path is outside the managed skills directory.",
+            );
+            return;
+        }
+
+        if (await pathExists(installation.installedSkillDirectoryPath)) {
+            if (!(await directoryExists(installation.installedSkillDirectoryPath))) {
+                context.logger.warn(
+                    {
+                        agentName: installation.agentName,
+                        path: installation.installedSkillDirectoryPath,
+                        skillName: skill.name,
+                    },
+                    "Local skill startup synchronization skipped because the target is not a directory.",
+                );
+                return;
+            }
+
+            const [canonicalContent, targetContent] = await Promise.all([
+                readSkillFileContent(skill.path),
+                readSkillFileContent(installation.installedSkillDirectoryPath),
+            ]);
+
+            // Canonical without SKILL.md indicates an aborted init; do not
+            // overwrite an existing target with that incomplete state.
+            if (canonicalContent === undefined) {
+                return;
+            }
+
+            if (canonicalContent !== targetContent) {
+                const metadata = await readManagedSkillMetadata(
+                    installation.installedSkillDirectoryPath,
+                );
+
+                // Registry-managed installations under the same skill name are
+                // owned by the registry sync path; local sync must not overwrite
+                // them.
+                if (metadata?.packageName !== undefined) {
+                    return;
+                }
+
+                context.logger.warn(
+                    {
+                        agentName: installation.agentName,
+                        path: installation.installedSkillDirectoryPath,
+                        skillName: skill.name,
+                    },
+                    "Local skill startup synchronization skipped because the target is not managed by oo.",
+                );
+                return;
+            }
+
+            if (
+                await isManagedSkillPublicationCurrent(
+                    installation.installedSkillDirectoryPath,
+                )
+            ) {
+                return;
+            }
+        }
+
+        await publishBundledSkillInstallation({
+            canonicalSkillDirectoryPath: skill.path,
+            installedSkillDirectoryPath: installation.installedSkillDirectoryPath,
+        });
+
+        context.logger.info(
+            {
+                agentName: installation.agentName,
+                canonicalPath: skill.path,
+                path: installation.installedSkillDirectoryPath,
+                skillName: skill.name,
+            },
+            "Local skill synchronized during CLI startup.",
+        );
+    }
+    catch (error) {
+        context.logger.warn(
+            {
+                agentName: installation.agentName,
+                err: error,
+                path: installation.installedSkillDirectoryPath,
+                skillName: skill.name,
+            },
+            "Local skill startup synchronization failed.",
+        );
+    }
+}
+
 async function listCanonicalRegistrySkills(
     context: Pick<SkillSyncContext, "logger" | "settingsStore">,
 ): Promise<CanonicalRegistrySkill[]> {
-    const canonicalRootDirectoryPath
-        = resolveManagedSkillCanonicalRootDirectoryPath(
+    return listCanonicalSkills({
+        canonicalRootDirectoryPath: resolveManagedSkillCanonicalRootDirectoryPath(
             context.settingsStore.getFilePath(),
-        );
-    let entries: string[];
+        ),
+        inspect: async (entryName, canonicalSkillDirectoryPath) => {
+            const metadata = await readManagedSkillMetadata(
+                canonicalSkillDirectoryPath,
+            );
 
+            if (metadata?.packageName === undefined) {
+                return undefined;
+            }
+
+            return {
+                metadata: {
+                    packageName: metadata.packageName,
+                    version: metadata.version,
+                },
+                name: entryName,
+                path: canonicalSkillDirectoryPath,
+            } satisfies CanonicalRegistrySkill;
+        },
+        inspectionFailureMessage:
+            "Canonical registry skill inspection failed during startup synchronization.",
+        logger: context.logger,
+    });
+}
+
+async function listCanonicalLocalSkills(
+    context: Pick<SkillSyncContext, "logger" | "settingsStore">,
+): Promise<CanonicalLocalSkill[]> {
+    return listCanonicalSkills({
+        canonicalRootDirectoryPath: resolveLocalSkillCanonicalRootDirectoryPath(
+            context.settingsStore.getFilePath(),
+        ),
+        inspect: async (entryName, canonicalSkillDirectoryPath) => ({
+            name: entryName,
+            path: canonicalSkillDirectoryPath,
+        } satisfies CanonicalLocalSkill),
+        inspectionFailureMessage:
+            "Canonical local skill inspection failed during startup synchronization.",
+        logger: context.logger,
+    });
+}
+
+async function listCanonicalSkills<T>(options: {
+    canonicalRootDirectoryPath: string;
+    inspect: (
+        entryName: string,
+        canonicalSkillDirectoryPath: string,
+    ) => Promise<T | undefined>;
+    inspectionFailureMessage: string;
+    logger: SkillSyncContext["logger"];
+}): Promise<T[]> {
+    const entries = await readCanonicalSkillEntryNames(
+        options.canonicalRootDirectoryPath,
+    );
+
+    const skills = await Promise.all(
+        entries.map(async (entryName) => {
+            const canonicalSkillDirectoryPath = join(
+                options.canonicalRootDirectoryPath,
+                entryName,
+            );
+
+            try {
+                if (!(await directoryExists(canonicalSkillDirectoryPath))) {
+                    return undefined;
+                }
+
+                return await options.inspect(entryName, canonicalSkillDirectoryPath);
+            }
+            catch (error) {
+                options.logger.warn(
+                    {
+                        err: error,
+                        path: canonicalSkillDirectoryPath,
+                        skillName: entryName,
+                    },
+                    options.inspectionFailureMessage,
+                );
+
+                return undefined;
+            }
+        }),
+    );
+
+    return skills.filter(skill => skill !== undefined);
+}
+
+async function readCanonicalSkillEntryNames(
+    canonicalRootDirectoryPath: string,
+): Promise<string[]> {
     try {
-        entries = (await readdir(canonicalRootDirectoryPath, {
+        return (await readdir(canonicalRootDirectoryPath, {
             withFileTypes: true,
         }))
             .filter(entry => entry.isDirectory() || entry.isSymbolicLink())
@@ -376,52 +592,6 @@ async function listCanonicalRegistrySkills(
 
         throw error;
     }
-
-    const skills = await Promise.all(
-        entries.map(async (entryName) => {
-            const canonicalSkillDirectoryPath = join(
-                canonicalRootDirectoryPath,
-                entryName,
-            );
-
-            try {
-                if (!(await directoryExists(canonicalSkillDirectoryPath))) {
-                    return undefined;
-                }
-
-                const metadata = await readManagedSkillMetadata(
-                    canonicalSkillDirectoryPath,
-                );
-
-                if (metadata?.packageName === undefined) {
-                    return undefined;
-                }
-
-                return {
-                    metadata: {
-                        packageName: metadata.packageName,
-                        version: metadata.version,
-                    },
-                    name: entryName,
-                    path: canonicalSkillDirectoryPath,
-                } satisfies CanonicalRegistrySkill;
-            }
-            catch (error) {
-                context.logger.warn(
-                    {
-                        err: error,
-                        path: canonicalSkillDirectoryPath,
-                        skillName: entryName,
-                    },
-                    "Canonical registry skill inspection failed during startup synchronization.",
-                );
-
-                return undefined;
-            }
-        }),
-    );
-
-    return skills.filter(skill => skill !== undefined);
 }
 
 async function readManagedSkillTargetState<Metadata>(

--- a/src/application/commands/skills/bundled-skill-filesystem.ts
+++ b/src/application/commands/skills/bundled-skill-filesystem.ts
@@ -2,250 +2,29 @@ import {
     cp,
     lstat,
     mkdir,
-    readlink,
-    realpath,
     rm,
     rmdir,
-    symlink,
 } from "node:fs/promises";
-import { basename, dirname, join, relative, resolve } from "node:path";
+import { dirname } from "node:path";
 import process from "node:process";
-
-export interface BundledSkillPublicationResult {
-    mode: "copy" | "symlink";
-    path: string;
-}
-
-export type BundledSkillPublicationMode = "copy" | "symlink-or-copy";
-
-interface BundledSkillPublicationDependencies {
-    createDirectorySymlink?: (
-        targetPath: string,
-        linkPath: string,
-    ) => Promise<boolean>;
-}
-
-type BundledSkillDirectorySymlinkAttempt
-    = | {
-        kind: "reuse";
-    }
-    | {
-        kind: "create";
-        resolvedLinkPath: string;
-        resolvedTargetPath: string;
-    };
-
-export interface CreateBundledSkillDirectorySymlinkDependencies {
-    lstat?: (path: string) => Promise<{
-        isSymbolicLink: () => boolean;
-    }>;
-    mkdir?: (
-        path: string,
-        options: {
-            recursive: true;
-        },
-    ) => Promise<void>;
-    readlink?: (path: string) => Promise<string>;
-    realpath?: (path: string) => Promise<string>;
-    removePath?: (path: string) => Promise<void>;
-    resolveParentSymlinks?: (path: string) => Promise<string>;
-    symlink?: (
-        targetPath: string,
-        linkPath: string,
-        type: "dir" | "junction",
-    ) => Promise<void>;
-}
-
-export interface RemoveBundledSkillSymbolicPathDependencies {
-    rm?: (
-        path: string,
-        options: {
-            force: true;
-        },
-    ) => Promise<void>;
-    rmdir?: (path: string) => Promise<void>;
-}
 
 export async function publishBundledSkillInstallation(
     options: {
         canonicalSkillDirectoryPath: string;
         installedSkillDirectoryPath: string;
-        publicationMode?: BundledSkillPublicationMode;
     },
-    dependencies: BundledSkillPublicationDependencies = {},
-): Promise<BundledSkillPublicationResult> {
-    const publicationMode = options.publicationMode ?? "symlink-or-copy";
-
+): Promise<void> {
     await mkdir(dirname(options.installedSkillDirectoryPath), { recursive: true });
-
-    if (publicationMode === "symlink-or-copy") {
-        const createDirectoryLink
-            = dependencies.createDirectorySymlink ?? createBundledSkillDirectorySymlink;
-        const symlinkCreated = await createDirectoryLink(
-            options.canonicalSkillDirectoryPath,
-            options.installedSkillDirectoryPath,
-        );
-
-        if (symlinkCreated) {
-            return {
-                mode: "symlink",
-                path: options.installedSkillDirectoryPath,
-            };
-        }
-    }
-
     await copyBundledSkillDirectory(
         options.canonicalSkillDirectoryPath,
         options.installedSkillDirectoryPath,
     );
-
-    return {
-        mode: "copy",
-        path: options.installedSkillDirectoryPath,
-    };
 }
 
 export function isNodeNotFoundError(
     error: unknown,
 ): error is NodeJS.ErrnoException {
     return error instanceof Error && "code" in error && error.code === "ENOENT";
-}
-
-function isSymlinkLoopError(error: unknown): error is NodeJS.ErrnoException {
-    return error instanceof Error && "code" in error && error.code === "ELOOP";
-}
-
-export async function createBundledSkillDirectorySymlink(
-    targetPath: string,
-    linkPath: string,
-    dependencies: CreateBundledSkillDirectorySymlinkDependencies = {},
-): Promise<boolean> {
-    const lstatFn = dependencies.lstat ?? lstat;
-    const mkdirFn = dependencies.mkdir ?? mkdir;
-    const readlinkFn = dependencies.readlink ?? readlink;
-    const realpathFn = dependencies.realpath ?? realpath;
-    const removePathFn = dependencies.removePath ?? removePath;
-    const resolveParentSymlinksFn
-        = dependencies.resolveParentSymlinks ?? resolveParentSymlinks;
-    const symlinkFn = dependencies.symlink ?? symlink;
-
-    try {
-        const attempt = await resolveBundledSkillDirectorySymlinkAttempt(
-            targetPath,
-            linkPath,
-            {
-                lstat: lstatFn,
-                readlink: readlinkFn,
-                realpath: realpathFn,
-                removePath: removePathFn,
-                resolveParentSymlinks: resolveParentSymlinksFn,
-            },
-        );
-
-        if (attempt.kind === "reuse") {
-            return true;
-        }
-
-        const linkDirectoryPath = dirname(attempt.resolvedLinkPath);
-
-        await mkdirFn(linkDirectoryPath, { recursive: true });
-
-        const symlinkTargetPath = process.platform === "win32"
-            ? attempt.resolvedTargetPath
-            : relative(
-                    await resolveParentSymlinksFn(linkDirectoryPath),
-                    attempt.resolvedTargetPath,
-                );
-
-        await symlinkFn(
-            symlinkTargetPath,
-            attempt.resolvedLinkPath,
-            process.platform === "win32" ? "junction" : "dir",
-        );
-
-        return true;
-    }
-    catch {
-        return false;
-    }
-}
-
-async function resolveBundledSkillDirectorySymlinkAttempt(
-    targetPath: string,
-    linkPath: string,
-    dependencies: Pick<
-        CreateBundledSkillDirectorySymlinkDependencies,
-        "lstat" | "readlink" | "realpath" | "removePath" | "resolveParentSymlinks"
-    >,
-): Promise<BundledSkillDirectorySymlinkAttempt> {
-    const resolvedTargetPath = resolve(targetPath);
-    const resolvedLinkPath = resolve(linkPath);
-    const realpathFn = dependencies.realpath ?? realpath;
-    const [realTargetPath, realLinkPath] = await Promise.all([
-        realpathFn(resolvedTargetPath).catch(() => resolvedTargetPath),
-        realpathFn(resolvedLinkPath).catch(() => resolvedLinkPath),
-    ]);
-
-    if (realTargetPath === realLinkPath) {
-        return {
-            kind: "reuse",
-        };
-    }
-
-    const resolveParentSymlinksFn
-        = dependencies.resolveParentSymlinks ?? resolveParentSymlinks;
-    const [realTargetPathWithParents, realLinkPathWithParents] = await Promise.all([
-        resolveParentSymlinksFn(resolvedTargetPath),
-        resolveParentSymlinksFn(resolvedLinkPath),
-    ]);
-
-    if (realTargetPathWithParents === realLinkPathWithParents) {
-        return {
-            kind: "reuse",
-        };
-    }
-
-    const lstatFn = dependencies.lstat ?? lstat;
-    const readlinkFn = dependencies.readlink ?? readlink;
-    const removePathFn = dependencies.removePath ?? removePath;
-
-    try {
-        const existingStats = await lstatFn(resolvedLinkPath);
-
-        if (existingStats.isSymbolicLink()) {
-            const existingTarget = await readlinkFn(resolvedLinkPath);
-
-            if (
-                resolveSymlinkTarget(resolvedLinkPath, existingTarget)
-                === resolvedTargetPath
-            ) {
-                return {
-                    kind: "reuse",
-                };
-            }
-        }
-
-        await removePathFn(resolvedLinkPath);
-    }
-    catch (error) {
-        if (isSymlinkLoopError(error)) {
-            try {
-                await removePathFn(resolvedLinkPath);
-            }
-            catch {
-                // Let symlink creation determine whether copy fallback is needed.
-            }
-        }
-        else if (!isNodeNotFoundError(error)) {
-            throw error;
-        }
-    }
-
-    return {
-        kind: "create",
-        resolvedLinkPath,
-        resolvedTargetPath,
-    };
 }
 
 async function copyBundledSkillDirectory(
@@ -265,7 +44,7 @@ export async function removePath(path: string): Promise<void> {
         const pathStats = await lstat(path);
 
         if (pathStats.isSymbolicLink()) {
-            await removeBundledSkillSymbolicPath(path);
+            await removeSymbolicPath(path);
             return;
         }
 
@@ -280,19 +59,15 @@ export async function removePath(path: string): Promise<void> {
     }
 }
 
-export async function removeBundledSkillSymbolicPath(
+async function removeSymbolicPath(
     path: string,
-    dependencies: RemoveBundledSkillSymbolicPathDependencies = {},
 ): Promise<void> {
-    const rmFn = dependencies.rm ?? rm;
-    const rmdirFn = dependencies.rmdir ?? rmdir;
-
     try {
-        await rmFn(path, { force: true });
+        await rm(path, { force: true });
     }
     catch (error) {
         if (process.platform === "win32" && isWindowsBadAddressError(error)) {
-            await rmdirFn(path);
+            await rmdir(path);
             return;
         }
 
@@ -304,26 +79,4 @@ function isWindowsBadAddressError(
     error: unknown,
 ): error is NodeJS.ErrnoException {
     return error instanceof Error && "code" in error && error.code === "EFAULT";
-}
-
-async function resolveParentSymlinks(path: string): Promise<string> {
-    const resolvedPath = resolve(path);
-    const parentPath = dirname(resolvedPath);
-    const baseName = basename(resolvedPath);
-
-    try {
-        const realParentPath = await realpath(parentPath);
-
-        return join(realParentPath, baseName);
-    }
-    catch {
-        return resolvedPath;
-    }
-}
-
-function resolveSymlinkTarget(
-    linkPath: string,
-    linkTargetPath: string,
-): string {
-    return resolve(dirname(linkPath), linkTargetPath);
 }

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./bundled-skill-paths.ts";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
 import {
+    resolveLocalSkillCanonicalDirectoryPath,
     resolveManagedSkillCanonicalDirectoryPath,
     resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
@@ -246,7 +247,7 @@ describe("skills CLI", () => {
         }
     });
 
-    test("converts synchronized registry skill targets to copies for copy-only hosts", async () => {
+    test("converts synchronized registry symlink targets to copies", async () => {
         const sandbox = await createCliSandbox();
         const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
         const codeBuddySkillsDirectory = join(codeBuddyHomeDirectory, "skills");
@@ -300,6 +301,127 @@ describe("skills CLI", () => {
             );
             expect(content).toContain(
                 `"msg":"Registry skill synchronized during CLI startup."`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("converts synchronized local symlink targets to copies", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const codexSkillsDirectory = join(codexHomeDirectory, "skills");
+        const codexSkillDirectoryPath = join(codexSkillsDirectory, "campaign-writer");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "campaign-writer",
+        );
+
+        try {
+            await mkdir(codexSkillsDirectory, { recursive: true });
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(canonicalSkillDirectoryPath, "SKILL.md"),
+                "# Campaign Writer\n",
+            );
+            await symlink(
+                canonicalSkillDirectoryPath,
+                codexSkillDirectoryPath,
+                process.platform === "win32" ? "junction" : "dir",
+            );
+
+            const result = await sandbox.run(["--help"], {
+                fetcher: async () => {
+                    throw new Error("startup synchronization should not fetch");
+                },
+            });
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain("Options:");
+            expect(await realpath(codexSkillDirectoryPath)).not.toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect((await lstat(codexSkillDirectoryPath)).isSymbolicLink()).toBeFalse();
+            expect(await readFile(join(codexSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
+                "# Campaign Writer\n",
+            );
+            expect(content).toContain(
+                `"msg":"Local skill synchronized during CLI startup."`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not overwrite synchronized registry targets with same-name local skills", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const codexSkillsDirectory = join(codexHomeDirectory, "skills");
+        const codexSkillDirectoryPath = join(codexSkillsDirectory, "chatgpt");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const registryCanonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+        const localCanonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "chatgpt",
+        );
+
+        try {
+            await mkdir(codexSkillsDirectory, { recursive: true });
+            await mkdir(registryCanonicalSkillDirectoryPath, { recursive: true });
+            await mkdir(localCanonicalSkillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(registryCanonicalSkillDirectoryPath, "SKILL.md"),
+                "# Registry ChatGPT\n",
+            );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(registryCanonicalSkillDirectoryPath),
+                renderSkillMetadataJson({
+                    packageName: "openai",
+                    version: "0.0.3",
+                }),
+            );
+            await Bun.write(
+                join(localCanonicalSkillDirectoryPath, "SKILL.md"),
+                "# Local ChatGPT\n",
+            );
+
+            const result = await sandbox.run(["--help"], {
+                fetcher: async () => {
+                    throw new Error("startup synchronization should not fetch");
+                },
+            });
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(await readFile(join(codexSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
+                "# Registry ChatGPT\n",
+            );
+            expect(await readFile(
+                resolveManagedSkillMetadataFilePath(codexSkillDirectoryPath),
+                "utf8",
+            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }));
+            expect(content).toContain(
+                `"msg":"Registry skill synchronized during CLI startup."`,
+            );
+            expect(content).not.toContain(
+                `"msg":"Local skill synchronized during CLI startup."`,
             );
         }
         finally {

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -129,17 +129,21 @@ describe("skills commands", () => {
                     skill_ids_truncated: false,
                 },
             });
-            expect(await realpath(ooSkillDirectoryPath)).toBe(
-                await realpath(ooCanonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                ooSkillDirectoryPath,
+                ooCanonicalSkillDirectoryPath,
             );
-            expect(await realpath(findSkillsDirectoryPath)).toBe(
-                await realpath(findSkillsCanonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                findSkillsDirectoryPath,
+                findSkillsCanonicalSkillDirectoryPath,
             );
-            expect(await realpath(createSkillDirectoryPath)).toBe(
-                await realpath(createSkillCanonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                createSkillDirectoryPath,
+                createSkillCanonicalSkillDirectoryPath,
             );
-            expect(await realpath(publishSkillDirectoryPath)).toBe(
-                await realpath(publishSkillCanonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                publishSkillDirectoryPath,
+                publishSkillCanonicalSkillDirectoryPath,
             );
 
             for (const file of getBundledSkillFiles("oo")) {
@@ -306,8 +310,9 @@ describe("skills commands", () => {
                 `Installed skill oo to ${skillDirectoryPath}.\n`,
             );
             expect(result.stderr).toBe("");
-            expect(await realpath(skillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                skillDirectoryPath,
+                canonicalSkillDirectoryPath,
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: resultVersion }),
@@ -357,8 +362,9 @@ describe("skills commands", () => {
                 `Installed skill oo to ${skillDirectoryPath}.\n`,
             );
             expect(result.stderr).toBe("");
-            expect(await realpath(skillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                skillDirectoryPath,
+                canonicalSkillDirectoryPath,
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: resultVersion }),
@@ -400,8 +406,9 @@ describe("skills commands", () => {
                 `Installed skill oo-find-skills to ${skillDirectoryPath}.\n`,
             );
             expect(result.stderr).toBe("");
-            expect(await realpath(skillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                skillDirectoryPath,
+                canonicalSkillDirectoryPath,
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: resultVersion }),
@@ -440,8 +447,9 @@ describe("skills commands", () => {
                 `Installed skill oo-publish-skill to ${skillDirectoryPath}.\n`,
             );
             expect(result.stderr).toBe("");
-            expect(await realpath(skillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                skillDirectoryPath,
+                canonicalSkillDirectoryPath,
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: resultVersion }),
@@ -508,11 +516,13 @@ describe("skills commands", () => {
             expect(result.stdout).toBe(
                 "Installed skill oo to 2 agents: Codex, Claude Code.\n",
             );
-            expect(await realpath(codexOoSkillDirectoryPath)).toBe(
-                await realpath(codexCanonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                codexOoSkillDirectoryPath,
+                codexCanonicalSkillDirectoryPath,
             );
-            expect(await realpath(claudeOoSkillDirectoryPath)).toBe(
-                await realpath(claudeCanonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                claudeOoSkillDirectoryPath,
+                claudeCanonicalSkillDirectoryPath,
             );
 
             for (const file of getBundledSkillFiles("oo", "codex")) {
@@ -565,8 +575,9 @@ describe("skills commands", () => {
             expect(result.stdout).toBe(
                 `Installed skill oo to ${skillDirectoryPath}.\n`,
             );
-            expect(await realpath(skillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                skillDirectoryPath,
+                canonicalSkillDirectoryPath,
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: "9.9.9" }),
@@ -723,8 +734,9 @@ describe("skills commands", () => {
                 `Installed skill oo to ${skillDirectoryPath}.\n`,
             );
             expect((await stat(qoderWorkSkillsDirectoryPath)).isDirectory()).toBeTrue();
-            expect(await realpath(skillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                skillDirectoryPath,
+                canonicalSkillDirectoryPath,
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson({ version: "9.9.9" }),
@@ -1804,8 +1816,9 @@ describe("skills commands", () => {
             expect(result.stdout).toBe(
                 `Installed skill chatgpt to ${skillDirectoryPath}.\n`,
             );
-            expect(await realpath(skillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                skillDirectoryPath,
+                canonicalSkillDirectoryPath,
             );
             expect(await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8")).toBe(
                 [
@@ -2273,14 +2286,16 @@ describe("skills commands", () => {
             );
             const canonicalSkillRealPath = await realpath(canonicalSkillDirectoryPath);
 
-            for (const linkedSkillDirectoryPath of [
+            for (const copiedSkillDirectoryPath of [
                 codexSkillDirectoryPath,
                 claudeSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
             ]) {
-                expect(await realpath(linkedSkillDirectoryPath)).toBe(
+                expect(await realpath(copiedSkillDirectoryPath)).not.toBe(
                     canonicalSkillRealPath,
                 );
+                expect((await lstat(copiedSkillDirectoryPath)).isSymbolicLink())
+                    .toBeFalse();
             }
 
             for (const copiedSkillDirectoryPath of [
@@ -2377,8 +2392,9 @@ describe("skills commands", () => {
             expect(result.stdout).toBe(
                 `Installed skill chatgpt to ${skillDirectoryPath}.\n`,
             );
-            expect(await realpath(skillDirectoryPath)).toBe(
-                await realpath(canonicalSkillDirectoryPath),
+            await expectCopiedSkillDirectory(
+                skillDirectoryPath,
+                canonicalSkillDirectoryPath,
             );
         }
         finally {
@@ -2923,8 +2939,9 @@ describe("skills commands", () => {
             await expect(stat(legacyRegistryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
-            expect(await realpath(ooSkillDirectoryPath)).toBe(
-                await realpath(newOoCanonicalPath),
+            await expectCopiedSkillDirectory(
+                ooSkillDirectoryPath,
+                newOoCanonicalPath,
             );
         }
         finally {
@@ -2932,3 +2949,13 @@ describe("skills commands", () => {
         }
     });
 });
+
+async function expectCopiedSkillDirectory(
+    skillDirectoryPath: string,
+    canonicalSkillDirectoryPath: string,
+): Promise<void> {
+    expect(await realpath(skillDirectoryPath)).not.toBe(
+        await realpath(canonicalSkillDirectoryPath),
+    );
+    expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
+}

--- a/src/application/commands/skills/init.test.ts
+++ b/src/application/commands/skills/init.test.ts
@@ -53,14 +53,15 @@ describe("skills init command", () => {
             expect(result.stdout).toBe(
                 [
                     `Initialized skill campaign-writer in canonical storage at ${canonicalSkillDirectoryPath}.`,
-                    `Linked skill campaign-writer to ${skillDirectoryPath}.`,
+                    `Copied skill campaign-writer to ${skillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );
             expect(result.stderr).toBe("");
-            expect(await realpath(skillDirectoryPath)).toBe(
+            expect(await realpath(skillDirectoryPath)).not.toBe(
                 await realpath(canonicalSkillDirectoryPath),
             );
+            expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
             await expect(
                 stat(join(canonicalSkillDirectoryPath, ".oo-metadata.json")),
             ).rejects.toMatchObject({
@@ -176,7 +177,7 @@ describe("skills init command", () => {
         }
     });
 
-    test("initializes a local skill by copying for non-symlink hosts", async () => {
+    test("initializes a local skill by copying for CodeBuddy", async () => {
         const sandbox = await createCliSandbox();
         const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
         const skillDirectoryPath = join(codeBuddyHomeDirectory, "skills", "copy-skill");
@@ -460,7 +461,7 @@ describe("skills init command", () => {
             expect(result.stdout).toBe(
                 [
                     `Initialized skill ${normalizedSkillName} in canonical storage at ${canonicalSkillDirectoryPath}.`,
-                    `Linked skill ${normalizedSkillName} to ${join(codexHomeDirectory, "skills", normalizedSkillName)}.`,
+                    `Copied skill ${normalizedSkillName} to ${join(codexHomeDirectory, "skills", normalizedSkillName)}.`,
                     "",
                 ].join("\n"),
             );

--- a/src/application/commands/skills/init.ts
+++ b/src/application/commands/skills/init.ts
@@ -23,7 +23,6 @@ import {
     isLocalSkillPathContained,
     resolveLocalSkillCanonicalDirectoryPath,
 } from "./managed-skill-paths.ts";
-import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
 import {
     installedRegistrySkillCompatibility,
     renderOoPackageExecutionGuidance,
@@ -42,11 +41,6 @@ export interface LocalSkillHostPublicationTarget {
     agentName: BundledSkillAgentName;
     homeDirectory: string;
     installedSkillDirectoryPath: string;
-}
-
-export interface LocalSkillHostPublicationResult {
-    mode: "copy" | "symlink";
-    path: string;
 }
 
 interface OOSkillFrontmatter {
@@ -165,7 +159,6 @@ async function initializeLocalSkill(
     await mkdir(canonicalSkillDirectoryPath, { recursive: true });
 
     const publishedTargets: LocalSkillHostPublicationTarget[] = [];
-    const publishedResults: LocalSkillHostPublicationResult[] = [];
 
     try {
         await Bun.write(
@@ -174,26 +167,18 @@ async function initializeLocalSkill(
         );
 
         for (const target of targets) {
-            const published = await publishBundledSkillInstallation({
+            await publishBundledSkillInstallation({
                 canonicalSkillDirectoryPath,
                 installedSkillDirectoryPath: target.installedSkillDirectoryPath,
-                publicationMode: resolveManagedSkillPublicationMode(
-                    target.agentName,
-                ),
             });
 
             publishedTargets.push(target);
-            publishedResults.push({
-                mode: published.mode,
-                path: published.path,
-            });
 
             context.logger.info(
                 {
                     agentName: target.agentName,
                     canonicalPath: canonicalSkillDirectoryPath,
-                    installMode: published.mode,
-                    path: published.path,
+                    path: target.installedSkillDirectoryPath,
                     skillName,
                 },
                 "Local skill initialized.",
@@ -208,12 +193,12 @@ async function initializeLocalSkill(
             }),
         );
 
-        for (const publishedResult of publishedResults) {
+        for (const target of publishedTargets) {
             writeLine(
                 context.stdout,
-                context.translator.t(resolveSkillInitPublicationMessageKey(publishedResult.mode), {
+                context.translator.t("skills.init.copied", {
                     name: skillName,
-                    path: publishedResult.path,
+                    path: target.installedSkillDirectoryPath,
                 }),
             );
         }
@@ -224,17 +209,6 @@ async function initializeLocalSkill(
             removePath(canonicalSkillDirectoryPath),
         ]);
         throw error;
-    }
-}
-
-export function resolveSkillInitPublicationMessageKey(
-    mode: LocalSkillHostPublicationResult["mode"],
-): "skills.init.linked" | "skills.init.copied" {
-    switch (mode) {
-        case "symlink":
-            return "skills.init.linked";
-        case "copy":
-            return "skills.init.copied";
     }
 }
 

--- a/src/application/commands/skills/managed-skill-publication.test.ts
+++ b/src/application/commands/skills/managed-skill-publication.test.ts
@@ -1,46 +1,65 @@
+import { mkdir, rm, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import process from "node:process";
 import { describe, expect, test } from "bun:test";
 
-import { availableBundledSkillAgentNames } from "./embedded-assets.ts";
 import {
     isManagedSkillPublicationCurrent,
-    resolveManagedSkillPublicationMode,
 } from "./managed-skill-publication.ts";
 
-describe("managed skill publication policy", () => {
-    test("allows symlink publication only for explicitly supported agents", () => {
-        const modes = Object.fromEntries(
-            availableBundledSkillAgentNames.map(agentName => [
-                agentName,
-                resolveManagedSkillPublicationMode(agentName),
-            ]),
+describe("managed skill publication state", () => {
+    test("treats a copied target as current", async () => {
+        const skillDirectoryPath = join(
+            tmpdir(),
+            `oo-managed-skill-publication-target-${Bun.randomUUIDv7()}`,
         );
 
-        expect(modes).toEqual({
-            "claude": "symlink-or-copy",
-            "codebuddy": "copy",
-            "codex": "symlink-or-copy",
-            "hermes": "copy",
-            "openclaw": "copy",
-            "qoderwork": "symlink-or-copy",
-            "trae": "copy",
-            "trae-cn": "copy",
-            "workbuddy": "copy",
-        });
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+
+            await expect(
+                isManagedSkillPublicationCurrent(skillDirectoryPath),
+            ).resolves.toBeTrue();
+        }
+        finally {
+            await rm(skillDirectoryPath, { force: true, recursive: true });
+        }
     });
 
-    test("treats a missing copy-mode target as not current", async () => {
+    test("treats a symlink target as not current", async () => {
+        const rootDirectoryPath = join(
+            tmpdir(),
+            `oo-linked-managed-skill-publication-target-${Bun.randomUUIDv7()}`,
+        );
+        const canonicalSkillDirectoryPath = join(rootDirectoryPath, "canonical");
+        const installedSkillDirectoryPath = join(rootDirectoryPath, "installed");
+
+        try {
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+            await symlink(
+                canonicalSkillDirectoryPath,
+                installedSkillDirectoryPath,
+                process.platform === "win32" ? "junction" : "dir",
+            );
+
+            await expect(
+                isManagedSkillPublicationCurrent(installedSkillDirectoryPath),
+            ).resolves.toBeFalse();
+        }
+        finally {
+            await rm(rootDirectoryPath, { force: true, recursive: true });
+        }
+    });
+
+    test("treats a missing target as not current", async () => {
         const missingSkillDirectoryPath = join(
             tmpdir(),
             `oo-missing-managed-skill-publication-target-${Bun.randomUUIDv7()}`,
         );
 
         await expect(
-            isManagedSkillPublicationCurrent(
-                missingSkillDirectoryPath,
-                "copy",
-            ),
+            isManagedSkillPublicationCurrent(missingSkillDirectoryPath),
         ).resolves.toBeFalse();
     });
 });

--- a/src/application/commands/skills/managed-skill-publication.ts
+++ b/src/application/commands/skills/managed-skill-publication.ts
@@ -1,40 +1,17 @@
-import type { BundledSkillPublicationMode } from "./bundled-skill-filesystem.ts";
-import type { BundledSkillAgentName } from "./embedded-assets.ts";
-
 import { lstat } from "node:fs/promises";
 import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
 
-const symlinkCapableManagedSkillAgentNames: ReadonlySet<BundledSkillAgentName> = new Set([
-    "claude",
-    "codex",
-    "qoderwork",
-]);
-
-export function resolveManagedSkillPublicationMode(
-    agentName: BundledSkillAgentName,
-): BundledSkillPublicationMode {
-    return symlinkCapableManagedSkillAgentNames.has(agentName)
-        ? "symlink-or-copy"
-        : "copy";
-}
-
 export async function isManagedSkillPublicationCurrent(
     skillDirectoryPath: string,
-    publicationMode: BundledSkillPublicationMode,
 ): Promise<boolean> {
-    switch (publicationMode) {
-        case "copy":
-            try {
-                return !(await lstat(skillDirectoryPath)).isSymbolicLink();
-            }
-            catch (error) {
-                if (isNodeNotFoundError(error)) {
-                    return false;
-                }
+    try {
+        return !(await lstat(skillDirectoryPath)).isSymbolicLink();
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
 
-                throw error;
-            }
-        case "symlink-or-copy":
-            return true;
+        throw error;
     }
 }

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -500,7 +500,7 @@ describe("skills publish command", () => {
                 packageName: "@alice/agent-skill",
                 version: "0.3.0",
             });
-            expect((await lstat(agentSkillDirectoryPath)).isSymbolicLink()).toBeTrue();
+            expect((await lstat(agentSkillDirectoryPath)).isSymbolicLink()).toBeFalse();
             const telemetryPayload = parseTelemetryRowPayload(
                 readTelemetryRowsForTest(
                     join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),

--- a/src/application/commands/skills/publish.ts
+++ b/src/application/commands/skills/publish.ts
@@ -33,7 +33,6 @@ import {
 } from "./embedded-assets.ts";
 import {
     resolveLocalSkillPublicationTargets,
-    resolveSkillInitPublicationMessageKey,
 } from "./init.ts";
 import {
     confirmInteractiveValue,
@@ -51,7 +50,6 @@ import {
     resolveManagedSkillDirectoryPath,
     resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
-import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
 import {
     convertSkillDirectoryToPackage,
     publishConvertedSkillPackage,
@@ -828,10 +826,9 @@ async function adoptSkillPublishSource(
             options.source.skillDirectoryPath,
         )) {
             activePublicationTarget = target;
-            const published = await publishBundledSkillInstallation({
+            await publishBundledSkillInstallation({
                 canonicalSkillDirectoryPath: options.localSkillDirectoryPath,
                 installedSkillDirectoryPath: target.installedSkillDirectoryPath,
-                publicationMode: resolveManagedSkillPublicationMode(target.agentName),
             });
 
             publishedTargets.push(target);
@@ -839,13 +836,10 @@ async function adoptSkillPublishSource(
 
             writeLine(
                 options.context.stdout,
-                options.context.translator.t(
-                    resolveSkillInitPublicationMessageKey(published.mode),
-                    {
-                        name: options.source.skillId,
-                        path: published.path,
-                    },
-                ),
+                options.context.translator.t("skills.init.copied", {
+                    name: options.source.skillId,
+                    path: target.installedSkillDirectoryPath,
+                }),
             );
         }
 

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -290,7 +290,6 @@ async function executeInstallActions(
                             packageInfo.packageVersion,
                         ),
                         agentName: publication.agentName,
-                        installMode: publication.mode,
                         path: publication.path,
                         skillName,
                     },

--- a/src/application/commands/skills/registry-skill-publication.ts
+++ b/src/application/commands/skills/registry-skill-publication.ts
@@ -1,4 +1,3 @@
-import type { BundledSkillPublicationResult } from "./bundled-skill-filesystem.ts";
 import type { BundledSkillAgentName } from "./embedded-assets.ts";
 import type { ManagedSkillHostInstallation } from "./managed-skill-hosts.ts";
 import type { ExtractedRegistryPackageArchive } from "./registry-skill-archive.ts";
@@ -19,7 +18,6 @@ import {
 import {
     resolveManagedSkillCanonicalDirectoryPath,
 } from "./managed-skill-paths.ts";
-import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
 import { requireExtractedRegistrySkillDirectory } from "./registry-skill-archive.ts";
 import { rewriteInstalledRegistrySkillMarkdown } from "./registry-skill-markdown.ts";
 
@@ -31,8 +29,9 @@ export interface PreparedRegistrySkillPublication {
     skillName: string;
 }
 
-export interface RegistrySkillPublicationResult extends BundledSkillPublicationResult {
+export interface RegistrySkillPublicationResult {
     agentName: BundledSkillAgentName;
+    path: string;
 }
 
 export async function prepareRegistrySkillPublication(options: {
@@ -91,17 +90,14 @@ export async function publishPreparedRegistrySkillPublication(
 
     return Promise.all(
         preparedPublication.hostInstallations.map(async (installation) => {
-            const publication = await publishBundledSkillInstallation({
+            await publishBundledSkillInstallation({
                 canonicalSkillDirectoryPath: preparedPublication.canonicalSkillDirectoryPath,
                 installedSkillDirectoryPath: installation.installedSkillDirectoryPath,
-                publicationMode: resolveManagedSkillPublicationMode(
-                    installation.agentName,
-                ),
             });
 
             return {
-                ...publication,
                 agentName: installation.agentName,
+                path: installation.installedSkillDirectoryPath,
             };
         }),
     );

--- a/src/application/commands/skills/shared.test.ts
+++ b/src/application/commands/skills/shared.test.ts
@@ -1,430 +1,93 @@
-import { mkdir, readFile, realpath, rm, stat } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import { lstat, mkdir, readFile, realpath, rm, stat, symlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import process from "node:process";
 
 import { describe, expect, test } from "bun:test";
 
 import {
     createTemporaryDirectory,
-    platformDescribe,
 } from "../../../../__tests__/helpers.ts";
 import {
-    createBundledSkillDirectorySymlink,
     publishBundledSkillInstallation,
-    removeBundledSkillSymbolicPath,
 } from "./bundled-skill-filesystem.ts";
 
 describe("bundled skill publication", () => {
-    test("publishes the bundled skill through a symlink-compatible path", async () => {
+    test("copies the bundled skill into the installed path", async () => {
         const fixture = await createBundledSkillPublicationFixture();
 
         try {
-            const result = await publishBundledSkillInstallation({
+            await publishBundledSkillInstallation({
                 canonicalSkillDirectoryPath: fixture.canonicalSkillDirectoryPath,
                 installedSkillDirectoryPath: fixture.installedSkillDirectoryPath,
             });
 
-            expect(result).toEqual({
-                mode: "symlink",
-                path: fixture.installedSkillDirectoryPath,
-            });
             expect(await readFile(join(fixture.installedSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
                 "skill\n",
             );
-            expect(await realpath(fixture.installedSkillDirectoryPath)).toBe(
-                await realpath(fixture.canonicalSkillDirectoryPath),
-            );
-        }
-        finally {
-            await fixture.cleanup();
-        }
-    });
-
-    test("falls back to copying when symlink creation fails", async () => {
-        const fixture = await createBundledSkillPublicationFixture();
-
-        try {
-            const result = await publishBundledSkillInstallation(
-                {
-                    canonicalSkillDirectoryPath: fixture.canonicalSkillDirectoryPath,
-                    installedSkillDirectoryPath: fixture.installedSkillDirectoryPath,
-                },
-                {
-                    createDirectorySymlink: async () => false,
-                },
-            );
-
-            expect(result).toEqual({
-                mode: "copy",
-                path: fixture.installedSkillDirectoryPath,
-            });
-            expect(await readFile(join(fixture.installedSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
-                "skill\n",
+            expect(await readFile(join(fixture.installedSkillDirectoryPath, "agents", "openai.yaml"), "utf8")).toBe(
+                "OOMOL\n",
             );
             expect(await realpath(fixture.installedSkillDirectoryPath)).not.toBe(
                 await realpath(fixture.canonicalSkillDirectoryPath),
             );
+            expect((await lstat(fixture.installedSkillDirectoryPath)).isSymbolicLink()).toBeFalse();
         }
         finally {
             await fixture.cleanup();
         }
     });
 
-    test("copies directly when publication mode disables symlinks", async () => {
-        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
-        const canonicalSkillDirectoryPath = join(
-            rootDirectory,
-            "config",
-            "skills",
-            "oo",
-        );
-        const installedSkillDirectoryPath = join(
-            rootDirectory,
-            ".openclaw",
-            "skills",
-            "oo",
-        );
-
-        try {
-            await mkdir(join(canonicalSkillDirectoryPath, "references"), {
-                recursive: true,
-            });
-            await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "skill\n");
-            await Bun.write(
-                join(canonicalSkillDirectoryPath, "references", "guide.md"),
-                "guide\n",
-            );
-
-            const result = await publishBundledSkillInstallation(
-                {
-                    canonicalSkillDirectoryPath,
-                    installedSkillDirectoryPath,
-                    publicationMode: "copy",
-                },
-                {
-                    createDirectorySymlink: async () => {
-                        throw new Error("copy mode should skip symlink creation");
-                    },
-                },
-            );
-
-            expect(result).toEqual({
-                mode: "copy",
-                path: installedSkillDirectoryPath,
-            });
-            expect(await readFile(join(installedSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
-                "skill\n",
-            );
-            expect(await readFile(join(installedSkillDirectoryPath, "references", "guide.md"), "utf8")).toBe(
-                "guide\n",
-            );
-            expect(await realpath(installedSkillDirectoryPath)).not.toBe(
-                await realpath(canonicalSkillDirectoryPath),
-            );
-        }
-        finally {
-            await rm(rootDirectory, { force: true, recursive: true });
-        }
-    });
-
-    test("returns false when symlink creation throws", async () => {
-        const result = await createBundledSkillDirectorySymlink(
-            "/tmp/canonical/skills/oo",
-            "/tmp/agent/skills/oo",
-            {
-                lstat: async () => {
-                    const error = new Error("missing") as NodeJS.ErrnoException;
-
-                    error.code = "ENOENT";
-
-                    throw error;
-                },
-                mkdir: async () => undefined,
-                readlink: async () => {
-                    throw new Error("readlink should not run when the link is missing");
-                },
-                realpath: async path => path,
-                removePath: async () => {
-                    throw new Error("removePath should not run when the link is missing");
-                },
-                resolveParentSymlinks: async path => path,
-                symlink: async () => {
-                    throw new Error("boom");
-                },
-            },
-        );
-
-        expect(result).toBeFalse();
-    });
-
-    test("replaces an existing directory at the installed path before creating a symlink", async () => {
+    test("replaces an existing installed directory before copying", async () => {
         const fixture = await createBundledSkillPublicationFixture();
 
         try {
             await mkdir(fixture.installedSkillDirectoryPath, { recursive: true });
             await Bun.write(join(fixture.installedSkillDirectoryPath, "stale.txt"), "stale\n");
 
-            const result = await publishBundledSkillInstallation({
+            await publishBundledSkillInstallation({
                 canonicalSkillDirectoryPath: fixture.canonicalSkillDirectoryPath,
                 installedSkillDirectoryPath: fixture.installedSkillDirectoryPath,
             });
 
-            expect(result).toEqual({
-                mode: "symlink",
-                path: fixture.installedSkillDirectoryPath,
-            });
-            expect(await realpath(fixture.installedSkillDirectoryPath)).toBe(
-                await realpath(fixture.canonicalSkillDirectoryPath),
-            );
             await expect(stat(join(fixture.installedSkillDirectoryPath, "stale.txt"))).rejects.toMatchObject({
                 code: "ENOENT",
             });
+            expect((await lstat(fixture.installedSkillDirectoryPath)).isSymbolicLink()).toBeFalse();
         }
         finally {
             await fixture.cleanup();
         }
     });
 
-    test("reuses an existing symlink when it already points to the target", async () => {
-        const createdSymlinks: Array<{
-            linkPath: string;
-            targetPath: string;
-            type: string | null | undefined;
-        }> = [];
+    test("replaces a historical symlink installation with a copied directory", async () => {
+        const fixture = await createBundledSkillPublicationFixture();
 
-        const result = await createBundledSkillDirectorySymlink(
-            "/tmp/canonical/skills/oo",
-            "/tmp/agent/skills/oo",
-            {
-                lstat: async () => ({
-                    isSymbolicLink: () => true,
-                }),
-                mkdir: async () => undefined,
-                readlink: async () => "../../canonical/skills/oo",
-                realpath: async path => path,
-                removePath: async () => {
-                    throw new Error("expected the existing symlink to be reused");
-                },
-                resolveParentSymlinks: async path => path,
-                symlink: async (targetPath, linkPath, type) => {
-                    createdSymlinks.push({ linkPath, targetPath, type });
-                },
-            },
-        );
-
-        expect(result).toBeTrue();
-        expect(createdSymlinks).toHaveLength(0);
-    });
-});
-
-registerPosixBundledSkillPublicationTests("darwin");
-registerPosixBundledSkillPublicationTests("linux");
-
-platformDescribe.win32("bundled skill publication on win32", () => {
-    test("cleans a broken symlink loop before creating a junction in win32 mode", async () => {
-        const removedPaths: string[] = [];
-        const createdSymlinks: Array<{
-            linkPath: string;
-            targetPath: string;
-            type: string | null | undefined;
-        }> = [];
-        const targetPath = "/windows/canonical/oo";
-        const linkPath = "/windows/agent/oo";
-        const resolvedTargetPath = resolve(targetPath);
-        const resolvedLinkPath = resolve(linkPath);
-
-        const result = await createBundledSkillDirectorySymlink(
-            targetPath,
-            linkPath,
-            {
-                lstat: async () => {
-                    const error = new Error("loop") as NodeJS.ErrnoException;
-
-                    error.code = "ELOOP";
-
-                    throw error;
-                },
-                mkdir: async () => undefined,
-                readlink: async () => {
-                    throw new Error("readlink should not run when lstat fails");
-                },
-                realpath: async path => path,
-                removePath: async (path) => {
-                    removedPaths.push(path);
-                },
-                resolveParentSymlinks: async path => path,
-                symlink: async (createdTargetPath, createdLinkPath, type) => {
-                    createdSymlinks.push({
-                        linkPath: createdLinkPath,
-                        targetPath: createdTargetPath,
-                        type,
-                    });
-                },
-            },
-        );
-
-        expect(result).toBeTrue();
-        expect(removedPaths).toEqual([resolvedLinkPath]);
-        expect(createdSymlinks).toEqual([
-            {
-                linkPath: resolvedLinkPath,
-                targetPath: resolvedTargetPath,
-                type: "junction",
-            },
-        ]);
-    });
-
-    test("falls back to rmdir when removing a junction hits EFAULT on win32", async () => {
-        const removedWithRmdir: string[] = [];
-        const junctionPath = "C:\\Users\\Tester\\.codex\\skills\\oo";
-
-        await removeBundledSkillSymbolicPath(junctionPath, {
-            rm: async () => {
-                const error = new Error("bad address") as NodeJS.ErrnoException;
-
-                error.code = "EFAULT";
-
-                throw error;
-            },
-            rmdir: async (path) => {
-                removedWithRmdir.push(path);
-            },
-        });
-
-        expect(removedWithRmdir).toEqual([junctionPath]);
-    });
-});
-
-function registerPosixBundledSkillPublicationTests(
-    platform: "darwin" | "linux",
-): void {
-    const scopedDescribe = platform === "darwin"
-        ? platformDescribe.darwin
-        : platformDescribe.linux;
-
-    scopedDescribe(`bundled skill publication on ${platform}`, () => {
-        test("replaces an existing directory before creating a symlink", async () => {
-            const removedPaths: string[] = [];
-            const createdSymlinks: Array<{
-                linkPath: string;
-                targetPath: string;
-                type: string | null | undefined;
-            }> = [];
-            const targetPath = "/tmp/canonical/skills/oo";
-            const linkPath = "/tmp/agent/skills/oo";
-            const resolvedTargetPath = resolve(targetPath);
-            const resolvedLinkPath = resolve(linkPath);
-
-            const result = await createBundledSkillDirectorySymlink(
-                targetPath,
-                linkPath,
-                {
-                    lstat: async () => ({
-                        isSymbolicLink: () => false,
-                    }) as Awaited<ReturnType<typeof stat>>,
-                    mkdir: async () => undefined,
-                    readlink: async () => {
-                        throw new Error("readlink should not run for directories");
-                    },
-                    realpath: async path => path,
-                    removePath: async (path) => {
-                        removedPaths.push(path);
-                    },
-                    resolveParentSymlinks: async path => path,
-                    symlink: async (createdTargetPath, createdLinkPath, type) => {
-                        createdSymlinks.push({
-                            linkPath: createdLinkPath,
-                            targetPath: createdTargetPath,
-                            type,
-                        });
-                    },
-                },
+        try {
+            await mkdir(dirname(fixture.installedSkillDirectoryPath), { recursive: true });
+            await symlink(
+                fixture.canonicalSkillDirectoryPath,
+                fixture.installedSkillDirectoryPath,
+                process.platform === "win32" ? "junction" : "dir",
             );
 
-            expect(result).toBeTrue();
-            expect(removedPaths).toEqual([resolvedLinkPath]);
-            expect(createdSymlinks).toEqual([
-                {
-                    linkPath: resolvedLinkPath,
-                    targetPath: relative(dirname(resolvedLinkPath), resolvedTargetPath),
-                    type: "dir",
-                },
-            ]);
-        });
-
-        test("uses the symlink-resolved parent directory when computing a relative POSIX target", async () => {
-            const createdSymlinks: Array<{
-                linkPath: string;
-                targetPath: string;
-                type: string | null | undefined;
-            }> = [];
-            const targetPath = "/tmp/canonical/skills/oo";
-            const linkPath = "/tmp/link-parent/skills/oo";
-            const resolvedTargetPath = resolve(targetPath);
-            const resolvedLinkPath = resolve(linkPath);
-            const resolvedLinkDirectoryPath = dirname(resolvedLinkPath);
-            const realLinkDirectoryPath = "/private/tmp/link-parent/skills";
-
-            const result = await createBundledSkillDirectorySymlink(
-                targetPath,
-                linkPath,
-                {
-                    lstat: async () => {
-                        const error = new Error("missing") as NodeJS.ErrnoException;
-
-                        error.code = "ENOENT";
-
-                        throw error;
-                    },
-                    mkdir: async () => undefined,
-                    readlink: async () => {
-                        throw new Error("readlink should not run when the link is missing");
-                    },
-                    realpath: async path => path,
-                    removePath: async () => {
-                        throw new Error("removePath should not run when the link is missing");
-                    },
-                    resolveParentSymlinks: async path =>
-                        path === resolvedLinkDirectoryPath ? realLinkDirectoryPath : path,
-                    symlink: async (createdTargetPath, createdLinkPath, type) => {
-                        createdSymlinks.push({
-                            linkPath: createdLinkPath,
-                            targetPath: createdTargetPath,
-                            type,
-                        });
-                    },
-                },
-            );
-
-            expect(result).toBeTrue();
-            expect(createdSymlinks).toEqual([
-                {
-                    linkPath: resolvedLinkPath,
-                    targetPath: relative(realLinkDirectoryPath, resolvedTargetPath),
-                    type: "dir",
-                },
-            ]);
-        });
-
-        test("rethrows EFAULT when removing a symbolic path on POSIX", async () => {
-            const symlinkPath = "/tmp/.codex/skills/oo";
-
-            await expect(removeBundledSkillSymbolicPath(symlinkPath, {
-                rm: async () => {
-                    const error = new Error("bad address") as NodeJS.ErrnoException;
-
-                    error.code = "EFAULT";
-
-                    throw error;
-                },
-                rmdir: async () => {
-                    throw new Error("rmdir should not run on POSIX");
-                },
-            })).rejects.toMatchObject({
-                code: "EFAULT",
+            await publishBundledSkillInstallation({
+                canonicalSkillDirectoryPath: fixture.canonicalSkillDirectoryPath,
+                installedSkillDirectoryPath: fixture.installedSkillDirectoryPath,
             });
-        });
+
+            expect(await readFile(join(fixture.installedSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
+                "skill\n",
+            );
+            expect(await realpath(fixture.installedSkillDirectoryPath)).not.toBe(
+                await realpath(fixture.canonicalSkillDirectoryPath),
+            );
+            expect((await lstat(fixture.installedSkillDirectoryPath)).isSymbolicLink()).toBeFalse();
+        }
+        finally {
+            await fixture.cleanup();
+        }
     });
-}
+});
 
 async function createBundledSkillPublicationFixture(): Promise<{
     canonicalSkillDirectoryPath: string;

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -1,6 +1,5 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 
-import type { BundledSkillPublicationResult } from "./bundled-skill-filesystem.ts";
 import type {
     BundledSkillAgentName,
     BundledSkillName,
@@ -36,7 +35,6 @@ import {
     resolveAvailableManagedSkillHosts,
     resolveManagedSkillHostInstallation,
 } from "./managed-skill-hosts.ts";
-import { resolveManagedSkillPublicationMode } from "./managed-skill-publication.ts";
 
 export interface BundledSkillHostInstallation extends ManagedSkillHostInstallation {
     canonicalSkillDirectoryPath: string;
@@ -66,7 +64,7 @@ export async function installBundledSkill(
     const publications: ManagedSkillInstallPublication[] = [];
 
     for (const installation of installations) {
-        const publishedInstallation = await publishManagedBundledSkill({
+        const installedSkillDirectoryPath = await publishManagedBundledSkill({
             agentName: installation.agentName,
             homeDirectory: installation.homeDirectory,
             settingsFilePath: context.settingsStore.getFilePath(),
@@ -76,14 +74,13 @@ export async function installBundledSkill(
 
         publications.push({
             agentName: installation.agentName,
-            path: publishedInstallation.path,
+            path: installedSkillDirectoryPath,
         });
         context.logger.info(
             {
                 agentName: installation.agentName,
                 canonicalPath: installation.canonicalSkillDirectoryPath,
-                installMode: publishedInstallation.mode,
-                path: publishedInstallation.path,
+                path: installedSkillDirectoryPath,
                 skillName,
                 version: context.version,
             },
@@ -103,13 +100,12 @@ export async function publishManagedBundledSkill(options: {
     settingsFilePath: string;
     skillName: BundledSkillName;
     version: string;
-}): Promise<BundledSkillPublicationResult> {
+}): Promise<string> {
     const installationPaths = await writeBundledSkillCanonicalInstallation(options);
 
-    return publishBundledSkillInstallation({
-        ...installationPaths,
-        publicationMode: resolveManagedSkillPublicationMode(options.agentName),
-    });
+    await publishBundledSkillInstallation(installationPaths);
+
+    return installationPaths.installedSkillDirectoryPath;
 }
 
 export async function resolveAvailableBundledSkillHostInstallations(

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -268,7 +268,7 @@ describe("skills update command", () => {
         }
     });
 
-    test("updates a published managed skill by copying for non-symlink hosts", async () => {
+    test("updates a published managed skill by copying to the host target", async () => {
         const sandbox = await createCliSandbox();
         const hermesHomeDirectory = resolveHermesHomeDirectory(sandbox.env);
         const storePaths = resolveStorePaths({

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -28,7 +28,6 @@ import {
 } from "./managed-skill-paths.ts";
 import {
     isManagedSkillPublicationCurrent,
-    resolveManagedSkillPublicationMode,
 } from "./managed-skill-publication.ts";
 import { extractRegistryPackageArchive } from "./registry-skill-archive.ts";
 import {
@@ -642,7 +641,6 @@ async function isRegistrySkillCurrentInAllHosts(
                 ),
                 publicationCurrent: await isManagedSkillPublicationCurrent(
                     installation.installedSkillDirectoryPath,
-                    resolveManagedSkillPublicationMode(installation.agentName),
                 ),
             };
         }),

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -662,7 +662,6 @@ export const enMessages = {
     "labels.status": "Status",
     "labels.version": "Version",
     "skills.init.success": "Initialized skill {name} in canonical storage at {path}.",
-    "skills.init.linked": "Linked skill {name} to {path}.",
     "skills.init.copied": "Copied skill {name} to {path}.",
     "skills.publish.success":
         "Published skill {name} as {visibility} package {packageName}@{version}. View it at {hubUrl}.",
@@ -1441,7 +1440,6 @@ export const zhMessages = {
     "labels.status": "状态",
     "labels.version": "版本",
     "skills.init.success": "已在 canonical 存储 {path} 初始化 skill {name}。",
-    "skills.init.linked": "已将 skill {name} 软链接到 {path}。",
     "skills.init.copied": "已将 skill {name} 复制到 {path}。",
     "skills.publish.success":
         "已将 skill {name} 以{visibility}发布为 {packageName}@{version}。可在 {hubUrl} 查看。",


### PR DESCRIPTION
Remove symlink publication for bundled, registry, and local skills because supported agents handle linked skill directories inconsistently.

Startup synchronization now treats existing managed symlink targets as stale and replaces them with copied directories. Local canonical skills are also synchronized to newly detected hosts without overwriting registry-managed targets.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/oomol-lab/codesmith/oo-cli/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->