### PR TITLE
[codex] support versioned package installs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -650,7 +650,9 @@ Install bundled or published skills into supported local skill directories.
   `oo-create-skill`, or `oo-publish-skill`, the command installs the
   corresponding bundled skill.
 - Arguments: when `[packageName]` is a published package name, the command
-  installs skills from that package.
+  installs skills from that package. `[packageName]` may include an explicit
+  version as `<packageName>@<version>`, including scoped package forms such as
+  `@scope/name@1.2.3`.
 - Arguments: `[packageName]` may also use `<packageName>#<shareID>`. In that
   form, the command reads the package skill list from `<packageName>` and
   downloads the package archive through the share identified by `<shareID>`.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -549,7 +549,9 @@ skills。
 - 参数：当 `[packageName]` 为 `oo`、`oo-find-skills`、`oo-create-skill` 或
   `oo-publish-skill` 时，命令安装对应的内置 skill。
 - 参数：当 `[packageName]` 为已发布 package 名称时，命令从该 package 中
-  安装 skill。
+  安装 skill。`[packageName]` 可以包含显式版本，格式为
+  `<packageName>@<version>`，也支持 `@scope/name@1.2.3` 这类 scoped package
+  形式。
 - 参数：`[packageName]` 也可以使用 `<packageName>#<shareID>`。这种形式会从
   `<packageName>` 读取 package 的 skill 列表，并通过 `<shareID>` 对应的 share
   下载 package 归档。

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -568,6 +568,64 @@ describe("skills commands", () => {
         }
     });
 
+    test("installs a registry package when a bundled skill name has an explicit version", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "runtime");
+        const requests: Request[] = [];
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "oo@0.0.2", "--skill", "runtime"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "oo",
+                                version: "0.0.2",
+                                skills: [
+                                    {
+                                        description: "Run OO workflows",
+                                        name: "runtime",
+                                        title: "Runtime",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/oo/-/meta/oo-0.0.2.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/runtime/SKILL.md": "# Runtime\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Installed skill runtime to ${skillDirectoryPath}.\n`,
+            );
+            expect(requests.map(request => request.url)).toEqual([
+                "https://registry.oomol.com/-/oomol/package-info/oo/0.0.2",
+                "https://registry.oomol.com/oo/-/meta/oo-0.0.2.tgz",
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("explicit bundled skill install overwrites a managed development-version installation", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
@@ -2113,6 +2171,68 @@ describe("skills commands", () => {
                     skill_ids_truncated: false,
                 },
             });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("installs a scoped registry skill by explicit package version", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const metadataFilePath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
+        const requests: Request[] = [];
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "@alice/openai@0.0.2", "--skill", "chatgpt"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "@alice/openai",
+                                version: "0.0.2",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/@alice/openai/-/meta/openai-0.0.2.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Installed skill chatgpt to ${skillDirectoryPath}.\n`,
+            );
+            expect(requests.map(request => request.url)).toEqual([
+                "https://registry.oomol.com/-/oomol/package-info/%40alice%2Fopenai/0.0.2",
+                "https://registry.oomol.com/@alice/openai/-/meta/openai-0.0.2.tgz",
+            ]);
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "@alice/openai", version: "0.0.2" })),
+            );
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -8,6 +8,7 @@ import type { ManagedSkillInstallSummary } from "./install-output.ts";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
+import { parsePackageSpecifier } from "../package/shared.ts";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
 import { writeManagedSkillInstallSummary } from "./install-output.ts";
 import { migrateLegacyCanonicalSkillLayout } from "./legacy-canonical-migration.ts";
@@ -26,8 +27,10 @@ interface SkillsInstallInput {
 }
 
 interface SkillsInstallPackageSpecifier {
+    hasExplicitPackageVersion: boolean;
     packageName: string;
     packageShareId?: string;
+    packageVersion: string;
 }
 
 export const presetSkillPackageNames = ["@alwaysmavs/gpt-image-2"] as const;
@@ -107,6 +110,7 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
 
         if (
             packageSpecifier.packageShareId === undefined
+            && !packageSpecifier.hasExplicitPackageVersion
             && isBundledSkillName(packageSpecifier.packageName)
         ) {
             context.telemetry?.recordProperties({
@@ -129,6 +133,7 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
                 all: input.all === true,
                 packageName: packageSpecifier.packageName,
                 packageShareId: packageSpecifier.packageShareId,
+                packageVersion: packageSpecifier.packageVersion,
                 skillNames: input.skill ?? [],
                 yes: input.yes === true,
             },
@@ -184,16 +189,14 @@ function parseSkillsInstallPackageSpecifier(
     const shareSeparatorIndex = trimmedSpecifier.indexOf("#");
 
     if (shareSeparatorIndex < 0) {
-        return {
-            packageName: trimmedSpecifier,
-        };
+        return parseSkillsInstallPackageIdentity(trimmedSpecifier);
     }
 
-    const packageName = trimmedSpecifier.slice(0, shareSeparatorIndex).trim();
+    const packageIdentity = trimmedSpecifier.slice(0, shareSeparatorIndex).trim();
     const packageShareId = trimmedSpecifier.slice(shareSeparatorIndex + 1).trim();
 
     if (
-        packageName === ""
+        packageIdentity === ""
         || packageShareId === ""
         || packageShareId.includes("#")
     ) {
@@ -203,7 +206,21 @@ function parseSkillsInstallPackageSpecifier(
     }
 
     return {
-        packageName,
+        ...parseSkillsInstallPackageIdentity(packageIdentity),
         packageShareId,
+    };
+}
+
+function parseSkillsInstallPackageIdentity(
+    packageIdentity: string,
+): Omit<SkillsInstallPackageSpecifier, "packageShareId"> {
+    const packageSpecifier = parsePackageSpecifier(packageIdentity, {
+        errorKey: "errors.skills.install.invalidPackageSpecifier",
+    });
+
+    return {
+        hasExplicitPackageVersion: packageIdentity !== packageSpecifier.packageName,
+        packageName: packageSpecifier.packageName,
+        packageVersion: packageSpecifier.packageVersion,
     };
 }


### PR DESCRIPTION
## Summary

- Parse `oo skills install` package arguments with the shared package specifier parser so explicit versions are supported.
- Pass the parsed package version into the registry package-info request instead of treating the whole specifier as the package name.
- Document `<packageName>@<version>` support for skill installs in English and Chinese command docs.

## Root Cause

`oo skills install` only split the optional `#shareID` suffix. A scoped versioned specifier such as `@zjxuyunshi/tmall-product-images@0.0.2` was left intact as the package name, so the registry package-info lookup queried the wrong package identity and returned 404.

## Validation

- `bun run lint:fix`
- `bun run ts-check`
- `bun run test`