### PR TITLE
feat(self-update): run skills update after install and update

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -258,9 +258,12 @@ Install one managed `oo` release into the local self-managed runtime.
   could not be updated — followed by the restart-shell note. The user can
   then decide whether to update the failed profiles manually.
 - Notes: after a successful install workflow, the CLI silently runs
-  `oo skills add` with the managed executable so bundled skills refresh to the
-  installed CLI version. That command also includes any successfully installed
-  preset registry skills in the same skill summary.
+  `oo skills add` followed by `oo skills update` with the managed executable,
+  so bundled skills refresh to the installed CLI version and any installed
+  oo-managed published skills are checked and updated. The `oo skills add`
+  step also includes any successfully installed preset registry skills in the
+  same skill summary. Child command stdout/stderr is not forwarded, and
+  failures do not change the install result.
 - Notes: when the current version is `0.0.0-development`, the CLI prints the
   managed install/update unsupported message and exits successfully.
 
@@ -288,8 +291,8 @@ Update the managed `oo` install to the latest published release.
 - Notes: `oo update` ensures the managed install is current and usable, and
   does not expose a separate `--force` flag.
 - Notes: when the latest published release matches the current version, update
-  still runs `oo skills add` for the active managed version before printing the
-  up-to-date message.
+  still runs the managed skill refresh and update maintenance for the active
+  managed version before printing the up-to-date message.
 - Notes: after a successful update, the CLI best-effort removes legacy global
   `@oomol-lab/oo-cli` package-manager installs that appear anywhere on `PATH`;
   when `PATH` yields no `oo` candidates, the CLI falls back to the current
@@ -311,9 +314,12 @@ Update the managed `oo` install to the latest published release.
   could not be updated — followed by the restart-shell note. The user can
   then decide whether to update the failed profiles manually.
 - Notes: after a successful update workflow, the CLI silently runs
-  `oo skills add` with the managed executable so bundled skills refresh to the
-  installed CLI version. That command also includes any successfully installed
-  preset registry skills in the same skill summary.
+  `oo skills add` followed by `oo skills update` with the managed executable,
+  so bundled skills refresh to the installed CLI version and any installed
+  oo-managed published skills are checked and updated. The `oo skills add`
+  step also includes any successfully installed preset registry skills in the
+  same skill summary. Child command stdout/stderr is not forwarded, and
+  failures do not change the update result.
 - Notes: when the current version is `0.0.0-development`, the CLI prints the
   managed install/update unsupported message and exits successfully.
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -224,9 +224,11 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 说明：当部分 shell profile 配置成功、另一部分失败时，install 会分别列出两组
   ——已配置的 profile 和未能配置的 profile，并附带重启 shell 的提示；用户可据此
   决定是否手动补全未配置的 profile。
-- 说明：install 成功后，CLI 会使用托管的可执行文件静默执行一次
-  `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。该命令也会把
-  安装成功的预设 registry skills 合并进同一份 skill 摘要。
+- 说明：install 成功后，CLI 会使用托管的可执行文件依次静默执行
+  `oo skills add` 与 `oo skills update`，让 bundled skills 刷新到已安装的 CLI
+  版本，同时检查并更新已安装的 oo-managed published skills。`oo skills add`
+  也会把安装成功的预设 registry skills 合并进同一份 skill 摘要。子命令的
+  stdout/stderr 不会透传；即使失败，也不会改变 install 的结果。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /
   update 的提示，并以成功状态退出。
 
@@ -250,7 +252,7 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 说明：`oo update` 会确保托管安装保持为当前可用状态，不额外暴露
   `--force`。
 - 说明：当最新发布版本与当前版本一致时，update 仍会先为当前激活的托管版本
-  执行 `oo skills add`，再输出“已是最新版本”的消息。
+  执行托管 skill 刷新与更新维护流程，再输出“已是最新版本”的消息。
 - 说明：update 成功后，CLI 会尽力移除在 `PATH` 中任意位置出现的旧全局
   package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到 `oo`
   候选项，CLI 会回退到当前命令路径进行判断。对于 npm 安装，清理命令会在可推断时
@@ -265,9 +267,11 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 说明：当部分 shell profile 配置成功、另一部分失败时，update 会分别列出两组
   ——已配置的 profile 和未能配置的 profile，并附带重启 shell 的提示；用户可据此
   决定是否手动补全未配置的 profile。
-- 说明：update 成功后，CLI 会使用托管的可执行文件静默执行一次
-  `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。该命令也会把
-  安装成功的预设 registry skills 合并进同一份 skill 摘要。
+- 说明：update 成功后，CLI 会使用托管的可执行文件依次静默执行
+  `oo skills add` 与 `oo skills update`，让 bundled skills 刷新到已安装的 CLI
+  版本，同时检查并更新已安装的 oo-managed published skills。`oo skills add`
+  也会把安装成功的预设 registry skills 合并进同一份 skill 摘要。子命令的
+  stdout/stderr 不会透传；即使失败，也不会改变 update 的结果。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /
   update 的提示，并以成功状态退出。
 

--- a/src/application/commands/self-update.cli.test.ts
+++ b/src/application/commands/self-update.cli.test.ts
@@ -299,7 +299,7 @@ describe("self-update commands", () => {
                 stdout: `Installed oo 2.0.0.\nExecutable: <EXECUTABLE_PATH>\nAdded <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.\n`,
             });
             expect(selfUpdateRuntime.commands).toEqual(
-                createExpectedManagedSkillInstallCommands(targetVersionPath),
+                createExpectedManagedSkillMaintenanceCommands(targetVersionPath),
             );
         }
         finally {
@@ -353,6 +353,8 @@ describe("self-update commands", () => {
             expect(snapshot.stderr).toContain("Activated executable.");
             expect(snapshot.stderr).toContain("Verified installation.");
             expect(snapshot.stderr).toContain("Cleaned up old artifacts.");
+            expect(snapshot.stderr).toContain("Updating installed skills...");
+            expect(snapshot.stderr).toContain("Finished installed skill update.");
         }
         finally {
             await sandbox.cleanup();
@@ -455,7 +457,7 @@ describe("self-update commands", () => {
                 },
             });
             expect(selfUpdateRuntime.commands).toEqual(
-                createExpectedManagedSkillInstallCommands(targetVersionPath),
+                createExpectedManagedSkillMaintenanceCommands(targetVersionPath),
             );
         }
         finally {
@@ -694,7 +696,7 @@ describe("self-update commands", () => {
             expect(latestRequestCount).toBe(1);
             expect(binaryRequestCount).toBe(0);
             expect(selfUpdateRuntime.commands).toEqual(
-                createExpectedManagedSkillInstallCommands(currentVersionPath),
+                createExpectedManagedSkillMaintenanceCommands(currentVersionPath),
             );
         }
         finally {
@@ -758,7 +760,7 @@ describe("self-update commands", () => {
             expect(latestRequestCount).toBe(1);
             expect(binaryRequestCount).toBe(1);
             expect(selfUpdateRuntime.commands).toEqual(
-                createExpectedManagedSkillInstallCommands(currentVersionPath),
+                createExpectedManagedSkillMaintenanceCommands(currentVersionPath),
             );
             expect((await stat(legacyVersionPath)).isDirectory()).toBeTrue();
             await expect(Bun.file(currentVersionPath).exists()).resolves.toBeTrue();
@@ -872,7 +874,7 @@ describe("self-update commands", () => {
             expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             expect(binaryRequestCount).toBe(1);
             expect(legacyCleanup.commands).toEqual([
-                ...createExpectedManagedSkillInstallCommands(currentVersionPath),
+                ...createExpectedManagedSkillMaintenanceCommands(currentVersionPath),
                 {
                     commandArguments: [
                         "uninstall",
@@ -937,6 +939,8 @@ describe("self-update commands", () => {
             expect(snapshot.stderr).toContain("Activated executable.");
             expect(snapshot.stderr).toContain("Verified installation.");
             expect(snapshot.stderr).toContain("Cleaned up old artifacts.");
+            expect(snapshot.stderr).toContain("Updating installed skills...");
+            expect(snapshot.stderr).toContain("Finished installed skill update.");
         }
         finally {
             await sandbox.cleanup();
@@ -1043,12 +1047,17 @@ interface CapturedSelfUpdateCommand {
     timeoutMs: number;
 }
 
-function createExpectedManagedSkillInstallCommands(
+function createExpectedManagedSkillMaintenanceCommands(
     commandPath: string,
 ): CapturedSelfUpdateCommand[] {
     return [
         {
             commandArguments: ["skills", "add"],
+            commandPath,
+            timeoutMs: 40_000,
+        },
+        {
+            commandArguments: ["skills", "update"],
             commandPath,
             timeoutMs: 40_000,
         },

--- a/src/application/commands/update.ts
+++ b/src/application/commands/update.ts
@@ -5,6 +5,7 @@ import process from "node:process";
 import { z } from "zod";
 import {
     attemptManagedSkillInstall,
+    attemptManagedSkillUpdate,
     isManagedVersionExecutableInstalled,
     resolveManagedSkillInstallCommandPath,
 } from "../self-update/bundled-skills.ts";
@@ -119,12 +120,25 @@ export const updateCommand: CliCommandDefinition<
                     version: context.version,
                 })
             ) {
+                const managedSkillCommandPath = await resolveManagedSkillInstallCommandPath({
+                    env: context.env,
+                    platform: process.platform,
+                    version: context.version,
+                });
+
                 await attemptManagedSkillInstall({
-                    commandPath: await resolveManagedSkillInstallCommandPath({
+                    commandPath: managedSkillCommandPath,
+                    runtime: {
                         env: context.env,
-                        platform: process.platform,
-                        version: context.version,
-                    }),
+                        logger: context.logger,
+                        ...context.selfUpdateRuntime,
+                    },
+                });
+                progressReporter?.setStage("skillsUpdate", {
+                    version: context.version,
+                });
+                await attemptManagedSkillUpdate({
+                    commandPath: managedSkillCommandPath,
                     runtime: {
                         env: context.env,
                         logger: context.logger,

--- a/src/application/commands/update.ts
+++ b/src/application/commands/update.ts
@@ -126,6 +126,9 @@ export const updateCommand: CliCommandDefinition<
                     version: context.version,
                 });
 
+                progressReporter?.setStage("skillsUpdate", {
+                    version: context.version,
+                });
                 await attemptManagedSkillInstall({
                     commandPath: managedSkillCommandPath,
                     runtime: {
@@ -133,9 +136,6 @@ export const updateCommand: CliCommandDefinition<
                         logger: context.logger,
                         ...context.selfUpdateRuntime,
                     },
-                });
-                progressReporter?.setStage("skillsUpdate", {
-                    version: context.version,
                 });
                 await attemptManagedSkillUpdate({
                     commandPath: managedSkillCommandPath,

--- a/src/application/self-update/bundled-skills.ts
+++ b/src/application/self-update/bundled-skills.ts
@@ -9,7 +9,7 @@ import {
     resolveSelfUpdateVersionExecutablePath,
 } from "./paths.ts";
 
-const managedSkillInstallTimeoutMs = 40_000;
+const managedSkillMaintenanceTimeoutMs = 40_000;
 
 export async function resolveManagedSkillInstallCommandPath(options: {
     env: Record<string, string | undefined>;
@@ -76,10 +76,27 @@ export async function attemptManagedSkillInstall(options: {
         commandPath: options.commandPath,
         failureMessage: "Managed skill install failed.",
         logContext: {
-            timeoutMs: managedSkillInstallTimeoutMs,
+            timeoutMs: managedSkillMaintenanceTimeoutMs,
         },
         runtime: options.runtime,
         successMessage: "Managed skill install completed.",
-        timeoutMs: managedSkillInstallTimeoutMs,
+        timeoutMs: managedSkillMaintenanceTimeoutMs,
+    });
+}
+
+export async function attemptManagedSkillUpdate(options: {
+    commandPath: string;
+    runtime: SelfUpdateCommandRuntime;
+}): Promise<void> {
+    await runSelfUpdateCommandWithLogging({
+        commandArguments: ["skills", "update"],
+        commandPath: options.commandPath,
+        failureMessage: "Managed skill update failed.",
+        logContext: {
+            timeoutMs: managedSkillMaintenanceTimeoutMs,
+        },
+        runtime: options.runtime,
+        successMessage: "Managed skill update completed.",
+        timeoutMs: managedSkillMaintenanceTimeoutMs,
     });
 }

--- a/src/application/self-update/core.test.ts
+++ b/src/application/self-update/core.test.ts
@@ -446,7 +446,7 @@ describe("performSelfUpdateOperation", () => {
 
             expect(result.status).toBe("installed");
             expect(invokedCommands).toEqual([
-                ...createExpectedManagedSkillInstallCommands(targetVersionPath),
+                ...createExpectedManagedSkillMaintenanceCommands(targetVersionPath),
                 {
                     commandArguments: ["remove", "-g", "@oomol-lab/oo-cli"],
                     commandPath: "/mock/bin/pnpm",
@@ -527,7 +527,7 @@ describe("performSelfUpdateOperation", () => {
 
             expect(result.status).toBe("installed");
             expect(invokedCommands).toEqual([
-                ...createExpectedManagedSkillInstallCommands(targetVersionPath),
+                ...createExpectedManagedSkillMaintenanceCommands(targetVersionPath),
                 {
                     commandArguments: ["remove", "-g", "@oomol-lab/oo-cli"],
                     commandPath: "/mock/bin/bun",
@@ -624,6 +624,10 @@ describe("performSelfUpdateOperation", () => {
                 },
                 {
                     stage: "cleanup",
+                    version: "2.0.0",
+                },
+                {
+                    stage: "skillsUpdate",
                     version: "2.0.0",
                 },
             ]);
@@ -951,6 +955,10 @@ describe("performSelfUpdateOperation", () => {
                     stage: "cleanup",
                     version: "2.0.0",
                 },
+                {
+                    stage: "skillsUpdate",
+                    version: "2.0.0",
+                },
             ]);
         }
         finally {
@@ -1020,13 +1028,17 @@ function createSuccessfulSelfUpdateCommandRunner(
     };
 }
 
-function createExpectedManagedSkillInstallCommands(commandPath: string): Array<{
+function createExpectedManagedSkillMaintenanceCommands(commandPath: string): Array<{
     commandArguments: readonly string[];
     commandPath: string;
 }> {
     return [
         {
             commandArguments: ["skills", "add"],
+            commandPath,
+        },
+        {
+            commandArguments: ["skills", "update"],
             commandPath,
         },
     ];

--- a/src/application/self-update/core.ts
+++ b/src/application/self-update/core.ts
@@ -203,13 +203,13 @@ export async function performSelfUpdateOperation(options: {
             options.targetVersion,
         );
 
-        await attemptManagedSkillInstall({
-            commandPath: targetVersionCommandPath,
-            runtime: options.runtime,
-        });
         options.reportStage?.({
             stage: "skillsUpdate",
             version: options.targetVersion,
+        });
+        await attemptManagedSkillInstall({
+            commandPath: targetVersionCommandPath,
+            runtime: options.runtime,
         });
         await attemptManagedSkillUpdate({
             commandPath: targetVersionCommandPath,

--- a/src/application/self-update/core.ts
+++ b/src/application/self-update/core.ts
@@ -19,7 +19,10 @@ import {
     fetchLatestCliReleaseVersion,
     parseLatestCliSemverReleaseVersion,
 } from "../update/release-metadata.ts";
-import { attemptManagedSkillInstall } from "./bundled-skills.ts";
+import {
+    attemptManagedSkillInstall,
+    attemptManagedSkillUpdate,
+} from "./bundled-skills.ts";
 import { resolveSelfUpdateCommandResolution } from "./command-resolution.ts";
 import { attemptLegacyPackageManagerUninstall } from "./legacy-installation.ts";
 import {
@@ -195,11 +198,21 @@ export async function performSelfUpdateOperation(options: {
             platform: options.runtime.platform,
             targetVersion: options.targetVersion,
         });
+        const targetVersionCommandPath = resolveSelfUpdateVersionExecutablePath(
+            paths,
+            options.targetVersion,
+        );
+
         await attemptManagedSkillInstall({
-            commandPath: resolveSelfUpdateVersionExecutablePath(
-                paths,
-                options.targetVersion,
-            ),
+            commandPath: targetVersionCommandPath,
+            runtime: options.runtime,
+        });
+        options.reportStage?.({
+            stage: "skillsUpdate",
+            version: options.targetVersion,
+        });
+        await attemptManagedSkillUpdate({
+            commandPath: targetVersionCommandPath,
             runtime: options.runtime,
         });
         await attemptLegacyPackageManagerUninstall(options.runtime);

--- a/src/application/self-update/progress.ts
+++ b/src/application/self-update/progress.ts
@@ -5,7 +5,8 @@ export type SelfUpdateOperationStage
         | "reuse"
         | "activate"
         | "verify"
-        | "cleanup";
+        | "cleanup"
+        | "skillsUpdate";
 
 // All stages including "resolve", which is managed at the command level.
 export type SelfUpdateProgressStage = SelfUpdateOperationStage | "resolve";

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -728,6 +728,8 @@ export const enMessages = {
     "selfUpdate.progress.verify.complete": "Verified installation.",
     "selfUpdate.progress.cleanup.start": "Cleaning up old artifacts...",
     "selfUpdate.progress.cleanup.complete": "Cleaned up old artifacts.",
+    "selfUpdate.progress.skillsUpdate.start": "Updating installed skills...",
+    "selfUpdate.progress.skillsUpdate.complete": "Finished installed skill update.",
     "selfUpdate.lockBusy":
         "Another update is already in progress. Please try again later.",
     "selfUpdate.lockBusyWithPid":
@@ -1626,6 +1628,8 @@ export const zhMessages = {
     "selfUpdate.progress.verify.complete": "已校验安装结果。",
     "selfUpdate.progress.cleanup.start": "正在清理旧产物...",
     "selfUpdate.progress.cleanup.complete": "已清理旧产物。",
+    "selfUpdate.progress.skillsUpdate.start": "正在更新已安装的 skill...",
+    "selfUpdate.progress.skillsUpdate.complete": "已完成已安装 skill 更新。",
     "selfUpdate.lockBusy":
         "另一个更新已在进行中，请稍后再试。",
     "selfUpdate.lockBusyWithPid":


### PR DESCRIPTION
After the managed install/update workflow finishes refreshing bundled skills via `oo skills add`, also run `oo skills update` against the managed executable so any installed oo-managed published skills get checked and upgraded in the same pass. Previously users had to invoke `oo skills update` manually to pick up new published skill versions after upgrading the CLI.

Introduce a new `skillsUpdate` progress stage with matching en/zh messages so the progress reporter can surface the extra maintenance step, and update the install/update docs to reflect the combined skill maintenance sequence.