### PR TITLE
[codex] add LLM client config command

### DIFF
--- a/contrib/skills/claude/oo-create-skill/SKILL.md
+++ b/contrib/skills/claude/oo-create-skill/SKILL.md
@@ -222,6 +222,11 @@ When the workflow crosses the local/cloud file boundary, include the
 `oo file upload` and `oo file download` guidance from the Constitution in the
 generated skill.
 
+When generated skill code needs an OOMOL-hosted LLM client, instruct future
+agents to run `oo llm config --json` at runtime and use the returned `apiKey`,
+`baseUrl`, and `model`. Do not hardcode, persist, log, or print the API key,
+and do not tell future agents to read local auth files directly.
+
 Review the frontmatter `description` before finishing: user-visible outcome
 first, common request language, relevant artifacts, and user-visible services,
 models, products, or workflow names when useful. Keep caveats, execution

--- a/contrib/skills/claude/oo/SKILL.md
+++ b/contrib/skills/claude/oo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oo
-description: First-choice router for tasks whose outcome lives outside this workspace, including connected third-party accounts (email, calendar, drive, chat, notes, issue tracker, code host, CRM, storage, etc.), an external API, or a managed AI pipeline (OCR, translation, transcription, TTS, text-to-image, subtitles, long-document understanding). Use only when the user wants an existing hosted capability or connector workflow, not a local implementation. Concrete capabilities are discovered at runtime, so no package, block, connector, or action names are assumed in advance. Match intent across languages. Skip pure local coding, shell glue, repo edits, and text-only answers an LLM can complete without hosted capability execution.
+description: First-choice router for tasks whose outcome lives outside this workspace, including connected third-party accounts (email, calendar, drive, chat, notes, issue tracker, code host, CRM, storage, etc.), an external API, or a managed AI pipeline (OCR, translation, transcription, TTS, text-to-image, subtitles, long-document understanding). Use when local code needs OOMOL LLM client configuration such as an OpenAI-compatible base URL, API key, or model name. Otherwise use only when the user wants an existing hosted capability or connector workflow, not a local implementation. Concrete capabilities are discovered at runtime, so no package, block, connector, or action names are assumed in advance. Match intent across languages. Skip other pure local coding, shell glue, repo edits, and text-only answers an LLM can complete without hosted capability execution.
 allowed-tools: [Bash(oo *)]
 ---
 
@@ -14,6 +14,13 @@ If the user wants to find, compare, or install published OOMOL/oo skills, use
 `oo-find-skills` instead of this skill.
 
 Read only the reference file needed for the current state.
+
+## LLM client config mode
+
+If local code you are writing or running needs an OpenAI-compatible base URL,
+API key, or model name for OOMOL's LLM API, read
+[references/llm-client.md](references/llm-client.md). Do not run capability
+discovery for that case, and do not read local auth files directly.
 
 ## Constitution
 
@@ -162,6 +169,8 @@ unsupported input shape, or a blocker-specific fallback.
   [references/task-lifecycle.md](references/task-lifecycle.md)
 - Auth and billing blockers:
   [references/auth-and-billing.md](references/auth-and-billing.md)
+- OOMOL LLM client configuration for local code:
+  [references/llm-client.md](references/llm-client.md)
 
 ## Decision sketches
 

--- a/contrib/skills/claude/oo/references/auth-and-billing.md
+++ b/contrib/skills/claude/oo/references/auth-and-billing.md
@@ -21,6 +21,17 @@ becomes relevant.
 - `oo cloud-task result`
 - `oo cloud-task wait`
 
+## LLM client config
+
+When skill code needs to call the OOMOL LLM API directly, run:
+
+```bash
+oo llm config --json
+```
+
+The JSON output contains `apiKey`, `baseUrl`, and `model`. Treat `apiKey` as a
+secret. Do not print it in user-facing responses, logs, or generated files.
+
 ## If auth may be the blocker
 
 Run:

--- a/contrib/skills/claude/oo/references/llm-client.md
+++ b/contrib/skills/claude/oo/references/llm-client.md
@@ -1,0 +1,26 @@
+# LLM Client Config
+
+Read this file when local code you write or run needs OOMOL-hosted LLM client
+configuration, an OpenAI-compatible base URL, an API key, or the default OOMOL
+model.
+
+Run:
+
+```bash
+oo llm config --json
+```
+
+The JSON output contains:
+
+- `apiKey`: current account API key.
+- `baseUrl`: OOMOL LLM API base URL.
+- `model`: default model name, currently `oomol-chat`.
+
+Use these fields to configure OpenAI-compatible clients and libraries. Map
+`baseUrl` to the library's base URL option, `apiKey` to its API key or
+authorization option, and `model` to the model name.
+
+Do not read `auth.toml` directly. Do not hardcode, persist, log, or print
+`apiKey` in generated code, user-facing responses, debug output, or generated
+files. For generated code, call `oo llm config --json` at runtime and pass the
+values into the client in memory.

--- a/contrib/skills/codebuddy/oo-create-skill/SKILL.md
+++ b/contrib/skills/codebuddy/oo-create-skill/SKILL.md
@@ -221,6 +221,11 @@ When the workflow crosses the local/cloud file boundary, include the
 `oo file upload` and `oo file download` guidance from the Constitution in the
 generated skill.
 
+When generated skill code needs an OOMOL-hosted LLM client, instruct future
+agents to run `oo llm config --json` at runtime and use the returned `apiKey`,
+`baseUrl`, and `model`. Do not hardcode, persist, log, or print the API key,
+and do not tell future agents to read local auth files directly.
+
 Review the frontmatter `description` before finishing: user-visible outcome
 first, common request language, relevant artifacts, and user-visible services,
 models, products, or workflow names when useful. Keep caveats, execution

--- a/contrib/skills/codebuddy/oo/SKILL.md
+++ b/contrib/skills/codebuddy/oo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oo
-description: First-choice router for tasks whose outcome lives outside this workspace, including connected third-party accounts (email, calendar, drive, chat, notes, issue tracker, code host, CRM, storage, etc.), an external API, or a managed AI pipeline (OCR, translation, transcription, TTS, text-to-image, subtitles, long-document understanding). Use only when the user wants an existing hosted capability or connector workflow, not a local implementation. Concrete capabilities are discovered at runtime, so no package, block, connector, or action names are assumed in advance. Match intent across languages. Skip pure local coding, shell glue, repo edits, and text-only answers an LLM can complete without hosted capability execution.
+description: First-choice router for tasks whose outcome lives outside this workspace, including connected third-party accounts (email, calendar, drive, chat, notes, issue tracker, code host, CRM, storage, etc.), an external API, or a managed AI pipeline (OCR, translation, transcription, TTS, text-to-image, subtitles, long-document understanding). Use when local code needs OOMOL LLM client configuration such as an OpenAI-compatible base URL, API key, or model name. Otherwise use only when the user wants an existing hosted capability or connector workflow, not a local implementation. Concrete capabilities are discovered at runtime, so no package, block, connector, or action names are assumed in advance. Match intent across languages. Skip other pure local coding, shell glue, repo edits, and text-only answers an LLM can complete without hosted capability execution.
 ---
 
 # oo
@@ -13,6 +13,13 @@ If the user wants to find, compare, or install published OOMOL/oo skills, use
 `oo-find-skills` instead of this skill.
 
 Read only the reference file needed for the current state.
+
+## LLM client config mode
+
+If local code you are writing or running needs an OpenAI-compatible base URL,
+API key, or model name for OOMOL's LLM API, read
+[references/llm-client.md](references/llm-client.md). Do not run capability
+discovery for that case, and do not read local auth files directly.
 
 ## Constitution
 
@@ -161,6 +168,8 @@ unsupported input shape, or a blocker-specific fallback.
   [references/task-lifecycle.md](references/task-lifecycle.md)
 - Auth and billing blockers:
   [references/auth-and-billing.md](references/auth-and-billing.md)
+- OOMOL LLM client configuration for local code:
+  [references/llm-client.md](references/llm-client.md)
 
 ## Decision sketches
 

--- a/contrib/skills/codebuddy/oo/references/auth-and-billing.md
+++ b/contrib/skills/codebuddy/oo/references/auth-and-billing.md
@@ -21,6 +21,17 @@ becomes relevant.
 - `oo cloud-task result`
 - `oo cloud-task wait`
 
+## LLM client config
+
+When skill code needs to call the OOMOL LLM API directly, run:
+
+```bash
+oo llm config --json
+```
+
+The JSON output contains `apiKey`, `baseUrl`, and `model`. Treat `apiKey` as a
+secret. Do not print it in user-facing responses, logs, or generated files.
+
 ## If auth may be the blocker
 
 Run:

--- a/contrib/skills/codebuddy/oo/references/llm-client.md
+++ b/contrib/skills/codebuddy/oo/references/llm-client.md
@@ -1,0 +1,26 @@
+# LLM Client Config
+
+Read this file when local code you write or run needs OOMOL-hosted LLM client
+configuration, an OpenAI-compatible base URL, an API key, or the default OOMOL
+model.
+
+Run:
+
+```bash
+oo llm config --json
+```
+
+The JSON output contains:
+
+- `apiKey`: current account API key.
+- `baseUrl`: OOMOL LLM API base URL.
+- `model`: default model name, currently `oomol-chat`.
+
+Use these fields to configure OpenAI-compatible clients and libraries. Map
+`baseUrl` to the library's base URL option, `apiKey` to its API key or
+authorization option, and `model` to the model name.
+
+Do not read `auth.toml` directly. Do not hardcode, persist, log, or print
+`apiKey` in generated code, user-facing responses, debug output, or generated
+files. For generated code, call `oo llm config --json` at runtime and pass the
+values into the client in memory.

--- a/contrib/skills/codex/oo-create-skill/SKILL.md
+++ b/contrib/skills/codex/oo-create-skill/SKILL.md
@@ -252,6 +252,11 @@ When the workflow crosses the local/cloud file boundary, include the
 `oo file upload` and `oo file download` guidance from the Constitution in the
 generated skill.
 
+When generated skill code needs an OOMOL-hosted LLM client, instruct future
+agents to run `oo llm config --json` at runtime and use the returned `apiKey`,
+`baseUrl`, and `model`. Do not hardcode, persist, log, or print the API key,
+and do not tell future agents to read local auth files directly.
+
 Review the frontmatter `description` before finishing: user-visible outcome
 first, common request language, relevant artifacts, and user-visible services,
 models, products, or workflow names when useful. Keep caveats, execution

--- a/contrib/skills/codex/oo/SKILL.md
+++ b/contrib/skills/codex/oo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oo
-description: First-choice router for tasks whose outcome lives outside this workspace, including connected third-party accounts (email, calendar, drive, chat, notes, issue tracker, code host, CRM, storage, etc.), an external API, or a managed AI pipeline (OCR, translation, transcription, TTS, text-to-image, subtitles, long-document understanding). Use only when the user wants an existing hosted capability or connector workflow, not a local implementation. Concrete capabilities are discovered at runtime, so no package, block, connector, or action names are assumed in advance. Match intent across languages. Skip pure local coding, shell glue, repo edits, and text-only answers an LLM can complete without hosted capability execution.
+description: First-choice router for tasks whose outcome lives outside this workspace, including connected third-party accounts (email, calendar, drive, chat, notes, issue tracker, code host, CRM, storage, etc.), an external API, or a managed AI pipeline (OCR, translation, transcription, TTS, text-to-image, subtitles, long-document understanding). Use when local code needs OOMOL LLM client configuration such as an OpenAI-compatible base URL, API key, or model name. Otherwise use only when the user wants an existing hosted capability or connector workflow, not a local implementation. Concrete capabilities are discovered at runtime, so no package, block, connector, or action names are assumed in advance. Match intent across languages. Skip other pure local coding, shell glue, repo edits, and text-only answers an LLM can complete without hosted capability execution.
 ---
 
 # oo
@@ -13,6 +13,13 @@ If the user wants to find, compare, or install published OOMOL/oo skills, use
 `oo-find-skills` instead of this skill.
 
 Read only the reference file needed for the current state.
+
+## LLM client config mode
+
+If local code you are writing or running needs an OpenAI-compatible base URL,
+API key, or model name for OOMOL's LLM API, read
+[references/llm-client.md](references/llm-client.md). Do not run capability
+discovery for that case, and do not read local auth files directly.
 
 ## Runtime note
 
@@ -169,6 +176,8 @@ unsupported input shape, or a blocker-specific fallback.
   [references/task-lifecycle.md](references/task-lifecycle.md)
 - Auth and billing blockers:
   [references/auth-and-billing.md](references/auth-and-billing.md)
+- OOMOL LLM client configuration for local code:
+  [references/llm-client.md](references/llm-client.md)
 
 ## Decision sketches
 

--- a/contrib/skills/codex/oo/references/auth-and-billing.md
+++ b/contrib/skills/codex/oo/references/auth-and-billing.md
@@ -21,6 +21,17 @@ becomes relevant.
 - `oo cloud-task result`
 - `oo cloud-task wait`
 
+## LLM client config
+
+When skill code needs to call the OOMOL LLM API directly, run:
+
+```bash
+oo llm config --json
+```
+
+The JSON output contains `apiKey`, `baseUrl`, and `model`. Treat `apiKey` as a
+secret. Do not print it in user-facing responses, logs, or generated files.
+
 ## If auth may be the blocker
 
 Run:

--- a/contrib/skills/codex/oo/references/llm-client.md
+++ b/contrib/skills/codex/oo/references/llm-client.md
@@ -1,0 +1,26 @@
+# LLM Client Config
+
+Read this file when local code you write or run needs OOMOL-hosted LLM client
+configuration, an OpenAI-compatible base URL, an API key, or the default OOMOL
+model.
+
+Run:
+
+```bash
+oo llm config --json
+```
+
+The JSON output contains:
+
+- `apiKey`: current account API key.
+- `baseUrl`: OOMOL LLM API base URL.
+- `model`: default model name, currently `oomol-chat`.
+
+Use these fields to configure OpenAI-compatible clients and libraries. Map
+`baseUrl` to the library's base URL option, `apiKey` to its API key or
+authorization option, and `model` to the model name.
+
+Do not read `auth.toml` directly. Do not hardcode, persist, log, or print
+`apiKey` in generated code, user-facing responses, debug output, or generated
+files. For generated code, call `oo llm config --json` at runtime and pass the
+values into the client in memory.

--- a/contrib/skills/openclaw/oo-create-skill/SKILL.md
+++ b/contrib/skills/openclaw/oo-create-skill/SKILL.md
@@ -221,6 +221,11 @@ When the workflow crosses the local/cloud file boundary, include the
 `oo file upload` and `oo file download` guidance from the Constitution in the
 generated skill.
 
+When generated skill code needs an OOMOL-hosted LLM client, instruct future
+agents to run `oo llm config --json` at runtime and use the returned `apiKey`,
+`baseUrl`, and `model`. Do not hardcode, persist, log, or print the API key,
+and do not tell future agents to read local auth files directly.
+
 Review the frontmatter `description` before finishing: user-visible outcome
 first, common request language, relevant artifacts, and user-visible services,
 models, products, or workflow names when useful. Keep caveats, execution

--- a/contrib/skills/openclaw/oo/SKILL.md
+++ b/contrib/skills/openclaw/oo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oo
-description: First-choice router for tasks whose outcome lives outside this workspace, including connected third-party accounts (email, calendar, drive, chat, notes, issue tracker, code host, CRM, storage, etc.), an external API, or a managed AI pipeline (OCR, translation, transcription, TTS, text-to-image, subtitles, long-document understanding). Use only when the user wants an existing hosted capability or connector workflow, not a local implementation. Concrete capabilities are discovered at runtime, so no package, block, connector, or action names are assumed in advance. Match intent across languages. Skip pure local coding, shell glue, repo edits, and text-only answers an LLM can complete without hosted capability execution.
+description: First-choice router for tasks whose outcome lives outside this workspace, including connected third-party accounts (email, calendar, drive, chat, notes, issue tracker, code host, CRM, storage, etc.), an external API, or a managed AI pipeline (OCR, translation, transcription, TTS, text-to-image, subtitles, long-document understanding). Use when local code needs OOMOL LLM client configuration such as an OpenAI-compatible base URL, API key, or model name. Otherwise use only when the user wants an existing hosted capability or connector workflow, not a local implementation. Concrete capabilities are discovered at runtime, so no package, block, connector, or action names are assumed in advance. Match intent across languages. Skip other pure local coding, shell glue, repo edits, and text-only answers an LLM can complete without hosted capability execution.
 ---
 
 # oo
@@ -13,6 +13,13 @@ If the user wants to find, compare, or install published OOMOL/oo skills, use
 `oo-find-skills` instead of this skill.
 
 Read only the reference file needed for the current state.
+
+## LLM client config mode
+
+If local code you are writing or running needs an OpenAI-compatible base URL,
+API key, or model name for OOMOL's LLM API, read
+[references/llm-client.md](references/llm-client.md). Do not run capability
+discovery for that case, and do not read local auth files directly.
 
 ## Constitution
 
@@ -161,6 +168,8 @@ unsupported input shape, or a blocker-specific fallback.
   [references/task-lifecycle.md](references/task-lifecycle.md)
 - Auth and billing blockers:
   [references/auth-and-billing.md](references/auth-and-billing.md)
+- OOMOL LLM client configuration for local code:
+  [references/llm-client.md](references/llm-client.md)
 
 ## Decision sketches
 

--- a/contrib/skills/openclaw/oo/references/auth-and-billing.md
+++ b/contrib/skills/openclaw/oo/references/auth-and-billing.md
@@ -21,6 +21,17 @@ becomes relevant.
 - `oo cloud-task result`
 - `oo cloud-task wait`
 
+## LLM client config
+
+When skill code needs to call the OOMOL LLM API directly, run:
+
+```bash
+oo llm config --json
+```
+
+The JSON output contains `apiKey`, `baseUrl`, and `model`. Treat `apiKey` as a
+secret. Do not print it in user-facing responses, logs, or generated files.
+
 ## If auth may be the blocker
 
 Run:

--- a/contrib/skills/openclaw/oo/references/llm-client.md
+++ b/contrib/skills/openclaw/oo/references/llm-client.md
@@ -1,0 +1,26 @@
+# LLM Client Config
+
+Read this file when local code you write or run needs OOMOL-hosted LLM client
+configuration, an OpenAI-compatible base URL, an API key, or the default OOMOL
+model.
+
+Run:
+
+```bash
+oo llm config --json
+```
+
+The JSON output contains:
+
+- `apiKey`: current account API key.
+- `baseUrl`: OOMOL LLM API base URL.
+- `model`: default model name, currently `oomol-chat`.
+
+Use these fields to configure OpenAI-compatible clients and libraries. Map
+`baseUrl` to the library's base URL option, `apiKey` to its API key or
+authorization option, and `model` to the model name.
+
+Do not read `auth.toml` directly. Do not hardcode, persist, log, or print
+`apiKey` in generated code, user-facing responses, debug output, or generated
+files. For generated code, call `oo llm config --json` at runtime and pass the
+values into the client in memory.

--- a/contrib/skills/qoderwork/oo-create-skill/SKILL.md
+++ b/contrib/skills/qoderwork/oo-create-skill/SKILL.md
@@ -221,6 +221,11 @@ When the workflow crosses the local/cloud file boundary, include the
 `oo file upload` and `oo file download` guidance from the Constitution in the
 generated skill.
 
+When generated skill code needs an OOMOL-hosted LLM client, instruct future
+agents to run `oo llm config --json` at runtime and use the returned `apiKey`,
+`baseUrl`, and `model`. Do not hardcode, persist, log, or print the API key,
+and do not tell future agents to read local auth files directly.
+
 Review the frontmatter `description` before finishing: user-visible outcome
 first, common request language, relevant artifacts, and user-visible services,
 models, products, or workflow names when useful. Keep caveats, execution

--- a/contrib/skills/qoderwork/oo/SKILL.md
+++ b/contrib/skills/qoderwork/oo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oo
-description: First-choice router for tasks whose outcome lives outside this workspace, including connected third-party accounts (email, calendar, drive, chat, notes, issue tracker, code host, CRM, storage, etc.), an external API, or a managed AI pipeline (OCR, translation, transcription, TTS, text-to-image, subtitles, long-document understanding). Use only when the user wants an existing hosted capability or connector workflow, not a local implementation. Concrete capabilities are discovered at runtime, so no package, block, connector, or action names are assumed in advance. Match intent across languages. Skip pure local coding, shell glue, repo edits, and text-only answers an LLM can complete without hosted capability execution.
+description: First-choice router for tasks whose outcome lives outside this workspace, including connected third-party accounts (email, calendar, drive, chat, notes, issue tracker, code host, CRM, storage, etc.), an external API, or a managed AI pipeline (OCR, translation, transcription, TTS, text-to-image, subtitles, long-document understanding). Use when local code needs OOMOL LLM client configuration such as an OpenAI-compatible base URL, API key, or model name. Otherwise use only when the user wants an existing hosted capability or connector workflow, not a local implementation. Concrete capabilities are discovered at runtime, so no package, block, connector, or action names are assumed in advance. Match intent across languages. Skip other pure local coding, shell glue, repo edits, and text-only answers an LLM can complete without hosted capability execution.
 ---
 
 # oo
@@ -13,6 +13,13 @@ If the user wants to find, compare, or install published OOMOL/oo skills, use
 `oo-find-skills` instead of this skill.
 
 Read only the reference file needed for the current state.
+
+## LLM client config mode
+
+If local code you are writing or running needs an OpenAI-compatible base URL,
+API key, or model name for OOMOL's LLM API, read
+[references/llm-client.md](references/llm-client.md). Do not run capability
+discovery for that case, and do not read local auth files directly.
 
 ## Constitution
 
@@ -161,6 +168,8 @@ unsupported input shape, or a blocker-specific fallback.
   [references/task-lifecycle.md](references/task-lifecycle.md)
 - Auth and billing blockers:
   [references/auth-and-billing.md](references/auth-and-billing.md)
+- OOMOL LLM client configuration for local code:
+  [references/llm-client.md](references/llm-client.md)
 
 ## Decision sketches
 

--- a/contrib/skills/qoderwork/oo/references/auth-and-billing.md
+++ b/contrib/skills/qoderwork/oo/references/auth-and-billing.md
@@ -21,6 +21,17 @@ becomes relevant.
 - `oo cloud-task result`
 - `oo cloud-task wait`
 
+## LLM client config
+
+When skill code needs to call the OOMOL LLM API directly, run:
+
+```bash
+oo llm config --json
+```
+
+The JSON output contains `apiKey`, `baseUrl`, and `model`. Treat `apiKey` as a
+secret. Do not print it in user-facing responses, logs, or generated files.
+
 ## If auth may be the blocker
 
 Run:

--- a/contrib/skills/qoderwork/oo/references/llm-client.md
+++ b/contrib/skills/qoderwork/oo/references/llm-client.md
@@ -1,0 +1,26 @@
+# LLM Client Config
+
+Read this file when local code you write or run needs OOMOL-hosted LLM client
+configuration, an OpenAI-compatible base URL, an API key, or the default OOMOL
+model.
+
+Run:
+
+```bash
+oo llm config --json
+```
+
+The JSON output contains:
+
+- `apiKey`: current account API key.
+- `baseUrl`: OOMOL LLM API base URL.
+- `model`: default model name, currently `oomol-chat`.
+
+Use these fields to configure OpenAI-compatible clients and libraries. Map
+`baseUrl` to the library's base URL option, `apiKey` to its API key or
+authorization option, and `model` to the model name.
+
+Do not read `auth.toml` directly. Do not hardcode, persist, log, or print
+`apiKey` in generated code, user-facing responses, debug output, or generated
+files. For generated code, call `oo llm config --json` at runtime and pass the
+values into the client in memory.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -66,6 +66,21 @@ option.
 
 Alias for `oo auth logout`.
 
+## LLM
+
+### `oo llm config`
+
+Print the current account's LLM client configuration as JSON.
+
+- Authentication: requires the current OOMOL account.
+- Options: `--format=json` and `--json` are accepted for consistency with other
+  structured output commands. The command always prints JSON.
+- Output: a JSON object with:
+  - `apiKey`: the current account API key.
+  - `baseUrl`: the LLM API base URL, derived from the current account endpoint.
+  - `model`: the default model name, currently `oomol-chat`.
+- Production output uses `https://llm.oomol.com/` as `baseUrl`.
+
 ## Configuration
 
 - Notes: when the persisted settings file contains unknown keys, the CLI

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -58,6 +58,21 @@
 
 `oo auth logout` 的别名。
 
+## LLM
+
+### `oo llm config`
+
+以 JSON 输出当前账号的 LLM client 配置。
+
+- 认证：要求存在当前 OOMOL 账号。
+- 选项：`--format=json` 和 `--json` 会被接受，以便与其他结构化输出命令保持一致。
+  该命令始终输出 JSON。
+- 输出：JSON 对象包含：
+  - `apiKey`：当前账号 API key。
+  - `baseUrl`：根据当前账号 endpoint 派生出的 LLM API base URL。
+  - `model`：默认模型名，当前为 `oomol-chat`。
+- 生产环境输出的 `baseUrl` 为 `https://llm.oomol.com/`。
+
 ## 配置
 
 - 说明：如果持久化 settings 文件里存在未知 key，CLI 会忽略这些 key，并在

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -45,6 +45,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
+  llm                       Manage LLM client config
   login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
@@ -80,6 +81,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
+  llm                       Manage LLM client config
   login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
@@ -118,6 +120,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
+  llm                       Manage LLM client config
   login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
@@ -154,6 +157,7 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
   cloud-task                管理云任务
   connector                 管理 connector action
   file                      管理临时文件传输
+  llm                       管理 LLM client 配置
   login [options]           登录 OOMOL 账号（auth login 的别名）
   logout                    登出当前账号（auth logout 的别名）
   completion <shell>        生成 shell 补全脚本
@@ -186,6 +190,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
+  llm                       Manage LLM client config
   login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
@@ -222,6 +227,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
+  llm                       Manage LLM client config
   login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts

--- a/src/application/commands/catalog.ts
+++ b/src/application/commands/catalog.ts
@@ -9,6 +9,7 @@ import { configCommand } from "./config/index.ts";
 import { connectorCommand } from "./connector/index.ts";
 import { fileCommand } from "./file/index.ts";
 import { installCommand } from "./install.ts";
+import { llmCommand } from "./llm/index.ts";
 import { logCommand } from "./log/index.ts";
 import { loginCommand } from "./login.ts";
 import { logoutCommand } from "./logout.ts";
@@ -46,6 +47,7 @@ export function createCliCatalog(): CliCatalog {
             connectorCommand,
             fileCommand,
             installCommand,
+            llmCommand,
             loginCommand,
             logoutCommand,
             completionCommand,

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -31,6 +31,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
+  llm                       Manage LLM client config
   login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
   completion <shell>        Generate shell completion scripts
@@ -63,6 +64,7 @@ Commands:
   cloud-task                管理云任务
   connector                 管理 connector action
   file                      管理临时文件传输
+  llm                       管理 LLM client 配置
   login [options]           登录 OOMOL 账号（auth login 的别名）
   logout                    登出当前账号（auth logout 的别名）
   completion <shell>        生成 shell 补全脚本

--- a/src/application/commands/llm/config.ts
+++ b/src/application/commands/llm/config.ts
@@ -1,0 +1,45 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
+import { createFormatInputError } from "../shared/input-parsing.ts";
+
+const llmConfigFormatValues = ["json"] as const;
+const defaultLlmModel = "oomol-chat";
+
+interface LlmConfigInput {
+    format?: (typeof llmConfigFormatValues)[number];
+}
+
+interface LlmConfigOutput {
+    apiKey: string;
+    baseUrl: string;
+    model: string;
+}
+
+export const llmConfigCommand: CliCommandDefinition<LlmConfigInput> = {
+    name: "config",
+    excludeFromTelemetry: true,
+    summaryKey: "commands.llm.config.summary",
+    descriptionKey: "commands.llm.config.description",
+    options: [...jsonOutputOptions],
+    inputSchema: z.object({
+        format: z.enum(llmConfigFormatValues).optional(),
+    }),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+    handler: async (_, context) => {
+        const account = await requireCurrentAccount(context);
+        const config: LlmConfigOutput = {
+            apiKey: account.apiKey,
+            baseUrl: createLlmBaseUrl(account.endpoint),
+            model: defaultLlmModel,
+        };
+
+        writeJsonOutput(context.stdout, config);
+    },
+};
+
+function createLlmBaseUrl(endpoint: string): string {
+    return new URL(`https://llm.${endpoint}/`).toString();
+}

--- a/src/application/commands/llm/index.cli.test.ts
+++ b/src/application/commands/llm/index.cli.test.ts
@@ -1,0 +1,133 @@
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    createCliSandbox,
+    createCliSnapshot,
+    readLatestLogContent,
+    writeAuthFile,
+} from "../../../../__tests__/helpers.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import { readTelemetryRowsForTest } from "../../telemetry/outbox.ts";
+
+describe("llm CLI", () => {
+    test("prints current LLM client config as json", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["llm", "config", "--json"], {
+                fetcher: async () => {
+                    throw new Error("llm config should not make network requests");
+                },
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(JSON.parse(result.stdout)).toEqual({
+                apiKey: "secret-1",
+                baseUrl: "https://llm.oomol.com/",
+                model: "oomol-chat",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("derives the LLM base URL from the active account endpoint", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox, {
+                accounts: [
+                    {
+                        apiKey: "secret-2",
+                        endpoint: "staging.oomol.test",
+                        id: "user-2",
+                        name: "Bob",
+                    },
+                ],
+            });
+
+            const jsonAliasResult = await sandbox.run(["llm", "config", "--json"]);
+            const jsonFormatResult = await sandbox.run([
+                "llm",
+                "config",
+                "--format=json",
+            ]);
+
+            expect(JSON.parse(jsonAliasResult.stdout)).toEqual({
+                apiKey: "secret-2",
+                baseUrl: "https://llm.staging.oomol.test/",
+                model: "oomol-chat",
+            });
+            expect(JSON.parse(jsonFormatResult.stdout)).toEqual({
+                apiKey: "secret-2",
+                baseUrl: "https://llm.staging.oomol.test/",
+                model: "oomol-chat",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not log or emit telemetry when printing LLM config", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["llm", "config", "--json"]);
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(content).not.toContain("secret-1");
+            expect(readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            )).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("requires login before printing LLM config", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["llm", "config", "--json"]);
+
+            expect(createCliSnapshot(result)).toEqual({
+                exitCode: 1,
+                stderr: "You must log in before using this command.\n",
+                stdout: "",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("validates the LLM config format option", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["llm", "config", "--format=yaml"]);
+
+            expect(createCliSnapshot(result)).toEqual({
+                exitCode: 2,
+                stderr: "Invalid format: yaml. Use json.\n",
+                stdout: "",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/llm/index.ts
+++ b/src/application/commands/llm/index.ts
@@ -1,0 +1,12 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { llmConfigCommand } from "./config.ts";
+
+export const llmCommand: CliCommandDefinition = {
+    name: "llm",
+    summaryKey: "commands.llm.summary",
+    descriptionKey: "commands.llm.description",
+    children: [
+        llmConfigCommand,
+    ],
+};

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -18,6 +18,7 @@ describe("embedded skill assets", () => {
             "SKILL.md",
             "agents/openai.yaml",
             "references/auth-and-billing.md",
+            "references/llm-client.md",
             "references/search-and-selection.md",
             "references/package-execution.md",
             "references/connector-execution.md",
@@ -27,6 +28,7 @@ describe("embedded skill assets", () => {
         expect(getBundledSkillFiles("oo", "claude").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "references/auth-and-billing.md",
+            "references/llm-client.md",
             "references/search-and-selection.md",
             "references/package-execution.md",
             "references/connector-execution.md",
@@ -36,6 +38,7 @@ describe("embedded skill assets", () => {
         expect(getBundledSkillFiles("oo", "hermes").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "references/auth-and-billing.md",
+            "references/llm-client.md",
             "references/search-and-selection.md",
             "references/package-execution.md",
             "references/connector-execution.md",
@@ -45,6 +48,7 @@ describe("embedded skill assets", () => {
         expect(getBundledSkillFiles("oo", "codebuddy").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "references/auth-and-billing.md",
+            "references/llm-client.md",
             "references/search-and-selection.md",
             "references/package-execution.md",
             "references/connector-execution.md",
@@ -54,6 +58,7 @@ describe("embedded skill assets", () => {
         expect(getBundledSkillFiles("oo", "workbuddy").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "references/auth-and-billing.md",
+            "references/llm-client.md",
             "references/search-and-selection.md",
             "references/package-execution.md",
             "references/connector-execution.md",
@@ -63,6 +68,7 @@ describe("embedded skill assets", () => {
         expect(getBundledSkillFiles("oo", "trae").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "references/auth-and-billing.md",
+            "references/llm-client.md",
             "references/search-and-selection.md",
             "references/package-execution.md",
             "references/connector-execution.md",
@@ -72,6 +78,7 @@ describe("embedded skill assets", () => {
         expect(getBundledSkillFiles("oo", "trae-cn").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "references/auth-and-billing.md",
+            "references/llm-client.md",
             "references/search-and-selection.md",
             "references/package-execution.md",
             "references/connector-execution.md",
@@ -81,6 +88,7 @@ describe("embedded skill assets", () => {
         expect(getBundledSkillFiles("oo", "openclaw").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "references/auth-and-billing.md",
+            "references/llm-client.md",
             "references/search-and-selection.md",
             "references/package-execution.md",
             "references/connector-execution.md",
@@ -90,6 +98,7 @@ describe("embedded skill assets", () => {
         expect(getBundledSkillFiles("oo", "qoderwork").map(file => file.relativePath)).toEqual([
             "SKILL.md",
             "references/auth-and-billing.md",
+            "references/llm-client.md",
             "references/search-and-selection.md",
             "references/package-execution.md",
             "references/connector-execution.md",
@@ -408,6 +417,38 @@ describe("embedded skill assets", () => {
             expect(content).toContain("reply with `1` to install or `2` to skip");
             expect(content).toContain("Treat a `1` response as explicit agreement");
             expect(content).toContain("Do not install unless the user explicitly agrees");
+        }
+    });
+
+    test("guides local code toward oo LLM client config", async () => {
+        for (const agentName of availableBundledSkillAgentNames) {
+            const skillFiles = getBundledSkillFiles("oo", agentName);
+            const skillFile = skillFiles.find(file => file.relativePath === "SKILL.md");
+            const llmGuide = skillFiles.find(
+                file => file.relativePath === "references/llm-client.md",
+            );
+
+            if (skillFile === undefined || llmGuide === undefined) {
+                throw new Error(`Missing ${agentName} oo LLM client guidance`);
+            }
+
+            const skillContent = normalizeMarkdownWrappingForAssertion(
+                await Bun.file(skillFile.sourcePath).text(),
+            );
+            const llmGuideContent = normalizeMarkdownWrappingForAssertion(
+                await Bun.file(llmGuide.sourcePath).text(),
+            );
+
+            expect(skillContent).toContain("LLM client config mode");
+            expect(skillContent).toContain("local code");
+            expect(skillContent).toContain("references/llm-client.md");
+            expect(llmGuideContent).toContain("oo llm config --json");
+            expect(llmGuideContent).toContain("OpenAI-compatible");
+            expect(llmGuideContent).toContain("baseUrl");
+            expect(llmGuideContent).toContain("apiKey");
+            expect(llmGuideContent).toContain("oomol-chat");
+            expect(llmGuideContent).toContain("Do not read `auth.toml` directly");
+            expect(llmGuideContent).toContain("Do not hardcode");
         }
     });
 
@@ -780,6 +821,13 @@ describe("embedded skill assets", () => {
             expect(content).toContain("A successful");
             expect(content).toContain("file path alone is not enough");
             expect(content).toContain("local/cloud file boundary");
+            expect(content).toContain("oo llm config --json");
+            expect(content).toContain("OOMOL-hosted LLM client");
+            expect(content).toContain("returned `apiKey`");
+            expect(content).toContain("`baseUrl`");
+            expect(content).toContain("`model`");
+            expect(content).toContain("Do not hardcode");
+            expect(content).toContain("read local auth files directly");
             expect(content).not.toContain("oo-upload");
             expect(content).not.toContain("oo-download");
         }

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -5,6 +5,7 @@ import ooPublishSkillClaudeSkillPath from "../../../../contrib/skills/claude/oo-
 import ooClaudeAuthAndBillingReferencePath from "../../../../contrib/skills/claude/oo/references/auth-and-billing.md" with { type: "file" };
 import ooClaudeConnectorExecutionReferencePath from "../../../../contrib/skills/claude/oo/references/connector-execution.md" with { type: "file" };
 import ooClaudeFileTransferReferencePath from "../../../../contrib/skills/claude/oo/references/file-transfer.md" with { type: "file" };
+import ooClaudeLlmClientReferencePath from "../../../../contrib/skills/claude/oo/references/llm-client.md" with { type: "file" };
 import ooClaudePackageExecutionReferencePath from "../../../../contrib/skills/claude/oo/references/package-execution.md" with { type: "file" };
 import ooClaudeSearchAndSelectionReferencePath from "../../../../contrib/skills/claude/oo/references/search-and-selection.md" with { type: "file" };
 import ooClaudeTaskLifecycleReferencePath from "../../../../contrib/skills/claude/oo/references/task-lifecycle.md" with { type: "file" };
@@ -16,6 +17,7 @@ import ooPublishSkillCodeBuddySkillPath from "../../../../contrib/skills/codebud
 import ooCodeBuddyAuthAndBillingReferencePath from "../../../../contrib/skills/codebuddy/oo/references/auth-and-billing.md" with { type: "file" };
 import ooCodeBuddyConnectorExecutionReferencePath from "../../../../contrib/skills/codebuddy/oo/references/connector-execution.md" with { type: "file" };
 import ooCodeBuddyFileTransferReferencePath from "../../../../contrib/skills/codebuddy/oo/references/file-transfer.md" with { type: "file" };
+import ooCodeBuddyLlmClientReferencePath from "../../../../contrib/skills/codebuddy/oo/references/llm-client.md" with { type: "file" };
 import ooCodeBuddyPackageExecutionReferencePath from "../../../../contrib/skills/codebuddy/oo/references/package-execution.md" with { type: "file" };
 import ooCodeBuddySearchAndSelectionReferencePath from "../../../../contrib/skills/codebuddy/oo/references/search-and-selection.md" with { type: "file" };
 import ooCodeBuddyTaskLifecycleReferencePath from "../../../../contrib/skills/codebuddy/oo/references/task-lifecycle.md" with { type: "file" };
@@ -31,6 +33,7 @@ import ooOpenAIAgentPath from "../../../../contrib/skills/codex/oo/agents/openai
 import ooAuthAndBillingReferencePath from "../../../../contrib/skills/codex/oo/references/auth-and-billing.md" with { type: "file" };
 import ooConnectorExecutionReferencePath from "../../../../contrib/skills/codex/oo/references/connector-execution.md" with { type: "file" };
 import ooFileTransferReferencePath from "../../../../contrib/skills/codex/oo/references/file-transfer.md" with { type: "file" };
+import ooLlmClientReferencePath from "../../../../contrib/skills/codex/oo/references/llm-client.md" with { type: "file" };
 import ooPackageExecutionReferencePath from "../../../../contrib/skills/codex/oo/references/package-execution.md" with { type: "file" };
 import ooSearchAndSelectionReferencePath from "../../../../contrib/skills/codex/oo/references/search-and-selection.md" with { type: "file" };
 import ooTaskLifecycleReferencePath from "../../../../contrib/skills/codex/oo/references/task-lifecycle.md" with { type: "file" };
@@ -42,6 +45,7 @@ import ooPublishSkillOpenClawSkillPath from "../../../../contrib/skills/openclaw
 import ooOpenClawAuthAndBillingReferencePath from "../../../../contrib/skills/openclaw/oo/references/auth-and-billing.md" with { type: "file" };
 import ooOpenClawConnectorExecutionReferencePath from "../../../../contrib/skills/openclaw/oo/references/connector-execution.md" with { type: "file" };
 import ooOpenClawFileTransferReferencePath from "../../../../contrib/skills/openclaw/oo/references/file-transfer.md" with { type: "file" };
+import ooOpenClawLlmClientReferencePath from "../../../../contrib/skills/openclaw/oo/references/llm-client.md" with { type: "file" };
 import ooOpenClawPackageExecutionReferencePath from "../../../../contrib/skills/openclaw/oo/references/package-execution.md" with { type: "file" };
 import ooOpenClawSearchAndSelectionReferencePath from "../../../../contrib/skills/openclaw/oo/references/search-and-selection.md" with { type: "file" };
 import ooOpenClawTaskLifecycleReferencePath from "../../../../contrib/skills/openclaw/oo/references/task-lifecycle.md" with { type: "file" };
@@ -53,6 +57,7 @@ import ooPublishSkillQoderWorkSkillPath from "../../../../contrib/skills/qoderwo
 import ooQoderWorkAuthAndBillingReferencePath from "../../../../contrib/skills/qoderwork/oo/references/auth-and-billing.md" with { type: "file" };
 import ooQoderWorkConnectorExecutionReferencePath from "../../../../contrib/skills/qoderwork/oo/references/connector-execution.md" with { type: "file" };
 import ooQoderWorkFileTransferReferencePath from "../../../../contrib/skills/qoderwork/oo/references/file-transfer.md" with { type: "file" };
+import ooQoderWorkLlmClientReferencePath from "../../../../contrib/skills/qoderwork/oo/references/llm-client.md" with { type: "file" };
 import ooQoderWorkPackageExecutionReferencePath from "../../../../contrib/skills/qoderwork/oo/references/package-execution.md" with { type: "file" };
 import ooQoderWorkSearchAndSelectionReferencePath from "../../../../contrib/skills/qoderwork/oo/references/search-and-selection.md" with { type: "file" };
 import ooQoderWorkTaskLifecycleReferencePath from "../../../../contrib/skills/qoderwork/oo/references/task-lifecycle.md" with { type: "file" };
@@ -82,6 +87,7 @@ const ooCodexReferenceFiles = createOoReferenceFiles({
     authAndBilling: ooAuthAndBillingReferencePath,
     connectorExecution: ooConnectorExecutionReferencePath,
     fileTransfer: ooFileTransferReferencePath,
+    llmClient: ooLlmClientReferencePath,
     packageExecution: ooPackageExecutionReferencePath,
     searchAndSelection: ooSearchAndSelectionReferencePath,
     taskLifecycle: ooTaskLifecycleReferencePath,
@@ -90,6 +96,7 @@ const ooClaudeCompatibleReferenceFiles = createOoReferenceFiles({
     authAndBilling: ooClaudeAuthAndBillingReferencePath,
     connectorExecution: ooClaudeConnectorExecutionReferencePath,
     fileTransfer: ooClaudeFileTransferReferencePath,
+    llmClient: ooClaudeLlmClientReferencePath,
     packageExecution: ooClaudePackageExecutionReferencePath,
     searchAndSelection: ooClaudeSearchAndSelectionReferencePath,
     taskLifecycle: ooClaudeTaskLifecycleReferencePath,
@@ -98,6 +105,7 @@ const ooCodeBuddyReferenceFiles = createOoReferenceFiles({
     authAndBilling: ooCodeBuddyAuthAndBillingReferencePath,
     connectorExecution: ooCodeBuddyConnectorExecutionReferencePath,
     fileTransfer: ooCodeBuddyFileTransferReferencePath,
+    llmClient: ooCodeBuddyLlmClientReferencePath,
     packageExecution: ooCodeBuddyPackageExecutionReferencePath,
     searchAndSelection: ooCodeBuddySearchAndSelectionReferencePath,
     taskLifecycle: ooCodeBuddyTaskLifecycleReferencePath,
@@ -106,6 +114,7 @@ const ooOpenClawReferenceFiles = createOoReferenceFiles({
     authAndBilling: ooOpenClawAuthAndBillingReferencePath,
     connectorExecution: ooOpenClawConnectorExecutionReferencePath,
     fileTransfer: ooOpenClawFileTransferReferencePath,
+    llmClient: ooOpenClawLlmClientReferencePath,
     packageExecution: ooOpenClawPackageExecutionReferencePath,
     searchAndSelection: ooOpenClawSearchAndSelectionReferencePath,
     taskLifecycle: ooOpenClawTaskLifecycleReferencePath,
@@ -114,6 +123,7 @@ const ooQoderWorkReferenceFiles = createOoReferenceFiles({
     authAndBilling: ooQoderWorkAuthAndBillingReferencePath,
     connectorExecution: ooQoderWorkConnectorExecutionReferencePath,
     fileTransfer: ooQoderWorkFileTransferReferencePath,
+    llmClient: ooQoderWorkLlmClientReferencePath,
     packageExecution: ooQoderWorkPackageExecutionReferencePath,
     searchAndSelection: ooQoderWorkSearchAndSelectionReferencePath,
     taskLifecycle: ooQoderWorkTaskLifecycleReferencePath,
@@ -500,6 +510,7 @@ function createOoReferenceFiles(sourcePaths: {
     authAndBilling: string;
     connectorExecution: string;
     fileTransfer: string;
+    llmClient: string;
     packageExecution: string;
     searchAndSelection: string;
     taskLifecycle: string;
@@ -508,6 +519,10 @@ function createOoReferenceFiles(sourcePaths: {
         {
             relativePath: "references/auth-and-billing.md",
             sourcePath: sourcePaths.authAndBilling,
+        },
+        {
+            relativePath: "references/llm-client.md",
+            sourcePath: sourcePaths.llmClient,
         },
         {
             relativePath: "references/search-and-selection.md",

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -218,6 +218,14 @@ const commandTelemetryDecisions = {
         ],
         reason: "Records self-update state without raw version strings.",
     },
+    "llm": {
+        kind: "generic",
+        reason: "Command group; child commands make their own credential-output decisions.",
+    },
+    "llm.config": {
+        kind: "excluded",
+        reason: "This command intentionally prints the current account API key for LLM client setup.",
+    },
     "log": {
         kind: "generic",
         reason: "Command group; log paths and log contents must not be recorded.",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -104,6 +104,12 @@ export const enMessages = {
     "commands.install.description":
         "Install one oo-managed CLI release into the local managed runtime.",
     "commands.install.summary": "Install the CLI",
+    "commands.llm.config.description":
+        "Print the current account's LLM client configuration as JSON.",
+    "commands.llm.config.summary": "Show LLM client config",
+    "commands.llm.description":
+        "Expose LLM client configuration for the current account.",
+    "commands.llm.summary": "Manage LLM client config",
     "commands.help.summary": "Show help for a command",
     "commands.log.description": "Inspect persisted CLI debug logs.",
     "commands.log.summary": "Manage persisted debug logs",
@@ -958,6 +964,12 @@ export const zhMessages = {
     "commands.install.description":
         "把一个由 oo 管理的 CLI 版本安装到本地托管运行时中。",
     "commands.install.summary": "安装 CLI",
+    "commands.llm.config.description":
+        "以 JSON 输出当前账号的 LLM client 配置。",
+    "commands.llm.config.summary": "显示 LLM client 配置",
+    "commands.llm.description":
+        "导出当前账号可用的 LLM client 配置。",
+    "commands.llm.summary": "管理 LLM client 配置",
     "commands.help.summary": "显示命令帮助",
     "commands.log.description": "查看持久化的 CLI debug 日志。",
     "commands.log.summary": "管理持久化 debug 日志",


### PR DESCRIPTION
## Summary

- Add `oo llm config --json` to print the current account API key, derived OOMOL LLM base URL, and default `oomol-chat` model for OpenAI-compatible clients.
- Register the command in CLI help, docs, localization, telemetry decisions, and snapshots.
- Add bundled skill guidance so Codex and other supported agents know to use `oo llm config --json` when generated local code needs LLM provider configuration, without reading auth files directly or logging secrets.

## Validation

- `bun run lint:fix`
- `bun run ts-check`
- `git diff --check`
- `bun run test` (`964 pass`, `4 skip`, `0 fail`)

## Notes

This PR is draft by default because the command intentionally exposes a credential for local client setup and should get an explicit security/API contract review before merge.