### PR TITLE
feat(package): drop dir/save input handles from package info

### DIFF
--- a/src/application/commands/package/info.test.ts
+++ b/src/application/commands/package/info.test.ts
@@ -87,7 +87,7 @@ describe("packageInfoCommand", () => {
         expect(fetchCount).toBe(1);
         expect(cacheOptions).toHaveLength(2);
         expect(cacheOptions[0]).toEqual({
-            id: "package.info.v5",
+            id: "package.info.v6",
             defaultTtlMs: 2_592_000_000,
             maxEntries: 300,
         });

--- a/src/application/commands/package/shared.test.ts
+++ b/src/application/commands/package/shared.test.ts
@@ -183,6 +183,95 @@ describe("loadPackageInfo", () => {
         expect(response.blocks[0]?.inputHandle.plainObjectInput).not.toHaveProperty("ext");
     });
 
+    test("removes input handles whose ui widget targets cloud storage", async () => {
+        const cacheValues = new Map<string, string>();
+        const cache = createCache<string>({
+            delete(key) {
+                return cacheValues.delete(key);
+            },
+            get(key) {
+                return cacheValues.get(key) ?? null;
+            },
+            set(key, value) {
+                cacheValues.set(key, value);
+            },
+        });
+        const context = createPackageInfoContext(
+            cache,
+            (async () => new Response(JSON.stringify({
+                packageName: "storage-lab",
+                packageVersion: "1.0.0",
+                title: "Storage Lab",
+                description: "Cloud storage handle filter.",
+                blocks: [
+                    {
+                        blockName: "Run",
+                        title: "Run",
+                        description: "Mixed widgets.",
+                        inputHandleDefs: [
+                            {
+                                handle: "savePath",
+                                description: "Save path",
+                                json_schema: {
+                                    "type": "string",
+                                    "ui:widget": "save",
+                                },
+                            },
+                            {
+                                handle: "dirPath",
+                                description: "Directory path",
+                                json_schema: {
+                                    "type": "string",
+                                    "ui:widget": "dir",
+                                },
+                            },
+                            {
+                                handle: "filePath",
+                                description: "File path",
+                                json_schema: {
+                                    "type": "string",
+                                    "ui:widget": "file",
+                                },
+                            },
+                            {
+                                handle: "freeText",
+                                description: "Free text",
+                                json_schema: {
+                                    type: "string",
+                                },
+                            },
+                        ],
+                        outputHandleDefs: [
+                            {
+                                handle: "savedTo",
+                                description: "Save target",
+                                json_schema: {
+                                    "type": "string",
+                                    "ui:widget": "save",
+                                },
+                            },
+                        ],
+                    },
+                ],
+            }))) satisfies Fetcher,
+        );
+
+        const response = await loadPackageInfo(
+            parsePackageSpecifier("storage-lab@1.0.0"),
+            packageInfoAccount,
+            packageInfoRequestLanguage,
+            context,
+        );
+
+        const block = response.blocks[0];
+
+        expect(Object.keys(block?.inputHandle ?? {})).toEqual([
+            "filePath",
+            "freeText",
+        ]);
+        expect(Object.keys(block?.outputHandle ?? {})).toEqual(["savedTo"]);
+    });
+
     test("deserializes preloaded cached normalized responses without fetching", async () => {
         const cacheValues = new Map<string, string>();
         let fetchCount = 0;

--- a/src/application/commands/package/shared.ts
+++ b/src/application/commands/package/shared.ts
@@ -11,8 +11,9 @@ import {
 import { isAsciiDigit, isSemver as isValidSemver } from "../../semver.ts";
 import { patchHandleSchema } from "../shared/handle-schema.ts";
 import { requestText } from "../shared/request.ts";
+import { isStoragePathWidget } from "../shared/schema-utils.ts";
 
-const PACKAGE_INFO_CACHE_ID = "package.info.v5";
+const PACKAGE_INFO_CACHE_ID = "package.info.v6";
 const PACKAGE_INFO_CACHE_MAX_ENTRIES = 300;
 const PACKAGE_INFO_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const LATEST_PACKAGE_VERSION = "latest";
@@ -444,6 +445,12 @@ function transformInputHandleDefinitions(
             }
 
             const normalizedSchema = splitPackageInfoHandleSchema(handleDef.json_schema);
+
+            // Storage-path widgets target cloud paths the CLI surface cannot address.
+            if (isStoragePathWidget(normalizedSchema.ext)) {
+                return [];
+            }
+
             const transformedHandle: z.output<typeof transformedInputHandleSchema> = {
                 description: handleDef.description,
                 schema: patchHandleSchema(

--- a/src/application/commands/shared/schema-utils.ts
+++ b/src/application/commands/shared/schema-utils.ts
@@ -17,3 +17,11 @@ export function readWidgetName(ext: unknown): string | undefined {
 
     return ext.widget;
 }
+
+export const storagePathWidgets: ReadonlySet<string> = new Set(["dir", "save"]);
+
+export function isStoragePathWidget(ext: unknown): boolean {
+    const widgetName = readWidgetName(ext);
+
+    return widgetName !== undefined && storagePathWidgets.has(widgetName);
+}


### PR DESCRIPTION
The `dir` and `save` UI widgets bind to cloud-storage paths that the CLI surface cannot address. Filtering them out of `inputHandle` during transformation prevents `oo cloud-task run`, `oo package info`, and `oo skills publish` from exposing handles users have no way to satisfy. The shared `storagePathWidgets` constant lives in schema-utils so future call sites can reuse it.

Bump the package-info cache namespace to v6 to invalidate entries that still contain the now-filtered handles.