### PR TITLE
feat(skills): add typed metadata kind and local copy drift guards

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -761,8 +761,10 @@ Remove oo-managed skills from supported local skill directories.
   that host's installed directory has a `.oo-metadata.json` file that
   identifies bundled ownership.
 - Ownership rule: a local skill published by copying is removable from a
-  supported host only when that host's installed directory identifies local
+  supported host when that host's installed directory identifies local
   ownership and its `SKILL.md` content matches the local canonical `SKILL.md`.
+  A same-name legacy local copy without metadata is also removable when its
+  `SKILL.md` content matches the local canonical `SKILL.md`.
 - Canonical directory removed: bundled skills remove
   `<config-dir>/skills/bundled/<agent>/<skill>` for each installed agent, and
   local skills remove `<config-dir>/skills/local/<skill>`. Published skills

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -358,7 +358,9 @@ supported host directory that already exists.
   any newly detected supported host that is missing it.
 - Local skills: when a local skill already has a canonical copy under
   `<config-dir>/skills/local/<skill-id>`, `oo` publishes that copy to any newly
-  detected supported host that is missing it.
+  detected supported host that is missing it. Existing same-name local copies
+  with different `SKILL.md` content are left untouched during silent startup
+  synchronization; run `oo skills add` to refresh them explicitly.
 - Migration: existing oo-managed symlink targets from older releases are
   replaced with copied directories during startup synchronization.
 - Safety: startup synchronization does not fetch registry data, does not
@@ -376,8 +378,9 @@ List bundled, registry, and local skills.
   `${HERMES_HOME:-~/.hermes}/skills`, `~/.codebuddy/skills`,
   `~/.workbuddy/skills`, `~/.trae/skills`, `~/.trae-cn/skills`,
   `${OPENCLAW_HOME:-~/.openclaw}/skills`, and `~/.qoderwork/skills`. It keeps
-  only child directories whose
-  `.oo-metadata.json` can be parsed and contains a non-empty `version`.
+  only child directories whose `.oo-metadata.json` identifies an oo-managed
+  bundled, registry, or local skill. Existing legacy bundled and registry
+  metadata remains readable.
 - Local ownership rule: the command scans `<config-dir>/skills/local` and keeps
   child directories whose `SKILL.md` frontmatter includes a matching non-empty
   `name` and a non-empty `description`.
@@ -429,6 +432,8 @@ directory that already exists.
 - Generated `SKILL.md` body includes the managed oo execution notice and
   editable placeholder sections for when to use the skill, inputs, execution,
   result handling, and failure handling.
+- Metadata: the canonical directory and each copied agent target include
+  `.oo-metadata.json` identifying the skill as a local skill managed by `oo`.
 - Options: `--icon <icon>` writes a non-empty icon reference to `metadata.icon`
   in the generated `SKILL.md` frontmatter. The value may be an emoji, an image
   URL, or `:collection:icon:` where `collection` and `icon` are names from
@@ -485,9 +490,23 @@ Convert one skill into an OOMOL package and run the publish step.
   `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `trae-cn`,
   `openclaw`, and `qoderwork`.
 - Options: `-y, --yes` answers publish confirmation prompts with yes.
+- Options: `--force` allows publishing a local canonical skill even when an
+  oo-managed local copy in an agent directory has different `SKILL.md` content.
+  `--force` is independent from `-y, --yes`; answering prompts automatically
+  does not ignore local copy drift.
 - Source resolution: the command first checks
   `<config-dir>/skills/local/<skill-id>`. If present, that local skill is
   published.
+- Local source rule: `<config-dir>/skills/local/<skill-id>` is the only trusted
+  source for a local skill. Agent directories contain copied consumer targets
+  and are never used as the publish source while a canonical local source
+  exists.
+- Local copy drift: before publishing a local skill, the command checks
+  same-name oo-managed local copies in existing supported agent directories. If
+  any copy has different `SKILL.md` content, publishing fails by default and
+  tells you to retry with `--force`. With `--force`, the command publishes the
+  canonical local source and prints a warning that agent-side changes were
+  ignored.
 - Source resolution: bundled skills are rejected because they are managed by the
   oo CLI release.
 - Source resolution: registry skills under
@@ -502,11 +521,11 @@ Convert one skill into an OOMOL package and run the publish step.
   a filesystem path. A matching skill directory is adopted into local canonical
   storage before publishing.
 - Adoption: adopting a skill moves it to `<config-dir>/skills/local/<skill-id>`,
-  imports any managed `.oo-metadata.json` fields into `SKILL.md` frontmatter,
-  removes `.oo-metadata.json`, and publishes the local canonical copy to
-  supported agent skill directories. Adoption requires an interactive `[y/N]`
-  confirmation unless `-y, --yes` is provided. Adopted source directories must
-  not contain symbolic links.
+  imports any registry `.oo-metadata.json` package fields into `SKILL.md`
+  frontmatter, writes local ownership metadata, and publishes the local
+  canonical copy to supported agent skill directories. Adoption requires an
+  interactive `[y/N]` confirmation unless `-y, --yes` is provided. Adopted
+  source directories must not contain symbolic links.
 - Authentication: the command requires the current OOMOL account. The package
   name is always `@<lowercase-account.name>/<lowercase-skill-id>`.
 - Validation: the source directory must contain `SKILL.md` with frontmatter
@@ -519,7 +538,8 @@ Convert one skill into an OOMOL package and run the publish step.
 - Package contents: the skill directory's `.gitignore` controls which local
   files are excluded from the published package. When the skill has no
   `.gitignore`, the built-in package template is used. Symbolic links are
-  rejected during packaging.
+  rejected during packaging. `.oo-metadata.json` is always excluded from the
+  published package.
 - Registry safety: before publishing, the command looks up the latest remote
   package metadata. If the remote package already contains blocks, an
   interactive terminal prompts for confirmation with the standard `[y/N]`
@@ -534,7 +554,9 @@ Convert one skill into an OOMOL package and run the publish step.
 - Version resolution: if the requested version is not greater than the latest
   remote package version, the command publishes the next patch version.
 - Writeback: after the publish step succeeds, `SKILL.md` frontmatter is updated
-  with the final `metadata.packageName` and `metadata.version`.
+  with the final `metadata.packageName` and `metadata.version`. Local canonical
+  sources keep local ownership metadata; registry sources keep registry
+  ownership metadata.
 - Output: on success, text output prints the skill id, final package specifier,
   selected visibility (`private` or `public`), and the Hub package URL
   for the current account endpoint, for example
@@ -564,7 +586,9 @@ Install bundled or published skills into supported local skill directories.
 - Alias: `oo skills add [packageName]`.
 - Arguments: `[packageName]` is optional.
 - Arguments: when omitted, the command installs all bundled skills, then
-  best-effort installs all skills from preset registry skill packages.
+  best-effort installs all skills from preset registry skill packages, then
+  refreshes canonical local skills from `<config-dir>/skills/local` to existing
+  supported hosts.
 - Arguments: when `[packageName]` is `oo`, `oo-find-skills`,
   `oo-create-skill`, or `oo-publish-skill`, the command installs the
   corresponding bundled skill.
@@ -600,14 +624,17 @@ Install bundled or published skills into supported local skill directories.
   `qoderwork`.
 - Canonical directory: published skills are materialized to
   `<config-dir>/skills/registry/<skill-id>`.
+- Canonical directory: local skills are read from
+  `<config-dir>/skills/local/<skill-id>`. This canonical local directory is the
+  source of truth; agent directories contain copied consumer targets.
 - Migration: on first run after upgrading, `oo skills install` removes legacy
   canonical directories left over from earlier releases (`claude-skills/`,
   `openclaw-skills/`, and any Codex-bundled or registry skill directory that
   lived directly under `skills/`). Bundled skills are rebuilt automatically in
   the new layout; previously-installed published skills must be reinstalled
   with `oo skills install <packageName>`.
-- Target directory: bundled and published skills are published to each existing
-  supported host directory, currently
+- Target directory: bundled, published, and refreshed local skills are
+  published to each existing supported host directory, currently
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>`,
   `~/.claude/skills/<skill-id>`,
   `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`,
@@ -621,15 +648,22 @@ Install bundled or published skills into supported local skill directories.
   the command creates that root before publishing the selected skill.
 - Path rule: published skill names are accepted only when their resolved
   canonical and target directories remain under those local `skills` roots.
-- Installation mode: bundled and published skills are copied into every target
-  skills directory. Existing oo-managed symlink targets from older releases are
-  replaced with copied directories when the skill is synchronized, installed,
-  or updated.
-- Metadata: bundled skills write a hidden `.oo-metadata.json` file whose
-  `version` field matches the current `oo` version.
-- Metadata: published skills write a hidden `.oo-metadata.json` file whose
-  `version` field matches the package version and whose `packageName` field
-  records the source package.
+- Installation mode: bundled, published, and refreshed local skills are copied
+  into every target skills directory. Existing oo-managed symlink targets from
+  older releases are replaced with copied directories when the skill is
+  synchronized, installed, or updated.
+- Local refresh: for local skills, the canonical source wins. Existing
+  oo-managed local copies are overwritten from the canonical source; if their
+  `SKILL.md` content differs, the command prints a warning before overwriting
+  them. A same-name target without metadata is adopted only when its `SKILL.md`
+  content already matches the canonical local source. A target without metadata
+  and different content, or a target owned by bundled or registry metadata, is
+  treated as a conflict and is not overwritten by the local refresh path.
+- Metadata: new bundled, registry, and local writes include a hidden
+  `.oo-metadata.json` file with an oo source marker and schema version.
+  Bundled metadata records the current `oo` version; registry metadata records
+  the source package and package version; local metadata records local
+  ownership. Existing legacy bundled and registry metadata remains readable.
 - Notes: all registry requests for published skills send the active account's
   `Authorization` header.
 - Notes: when a package publishes multiple skills and the command runs outside
@@ -638,16 +672,16 @@ Install bundled or published skills into supported local skill directories.
   existing same-name skill, the command asks for `yes` or `no` before
   overwriting it in an interactive terminal.
 - Notes: existing target directories without valid `oo` metadata are treated as
-  non-OOMOL skills and are not overwritten.
+  non-OOMOL skills and are not overwritten, except for the local refresh
+  adoption case where the target has matching `SKILL.md` content.
 - Notes: in the interactive picker, conflicting skills are marked in the list;
   selecting one means it will be overwritten.
 - Notes: the command exits with an error when none of the supported Codex,
   Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, OpenClaw, or
   QoderWork home directories exists.
-- Notes: an existing bundled skill installation is considered managed by `oo`
-  only when its `.oo-metadata.json` file can be parsed and contains a
-  non-empty `version`. Otherwise `oo` treats it as a different skill and will
-  not overwrite it.
+- Notes: an existing bundled or registry skill installation is considered
+  managed by `oo` only when its `.oo-metadata.json` identifies that source.
+  Otherwise `oo` treats it as a different skill and will not overwrite it.
 
 ### `oo skills sync upload`
 
@@ -660,8 +694,8 @@ Upload installed oo-managed registry skills to the skills sync service.
   be repeated, and each value may contain comma-separated patterns. Patterns use
   gitignore-style matching.
 - Scope: the command uploads only installed published registry skills whose
-  `.oo-metadata.json` contains both `packageName` and `version`; bundled and
-  local skills are never uploaded.
+  `.oo-metadata.json` identifies registry ownership and package identity.
+  Bundled and local skills are never uploaded.
 - Request: the command sends `PUT https://api.<endpoint>/v1/skills` with a JSON
   array of `{ "packageName": string, "version": string, "skillName": string }`.
   The active account's `Authorization` header is included.
@@ -700,8 +734,8 @@ Update installed oo-managed published skills.
   Refresh them with `oo skills add`, or let a
   successful `oo install` or `oo update` refresh them automatically.
 - Ownership rule: a skill is considered managed for update only when its
-  `.oo-metadata.json` file can be parsed and contains a non-empty `version`;
-  otherwise the command treats the existing target as unmanaged.
+  `.oo-metadata.json` identifies registry ownership and package identity;
+  bundled and local metadata are ignored by this command.
 - Published skills: registry-backed skills derive their package identity from
   `.oo-metadata.json`, then fetch package info without an explicit version to
   determine the latest available package version.
@@ -724,11 +758,11 @@ Remove oo-managed skills from supported local skill directories.
   match, both are removed. Registry installations are removed before local
   installations.
 - Ownership rule: a bundled skill is removable from a supported host only when
-  that host's installed directory has a `.oo-metadata.json` file that can be
-  parsed and contains a non-empty `version`.
+  that host's installed directory has a `.oo-metadata.json` file that
+  identifies bundled ownership.
 - Ownership rule: a local skill published by copying is removable from a
-  supported host when its `SKILL.md` content matches the local canonical
-  `SKILL.md`.
+  supported host only when that host's installed directory identifies local
+  ownership and its `SKILL.md` content matches the local canonical `SKILL.md`.
 - Canonical directory removed: bundled skills remove
   `<config-dir>/skills/bundled/<agent>/<skill>` for each installed agent, and
   local skills remove `<config-dir>/skills/local/<skill>`. Published skills

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -640,9 +640,10 @@ skills。
   本地安装移除。
 - 所有权规则：对内置 skill 来说，只有当某个受支持 Agent 中的安装目录包含能识别
   bundled 所有权的 `.oo-metadata.json` 时，才允许从该 Agent 移除。
-- 所有权规则：通过复制发布的本地 skill，只有当受支持 Agent 中的安装目录能识别
-  local 所有权，并且 `SKILL.md` 内容与本地 canonical `SKILL.md` 一致时，才会被视
-  为可移除的本地安装。
+- 所有权规则：通过复制发布的本地 skill，当受支持 Agent 中的安装目录能识别
+  local 所有权，并且 `SKILL.md` 内容与本地 canonical `SKILL.md` 一致时，会被视为
+  可移除的本地安装。同名 legacy local 副本即使没有 metadata，只要 `SKILL.md`
+  内容与本地 canonical `SKILL.md` 一致，也会被视为可移除的本地安装。
 - 会同时移除 canonical 目录：内置 skill 会移除
   `<config-dir>/skills/bundled/<agent>/<skill>`（每个已安装 Agent 各一份），
   本地 skill 会移除 `<config-dir>/skills/local/<skill>`，已发布 skill 会移除

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -313,7 +313,8 @@ skills。
   到且尚未安装它的受支持 Agent。
 - 本地 skill：如果某个本地 skill 已经有 canonical 副本
   `<config-dir>/skills/local/<skill-id>`，`oo` 会把该副本发布到任何新检测到且尚未
-  安装它的受支持 Agent。
+  安装它的受支持 Agent。静默启动同步不会覆盖 `SKILL.md` 内容不同的同名本地副本；
+  如需显式刷新，请运行 `oo skills add`。
 - 迁移：旧版本留下的 oo-managed 软链接目标，会在启动同步期间替换为复制目录。
 - 安全规则：启动同步不会请求 registry，不要求登录，不会产生额外命令输出，也
   不会覆盖不由 `oo` 管理的同名目标。
@@ -328,8 +329,9 @@ skills。
   `${CODEX_HOME:-~/.codex}/skills`、`~/.claude/skills`，以及
   `${HERMES_HOME:-~/.hermes}/skills`、`~/.codebuddy/skills`、
   `~/.workbuddy/skills`、`~/.trae/skills`、`~/.trae-cn/skills`、
-  `${OPENCLAW_HOME:-~/.openclaw}/skills`、`~/.qoderwork/skills`。只保留包含
-  可解析 `.oo-metadata.json` 且其中包含非空 `version` 的子目录。
+  `${OPENCLAW_HOME:-~/.openclaw}/skills`、`~/.qoderwork/skills`。只保留
+  `.oo-metadata.json` 能识别为由 oo 管理的 bundled、registry 或 local skill 的
+  子目录；已有的 legacy bundled 和 registry metadata 仍可读取。
 - local 所有权规则：命令会扫描 `<config-dir>/skills/local`，只保留
   `SKILL.md` frontmatter 中包含匹配的非空 `name` 和非空 `description` 的子目录。
 - 输出：文本输出会先打印摘要行，再为每个唯一的可见 skill 身份打印一个块。
@@ -374,6 +376,8 @@ skills。
 - 生成的 `SKILL.md` frontmatter 包含 `compatibility: "Requires the oo CLI."`。
 - 生成的 `SKILL.md` 正文包含受管理的 oo 执行说明，以及用于描述适用场景、输入、
   执行、结果处理和失败处理的可编辑占位章节。
+- 元数据：canonical 目录和每个复制到 Agent 的目标目录都会包含
+  `.oo-metadata.json`，用于标记该 skill 是由 `oo` 管理的 local skill。
 - 选项：`--icon <icon>` 将非空 icon 引用写入生成的 `SKILL.md` frontmatter
   `metadata.icon`。值可以是 emoji、图片 URL，或 `:collection:icon:` 格式，
   其中 `collection` 和 `icon` 是 <https://icones.js.org/> 上的名称。
@@ -419,8 +423,18 @@ skills。
   作为来源提示。可选值为 `codex`、`claude`、`hermes`、`codebuddy`、
   `workbuddy`、`trae`、`trae-cn`、`openclaw` 和 `qoderwork`。
 - 选项：`-y, --yes` 会对发布过程中的确认提示自动回答 yes。
+- 选项：`--force` 允许在 Agent 目录中存在 `SKILL.md` 内容不同的 oo-managed local
+  副本时，仍继续发布本地 canonical skill。`--force` 与 `-y, --yes` 相互独立；
+  自动回答确认提示并不代表忽略本地副本漂移。
 - 来源解析：命令会先检查 `<config-dir>/skills/local/<skill-id>`。如果存在，则发布
   这个本地 skill。
+- 本地来源规则：`<config-dir>/skills/local/<skill-id>` 是 local skill 的唯一可信
+  来源。Agent 目录中的内容只是复制出去的消费副本；只要 canonical 本地来源存在，
+  发布就不会把 Agent 目录当成来源。
+- 本地副本漂移：发布 local skill 前，命令会检查所有已存在受支持 Agent 目录中的
+  同名 oo-managed local 副本。如果任一副本的 `SKILL.md` 内容不同，默认会失败并
+  提示使用 `--force`。传入 `--force` 时，命令会继续发布 canonical 本地来源，并
+  打印 warning 说明 Agent 侧变更已被忽略。
 - 来源解析：内置 skill 会被拒绝发布，因为它们由 oo CLI 版本管理。
 - 来源解析：可以发布 `<config-dir>/skills/registry/<skill-id>` 下的 registry
   skill。如果已安装元数据中的包名和目标包名不同，命令会使用交互式 `[y/N]`
@@ -431,9 +445,10 @@ skills。
 - 来源解析：如果仍未匹配，`<skill-id>` 会按文件系统路径解析。匹配到的 skill
   目录会先被接管到本地 canonical 存储，再继续发布。
 - 接管：接管会把 skill 移动到 `<config-dir>/skills/local/<skill-id>`，将已有
-  `.oo-metadata.json` 字段导入 `SKILL.md` frontmatter，删除 `.oo-metadata.json`，
-  并把本地 canonical 副本发布到受支持的 Agent skill 目录。接管需要交互式 `[y/N]`
-  确认；提供 `-y, --yes` 时会跳过该确认。被接管的源目录不能包含符号链接。
+  registry `.oo-metadata.json` 中的包字段导入 `SKILL.md` frontmatter，写入 local
+  所有权 metadata，并把本地 canonical 副本发布到受支持的 Agent skill 目录。接管
+  需要交互式 `[y/N]` 确认；提供 `-y, --yes` 时会跳过该确认。被接管的源目录不能
+  包含符号链接。
 - 认证：命令要求存在当前 OOMOL 账号。包名始终为
   `@<小写 account.name>/<小写 skill-id>`。
 - 校验：源目录必须包含 `SKILL.md`，其 frontmatter `name` 必须匹配
@@ -445,6 +460,7 @@ skills。
   `metadata.version` 时，默认使用 `0.0.1`。
 - 包内容：skill 目录中的 `.gitignore` 决定哪些本地文件不会进入发布包。如果
   skill 没有 `.gitignore`，则使用内置的包模板规则。打包时会拒绝符号链接。
+  `.oo-metadata.json` 永远不会进入发布包。
 - Registry 安全检查：发布前，命令会查询远端 latest 包元数据。如果远端包已经
   包含 blocks，交互式终端会按既有 `[y/N]` 确认风格询问是否继续。回答 no、
   直接回车，或在没有交互式 stdin 的环境中运行，都会在转换、PUT 和本地 metadata
@@ -455,7 +471,8 @@ skills。
   非交互式运行必须传入 `--visibility`。
 - 版本解析：如果请求版本不大于远端 latest 包版本，命令会发布下一个 patch 版本。
 - 回写：发布步骤成功后，命令会把最终的 `metadata.packageName` 和
-  `metadata.version` 写回 `SKILL.md` frontmatter。
+  `metadata.version` 写回 `SKILL.md` frontmatter。local canonical 来源会保留 local
+  所有权 metadata；registry 来源会保留 registry 所有权 metadata。
 - 输出：成功时，文本输出会打印 skill id、最终包标识、所选可见性（`private`
   或 `public`）以及当前账号 endpoint 对应的 Hub 包页面 URL，例如生产账号使用
   `https://hub.oomol.com/package/<packageName>`。失败时命令以非零状态退出，并保持
@@ -483,7 +500,8 @@ skills。
 - 别名：`oo skills add [packageName]`。
 - 参数：`[packageName]` 可选。
 - 参数：未提供时，该命令会安装全部内置 skill，然后尽力安装预设 registry
-  skill packages 里的全部 skill。
+  skill packages 里的全部 skill，最后把 `<config-dir>/skills/local` 中的
+  canonical local skills 刷新到已存在的受支持 Agent。
 - 参数：当 `[packageName]` 为 `oo`、`oo-find-skills`、`oo-create-skill` 或
   `oo-publish-skill` 时，命令安装对应的内置 skill。
 - 参数：当 `[packageName]` 为已发布 package 名称时，命令从该 package 中
@@ -512,11 +530,14 @@ skills。
   `qoderwork`。
 - canonical 目录：已发布 skill 会先释放到
   `<config-dir>/skills/registry/<skill-id>`。
+- canonical 目录：local skill 从 `<config-dir>/skills/local/<skill-id>` 读取。这个
+  canonical 本地目录是唯一可信来源；Agent 目录中的内容只是复制出去的消费副本。
 - 迁移：升级后首次运行 `oo skills install` 时，命令会清理历史遗留的 canonical
   目录（`claude-skills/`、`openclaw-skills/`，以及直接位于 `skills/` 下的旧
   Codex 内置 / 已发布 skill 目录）。内置 skill 会自动以新布局重建；之前安装
   的已发布 skill 需要通过 `oo skills install <packageName>` 重新安装。
-- 目标目录：内置和已发布 skill 会发布到所有已存在的受支持 Agent 目录，目前包括
+- 目标目录：内置、已发布以及被刷新的 local skill 会发布到所有已存在的受支持
+  Agent 目录，目前包括
   `${CODEX_HOME:-~/.codex}/skills/<skill-id>` 和
   `~/.claude/skills/<skill-id>`，以及
   `${HERMES_HOME:-~/.hermes}/skills/<skill-id>`、
@@ -528,13 +549,19 @@ skills。
   `~/.qoderwork/skills/<skill-id>`。
 - 目标目录：当已存在的受支持 Agent 缺少 `skills` 根目录时，命令会先创建该目录，
   再发布所选 skill。
-- 安装方式：内置和已发布 skill 会复制到每个目标 skills 目录。旧版本留下的
-  oo-managed 软链接目标，会在同步、安装或更新该 skill 时替换为复制目录。
-- 元数据：内置 skill 会写入一个隐藏的 `.oo-metadata.json` 文件，其中
-  `version` 字段记录当前 `oo` 版本。
-- 元数据：已发布 skill 也会写入一个隐藏的 `.oo-metadata.json` 文件，
-  其中 `version` 字段记录 package 版本，`packageName` 字段记录来源
-  package。
+- 安装方式：内置、已发布以及被刷新的 local skill 会复制到每个目标 skills 目录。
+  旧版本留下的 oo-managed 软链接目标，会在同步、安装或更新该 skill 时替换为复制
+  目录。
+- local 刷新：对 local skill 来说，canonical 来源优先。已有的 oo-managed local
+  副本会被 canonical 来源覆盖；如果其 `SKILL.md` 内容不同，命令会先打印 warning。
+  没有 metadata 的同名目标只有在 `SKILL.md` 内容已经与 canonical local 来源一致时
+  才会被纳入管理并刷新。没有 metadata 且内容不同的目标，或由 bundled/registry
+  metadata 标记所有权的目标，都会被视为冲突，不会被 local 刷新路径覆盖。
+- 元数据：新写入的 bundled、registry 和 local skill 都会包含隐藏的
+  `.oo-metadata.json` 文件，记录 oo 来源标记和 schema version。bundled metadata
+  记录当前 `oo` 版本；registry metadata 记录来源 package 与 package 版本；
+  local metadata 记录 local 所有权。已有的 legacy bundled 和 registry metadata
+  仍可读取。
 - 说明：安装已发布 skill 时，所有 registry 请求都会携带当前激活账号的
   `Authorization` header。
 - 说明：如果 package 下有多个 skill，且当前不是交互终端，则必须提供
@@ -542,14 +569,14 @@ skills。
 - 说明：如果显式安装的已发布 skill 与现有同名 skill 冲突，命令会在交互终
   端中要求用户输入 `yes` 或 `no` 决定是否覆盖。
 - 说明：如果目标目录已存在但没有有效的 `oo` 元数据，会被视为非 OOMOL
-  skill，命令不会覆盖它。
+  skill，命令不会覆盖它；唯一例外是 local 刷新时，目标 `SKILL.md` 内容已经与
+  canonical 来源一致，可以被纳入管理。
 - 说明：在交互选择页面中，存在重名冲突的 skill 会在列表中显示状态标记；
   只要用户仍然选择该项，就会执行覆盖。
 - 说明：当 Codex、Claude Code、Hermes、CodeBuddy、WorkBuddy、Trae、Trae CN、
   OpenClaw 和 QoderWork 的受支持根目录都不存在时，命令会直接报错退出。
-- 说明：只有当 bundled skill 的 `.oo-metadata.json` 可以被解析，且其中包
-  含非空的 `version` 时，`oo` 才会认为这是自己管理的内置 skill；否则会视
-  为其他 skill，并拒绝覆盖。
+- 说明：只有当 bundled 或 registry skill 的 `.oo-metadata.json` 能识别对应来源
+  时，`oo` 才会认为这是自己管理的安装；否则会视为其他 skill，并拒绝覆盖。
 
 ### `oo skills sync upload`
 
@@ -560,8 +587,8 @@ skills。
 - 选项：`-i, --ignore <patterns...>` 会按 `packageName` 或 skill 名称匹配并排除
   部分 registry skill。该选项可以重复使用，每个值也可以包含逗号分隔的多个模式。
   模式使用 gitignore 风格匹配。
-- 范围：命令只上传 `.oo-metadata.json` 中同时包含 `packageName` 和 `version`
-  的已发布 registry skill；bundled 和 local skill 永远不会被上传。
+- 范围：命令只上传 `.oo-metadata.json` 能识别 registry 所有权和包身份的已发布
+  registry skill；bundled 和 local skill 永远不会被上传。
 - 请求：命令会发送 `PUT https://api.<endpoint>/v1/skills`，请求体是
   `{ "packageName": string, "version": string, "skillName": string }` 的 JSON
   数组，并携带当前账号的 `Authorization` header。
@@ -592,8 +619,8 @@ skills。
 - 内置 skill：bundled `oo`、`oo-find-skills`、`oo-create-skill`、
   `oo-publish-skill` 等内置 skill 不在此命令处理范围内。请使用
   `oo skills add` 刷新，或让成功的 `oo install` / `oo update` 自动刷新它们。
-- 所有权规则：只有当 skill 的 `.oo-metadata.json` 可以被解析，且包含非空
-  `version` 时，update 才会认为它由 oo 管理；否则会把现有目标视为非托管。
+- 所有权规则：只有当 skill 的 `.oo-metadata.json` 能识别 registry 所有权和包身份
+  时，update 才会认为它由 oo 管理；bundled 和 local metadata 会被该命令忽略。
 - 已发布 skill：registry skill 会从 `.oo-metadata.json` 读取所属包名，再通过
   不带显式版本的 package info 请求判断最新可用版本。
 - 更新顺序：命令会先刷新 canonical 目录
@@ -611,10 +638,11 @@ skills。
 - 参数：提供 `[skill]` 时，命令会同时检查本地 canonical 存储和已发布的
   registry 安装；如果两者都匹配同一个名称，会同时移除。registry 安装会先于
   本地安装移除。
-- 所有权规则：对内置 skill 来说，只有当某个受支持 Agent 中的安装目录包含可解
-  析且带有非空 `version` 的 `.oo-metadata.json` 时，才允许从该 Agent 移除。
-- 所有权规则：通过复制发布的本地 skill，如果受支持 Agent 中的 `SKILL.md`
-  内容与本地 canonical `SKILL.md` 一致，也会被视为可移除的本地安装。
+- 所有权规则：对内置 skill 来说，只有当某个受支持 Agent 中的安装目录包含能识别
+  bundled 所有权的 `.oo-metadata.json` 时，才允许从该 Agent 移除。
+- 所有权规则：通过复制发布的本地 skill，只有当受支持 Agent 中的安装目录能识别
+  local 所有权，并且 `SKILL.md` 内容与本地 canonical `SKILL.md` 一致时，才会被视
+  为可移除的本地安装。
 - 会同时移除 canonical 目录：内置 skill 会移除
   `<config-dir>/skills/bundled/<agent>/<skill>`（每个已安装 Agent 各一份），
   本地 skill 会移除 `<config-dir>/skills/local/<skill>`，已发布 skill 会移除

--- a/src/application/commands/skills/auto-sync.ts
+++ b/src/application/commands/skills/auto-sync.ts
@@ -18,6 +18,7 @@ import {
 } from "./bundled-skill-model.ts";
 import {
     directoryExists,
+    fileExists,
     isManagedBundledSkillInstallation,
     readInstalledBundledSkillMetadata,
 } from "./bundled-skill-observation.ts";
@@ -27,7 +28,13 @@ import {
 import {
     availableBundledSkillNames,
 } from "./embedded-assets.ts";
-import { readSkillFileContent } from "./local-skill-ownership.ts";
+import {
+    hasMatchingSkillFileHash,
+    isForeignManagedMetadataState,
+    readSkillFileHash,
+    readSkillMetadataFileState,
+    writeLocalSkillMetadata,
+} from "./local-skill-ownership.ts";
 import {
     resolveAvailableManagedSkillHosts,
     resolveManagedSkillHostInstallation,
@@ -53,9 +60,7 @@ interface ManagedSkillTargetState<Metadata> {
 }
 
 interface CanonicalRegistrySkill {
-    metadata: ManagedSkillMetadata & {
-        packageName: string;
-    };
+    metadata: ManagedSkillMetadata;
     name: string;
     path: string;
 }
@@ -398,6 +403,12 @@ async function synchronizeLocalSkill(
             return;
         }
 
+        // Canonical without SKILL.md indicates an aborted init; do not
+        // publish that incomplete state.
+        if (!(await fileExists(join(skill.path, "SKILL.md")))) {
+            return;
+        }
+
         if (await pathExists(installation.installedSkillDirectoryPath)) {
             if (!(await directoryExists(installation.installedSkillDirectoryPath))) {
                 context.logger.warn(
@@ -411,26 +422,30 @@ async function synchronizeLocalSkill(
                 return;
             }
 
-            const [canonicalContent, targetContent] = await Promise.all([
-                readSkillFileContent(skill.path),
-                readSkillFileContent(installation.installedSkillDirectoryPath),
-            ]);
+            const canonicalHash = await readSkillFileHash(skill.path);
 
-            // Canonical without SKILL.md indicates an aborted init; do not
-            // overwrite an existing target with that incomplete state.
-            if (canonicalContent === undefined) {
+            if (canonicalHash === undefined) {
                 return;
             }
 
-            if (canonicalContent !== targetContent) {
-                const metadata = await readManagedSkillMetadata(
-                    installation.installedSkillDirectoryPath,
-                );
+            const metadataState = await readSkillMetadataFileState(
+                installation.installedSkillDirectoryPath,
+            );
+            const targetMatchesCanonical = await hasMatchingSkillFileHash({
+                expectedHash: canonicalHash,
+                skillDirectoryPath: installation.installedSkillDirectoryPath,
+            });
 
-                // Registry-managed installations under the same skill name are
-                // owned by the registry sync path; local sync must not overwrite
-                // them.
-                if (metadata?.packageName !== undefined) {
+            if (!targetMatchesCanonical) {
+                if (metadataState.metadata?.kind === "local") {
+                    context.logger.warn(
+                        {
+                            agentName: installation.agentName,
+                            path: installation.installedSkillDirectoryPath,
+                            skillName: skill.name,
+                        },
+                        "Local skill startup synchronization skipped because the local target differs from canonical storage.",
+                    );
                     return;
                 }
 
@@ -444,16 +459,44 @@ async function synchronizeLocalSkill(
                 );
                 return;
             }
+            else if (isForeignManagedMetadataState(metadataState)) {
+                context.logger.warn(
+                    {
+                        agentName: installation.agentName,
+                        path: installation.installedSkillDirectoryPath,
+                        skillName: skill.name,
+                    },
+                    "Local skill startup synchronization skipped because the target belongs to another oo-managed source.",
+                );
+                return;
+            }
+            else if (metadataState.metadata?.kind === "local") {
+                if (
+                    await isManagedSkillPublicationCurrent(
+                        installation.installedSkillDirectoryPath,
+                    )
+                ) {
+                    return;
+                }
+            }
 
             if (
-                await isManagedSkillPublicationCurrent(
-                    installation.installedSkillDirectoryPath,
-                )
+                targetMatchesCanonical
+                && metadataState.metadata === undefined
+                && !metadataState.exists
             ) {
-                return;
+                context.logger.info(
+                    {
+                        agentName: installation.agentName,
+                        path: installation.installedSkillDirectoryPath,
+                        skillName: skill.name,
+                    },
+                    "Local skill startup synchronization adopted a legacy matching copy.",
+                );
             }
         }
 
+        await writeLocalSkillMetadata(skill.path);
         await publishBundledSkillInstallation({
             canonicalSkillDirectoryPath: skill.path,
             installedSkillDirectoryPath: installation.installedSkillDirectoryPath,
@@ -499,10 +542,7 @@ async function listCanonicalRegistrySkills(
             }
 
             return {
-                metadata: {
-                    packageName: metadata.packageName,
-                    version: metadata.version,
-                },
+                metadata,
                 name: entryName,
                 path: canonicalSkillDirectoryPath,
             } satisfies CanonicalRegistrySkill;

--- a/src/application/commands/skills/bundled-skill-model.test.ts
+++ b/src/application/commands/skills/bundled-skill-model.test.ts
@@ -6,15 +6,16 @@ import {
     parseBundledSkillMetadataContent,
     resolveBundledSkillInstallConflict,
 } from "./bundled-skill-model.ts";
+import { createBundledSkillMetadata } from "./skill-metadata.ts";
 
 describe("bundled skill model", () => {
     test("parses bundled skill metadata content", () => {
         expect(parseBundledSkillMetadataContent(
             `{"version":"${bundledSkillDevelopmentVersion}"}\n`,
-        )).toEqual({
-            version: bundledSkillDevelopmentVersion,
-        });
+        )).toEqual(createBundledSkillMetadata(bundledSkillDevelopmentVersion));
         expect(parseBundledSkillMetadataContent("{\"version\":\" 1.2.3 \"}\n")).toEqual({
+            kind: "bundled",
+            schemaVersion: 1,
             version: "1.2.3",
         });
         expect(parseBundledSkillMetadataContent("{\"version\":\"\"}\n")).toBeUndefined();

--- a/src/application/commands/skills/bundled-skill-model.ts
+++ b/src/application/commands/skills/bundled-skill-model.ts
@@ -1,8 +1,6 @@
-import { parseSkillMetadataWithVersion } from "./skill-metadata.ts";
+import type { BundledSkillMetadata } from "./skill-metadata.ts";
 
-export interface BundledSkillMetadata {
-    version: string;
-}
+import { parseSkillMetadataContent } from "./skill-metadata.ts";
 
 export const bundledSkillDevelopmentVersion = "0.0.0-development";
 
@@ -35,13 +33,11 @@ export function canUninstallManagedBundledSkillInstallation(input: {
 export function parseBundledSkillMetadataContent(
     content: string,
 ): BundledSkillMetadata | undefined {
-    const parsedMetadata = parseSkillMetadataWithVersion(content);
+    const parsedMetadata = parseSkillMetadataContent(content);
 
-    if (parsedMetadata === undefined) {
+    if (parsedMetadata?.kind !== "bundled") {
         return undefined;
     }
 
-    return {
-        version: parsedMetadata.version,
-    };
+    return parsedMetadata;
 }

--- a/src/application/commands/skills/bundled-skill-observation.test.ts
+++ b/src/application/commands/skills/bundled-skill-observation.test.ts
@@ -17,6 +17,10 @@ import {
     resolveTraeCnHomeDirectory,
     resolveTraeHomeDirectory,
 } from "./bundled-skill-paths.ts";
+import {
+    createBundledSkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
 
 describe("bundled skill observation", () => {
     test("reports directory and file existence from stat-backed wrappers", async () => {
@@ -57,11 +61,11 @@ describe("bundled skill observation", () => {
             await writeInstalledBundledSkillMetadata(skillDirectoryPath, {
                 version: "1.2.3",
             });
-            expect(await readInstalledBundledSkillMetadata(skillDirectoryPath)).toEqual({
-                version: "1.2.3",
-            });
+            expect(await readInstalledBundledSkillMetadata(skillDirectoryPath)).toEqual(
+                createBundledSkillMetadata("1.2.3"),
+            );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                "{\n  \"version\": \"1.2.3\"\n}\n",
+                renderSkillMetadataJson(createBundledSkillMetadata("1.2.3")),
             );
         }
         finally {

--- a/src/application/commands/skills/bundled-skill-observation.ts
+++ b/src/application/commands/skills/bundled-skill-observation.ts
@@ -1,5 +1,5 @@
-import type { BundledSkillMetadata } from "./bundled-skill-model.ts";
 import type { BundledSkillAgentName } from "./embedded-assets.ts";
+import type { BundledSkillMetadata } from "./skill-metadata.ts";
 
 import { readFile, stat } from "node:fs/promises";
 import { CliUserError } from "../../contracts/cli.ts";
@@ -12,7 +12,10 @@ import {
     resolveBundledSkillMetadataFilePath,
 } from "./bundled-skill-paths.ts";
 import { resolveManagedSkillHostMissingErrorKey } from "./managed-skill-host-errors.ts";
-import { renderSkillMetadataJson } from "./skill-metadata.ts";
+import {
+    createBundledSkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
 
 export async function requireBundledSkillHomeDirectory(
     context: Pick<{ env: Record<string, string | undefined> }, "env">,
@@ -98,10 +101,10 @@ export async function readInstalledBundledSkillMetadata(
 
 export async function writeInstalledBundledSkillMetadata(
     skillDirectoryPath: string,
-    metadata: BundledSkillMetadata,
+    metadata: Pick<BundledSkillMetadata, "version">,
 ): Promise<void> {
     await Bun.write(
         resolveBundledSkillMetadataFilePath(skillDirectoryPath),
-        renderSkillMetadataJson(metadata),
+        renderSkillMetadataJson(createBundledSkillMetadata(metadata.version)),
     );
 }

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -24,7 +24,10 @@ import {
     resolveManagedSkillCanonicalDirectoryPath,
     resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
-import { renderSkillMetadataJson } from "./skill-metadata.ts";
+import {
+    createBundledSkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
 
 describe("skills CLI", () => {
     test("requires login before installing published skills", async () => {
@@ -122,9 +125,7 @@ describe("skills CLI", () => {
             expect(result.stderr).toBe("");
             expect(result.stdout).toContain("Options:");
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({
-                    version: "9.9.9",
-                }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
             expect(await readFile(skillFilePath, "utf8")).toBe(
                 await readFile(getBundledSkillSourcePath("oo", "SKILL.md"), "utf8"),
@@ -181,7 +182,9 @@ describe("skills CLI", () => {
                         resolveBundledSkillMetadataFilePath(skillTarget.directoryPath),
                         "utf8",
                     ),
-                ).toBe(renderSkillMetadataJson({ version: installedVersion }));
+                ).toBe(renderSkillMetadataJson({
+                    version: installedVersion,
+                }));
             }
             expect(content).toContain(
                 `"msg":"Bundled skill startup synchronization skipped because the current CLI version is a development version."`,
@@ -416,7 +419,10 @@ describe("skills CLI", () => {
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(codexSkillDirectoryPath),
                 "utf8",
-            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }));
+            )).toBe(renderSkillMetadataJson({
+                packageName: "openai",
+                version: "0.0.3",
+            }));
             expect(content).toContain(
                 `"msg":"Registry skill synchronized during CLI startup."`,
             );

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -123,6 +123,8 @@ describe("skills commands", () => {
                 properties: {
                     bundled_skill: "__all__",
                     command_full: "skills.install",
+                    local_refresh_count_bucket: "0",
+                    local_refresh_performed: false,
                     package_kind: "bundled",
                     skill_ids_count_bucket: "1-5",
                     skill_ids_sample: [
@@ -354,6 +356,45 @@ describe("skills commands", () => {
             expect(await readFile(resolveManagedSkillMetadataFilePath(skillDirectoryPath), "utf8")).toBe(
                 renderSkillMetadataJson(createLocalSkillMetadata()),
             );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("refuses to overwrite a file at a local agent target during install", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillName = "file-target-helper";
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", skillName);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            skillName,
+        );
+
+        try {
+            await mkdir(join(codexHomeDirectory, "skills"), { recursive: true });
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(canonicalSkillDirectoryPath, "SKILL.md"),
+                createLocalSkillMarkdown(skillName, "Canonical helper.", "Canonical"),
+            );
+            await Bun.write(skillDirectoryPath, "occupied\n");
+
+            const result = await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toBe(
+                `Skill name ${skillName} is already used by a non-OOMOL skill at ${skillDirectoryPath}.\n`,
+            );
+            expect(await readFile(skillDirectoryPath, "utf8")).toBe("occupied\n");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -51,7 +51,12 @@ import {
     installedRegistrySkillCompatibility,
     renderOoPackageExecutionGuidance,
 } from "./registry-skill-markdown.ts";
-import { renderSkillMetadataJson } from "./skill-metadata.ts";
+import {
+    createBundledSkillMetadata,
+    createLocalSkillMetadata,
+    createRegistrySkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
 
 describe("skills commands", () => {
     const guidance = renderOoPackageExecutionGuidance();
@@ -167,16 +172,16 @@ describe("skills commands", () => {
                 ).toBe(await Bun.file(file.sourcePath).text());
             }
             expect(await readFile(ooMetadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: resultVersion }),
+                renderSkillMetadataJson(createBundledSkillMetadata(resultVersion)),
             );
             expect(await readFile(findSkillsMetadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: resultVersion }),
+                renderSkillMetadataJson(createBundledSkillMetadata(resultVersion)),
             );
             expect(await readFile(createSkillMetadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: resultVersion }),
+                renderSkillMetadataJson(createBundledSkillMetadata(resultVersion)),
             );
             expect(await readFile(publishSkillMetadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: resultVersion }),
+                renderSkillMetadataJson(createBundledSkillMetadata(resultVersion)),
             );
         }
         finally {
@@ -255,6 +260,205 @@ describe("skills commands", () => {
         }
     });
 
+    test("refreshes local canonical skills and overwrites drifted local agent copies", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillName = "local-helper";
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", skillName);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            skillName,
+        );
+        const canonicalSkillMarkdown = createLocalSkillMarkdown(
+            skillName,
+            "Canonical local helper.",
+            "Canonical",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), canonicalSkillMarkdown);
+            await Bun.write(
+                join(skillDirectoryPath, "SKILL.md"),
+                createLocalSkillMarkdown(skillName, "Agent local helper.", "Agent"),
+            );
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
+
+            const result = await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe(
+                `Warning: Local skill ${skillName} copy at ${skillDirectoryPath} differs from canonical storage and was overwritten.\n`,
+            );
+            expect(result.stdout).toContain(`Skills: oo, oo-find-skills, oo-create-skill, oo-publish-skill, ${skillName}`);
+            expect(await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8")).toBe(
+                canonicalSkillMarkdown,
+            );
+            expect(await readFile(resolveManagedSkillMetadataFilePath(skillDirectoryPath), "utf8")).toBe(
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
+            expect(await readFile(resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath), "utf8")).toBe(
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("adopts a matching legacy local agent copy during install", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillName = "legacy-local-helper";
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", skillName);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            skillName,
+        );
+        const skillMarkdown = createLocalSkillMarkdown(
+            skillName,
+            "Legacy local helper.",
+            "Legacy",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), skillMarkdown);
+            await Bun.write(join(skillDirectoryPath, "SKILL.md"), skillMarkdown);
+
+            const result = await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(await readFile(resolveManagedSkillMetadataFilePath(skillDirectoryPath), "utf8")).toBe(
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("refuses to overwrite an unmanaged conflicting local agent copy during install", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillName = "conflicting-local-helper";
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", skillName);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            skillName,
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(canonicalSkillDirectoryPath, "SKILL.md"),
+                createLocalSkillMarkdown(skillName, "Canonical helper.", "Canonical"),
+            );
+            await Bun.write(
+                join(skillDirectoryPath, "SKILL.md"),
+                createLocalSkillMarkdown(skillName, "Unmanaged helper.", "Unmanaged"),
+            );
+
+            const result = await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toBe(
+                `Skill name ${skillName} is already used by a non-OOMOL skill at ${skillDirectoryPath}.\n`,
+            );
+            expect(await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8")).toContain(
+                "Unmanaged helper.",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("refuses to overwrite a registry-owned local agent target during install", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillName = "registry-owned-helper";
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", skillName);
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            skillName,
+        );
+        const skillMarkdown = createLocalSkillMarkdown(
+            skillName,
+            "Canonical helper.",
+            "Canonical",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(canonicalSkillDirectoryPath, { recursive: true });
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), skillMarkdown);
+            await Bun.write(join(skillDirectoryPath, "SKILL.md"), skillMarkdown);
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+                renderSkillMetadataJson(createRegistrySkillMetadata({
+                    packageName: "registry-owned-helper",
+                    version: "1.0.0",
+                })),
+            );
+
+            const result = await sandbox.run(["skills", "install"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toBe(
+                `Skill name ${skillName} is already used by a non-OOMOL skill at ${skillDirectoryPath}.\n`,
+            );
+            expect(await readFile(resolveManagedSkillMetadataFilePath(skillDirectoryPath), "utf8")).toBe(
+                renderSkillMetadataJson(createRegistrySkillMetadata({
+                    packageName: "registry-owned-helper",
+                    version: "1.0.0",
+                })),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("colors compact bundled install summaries when stdout supports colors", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -315,7 +519,7 @@ describe("skills commands", () => {
                 canonicalSkillDirectoryPath,
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: resultVersion }),
+                renderSkillMetadataJson(createBundledSkillMetadata(resultVersion)),
             );
         }
         finally {
@@ -367,7 +571,7 @@ describe("skills commands", () => {
                 canonicalSkillDirectoryPath,
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: resultVersion }),
+                renderSkillMetadataJson(createBundledSkillMetadata(resultVersion)),
             );
             expect(await readFile(skillFilePath, "utf8")).toBe(
                 expectedSkillContent,
@@ -411,7 +615,7 @@ describe("skills commands", () => {
                 canonicalSkillDirectoryPath,
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: resultVersion }),
+                renderSkillMetadataJson(createBundledSkillMetadata(resultVersion)),
             );
         }
         finally {
@@ -452,7 +656,7 @@ describe("skills commands", () => {
                 canonicalSkillDirectoryPath,
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: resultVersion }),
+                renderSkillMetadataJson(createBundledSkillMetadata(resultVersion)),
             );
         }
         finally {
@@ -580,7 +784,7 @@ describe("skills commands", () => {
                 canonicalSkillDirectoryPath,
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: "9.9.9" }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
             await expect(
                 stat(join(skillDirectoryPath, "agents", "openai.yaml")),
@@ -632,7 +836,7 @@ describe("skills commands", () => {
             );
             expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: "9.9.9" }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
             const installedSkillMarkdown = await readFile(skillFilePath, "utf8");
 
@@ -682,7 +886,7 @@ describe("skills commands", () => {
             );
             expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: "9.9.9" }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
             await expect(
                 stat(join(skillDirectoryPath, "agents", "openai.yaml")),
@@ -739,7 +943,7 @@ describe("skills commands", () => {
                 canonicalSkillDirectoryPath,
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: "9.9.9" }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
             const installedSkillMarkdown = await readFile(skillFilePath, "utf8");
 
@@ -797,7 +1001,7 @@ describe("skills commands", () => {
             );
             expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: "9.9.9" }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
             expect(await readFile(skillFilePath, "utf8")).toBe(
                 await Bun.file(codeBuddySkillFile.sourcePath).text(),
@@ -852,7 +1056,7 @@ describe("skills commands", () => {
             );
             expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: "9.9.9" }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
             expect(await readFile(skillFilePath, "utf8")).toBe(
                 await Bun.file(workBuddySkillFile.sourcePath).text(),
@@ -912,7 +1116,7 @@ describe("skills commands", () => {
             );
             expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: "9.9.9" }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
             expect(await readFile(skillFilePath, "utf8")).toBe(
                 await Bun.file(traeSkillFile.sourcePath).text(),
@@ -972,7 +1176,7 @@ describe("skills commands", () => {
             );
             expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ version: "9.9.9" }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
             expect(await readFile(skillFilePath, "utf8")).toBe(
                 await Bun.file(traeCnSkillFile.sourcePath).text(),
@@ -1205,7 +1409,7 @@ describe("skills commands", () => {
             ]) {
                 await Bun.write(
                     resolveManagedSkillMetadataFilePath(skillDirectoryPath),
-                    renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
+                    renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.3" })),
                 );
                 await Bun.write(join(skillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
             }
@@ -1292,7 +1496,7 @@ describe("skills commands", () => {
             ]);
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(claudeSkillDirectoryPath),
-                renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
+                renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.3" })),
             );
             await Bun.write(join(claudeSkillDirectoryPath, "SKILL.md"), "# Registry\n");
             await Bun.write(join(registryCanonicalSkillDirectoryPath, "SKILL.md"), "# Registry\n");
@@ -1364,7 +1568,7 @@ describe("skills commands", () => {
             ]);
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(skillDirectoryPath),
-                renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
+                renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.3" })),
             );
             await Bun.write(join(skillDirectoryPath, "SKILL.md"), skillContent);
             await Bun.write(join(localCanonicalSkillDirectoryPath, "SKILL.md"), skillContent);
@@ -1472,7 +1676,7 @@ describe("skills commands", () => {
             await mkdir(escapedCanonicalSkillDirectoryPath, { recursive: true });
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(escapedSkillDirectoryPath),
-                renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
+                renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.3" })),
             );
             await Bun.write(installedSentinelPath, "installed\n");
             await Bun.write(canonicalSentinelPath, "canonical\n");
@@ -1713,7 +1917,7 @@ describe("skills commands", () => {
             });
             await Bun.write(
                 metadataFilePath,
-                renderSkillMetadataJson({ version: "9.9.9" }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
             await Bun.write(ownershipFilePath, "# OOMOL\n");
             await Bun.write(
@@ -1849,7 +2053,7 @@ describe("skills commands", () => {
                 ].join("\n"),
             );
             expect(await readFile(metadataFilePath, "utf8")).toBe(
-                renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
+                renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.3" })),
             );
             expect(requests).toHaveLength(2);
             expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
@@ -2329,7 +2533,7 @@ describe("skills commands", () => {
                     resolveManagedSkillMetadataFilePath(skillDirectoryPath),
                     "utf8",
                 )).toBe(
-                    renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
+                    renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.3" })),
                 );
             }
         }
@@ -2631,11 +2835,11 @@ describe("skills commands", () => {
             });
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
-                renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
+                renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.3" })),
             );
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath),
-                renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
+                renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.3" })),
             );
             await Bun.write(join(installedSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
             await Bun.write(join(canonicalSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
@@ -2958,4 +3162,20 @@ async function expectCopiedSkillDirectory(
         await realpath(canonicalSkillDirectoryPath),
     );
     expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
+}
+
+function createLocalSkillMarkdown(
+    skillName: string,
+    description: string,
+    heading: string,
+): string {
+    return [
+        "---",
+        `name: ${skillName}`,
+        `description: ${description}`,
+        "---",
+        "",
+        `# ${heading}`,
+        "",
+    ].join("\n");
 }

--- a/src/application/commands/skills/init.test.ts
+++ b/src/application/commands/skills/init.test.ts
@@ -18,6 +18,10 @@ import {
     installedRegistrySkillCompatibility,
     renderOoPackageExecutionGuidance,
 } from "./registry-skill-markdown.ts";
+import {
+    createLocalSkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
 
 describe("skills init command", () => {
     test("initializes a local skill and publishes it to existing supported hosts", async () => {
@@ -62,11 +66,12 @@ describe("skills init command", () => {
                 await realpath(canonicalSkillDirectoryPath),
             );
             expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
-            await expect(
-                stat(join(canonicalSkillDirectoryPath, ".oo-metadata.json")),
-            ).rejects.toMatchObject({
-                code: "ENOENT",
-            });
+            expect(await readFile(join(canonicalSkillDirectoryPath, ".oo-metadata.json"), "utf8")).toBe(
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
+            expect(await readFile(join(skillDirectoryPath, ".oo-metadata.json"), "utf8")).toBe(
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
             expect(
                 await readFile(join(canonicalSkillDirectoryPath, "SKILL.md"), "utf8"),
             ).toBe([

--- a/src/application/commands/skills/init.ts
+++ b/src/application/commands/skills/init.ts
@@ -19,6 +19,7 @@ import {
     resolveBundledSkillHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import { availableBundledSkillAgentNames } from "./embedded-assets.ts";
+import { writeLocalSkillMetadata } from "./local-skill-ownership.ts";
 import {
     isLocalSkillPathContained,
     resolveLocalSkillCanonicalDirectoryPath,
@@ -165,6 +166,7 @@ async function initializeLocalSkill(
             join(canonicalSkillDirectoryPath, "SKILL.md"),
             renderInitializedSkillMarkdown(skillName, description, icon, title),
         );
+        await writeLocalSkillMetadata(canonicalSkillDirectoryPath);
 
         for (const target of targets) {
             await publishBundledSkillInstallation({

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -6,6 +6,7 @@ import type { BundledSkillName } from "./embedded-assets.ts";
 
 import type { ManagedSkillInstallSummary } from "./install-output.ts";
 import { z } from "zod";
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
 import { writeManagedSkillInstallSummary } from "./install-output.ts";
 import { migrateLegacyCanonicalSkillLayout } from "./legacy-canonical-migration.ts";
@@ -80,7 +81,18 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
             }
 
             summaries.push(...await installPresetSkillPackages(context));
-            summaries.push(...await publishCanonicalLocalSkillsToAvailableHosts(context));
+            const localRefreshSummaries = await publishCanonicalLocalSkillsToAvailableHosts(
+                context,
+            );
+
+            context.telemetry?.recordProperties({
+                local_refresh_count_bucket: bucketTelemetryCount(
+                    localRefreshSummaries.length,
+                ),
+                local_refresh_performed: localRefreshSummaries.length > 0,
+            });
+
+            summaries.push(...localRefreshSummaries);
             writeManagedSkillInstallSummary(context, summaries);
             return;
         }

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -9,6 +9,9 @@ import { z } from "zod";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
 import { writeManagedSkillInstallSummary } from "./install-output.ts";
 import { migrateLegacyCanonicalSkillLayout } from "./legacy-canonical-migration.ts";
+import {
+    publishCanonicalLocalSkillsToAvailableHosts,
+} from "./local-skill-publication.ts";
 import { installRegistrySkills } from "./registry-skill-install.ts";
 import { installBundledSkill, isBundledSkillName } from "./shared.ts";
 import { createSkillIdsTelemetryProperties } from "./telemetry.ts";
@@ -77,6 +80,7 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
             }
 
             summaries.push(...await installPresetSkillPackages(context));
+            summaries.push(...await publishCanonicalLocalSkillsToAvailableHosts(context));
             writeManagedSkillInstallSummary(context, summaries);
             return;
         }

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -114,23 +114,30 @@ describe("skills list CLI", () => {
             expect(initResult.exitCode).toBe(0);
             expect(allSourcesResult.exitCode).toBe(0);
             expect(allSourcesResult.stderr).toBe("");
-            expect(allSourcesResult.stdout).toContain("campaign-writer\n");
-            expect(allSourcesResult.stdout).toContain("  Source: local\n");
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
-            expect(result.stdout).toBe(
-                [
-                    "✓ Found 1 skills.",
-                    "",
-                    "campaign-writer",
-                    "  Host: CodeBuddy",
-                    "  Source: local",
-                    "  Package: <local>",
-                    "  Version: unknown",
-                    `  Path: ${canonicalSkillDirectoryPath}`,
-                    "",
-                ].join("\n"),
-            );
+            const expectedOutput = [
+                "✓ Found 1 skills.",
+                "",
+                "campaign-writer",
+                "  Host: CodeBuddy",
+                "  Source: local",
+                "  Package: <local>",
+                "  Version: unknown",
+                `  Path: ${canonicalSkillDirectoryPath}`,
+                "",
+            ].join("\n");
+
+            expect(allSourcesResult.stdout.split("\ncampaign-writer\n")).toHaveLength(2);
+            expect(allSourcesResult.stdout).toContain([
+                "campaign-writer",
+                "  Host: CodeBuddy",
+                "  Source: local",
+                "  Package: <local>",
+                "  Version: unknown",
+                `  Path: ${canonicalSkillDirectoryPath}`,
+            ].join("\n"));
+            expect(result.stdout).toBe(expectedOutput);
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/list.test.ts
+++ b/src/application/commands/skills/list.test.ts
@@ -8,7 +8,11 @@ import {
     listLocalSkillInstallations,
     listManagedSkillInstallations,
 } from "./list.ts";
-import { renderSkillMetadataJson } from "./skill-metadata.ts";
+import {
+    createBundledSkillMetadata,
+    createRegistrySkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
 
 describe("skills list command helpers", () => {
     test("lists bundled skills before the remaining sorted names", async () => {
@@ -29,10 +33,10 @@ describe("skills list command helpers", () => {
 
             await Bun.write(
                 join(zebraSkillDirectoryPath, ".oo-metadata.json"),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/zebra",
                     version: "2.0.0",
-                }),
+                })),
             );
             await Bun.write(
                 join(alphaSkillDirectoryPath, ".oo-metadata.json"),
@@ -40,15 +44,11 @@ describe("skills list command helpers", () => {
             );
             await Bun.write(
                 join(ooSkillDirectoryPath, ".oo-metadata.json"),
-                renderSkillMetadataJson({
-                    version: "9.9.9",
-                }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
             await Bun.write(
                 join(ooFindSkillsDirectoryPath, ".oo-metadata.json"),
-                renderSkillMetadataJson({
-                    version: "9.9.9",
-                }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
 
             await expect(
@@ -56,7 +56,8 @@ describe("skills list command helpers", () => {
             ).resolves.toEqual([
                 {
                     metadata: {
-                        packageName: undefined,
+                        kind: "bundled",
+                        schemaVersion: 1,
                         version: "9.9.9",
                     },
                     name: "oo",
@@ -64,7 +65,8 @@ describe("skills list command helpers", () => {
                 },
                 {
                     metadata: {
-                        packageName: undefined,
+                        kind: "bundled",
+                        schemaVersion: 1,
                         version: "9.9.9",
                     },
                     name: "oo-find-skills",
@@ -77,7 +79,9 @@ describe("skills list command helpers", () => {
                 },
                 {
                     metadata: {
+                        kind: "registry",
                         packageName: "@oomol/zebra",
+                        schemaVersion: 1,
                         version: "2.0.0",
                     },
                     name: "zebra-skill",
@@ -102,17 +106,17 @@ describe("skills list command helpers", () => {
 
             await Bun.write(
                 join(alphaSkillDirectoryPath, ".oo-metadata.json"),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/alpha",
                     version: "1.0.0",
-                }),
+                })),
             );
             await Bun.write(
                 join(ooFindSkillsDirectoryPath, ".oo-metadata.json"),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/find-skills",
                     version: "1.0.0",
-                }),
+                })),
             );
 
             await expect(
@@ -120,7 +124,9 @@ describe("skills list command helpers", () => {
             ).resolves.toEqual([
                 {
                     metadata: {
+                        kind: "registry",
                         packageName: "@oomol/alpha",
+                        schemaVersion: 1,
                         version: "1.0.0",
                     },
                     name: "alpha-skill",
@@ -128,7 +134,9 @@ describe("skills list command helpers", () => {
                 },
                 {
                     metadata: {
+                        kind: "registry",
                         packageName: "@oomol/find-skills",
+                        schemaVersion: 1,
                         version: "1.0.0",
                     },
                     name: "oo-find-skills",

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -201,8 +201,8 @@ async function listSkillOutputItems(
     );
 
     return groupSkillListInstallationsByIdentity([
-        ...managedInstallations.map(createManagedSkillOutputItem),
         ...localOutputItems,
+        ...managedInstallations.map(createManagedSkillOutputItem),
     ]);
 }
 
@@ -290,7 +290,10 @@ function groupSkillListInstallationsByIdentity(
         }
 
         appendUniqueValues(group.hostNames, installation.hostNames);
-        appendUniqueValues(group.paths, installation.paths);
+
+        if (group.source !== "local") {
+            appendUniqueValues(group.paths, installation.paths);
+        }
     }
 
     return groups.sort(compareSkillListOutputItems);
@@ -557,6 +560,10 @@ function readManagedSkillListSource(
     skill: Pick<ManagedSkillListItem, "metadata" | "name" | "source">,
 ): SkillListSource {
     if (skill.source === "local") {
+        return "local";
+    }
+
+    if (skill.metadata?.kind === "local") {
         return "local";
     }
 

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -6,8 +6,11 @@ import type {
     ManagedSkillHostInstallation,
 } from "./managed-skill-hosts.ts";
 
-import type { ManagedSkillMetadata } from "./managed-skill-metadata.ts";
 import type { SkillMarkdownMatter } from "./skill-frontmatter.ts";
+import type {
+    RegistrySkillMetadata,
+    SkillMetadata,
+} from "./skill-metadata.ts";
 import { readdir, readFile, realpath } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
@@ -27,7 +30,6 @@ import {
     resolveAvailableManagedSkillHosts,
     resolveManagedSkillHostInstallations,
 } from "./managed-skill-hosts.ts";
-import { parseManagedSkillMetadataContent } from "./managed-skill-metadata.ts";
 import {
     isPathWithinDirectory,
     resolveLocalSkillCanonicalRootDirectoryPath,
@@ -41,6 +43,7 @@ import {
     parseSkillMarkdownMatter,
     toNonBlankString,
 } from "./skill-frontmatter.ts";
+import { parseSkillMetadataContent } from "./skill-metadata.ts";
 
 const managedSkillNameColor = "#59F78D";
 const managedSkillSourceColor = "#CAA8FA";
@@ -69,7 +72,7 @@ const managedSkillHostOrder = {
 type SkillListSource = (typeof skillListSourceValues)[number];
 
 export interface ManagedSkillListItem {
-    metadata?: ManagedSkillMetadata;
+    metadata?: SkillMetadata;
     name: string;
     path: string;
     source?: "local";
@@ -81,22 +84,29 @@ export interface ManagedSkillHostListItem extends ManagedSkillListItem {
 
 interface SkillListOutputItem {
     hostNames: BundledSkillAgentName[];
-    metadata?: ManagedSkillMetadata;
+    metadata?: SkillListDisplayMetadata;
     name: string;
     paths: string[];
     source: SkillListSource;
 }
 
 interface SkillListSortableItem {
-    metadata?: ManagedSkillMetadata;
+    metadata?: SkillListDisplayMetadata;
     name: string;
     source?: SkillListSource;
 }
 
 export interface LocalSkillListItem {
-    metadata?: ManagedSkillMetadata;
+    metadata?: SkillListDisplayMetadata;
     name: string;
     path: string;
+}
+
+interface SkillListDisplayMetadata {
+    icon?: string;
+    kind?: SkillMetadata["kind"];
+    packageName?: string;
+    version?: string;
 }
 
 type ManagedSkillListTextContext = Pick<CliExecutionContext, "stdout" | "translator">;
@@ -203,7 +213,7 @@ function createManagedSkillOutputItem(
 
     return {
         hostNames: [installation.hostName],
-        metadata: installation.metadata,
+        metadata: createSkillListDisplayMetadata(installation.metadata),
         name: installation.name,
         paths: [installation.path],
         source,
@@ -331,7 +341,7 @@ export async function listManagedSkillInstallations(
             }
 
             return {
-                metadata: parseManagedSkillMetadataContent(metadataContent),
+                metadata: parseSkillMetadataContent(metadataContent),
                 name: entryName,
                 path: skillDirectoryPath,
                 source: await readManagedSkillLocalSource(
@@ -550,11 +560,15 @@ function readManagedSkillListSource(
         return "local";
     }
 
-    if (skill.metadata?.packageName === undefined && isBundledSkillName(skill.name)) {
+    if (skill.metadata?.kind === "bundled") {
         return "bundled";
     }
 
-    return "registry";
+    if (skill.metadata?.kind === "registry") {
+        return "registry";
+    }
+
+    return isBundledSkillName(skill.name) ? "bundled" : "registry";
 }
 
 function readSkillListHostName(
@@ -649,6 +663,39 @@ function readBundledSkillNameOrder(
     }
 
     return availableBundledSkillNames.indexOf(skill.name);
+}
+
+function createSkillListDisplayMetadata(
+    metadata: SkillMetadata | undefined,
+): SkillListDisplayMetadata | undefined {
+    if (metadata === undefined) {
+        return undefined;
+    }
+
+    switch (metadata.kind) {
+        case "bundled":
+            return {
+                kind: metadata.kind,
+                version: metadata.version,
+            };
+        case "local":
+            return {
+                kind: metadata.kind,
+            };
+        case "registry":
+            return createRegistrySkillListDisplayMetadata(metadata);
+    }
+}
+
+function createRegistrySkillListDisplayMetadata(
+    metadata: RegistrySkillMetadata,
+): SkillListDisplayMetadata {
+    return {
+        ...(metadata.icon === undefined ? {} : { icon: metadata.icon }),
+        kind: metadata.kind,
+        packageName: metadata.packageName,
+        version: metadata.version,
+    };
 }
 
 async function readManagedSkillLocalSource(

--- a/src/application/commands/skills/local-skill-ownership.test.ts
+++ b/src/application/commands/skills/local-skill-ownership.test.ts
@@ -1,0 +1,66 @@
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
+import {
+    writeLocalSkillMetadata,
+} from "./local-skill-ownership.ts";
+import { resolveManagedSkillMetadataFilePath } from "./managed-skill-paths.ts";
+import {
+    createRegistrySkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
+
+describe("local skill ownership", () => {
+    test("does not overwrite registry metadata when writing local metadata", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-local-skill-ownership");
+        const skillDirectoryPath = join(rootDirectory, "registry-owned");
+        const metadataFilePath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
+        const metadataContent = renderSkillMetadataJson(createRegistrySkillMetadata({
+            packageName: "@alice/registry-owned",
+            version: "1.0.0",
+        }));
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(metadataFilePath, metadataContent);
+
+            await expect(writeLocalSkillMetadata(skillDirectoryPath)).rejects.toMatchObject({
+                key: "errors.skills.nameConflict",
+                params: {
+                    name: "registry-owned",
+                    path: skillDirectoryPath,
+                },
+            });
+            expect(await readFile(metadataFilePath, "utf8")).toBe(metadataContent);
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("does not overwrite unparseable metadata when writing local metadata", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-local-skill-ownership");
+        const skillDirectoryPath = join(rootDirectory, "invalid-owned");
+        const metadataFilePath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(metadataFilePath, "{\n");
+
+            await expect(writeLocalSkillMetadata(skillDirectoryPath)).rejects.toMatchObject({
+                key: "errors.skills.nameConflict",
+                params: {
+                    name: "invalid-owned",
+                    path: skillDirectoryPath,
+                },
+            });
+            expect(await readFile(metadataFilePath, "utf8")).toBe("{\n");
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+});

--- a/src/application/commands/skills/local-skill-ownership.ts
+++ b/src/application/commands/skills/local-skill-ownership.ts
@@ -5,8 +5,9 @@ import type {
 
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
+import { CliUserError } from "../../contracts/cli.ts";
 import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
 import { resolveManagedSkillMetadataFilePath } from "./managed-skill-paths.ts";
 import {
@@ -114,7 +115,17 @@ export async function writeLocalSkillMetadata(
     const desiredContent = renderSkillMetadataJson(createLocalSkillMetadata());
 
     try {
-        if (await readFile(metadataFilePath, "utf8") === desiredContent) {
+        const currentContent = await readFile(metadataFilePath, "utf8");
+        const currentMetadata = parseSkillMetadataContent(currentContent);
+
+        if (currentMetadata?.kind !== "local") {
+            throw new CliUserError("errors.skills.nameConflict", 1, {
+                name: basename(skillDirectoryPath),
+                path: skillDirectoryPath,
+            });
+        }
+
+        if (currentContent === desiredContent) {
             return;
         }
     }

--- a/src/application/commands/skills/local-skill-ownership.ts
+++ b/src/application/commands/skills/local-skill-ownership.ts
@@ -1,7 +1,19 @@
+import type {
+    LocalSkillMetadata,
+    SkillMetadata,
+} from "./skill-metadata.ts";
+
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
+import { resolveManagedSkillMetadataFilePath } from "./managed-skill-paths.ts";
+import {
+    createLocalSkillMetadata,
+    parseSkillMetadataContent,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
 
 export async function readSkillFileContent(
     skillDirectoryPath: string,
@@ -24,4 +36,93 @@ export async function hasMatchingSkillFileContent(options: {
 }): Promise<boolean> {
     return await readSkillFileContent(options.skillDirectoryPath)
         === options.expectedContent;
+}
+
+export async function readSkillFileHash(
+    skillDirectoryPath: string,
+): Promise<string | undefined> {
+    const content = await readSkillFileContent(skillDirectoryPath);
+
+    if (content === undefined) {
+        return undefined;
+    }
+
+    return createHash("sha256").update(content).digest("hex");
+}
+
+export async function hasMatchingSkillFileHash(options: {
+    expectedHash: string;
+    skillDirectoryPath: string;
+}): Promise<boolean> {
+    return await readSkillFileHash(options.skillDirectoryPath)
+        === options.expectedHash;
+}
+
+export async function readSkillMetadataFileState(
+    skillDirectoryPath: string,
+): Promise<{
+    exists: boolean;
+    metadata: SkillMetadata | undefined;
+}> {
+    try {
+        const content = await readFile(
+            resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+            "utf8",
+        );
+
+        return {
+            exists: true,
+            metadata: parseSkillMetadataContent(content),
+        };
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return {
+                exists: false,
+                metadata: undefined,
+            };
+        }
+
+        throw error;
+    }
+}
+
+export async function readLocalSkillMetadata(
+    skillDirectoryPath: string,
+): Promise<LocalSkillMetadata | undefined> {
+    const metadata = (await readSkillMetadataFileState(skillDirectoryPath)).metadata;
+
+    return metadata?.kind === "local" ? metadata : undefined;
+}
+
+// True when the metadata at the target identifies an oo-managed source
+// other than a local skill (bundled, registry, or a metadata file present
+// but unparseable).
+export function isForeignManagedMetadataState(state: {
+    exists: boolean;
+    metadata: SkillMetadata | undefined;
+}): boolean {
+    return state.metadata?.kind === "bundled"
+        || state.metadata?.kind === "registry"
+        || (state.exists && state.metadata === undefined);
+}
+
+export async function writeLocalSkillMetadata(
+    skillDirectoryPath: string,
+): Promise<void> {
+    const metadataFilePath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
+    const desiredContent = renderSkillMetadataJson(createLocalSkillMetadata());
+
+    try {
+        if (await readFile(metadataFilePath, "utf8") === desiredContent) {
+            return;
+        }
+    }
+    catch (error) {
+        if (!isNodeNotFoundError(error)) {
+            throw error;
+        }
+    }
+
+    await Bun.write(metadataFilePath, desiredContent);
 }

--- a/src/application/commands/skills/local-skill-publication.ts
+++ b/src/application/commands/skills/local-skill-publication.ts
@@ -10,6 +10,7 @@ import type {
 
 import { readdir } from "node:fs/promises";
 import { CliUserError } from "../../contracts/cli.ts";
+import { pathExists } from "../../shared/fs-utils.ts";
 import { writeLine } from "../shared/output.ts";
 import {
     isNodeNotFoundError,
@@ -213,8 +214,15 @@ async function shouldPublishLocalSkillToTarget(options: {
     installation: ManagedSkillHostInstallation;
     skillName: string;
 }): Promise<boolean> {
-    if (!(await directoryExists(options.installation.installedSkillDirectoryPath))) {
+    if (!(await pathExists(options.installation.installedSkillDirectoryPath))) {
         return true;
+    }
+
+    if (!(await directoryExists(options.installation.installedSkillDirectoryPath))) {
+        throw new CliUserError("errors.skills.nameConflict", 1, {
+            name: options.skillName,
+            path: options.installation.installedSkillDirectoryPath,
+        });
     }
 
     const metadataState = await readSkillMetadataFileState(

--- a/src/application/commands/skills/local-skill-publication.ts
+++ b/src/application/commands/skills/local-skill-publication.ts
@@ -1,0 +1,302 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+import type {
+    ManagedSkillInstallPublication,
+    ManagedSkillInstallSummary,
+} from "./install-output.ts";
+import type {
+    ManagedSkillHost,
+    ManagedSkillHostInstallation,
+} from "./managed-skill-hosts.ts";
+
+import { readdir } from "node:fs/promises";
+import { CliUserError } from "../../contracts/cli.ts";
+import { writeLine } from "../shared/output.ts";
+import {
+    isNodeNotFoundError,
+    publishBundledSkillInstallation,
+} from "./bundled-skill-filesystem.ts";
+import { directoryExists } from "./bundled-skill-observation.ts";
+import {
+    hasMatchingSkillFileHash,
+    isForeignManagedMetadataState,
+    readSkillFileHash,
+    readSkillMetadataFileState,
+    writeLocalSkillMetadata,
+} from "./local-skill-ownership.ts";
+import {
+    resolveAvailableManagedSkillHosts,
+    resolveManagedSkillHostInstallations,
+} from "./managed-skill-hosts.ts";
+import {
+    isLocalSkillPathContained,
+    resolveLocalSkillCanonicalDirectoryPath,
+    resolveLocalSkillCanonicalRootDirectoryPath,
+} from "./managed-skill-paths.ts";
+import {
+    isManagedSkillPublicationCurrent,
+} from "./managed-skill-publication.ts";
+
+export interface DriftedLocalSkillCopy {
+    agentName: ManagedSkillHostInstallation["agentName"];
+    path: string;
+}
+
+type LocalSkillPublicationContext = Pick<
+    CliExecutionContext,
+    "env" | "logger" | "settingsStore" | "stderr" | "translator"
+>;
+
+export async function publishCanonicalLocalSkillsToAvailableHosts(
+    context: LocalSkillPublicationContext,
+): Promise<ManagedSkillInstallSummary[]> {
+    const hosts = await resolveAvailableManagedSkillHosts(context.env);
+
+    if (hosts.length === 0) {
+        return [];
+    }
+
+    const settingsFilePath = context.settingsStore.getFilePath();
+    const skillNames = await listCanonicalLocalSkillNames(settingsFilePath);
+
+    return (
+        await Promise.all(skillNames.map(skillName =>
+            publishCanonicalLocalSkillToHosts({
+                context,
+                hosts,
+                settingsFilePath,
+                skillName,
+            }),
+        ))
+    ).filter(summary => summary.publications.length > 0);
+}
+
+export async function findDriftedLocalSkillCopies(options: {
+    context: Pick<CliExecutionContext, "env" | "settingsStore">;
+    skillName: string;
+}): Promise<DriftedLocalSkillCopy[]> {
+    const hosts = await resolveAvailableManagedSkillHosts(options.context.env);
+    const settingsFilePath = options.context.settingsStore.getFilePath();
+    const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+        settingsFilePath,
+        options.skillName,
+    );
+    const canonicalHash = await readSkillFileHash(canonicalSkillDirectoryPath);
+
+    if (canonicalHash === undefined) {
+        return [];
+    }
+
+    const hostInstallations = resolveManagedSkillHostInstallations(
+        hosts,
+        options.skillName,
+    );
+    const driftedCopies = await Promise.all(
+        hostInstallations.map(async (installation) => {
+            const metadata = (await readSkillMetadataFileState(
+                installation.installedSkillDirectoryPath,
+            )).metadata;
+
+            if (metadata?.kind !== "local") {
+                return undefined;
+            }
+
+            if (
+                await hasMatchingSkillFileHash({
+                    expectedHash: canonicalHash,
+                    skillDirectoryPath: installation.installedSkillDirectoryPath,
+                })
+            ) {
+                return undefined;
+            }
+
+            return {
+                agentName: installation.agentName,
+                path: installation.installedSkillDirectoryPath,
+            } satisfies DriftedLocalSkillCopy;
+        }),
+    );
+
+    return driftedCopies.filter(copy => copy !== undefined);
+}
+
+export async function publishCanonicalLocalSkillToHosts(options: {
+    context: LocalSkillPublicationContext;
+    hosts: readonly ManagedSkillHost[];
+    settingsFilePath: string;
+    skillName: string;
+}): Promise<ManagedSkillInstallSummary> {
+    const canonicalSkillDirectoryPath = resolveLocalSkillCanonicalDirectoryPath(
+        options.settingsFilePath,
+        options.skillName,
+    );
+    const canonicalHash = await readSkillFileHash(canonicalSkillDirectoryPath);
+
+    if (canonicalHash === undefined) {
+        return {
+            name: options.skillName,
+            publications: [],
+        };
+    }
+
+    await writeLocalSkillMetadata(canonicalSkillDirectoryPath);
+
+    const publications = await Promise.all(
+        resolveManagedSkillHostInstallations(options.hosts, options.skillName)
+            .map(installation =>
+                publishCanonicalLocalSkillToHost({
+                    canonicalHash,
+                    canonicalSkillDirectoryPath,
+                    context: options.context,
+                    installation,
+                    settingsFilePath: options.settingsFilePath,
+                    skillName: options.skillName,
+                }),
+            ),
+    );
+
+    return {
+        name: options.skillName,
+        publications: publications.filter(publication => publication !== undefined),
+    };
+}
+
+async function publishCanonicalLocalSkillToHost(options: {
+    canonicalHash: string;
+    canonicalSkillDirectoryPath: string;
+    context: LocalSkillPublicationContext;
+    installation: ManagedSkillHostInstallation;
+    settingsFilePath: string;
+    skillName: string;
+}): Promise<ManagedSkillInstallPublication | undefined> {
+    if (
+        !isLocalSkillPathContained(
+            options.installation.homeDirectory,
+            options.settingsFilePath,
+            options.skillName,
+        )
+    ) {
+        throw new CliUserError("errors.skills.invalidPath", 1, {
+            name: options.skillName,
+        });
+    }
+
+    const shouldPublish = await shouldPublishLocalSkillToTarget(options);
+
+    if (!shouldPublish) {
+        return undefined;
+    }
+
+    await publishBundledSkillInstallation({
+        canonicalSkillDirectoryPath: options.canonicalSkillDirectoryPath,
+        installedSkillDirectoryPath: options.installation.installedSkillDirectoryPath,
+    });
+
+    options.context.logger.info(
+        {
+            agentName: options.installation.agentName,
+            canonicalPath: options.canonicalSkillDirectoryPath,
+            path: options.installation.installedSkillDirectoryPath,
+            skillName: options.skillName,
+        },
+        "Local skill published from canonical storage.",
+    );
+
+    return {
+        agentName: options.installation.agentName,
+        path: options.installation.installedSkillDirectoryPath,
+    };
+}
+
+async function shouldPublishLocalSkillToTarget(options: {
+    canonicalHash: string;
+    context: LocalSkillPublicationContext;
+    installation: ManagedSkillHostInstallation;
+    skillName: string;
+}): Promise<boolean> {
+    if (!(await directoryExists(options.installation.installedSkillDirectoryPath))) {
+        return true;
+    }
+
+    const metadataState = await readSkillMetadataFileState(
+        options.installation.installedSkillDirectoryPath,
+    );
+
+    if (isForeignManagedMetadataState(metadataState)) {
+        throw new CliUserError("errors.skills.nameConflict", 1, {
+            name: options.skillName,
+            path: options.installation.installedSkillDirectoryPath,
+        });
+    }
+
+    const hasMatchingHash = await hasMatchingSkillFileHash({
+        expectedHash: options.canonicalHash,
+        skillDirectoryPath: options.installation.installedSkillDirectoryPath,
+    });
+
+    if (metadataState.metadata?.kind === "local") {
+        if (!hasMatchingHash) {
+            writeLocalSkillDriftWarning(options);
+            return true;
+        }
+
+        return !(await isManagedSkillPublicationCurrent(
+            options.installation.installedSkillDirectoryPath,
+        ));
+    }
+
+    if (hasMatchingHash) {
+        return true;
+    }
+
+    throw new CliUserError("errors.skills.nameConflict", 1, {
+        name: options.skillName,
+        path: options.installation.installedSkillDirectoryPath,
+    });
+}
+
+function writeLocalSkillDriftWarning(options: {
+    context: LocalSkillPublicationContext;
+    installation: ManagedSkillHostInstallation;
+    skillName: string;
+}): void {
+    options.context.logger.warn(
+        {
+            agentName: options.installation.agentName,
+            path: options.installation.installedSkillDirectoryPath,
+            skillName: options.skillName,
+        },
+        "Local skill copy differs from canonical storage and will be overwritten.",
+    );
+
+    writeLine(
+        options.context.stderr,
+        options.context.translator.t("warnings.skills.localCopyDriftOverwritten", {
+            name: options.skillName,
+            path: options.installation.installedSkillDirectoryPath,
+        }),
+    );
+}
+
+async function listCanonicalLocalSkillNames(
+    settingsFilePath: string,
+): Promise<string[]> {
+    const rootDirectoryPath = resolveLocalSkillCanonicalRootDirectoryPath(
+        settingsFilePath,
+    );
+
+    try {
+        const entries = await readdir(rootDirectoryPath, { withFileTypes: true });
+
+        return entries
+            .filter(entry => entry.isDirectory() || entry.isSymbolicLink())
+            .map(entry => entry.name)
+            .sort();
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return [];
+        }
+
+        throw error;
+    }
+}

--- a/src/application/commands/skills/managed-skill-metadata.test.ts
+++ b/src/application/commands/skills/managed-skill-metadata.test.ts
@@ -3,20 +3,20 @@ import { describe, expect, test } from "bun:test";
 import {
     parseManagedSkillMetadataContent,
 } from "./managed-skill-metadata.ts";
-import { renderSkillMetadataJson } from "./skill-metadata.ts";
+import {
+    createRegistrySkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
 
 describe("managed skill metadata", () => {
-    test("parses version-only metadata", () => {
+    test("rejects version-only bundled metadata", () => {
         expect(
             parseManagedSkillMetadataContent(
                 JSON.stringify({
                     version: "1.2.3",
                 }),
             ),
-        ).toEqual({
-            packageName: undefined,
-            version: "1.2.3",
-        });
+        ).toBeUndefined();
     });
 
     test("parses package-backed metadata", () => {
@@ -27,10 +27,10 @@ describe("managed skill metadata", () => {
                     version: "1.2.3",
                 }),
             ),
-        ).toEqual({
+        ).toEqual(createRegistrySkillMetadata({
             packageName: "@foo/bar",
             version: "1.2.3",
-        });
+        }));
     });
 
     test("rejects metadata with an empty version", () => {
@@ -57,13 +57,17 @@ describe("managed skill metadata", () => {
     test("renders metadata with packageName when present", () => {
         expect(
             renderSkillMetadataJson({
+                kind: "registry",
                 packageName: "openai",
+                schemaVersion: 1,
                 version: "0.0.3",
             }),
         ).toBe(
             [
                 "{",
+                "  \"kind\": \"registry\",",
                 "  \"packageName\": \"openai\",",
+                "  \"schemaVersion\": 1,",
                 "  \"version\": \"0.0.3\"",
                 "}",
                 "",

--- a/src/application/commands/skills/managed-skill-metadata.ts
+++ b/src/application/commands/skills/managed-skill-metadata.ts
@@ -1,63 +1,31 @@
+import type { RegistrySkillMetadata } from "./skill-metadata.ts";
+
 import { readFile } from "node:fs/promises";
 import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
 import { resolveManagedSkillMetadataFilePath } from "./managed-skill-paths.ts";
 import {
-    parseSkillMetadataWithVersion,
+    createRegistrySkillMetadata,
+    parseSkillMetadataContent,
     renderSkillMetadataJson,
 } from "./skill-metadata.ts";
 
-export interface ManagedSkillMetadata {
-    icon?: string;
-    packageName?: string;
-    version: string;
-}
+export type { RegistrySkillMetadata as ManagedSkillMetadata } from "./skill-metadata.ts";
 
 export function parseManagedSkillMetadataContent(
     content: string,
-): ManagedSkillMetadata | undefined {
-    const parsedMetadata = parseSkillMetadataWithVersion(content);
+): RegistrySkillMetadata | undefined {
+    const parsedMetadata = parseSkillMetadataContent(content);
 
-    if (parsedMetadata === undefined) {
+    if (parsedMetadata?.kind !== "registry") {
         return undefined;
     }
-    const rawPackageName = parsedMetadata.fields.packageName;
-    const rawIcon = parsedMetadata.fields.icon;
-    let icon: string | undefined;
-    let packageName: string | undefined;
 
-    if (rawIcon !== undefined) {
-        if (typeof rawIcon !== "string" || rawIcon.trim() === "") {
-            return undefined;
-        }
-
-        icon = rawIcon;
-    }
-
-    if (rawPackageName !== undefined) {
-        if (typeof rawPackageName !== "string" || rawPackageName.trim() === "") {
-            return undefined;
-        }
-
-        packageName = rawPackageName;
-    }
-
-    if (icon !== undefined) {
-        return {
-            icon,
-            packageName,
-            version: parsedMetadata.version,
-        };
-    }
-
-    return {
-        packageName,
-        version: parsedMetadata.version,
-    };
+    return parsedMetadata;
 }
 
 export async function readManagedSkillMetadata(
     skillDirectoryPath: string,
-): Promise<ManagedSkillMetadata | undefined> {
+): Promise<RegistrySkillMetadata | undefined> {
     try {
         return parseManagedSkillMetadataContent(
             await readFile(
@@ -77,10 +45,10 @@ export async function readManagedSkillMetadata(
 
 export async function writeManagedSkillMetadata(
     skillDirectoryPath: string,
-    metadata: ManagedSkillMetadata,
+    metadata: Pick<RegistrySkillMetadata, "icon" | "packageName" | "version">,
 ): Promise<void> {
     await Bun.write(
         resolveManagedSkillMetadataFilePath(skillDirectoryPath),
-        renderSkillMetadataJson(metadata),
+        renderSkillMetadataJson(createRegistrySkillMetadata(metadata)),
     );
 }

--- a/src/application/commands/skills/managed-skill-uninstall.ts
+++ b/src/application/commands/skills/managed-skill-uninstall.ts
@@ -18,8 +18,9 @@ import {
 } from "./bundled-skill-observation.ts";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
 import {
-    hasMatchingSkillFileContent,
-    readSkillFileContent,
+    hasMatchingSkillFileHash,
+    readLocalSkillMetadata,
+    readSkillFileHash,
 } from "./local-skill-ownership.ts";
 import {
     createMissingManagedSkillHostError,
@@ -482,7 +483,7 @@ async function resolveLocalSkillUninstallTargets(options: {
         return targets;
     }
 
-    const localSkillFileContent = await readSkillFileContent(
+    const localSkillFileHash = await readSkillFileHash(
         options.canonicalSkillDirectoryPath,
     );
 
@@ -496,9 +497,12 @@ async function resolveLocalSkillUninstallTargets(options: {
         }
 
         if (
-            localSkillFileContent !== undefined
-            && await hasMatchingSkillFileContent({
-                expectedContent: localSkillFileContent,
+            localSkillFileHash !== undefined
+            && await readLocalSkillMetadata(
+                installation.installedSkillDirectoryPath,
+            ) !== undefined
+            && await hasMatchingSkillFileHash({
+                expectedHash: localSkillFileHash,
                 skillDirectoryPath: installation.installedSkillDirectoryPath,
             })
         ) {

--- a/src/application/commands/skills/managed-skill-uninstall.ts
+++ b/src/application/commands/skills/managed-skill-uninstall.ts
@@ -19,8 +19,8 @@ import {
 import { availableBundledSkillNames } from "./embedded-assets.ts";
 import {
     hasMatchingSkillFileHash,
-    readLocalSkillMetadata,
     readSkillFileHash,
+    readSkillMetadataFileState,
 } from "./local-skill-ownership.ts";
 import {
     createMissingManagedSkillHostError,
@@ -496,16 +496,22 @@ async function resolveLocalSkillUninstallTargets(options: {
             continue;
         }
 
-        if (
-            localSkillFileHash !== undefined
-            && await readLocalSkillMetadata(
-                installation.installedSkillDirectoryPath,
-            ) !== undefined
-            && await hasMatchingSkillFileHash({
-                expectedHash: localSkillFileHash,
-                skillDirectoryPath: installation.installedSkillDirectoryPath,
-            })
-        ) {
+        if (localSkillFileHash === undefined) {
+            continue;
+        }
+
+        const metadataState = await readSkillMetadataFileState(
+            installation.installedSkillDirectoryPath,
+        );
+
+        if (metadataState.exists && metadataState.metadata?.kind !== "local") {
+            continue;
+        }
+
+        if (await hasMatchingSkillFileHash({
+            expectedHash: localSkillFileHash,
+            skillDirectoryPath: installation.installedSkillDirectoryPath,
+        })) {
             targets.push(installation);
         }
     }

--- a/src/application/commands/skills/package-conversion.test.ts
+++ b/src/application/commands/skills/package-conversion.test.ts
@@ -268,6 +268,45 @@ describe("skill package conversion", () => {
         ).not.toContain("icon:");
     });
 
+    test("excludes oo metadata even when a skill gitignore does not exclude it", async () => {
+        const sourceDirectoryPath = await createTemporaryDirectory("metadata-skill");
+        const packageRootDirectoryPath = await createTemporaryDirectory("metadata-package");
+
+        cleanup.track(sourceDirectoryPath);
+        cleanup.track(packageRootDirectoryPath);
+
+        await writeSkillFile(sourceDirectoryPath, [
+            "---",
+            "name: metadata-skill",
+            "description: Use a known package workflow.",
+            "---",
+            "",
+            "# Metadata",
+            "",
+        ].join("\n"));
+        await Bun.write(join(sourceDirectoryPath, ".gitignore"), "debug.local\n");
+        await Bun.write(
+            join(sourceDirectoryPath, ".oo-metadata.json"),
+            "{ \"kind\": \"local\", \"schemaVersion\": 1 }\n",
+        );
+
+        await convertSkillDirectoryToPackage({
+            packageName: "@alice/metadata-skill",
+            packageRootDirectoryPath,
+            skillDirectoryPath: sourceDirectoryPath,
+            skillId: "metadata-skill",
+            version: "0.0.1",
+        });
+
+        await expectPathMissing(join(
+            packageRootDirectoryPath,
+            "package",
+            "skills",
+            "metadata-skill",
+            ".oo-metadata.json",
+        ));
+    });
+
     test("uses source gitignore rules when converting a skill package", async () => {
         const sourceDirectoryPath = await createTemporaryDirectory("gitignore-skill");
         const packageRootDirectoryPath = await createTemporaryDirectory("gitignore-package");

--- a/src/application/commands/skills/package-conversion.ts
+++ b/src/application/commands/skills/package-conversion.ts
@@ -15,6 +15,9 @@ import { isSemver } from "../../semver.ts";
 import { isFileMissingError } from "../../shared/fs-errors.ts";
 import { getUnexpectedRequestErrorMessage } from "../shared/request.ts";
 import {
+    managedSkillMetadataFileName,
+} from "./managed-skill-paths.ts";
+import {
     skillPackageGitAttributesTemplate,
     skillPackageGitIgnoreTemplate,
 } from "./package-templates.ts";
@@ -147,6 +150,10 @@ export async function convertSkillDirectoryToPackage(
 
             if (sourceRelativePath === "") {
                 return true;
+            }
+
+            if (sourceRelativePath === managedSkillMetadataFileName) {
+                return false;
             }
 
             const metadata = await lstat(sourcePath);
@@ -668,6 +675,10 @@ async function isIgnoredPackageSkillPath(
 
     if (skillPath === undefined || skillPath.relativePath === "") {
         return false;
+    }
+
+    if (skillPath.relativePath === managedSkillMetadataFileName) {
+        return true;
     }
 
     const skillPackageIgnore = await readPackageSkillIgnore(

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -41,7 +41,10 @@ import {
 } from "./managed-skill-paths.ts";
 import { publishLocalSkillPackage, publishSkillPackage } from "./publish.ts";
 import { parseSkillMarkdownMatter } from "./skill-frontmatter.ts";
-import { renderSkillMetadataJson } from "./skill-metadata.ts";
+import {
+    createLocalSkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
 
 const emptyCatalog: CliCatalog = {
     name: "oo",
@@ -127,6 +130,134 @@ describe("skills publish command", () => {
                     visibility: "private",
                 },
             });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails before publishing when a local agent copy has drifted", async () => {
+        const skillId = "drifted-skill";
+        const { sandbox, skillDirectoryPath } = await createCliPublishSkillSandbox(
+            skillId,
+            [
+                "---",
+                `name: ${skillId}`,
+                "description: Use the canonical workflow.",
+                "---",
+                "",
+                "# Canonical",
+                "",
+            ].join("\n"),
+        );
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const agentSkillDirectoryPath = resolveManagedSkillDirectoryPath(
+            codexHomeDirectory,
+            skillId,
+        );
+        const requests: Request[] = [];
+
+        try {
+            await writeSkillFile(agentSkillDirectoryPath, [
+                "---",
+                `name: ${skillId}`,
+                "description: Use the drifted workflow.",
+                "---",
+                "",
+                "# Agent",
+                "",
+            ].join("\n"));
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(agentSkillDirectoryPath),
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
+
+            const result = await sandbox.run(
+                ["skills", "publish", skillId, "--visibility", "private"],
+                {
+                    fetcher: (input, init) => {
+                        requests.push(toRequest(input, init));
+                        return Promise.resolve(new Response("", { status: 201 }));
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                `Local skill ${skillId} has modified agent copies at ${agentSkillDirectoryPath}. Publishing uses canonical storage at ${skillDirectoryPath}; pass --force to ignore agent-side changes.\n`,
+            );
+            expect(requests).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("publishes canonical local content with --force when a local agent copy has drifted", async () => {
+        const skillId = "force-drifted-skill";
+        const { sandbox, skillDirectoryPath } = await createCliPublishSkillSandbox(
+            skillId,
+            [
+                "---",
+                `name: ${skillId}`,
+                "description: Use the canonical workflow.",
+                "---",
+                "",
+                "# Canonical",
+                "",
+            ].join("\n"),
+        );
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const agentSkillDirectoryPath = resolveManagedSkillDirectoryPath(
+            codexHomeDirectory,
+            skillId,
+        );
+        const requests: Request[] = [];
+
+        try {
+            await writeSkillFile(agentSkillDirectoryPath, [
+                "---",
+                `name: ${skillId}`,
+                "description: Use the drifted workflow.",
+                "---",
+                "",
+                "# Agent",
+                "",
+            ].join("\n"));
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(agentSkillDirectoryPath),
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
+
+            const result = await sandbox.run(
+                ["skills", "publish", skillId, "--visibility", "private", "--force"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.url.includes("/-/oomol/package-info/")) {
+                            return new Response("not found", { status: 404 });
+                        }
+
+                        return new Response("", { status: 201 });
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                `Published skill ${skillId} as private package @alice/${skillId}@0.0.1.`,
+            );
+            expect(result.stderr).toBe(
+                `Warning: Local skill ${skillId} has modified agent copies at ${agentSkillDirectoryPath}; publishing canonical storage at ${skillDirectoryPath} and ignoring agent-side changes.\n`,
+            );
+            expect(requests.map(request => request.method)).toEqual(["GET", "PUT"]);
+            expect(
+                await readFile(join(agentSkillDirectoryPath, "SKILL.md"), "utf8"),
+            ).toContain("# Agent");
         }
         finally {
             await sandbox.cleanup();
@@ -487,9 +618,9 @@ describe("skills publish command", () => {
             expect(result.stdout).toContain(
                 "Published skill agent-skill as private package @alice/agent-skill@0.3.0.",
             );
-            await expect(stat(resolveManagedSkillMetadataFilePath(localSkillDirectoryPath)))
-                .rejects
-                .toMatchObject({ code: "ENOENT" });
+            expect(await readFile(resolveManagedSkillMetadataFilePath(localSkillDirectoryPath), "utf8")).toBe(
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
 
             const parsed = parseSkillMarkdownMatter(
                 await readFile(join(localSkillDirectoryPath, "SKILL.md"), "utf8"),

--- a/src/application/commands/skills/publish.ts
+++ b/src/application/commands/skills/publish.ts
@@ -38,6 +38,10 @@ import {
     confirmInteractiveValue,
     selectInteractiveValue,
 } from "./interactive-prompts.ts";
+import { writeLocalSkillMetadata } from "./local-skill-ownership.ts";
+import {
+    findDriftedLocalSkillCopies,
+} from "./local-skill-publication.ts";
 import { createMissingManagedSkillHostError } from "./managed-skill-hosts.ts";
 import {
     parseManagedSkillMetadataContent,
@@ -61,6 +65,7 @@ import {
 
 interface SkillsPublishInput {
     agent?: string;
+    force?: boolean;
     skill: string;
     visibility?: string;
     yes?: boolean;
@@ -77,6 +82,7 @@ interface PublishLocalSkillPackageResult {
 
 interface PublishSkillPackageOptions {
     agentName?: BundledSkillAgentName;
+    force?: boolean;
     yes?: boolean;
 }
 
@@ -160,6 +166,11 @@ export const skillsPublishCommand: CliCommandDefinition<SkillsPublishInput> = {
             descriptionKey: "options.agent",
         },
         {
+            name: "force",
+            longFlag: "--force",
+            descriptionKey: "options.force",
+        },
+        {
             name: "visibility",
             longFlag: "--visibility",
             valueName: "visibility",
@@ -174,6 +185,7 @@ export const skillsPublishCommand: CliCommandDefinition<SkillsPublishInput> = {
     ],
     inputSchema: z.object({
         agent: z.string().optional(),
+        force: z.boolean().optional(),
         skill: z.string(),
         visibility: z.string().optional(),
         yes: z.boolean().optional(),
@@ -188,6 +200,7 @@ export const skillsPublishCommand: CliCommandDefinition<SkillsPublishInput> = {
             visibility,
             {
                 agentName,
+                force: input.force === true,
                 yes: input.yes === true,
             },
         );
@@ -235,6 +248,7 @@ export async function publishLocalSkillPackage(
     const packageName = resolveCanonicalSkillPackageName(account.name, skillId);
     context.telemetry?.recordProperties({
         adopted: false,
+        force: false,
         package_name: packageName,
         skill_id: skillId,
         source_kind: "local",
@@ -243,9 +257,11 @@ export async function publishLocalSkillPackage(
     return await publishResolvedSkillPackage(
         {
             account,
+            force: false,
             packageName,
             skillDirectoryPath,
             skillId,
+            sourceKind: "local",
             yes: false,
         },
         context,
@@ -265,6 +281,7 @@ export async function publishSkillPackage(
         agentName: options.agentName,
     });
     const yes = options.yes === true;
+    const force = options.force === true;
     const checkAuthoringEnvironment
         = dependencies.checkAuthoringEnvironment ?? checkLocalSkillAuthoringEnvironment;
     const requireAccount = dependencies.requireCurrentAccount ?? requireCurrentAccount;
@@ -275,6 +292,7 @@ export async function publishSkillPackage(
     const packageName = resolveCanonicalSkillPackageName(account.name, source.skillId);
     context.telemetry?.recordProperties({
         adopted: source.kind === "adoptable",
+        force,
         package_name: packageName,
         skill_id: source.skillId,
         source_kind: source.kind,
@@ -292,9 +310,11 @@ export async function publishSkillPackage(
     return await publishResolvedSkillPackage(
         {
             account,
+            force,
             packageName,
             skillDirectoryPath: publishSource.skillDirectoryPath,
             skillId: publishSource.skillId,
+            sourceKind: publishSource.kind,
             yes,
         },
         context,
@@ -306,9 +326,11 @@ export async function publishSkillPackage(
 async function publishResolvedSkillPackage(
     request: {
         account: AuthAccount;
+        force: boolean;
         packageName: string;
         skillDirectoryPath: string;
         skillId: string;
+        sourceKind: "local" | "registry";
         yes: boolean;
     },
     context: CliExecutionContext,
@@ -339,6 +361,16 @@ async function publishResolvedSkillPackage(
         skillDirectoryPath: request.skillDirectoryPath,
         skillId: request.skillId,
     });
+    if (request.sourceKind === "local") {
+        await validateLocalSkillCopiesBeforePublish({
+            context,
+            force: request.force,
+            localSkillDirectoryPath: request.skillDirectoryPath,
+            skillId: request.skillId,
+        });
+        await writeLocalSkillMetadata(request.skillDirectoryPath);
+    }
+
     const publishPlan = await resolveFinalPublishPlan({
         account: request.account,
         context,
@@ -389,6 +421,49 @@ async function publishResolvedSkillPackage(
         visibility: publishPlan.visibility,
         version: publishPlan.version,
     };
+}
+
+async function validateLocalSkillCopiesBeforePublish(options: {
+    context: CliExecutionContext;
+    force: boolean;
+    localSkillDirectoryPath: string;
+    skillId: string;
+}): Promise<void> {
+    const driftedCopies = await findDriftedLocalSkillCopies({
+        context: options.context,
+        skillName: options.skillId,
+    });
+
+    if (driftedCopies.length === 0) {
+        return;
+    }
+
+    const paths = driftedCopies.map(copy => copy.path).join(", ");
+
+    options.context.logger.warn(
+        {
+            paths: driftedCopies.map(copy => copy.path),
+            skillName: options.skillId,
+        },
+        "Local skill publish found agent copies that differ from canonical storage.",
+    );
+
+    if (!options.force) {
+        throw new CliUserError("errors.skills.publish.localCopyDrift", 1, {
+            localPath: options.localSkillDirectoryPath,
+            name: options.skillId,
+            paths,
+        });
+    }
+
+    writeLine(
+        options.context.stderr,
+        options.context.translator.t("warnings.skills.publishLocalCopyDriftIgnored", {
+            localPath: options.localSkillDirectoryPath,
+            name: options.skillId,
+            paths,
+        }),
+    );
 }
 
 function parseSkillPublishAgent(
@@ -811,6 +886,7 @@ async function adoptSkillPublishSource(
             options.source.skillId,
         );
         await importManagedMetadataToSkillFrontmatter(options.localSkillDirectoryPath);
+        await writeLocalSkillMetadata(options.localSkillDirectoryPath);
         await validateAdoptedLocalSkill(options.localSkillDirectoryPath, options.source.skillId);
 
         writeLine(

--- a/src/application/commands/skills/skill-metadata.test.ts
+++ b/src/application/commands/skills/skill-metadata.test.ts
@@ -1,11 +1,61 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+    createBundledSkillMetadata,
+    createLocalSkillMetadata,
+    createRegistrySkillMetadata,
+    parseSkillMetadataContent,
     parseSkillMetadataWithVersion,
     renderSkillMetadataJson,
 } from "./skill-metadata.ts";
 
 describe("skill metadata", () => {
+    test("parses typed metadata by kind", () => {
+        expect(parseSkillMetadataContent(JSON.stringify({
+            kind: "bundled",
+            schemaVersion: 1,
+            version: "1.2.3",
+        }))).toEqual(createBundledSkillMetadata("1.2.3"));
+        expect(parseSkillMetadataContent(JSON.stringify({
+            kind: "registry",
+            packageName: "@foo/bar",
+            schemaVersion: 1,
+            version: "2.0.0",
+        }))).toEqual(createRegistrySkillMetadata({
+            packageName: "@foo/bar",
+            version: "2.0.0",
+        }));
+        expect(parseSkillMetadataContent(JSON.stringify({
+            kind: "local",
+            schemaVersion: 1,
+        }))).toEqual(createLocalSkillMetadata());
+    });
+
+    test("parses legacy untyped metadata at the parser boundary", () => {
+        expect(parseSkillMetadataContent("{\"version\":\" 1.2.3 \"}\n")).toEqual(
+            createBundledSkillMetadata("1.2.3"),
+        );
+        expect(parseSkillMetadataContent(JSON.stringify({
+            packageName: "@foo/bar",
+            version: "2.0.0",
+        }))).toEqual(createRegistrySkillMetadata({
+            packageName: "@foo/bar",
+            version: "2.0.0",
+        }));
+    });
+
+    test("rejects unsupported typed metadata", () => {
+        expect(parseSkillMetadataContent(JSON.stringify({
+            kind: "local",
+            schemaVersion: 2,
+        }))).toBeUndefined();
+        expect(parseSkillMetadataContent(JSON.stringify({
+            kind: "registry",
+            packageName: "@foo/bar",
+            schemaVersion: 1,
+        }))).toBeUndefined();
+    });
+
     test("parses metadata when version is present and trims surrounding whitespace", () => {
         expect(parseSkillMetadataWithVersion("{\"version\":\" 1.2.3 \"}\n")).toEqual({
             fields: {

--- a/src/application/commands/skills/skill-metadata.ts
+++ b/src/application/commands/skills/skill-metadata.ts
@@ -1,11 +1,117 @@
+import { toNonBlankString } from "./skill-frontmatter.ts";
+
+export const skillMetadataSchemaVersion = 1;
+
+export interface BundledSkillMetadata {
+    kind: "bundled";
+    schemaVersion: typeof skillMetadataSchemaVersion;
+    version: string;
+}
+
+export interface RegistrySkillMetadata {
+    icon?: string;
+    kind: "registry";
+    packageName: string;
+    schemaVersion: typeof skillMetadataSchemaVersion;
+    version: string;
+}
+
+export interface LocalSkillMetadata {
+    kind: "local";
+    schemaVersion: typeof skillMetadataSchemaVersion;
+}
+
+export type SkillMetadata
+    = | BundledSkillMetadata
+        | LocalSkillMetadata
+        | RegistrySkillMetadata;
+
 export interface ParsedSkillMetadataWithVersion {
     fields: Readonly<Record<string, unknown>>;
     version: string;
 }
 
+export function createBundledSkillMetadata(
+    version: string,
+): BundledSkillMetadata {
+    return {
+        kind: "bundled",
+        schemaVersion: skillMetadataSchemaVersion,
+        version,
+    };
+}
+
+export function createRegistrySkillMetadata(options: {
+    icon?: string;
+    packageName: string;
+    version: string;
+}): RegistrySkillMetadata {
+    return {
+        ...(options.icon === undefined ? {} : { icon: options.icon }),
+        kind: "registry",
+        packageName: options.packageName,
+        schemaVersion: skillMetadataSchemaVersion,
+        version: options.version,
+    };
+}
+
+export function createLocalSkillMetadata(): LocalSkillMetadata {
+    return {
+        kind: "local",
+        schemaVersion: skillMetadataSchemaVersion,
+    };
+}
+
+export function parseSkillMetadataContent(
+    content: string,
+): SkillMetadata | undefined {
+    const fields = parseSkillMetadataFields(content);
+
+    if (fields === undefined) {
+        return undefined;
+    }
+
+    const typedMetadata = parseTypedSkillMetadata(fields);
+
+    if (typedMetadata !== undefined) {
+        return typedMetadata;
+    }
+
+    // TODO: Remove legacy untyped metadata parsing after existing installs have migrated.
+    return parseRegistrySkillMetadataFields(fields)
+        ?? parseLegacyBundledSkillMetadata(fields);
+}
+
 export function parseSkillMetadataWithVersion(
     content: string,
 ): ParsedSkillMetadataWithVersion | undefined {
+    const fields = parseSkillMetadataFields(content);
+
+    if (fields === undefined) {
+        return undefined;
+    }
+
+    const version = toNonBlankString(fields.version);
+
+    if (version === undefined) {
+        return undefined;
+    }
+
+    return {
+        fields,
+        version,
+    };
+}
+
+export function renderSkillMetadataJson(
+    metadata: object,
+): string {
+    return `${JSON.stringify(metadata, null, 2)}\n`;
+}
+
+function parseSkillMetadataFields(
+    content: string,
+): Record<string, unknown> | undefined {
     let parsedContent: unknown;
 
     try {
@@ -23,27 +129,69 @@ export function parseSkillMetadataWithVersion(
         return undefined;
     }
 
-    const fields = parsedContent as Record<string, unknown>;
-    const rawVersion = fields.version;
-
-    if (typeof rawVersion !== "string") {
-        return undefined;
-    }
-
-    const version = rawVersion.trim();
-
-    if (version === "") {
-        return undefined;
-    }
-
-    return {
-        fields,
-        version,
-    };
+    return parsedContent as Record<string, unknown>;
 }
 
-export function renderSkillMetadataJson(
-    metadata: object,
-): string {
-    return `${JSON.stringify(metadata, null, 2)}\n`;
+function parseTypedSkillMetadata(
+    fields: Readonly<Record<string, unknown>>,
+): SkillMetadata | undefined {
+    if (fields.schemaVersion !== skillMetadataSchemaVersion) {
+        return undefined;
+    }
+
+    switch (fields.kind) {
+        case "bundled":
+            return parseBundledSkillMetadataFields(fields);
+        case "registry":
+            return parseRegistrySkillMetadataFields(fields);
+        case "local":
+            return createLocalSkillMetadata();
+        default:
+            return undefined;
+    }
+}
+
+function parseBundledSkillMetadataFields(
+    fields: Readonly<Record<string, unknown>>,
+): BundledSkillMetadata | undefined {
+    const version = toNonBlankString(fields.version);
+
+    if (version === undefined) {
+        return undefined;
+    }
+
+    return createBundledSkillMetadata(version);
+}
+
+function parseRegistrySkillMetadataFields(
+    fields: Readonly<Record<string, unknown>>,
+): RegistrySkillMetadata | undefined {
+    const packageName = toNonBlankString(fields.packageName);
+    const version = toNonBlankString(fields.version);
+
+    if (packageName === undefined || version === undefined) {
+        return undefined;
+    }
+
+    if (fields.icon !== undefined) {
+        const icon = toNonBlankString(fields.icon);
+
+        if (icon === undefined) {
+            return undefined;
+        }
+
+        return createRegistrySkillMetadata({ icon, packageName, version });
+    }
+
+    return createRegistrySkillMetadata({ packageName, version });
+}
+
+function parseLegacyBundledSkillMetadata(
+    fields: Readonly<Record<string, unknown>>,
+): BundledSkillMetadata | undefined {
+    if (fields.packageName !== undefined) {
+        return undefined;
+    }
+
+    return parseBundledSkillMetadataFields(fields);
 }

--- a/src/application/commands/skills/sync.ts
+++ b/src/application/commands/skills/sync.ts
@@ -216,17 +216,14 @@ async function collectRegistrySkillSyncRecords(
 function createSkillSyncRecord(
     skill: Pick<ManagedSkillListItem, "metadata" | "name">,
 ): SkillSyncRecord | undefined {
-    const packageName = skill.metadata?.packageName;
-    const version = skill.metadata?.version;
-
-    if (packageName === undefined || version === undefined) {
+    if (skill.metadata?.kind !== "registry") {
         return undefined;
     }
 
     return {
-        packageName,
+        packageName: skill.metadata.packageName,
         skillName: skill.name,
-        version,
+        version: skill.metadata.version,
     };
 }
 

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -29,7 +29,10 @@ import {
     resolveManagedSkillCanonicalDirectoryPath,
     resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
-import { renderSkillMetadataJson } from "./skill-metadata.ts";
+import {
+    createRegistrySkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
 
 describe("skills update command", () => {
     test("skips bundled oo when no explicit skill names are provided", async () => {
@@ -190,7 +193,7 @@ describe("skills update command", () => {
             );
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(claudeInstalledSkillDirectoryPath),
-                renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }),
+                renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.3" })),
             );
 
             const result = await sandbox.run(
@@ -251,14 +254,14 @@ describe("skills update command", () => {
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(codexInstalledSkillDirectoryPath),
                 "utf8",
-            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }));
+            )).toBe(renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.4" })));
             expect(await readFile(join(codexInstalledSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
                 "# ChatGPT fresh",
             );
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(claudeInstalledSkillDirectoryPath),
                 "utf8",
-            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }));
+            )).toBe(renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.4" })));
             expect(await readFile(join(claudeInstalledSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
                 "# ChatGPT fresh",
             );
@@ -336,7 +339,7 @@ describe("skills update command", () => {
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
                 "utf8",
-            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }));
+            )).toBe(renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.4" })));
             expect(await readFile(join(installedSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
                 "# ChatGPT fresh",
             );
@@ -372,7 +375,7 @@ describe("skills update command", () => {
             });
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath),
-                renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }),
+                renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.4" })),
             );
 
             const result = await sandbox.run(
@@ -414,7 +417,7 @@ describe("skills update command", () => {
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(installedSkillDirectoryPath),
                 "utf8",
-            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }));
+            )).toBe(renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.4" })));
             expect(await readFile(join(installedSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
                 "# ChatGPT fresh",
             );
@@ -630,11 +633,11 @@ describe("skills update command", () => {
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(chatgptInstalledDirectoryPath),
                 "utf8",
-            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.4" }));
+            )).toBe(renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.4" })));
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(visionInstalledDirectoryPath),
                 "utf8",
-            )).toBe(renderSkillMetadataJson({ packageName: "openai", version: "0.0.3" }));
+            )).toBe(renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.3" })));
         }
         finally {
             await sandbox.cleanup();
@@ -741,7 +744,7 @@ describe("skills update command", () => {
         }
     });
 
-    test("fails when a non-bundled managed skill is missing package metadata", async () => {
+    test("does not consume legacy bundled metadata as a registry update target", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
@@ -793,11 +796,9 @@ describe("skills update command", () => {
             const result = await sandbox.run(["skills", "update", "custom"]);
 
             expect(result.exitCode).toBe(1);
-            expect(result.stdout).toBe(
-                "Failed to update skill custom: Managed skill custom cannot be updated in codex, claude because its package metadata is missing.\n",
-            );
+            expect(result.stdout).toBe("");
             expect(result.stderr).toBe(
-                "Managed skill custom cannot be updated in codex, claude because its package metadata is missing.\n",
+                "Skill custom in host codex is not managed by oo and cannot be updated.\n",
             );
         }
         finally {
@@ -825,11 +826,17 @@ async function writeManagedRegistrySkillInstallation(options: {
     );
     await Bun.write(
         resolveManagedSkillMetadataFilePath(options.canonicalSkillDirectoryPath),
-        renderSkillMetadataJson({ packageName: options.packageName, version: options.version }),
+        renderSkillMetadataJson(createRegistrySkillMetadata({
+            packageName: options.packageName,
+            version: options.version,
+        })),
     );
     await Bun.write(
         resolveManagedSkillMetadataFilePath(options.installedSkillDirectoryPath),
-        renderSkillMetadataJson({ packageName: options.packageName, version: options.version }),
+        renderSkillMetadataJson(createRegistrySkillMetadata({
+            packageName: options.packageName,
+            version: options.version,
+        })),
     );
 }
 

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -148,7 +148,7 @@ export async function updateManagedSkills(
         : undefined;
     const registrySkillGroups = groupRegistrySkills(selectedSkills);
     const unresolvedSkills = selectedSkills.filter(skill =>
-        !isBundledSkillName(skill.name) && skill.metadata?.packageName === undefined,
+        !isBundledSkillName(skill.name) && skill.metadata?.kind !== "registry",
     );
     const packageNames = registrySkillGroups.map(group => group.packageName);
     context.telemetry?.recordProperties({
@@ -323,7 +323,7 @@ function mergeManagedSkillInstallationsByName(
     const skillsByName = new Map<string, ManagedSkillUpdateItem>();
 
     for (const skill of skills) {
-        if (skill.metadata === undefined) {
+        if (skill.metadata?.kind !== "registry") {
             continue;
         }
 
@@ -338,17 +338,6 @@ function mergeManagedSkillInstallationsByName(
             existingSkill.hostNames,
             skill.hostNames,
         );
-
-        if (
-            existingSkill.metadata?.packageName === undefined
-            && skill.metadata.packageName !== undefined
-        ) {
-            skillsByName.set(skill.name, {
-                ...skill,
-                hostNames,
-            });
-            continue;
-        }
 
         skillsByName.set(skill.name, {
             ...existingSkill,
@@ -488,12 +477,11 @@ function groupRegistrySkills(
     const groups = new Map<string, ManagedSkillUpdateItem[]>();
 
     for (const skill of skills) {
-        const packageName = skill.metadata?.packageName;
-
-        if (packageName === undefined) {
+        if (skill.metadata?.kind !== "registry") {
             continue;
         }
 
+        const packageName = skill.metadata.packageName;
         const group = groups.get(packageName);
 
         if (group === undefined) {

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -270,6 +270,8 @@ const commandTelemetryDecisions = {
         kind: "properties",
         properties: [
             "bundled_skill",
+            "local_refresh_count_bucket",
+            "local_refresh_performed",
             "package_kind",
             "package_name",
             "skill_ids_count_bucket",

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -290,6 +290,7 @@ const commandTelemetryDecisions = {
         kind: "properties",
         properties: [
             "adopted",
+            "force",
             "package_name",
             "skill_id",
             "source_kind",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -351,6 +351,8 @@ export const enMessages = {
         "Bundled skill {name} cannot be published directly because it is managed by the oo CLI release. Create or adopt a local copy before publishing.",
     "errors.skills.publish.localSkillMissing":
         "Local skill {name} does not exist at {path}.",
+    "errors.skills.publish.localCopyDrift":
+        "Local skill {name} has modified agent copies at {paths}. Publishing uses canonical storage at {localPath}; pass --force to ignore agent-side changes.",
     "errors.skills.publish.registryMetadataMissing":
         "Registry skill {name} cannot be published because its metadata file at {path} does not identify a packageName.",
     "errors.skills.publish.registryPackageConfirmationRequired":
@@ -683,6 +685,10 @@ export const enMessages = {
         "Invalid choice. Enter y/yes or n/no.",
     "skills.publish.remoteBlocks.prompt":
         "Remote package {packageName}@{version} contains blocks. Continue publishing skill {name} as {packageName}? [y/N] ",
+    "warnings.skills.localCopyDriftOverwritten":
+        "Warning: Local skill {name} copy at {path} differs from canonical storage and was overwritten.",
+    "warnings.skills.publishLocalCopyDriftIgnored":
+        "Warning: Local skill {name} has modified agent copies at {paths}; publishing canonical storage at {localPath} and ignoring agent-side changes.",
     "skills.install.success": "Installed skill {name} to {path}.",
     "skills.install.summary.agentsLabel": "Agents",
     "skills.install.summary.detailLine": "{label}: {values}",
@@ -1135,6 +1141,8 @@ export const zhMessages = {
         "不能直接发布内置 skill {name}，因为它由 oo CLI 版本管理。请先创建或接管一个本地副本再发布。",
     "errors.skills.publish.localSkillMissing":
         "本地 skill {name} 不存在于 {path}。",
+    "errors.skills.publish.localCopyDrift":
+        "本地 skill {name} 的 Agent 副本在 {paths} 存在修改。发布只使用 canonical 存储 {localPath}；如需忽略 Agent 侧修改，请传入 --force。",
     "errors.skills.publish.registryMetadataMissing":
         "无法发布 registry skill {name}，因为它位于 {path} 的元数据文件没有标识 packageName。",
     "errors.skills.publish.registryPackageConfirmationRequired":
@@ -1461,6 +1469,10 @@ export const zhMessages = {
         "输入无效。请输入 y/yes 或 n/no。",
     "skills.publish.remoteBlocks.prompt":
         "远端包 {packageName}@{version} 中存在区块。是否继续将 skill {name} 发布为 {packageName}？[y/N] ",
+    "warnings.skills.localCopyDriftOverwritten":
+        "Warning: 本地 skill {name} 位于 {path} 的副本与 canonical 存储不一致，已被覆盖。",
+    "warnings.skills.publishLocalCopyDriftIgnored":
+        "Warning: 本地 skill {name} 的 Agent 副本在 {paths} 存在修改；将发布 canonical 存储 {localPath} 并忽略 Agent 侧修改。",
     "skills.install.success": "已将 skill {name} 安装到 {path}。",
     "skills.install.summary.agentsLabel": "Agents",
     "skills.install.summary.detailLine": "{label}：{values}",


### PR DESCRIPTION
Local skills previously had no managed metadata and were identified by SKILL.md content matching, which made it ambiguous when agent copies drifted from canonical storage. Introduce a typed skill metadata schema (kind: bundled | registry | local with schemaVersion) and write `.oo-metadata.json` for local skills as well.

With explicit ownership, `oo skills publish` now refuses when an agent-side local copy differs from canonical storage; pass --force to publish canonical anyway. `oo skills install` without arguments also refreshes canonical local skills to existing hosts, and hash-based comparison replaces full content reads on the install and sync paths.