### PR TITLE
feat(connector): add schema refresh subcommand

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -372,6 +372,16 @@ Show the stable schema contract for one connector action.
   `asyncLifecycle`, and optional `runOutputSchema`.
 - Notes: `--refresh` forces a fresh schema fetch for the selected action.
 
+### `oo connector schema refresh`
+
+Clear all locally cached connector action schemas.
+
+- Arguments: none.
+- Output: text output prints a single success line.
+- Notes: the command does not require authentication and does not fetch new
+  metadata immediately; later `oo connector schema` or `oo connector run`
+  invocations fetch and cache schemas again when needed.
+
 ### `oo connector run <serviceName>`
 
 Validate input data and run one connector action.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -320,6 +320,16 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   `asyncLifecycle` 和 `runOutputSchema`。
 - 说明：`--refresh` 会强制为选中的 action 重新获取 schema。
 
+### `oo connector schema refresh`
+
+清除所有本地缓存的 connector action schema。
+
+- 参数：无。
+- 输出：文本输出会打印一行成功信息。
+- 说明：该命令不要求登录，也不会立即请求远端 metadata；后续
+  `oo connector schema` 或 `oo connector run` 会在需要时重新获取并缓存
+  schema。
+
 ### `oo connector run <serviceName>`
 
 校验输入数据，并运行一个 connector action。

--- a/src/adapters/commander/localized-help.ts
+++ b/src/adapters/commander/localized-help.ts
@@ -69,6 +69,16 @@ export class LocalizedHelp extends Help {
         ]);
     }
 
+    override visibleGlobalOptions(cmd: Command): Option[] {
+        if (!this.showGlobalOptions || cmd.parent === null) {
+            return [];
+        }
+
+        const rootCommand = findRootCommand(cmd);
+
+        return rootCommand.options.filter(option => !option.hidden);
+    }
+
     override styleCommandDescription(description: string): string {
         const appDescription = this.translator.t("app.description");
 
@@ -93,6 +103,16 @@ export class LocalizedHelp extends Help {
 
         return sections.slice(1).join("\n\n");
     }
+}
+
+function findRootCommand(command: Command): Command {
+    let current = command;
+
+    while (current.parent !== null) {
+        current = current.parent;
+    }
+
+    return current;
 }
 
 function formatChoices(choices: readonly string[]): string {

--- a/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
@@ -118,6 +118,29 @@ Global Options:
   -V, --version          Show the current version
   --debug                Print the current log file path when the CLI exits
   --lang <lang>          Specify the display language
+
+Commands:
+  refresh                Clear connector action schema cache
+  help [command]         Show help for a command
+"
+,
+}
+`;
+
+exports[`connectorCommand CLI renders connector schema refresh help 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Clear all locally cached connector action schemas.
+
+Options:
+  -h, --help     Show help for command
+
+Global Options:
+  -V, --version  Show the current version
+  --debug        Print the current log file path when the CLI exits
+  --lang <lang>  Specify the display language
 "
 ,
 }
@@ -162,6 +185,17 @@ exports[`connectorCommand CLI supports connector schema with default json output
   "stderr": "",
   "stdout": 
 "{"description":"Send a Gmail message.","inputSchema":{"properties":{"to":{"type":"string"}},"required":["to"],"type":"object"},"name":"send_mail","outputSchema":{"type":"object"},"service":"gmail"}
+"
+,
+}
+`;
+
+exports[`connectorCommand CLI supports connector schema refresh subcommand by clearing cached metadata 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"Cleared locally cached connector action schemas.
 "
 ,
 }

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -426,6 +426,19 @@ describe("connectorCommand CLI", () => {
         }
     });
 
+    test("renders connector schema refresh help", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["connector", "schema", "refresh", "--help"]);
+
+            expect(createCliSnapshot(result)).toMatchSnapshot();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("supports connector run with cached schema and json output", async () => {
         const sandbox = await createCliSandbox();
 
@@ -1657,6 +1670,68 @@ describe("connectorCommand CLI", () => {
                     command_full: "connector.schema",
                     refresh: true,
                 },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports connector schema refresh subcommand by clearing cached metadata", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await seedConnectorActionSchema(
+                sandbox,
+                createConnectorActionFixture({
+                    description: "Cached schema.",
+                }),
+            );
+
+            const refreshResult = await sandbox.run(
+                ["connector", "schema", "refresh"],
+                {
+                    fetcher: async () => {
+                        throw new Error("Unexpected schema refresh request");
+                    },
+                },
+            );
+
+            await writeAuthFile(sandbox);
+
+            let metadataRequestCount = 0;
+            const schemaResult = await sandbox.run(
+                ["connector", "schema", "gmail", "--action", "send_mail"],
+                {
+                    fetcher: async () => {
+                        metadataRequestCount += 1;
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                description: "Fresh schema after cache refresh.",
+                                id: "gmail.send_mail",
+                                inputSchema: {
+                                    type: "object",
+                                },
+                                name: "send_mail",
+                                outputSchema: {
+                                    type: "object",
+                                },
+                                providerPermissions: [],
+                                requiredScopes: [],
+                                service: "gmail",
+                            },
+                        }));
+                    },
+                },
+            );
+
+            expect(createCliSnapshot(refreshResult)).toMatchSnapshot();
+            expect(metadataRequestCount).toBe(1);
+            expect(JSON.parse(schemaResult.stdout)).toMatchObject({
+                description: "Fresh schema after cache refresh.",
+                name: "send_mail",
+                service: "gmail",
             });
         }
         finally {

--- a/src/application/commands/connector/schema-cache.test.ts
+++ b/src/application/commands/connector/schema-cache.test.ts
@@ -18,6 +18,7 @@ import { CliUserError } from "../../contracts/cli.ts";
 
 import {
     cacheConnectorActionSchemas,
+    clearConnectorActionSchemaCache,
     createConnectorActionSchemaCacheKey,
     createConnectorActionSchemaOutput,
     deleteConnectorActionSchemaCache,
@@ -330,6 +331,46 @@ describe("connector schema cache", () => {
         expect(cache.get(secondKey)).toMatchObject({
             description: "Second account schema.",
         });
+    });
+
+    test("clearConnectorActionSchemaCache clears the schema namespace and legacy directory", async () => {
+        const rootPath = await createTemporaryDirectory("connector-schema-cache-clear");
+        const cache = createMemoryCache();
+        const firstKey = createConnectorActionSchemaCacheKey({
+            accountId: "user-1",
+            actionName: "send_mail",
+            endpoint: "oomol.com",
+            serviceName: "gmail",
+        });
+        const secondKey = createConnectorActionSchemaCacheKey({
+            accountId: "user-2",
+            actionName: "get_message",
+            endpoint: "oomol.com",
+            serviceName: "gmail",
+        });
+
+        try {
+            const legacyDirectoryPath = join(rootPath, "connector-actions");
+
+            await mkdir(legacyDirectoryPath, { recursive: true });
+            await Bun.write(join(legacyDirectoryPath, "old.json"), "{}");
+            cache.set(firstKey, createConnectorActionFixture());
+            cache.set(secondKey, createConnectorActionFixture({
+                description: "Second schema.",
+            }));
+
+            await clearConnectorActionSchemaCache(createCacheContext({
+                cache,
+                settingsFilePath: join(rootPath, "settings.toml"),
+            }));
+
+            expect(cache.get(firstKey)).toBeNull();
+            expect(cache.get(secondKey)).toBeNull();
+            await expect(Bun.file(legacyDirectoryPath).exists()).resolves.toBeFalse();
+        }
+        finally {
+            await rm(rootPath, { force: true, recursive: true });
+        }
     });
 
     test("createConnectorActionSchemaOutput exposes only the stable schema contract", () => {

--- a/src/application/commands/connector/schema-cache.ts
+++ b/src/application/commands/connector/schema-cache.ts
@@ -141,6 +141,13 @@ export async function cacheConnectorActionSchemas(
     }
 }
 
+export async function clearConnectorActionSchemaCache(
+    context: ConnectorActionSchemaCacheContext,
+): Promise<void> {
+    await cleanupLegacyConnectorActionSchemaCache(context);
+    openConnectorActionSchemaCache(context).clear();
+}
+
 export function deleteConnectorActionSchemaCache(
     identity: ConnectorActionSchemaIdentity,
     context: Pick<CliExecutionContext, "cacheStore">,

--- a/src/application/commands/connector/schema-refresh.ts
+++ b/src/application/commands/connector/schema-refresh.ts
@@ -1,0 +1,19 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import { writeLine } from "../shared/output.ts";
+import { clearConnectorActionSchemaCache } from "./schema-cache.ts";
+
+export const connectorSchemaRefreshCommand: CliCommandDefinition = {
+    name: "refresh",
+    summaryKey: "commands.connector.schema.refresh.summary",
+    descriptionKey: "commands.connector.schema.refresh.description",
+    inputSchema: z.object({}),
+    handler: async (_, context) => {
+        await clearConnectorActionSchemaCache(context);
+        writeLine(
+            context.stdout,
+            context.translator.t("connector.schema.refresh.success"),
+        );
+    },
+};

--- a/src/application/commands/connector/schema.ts
+++ b/src/application/commands/connector/schema.ts
@@ -8,6 +8,7 @@ import {
     createConnectorActionSchemaOutput,
     loadConnectorActionSchema,
 } from "./schema-cache.ts";
+import { connectorSchemaRefreshCommand } from "./schema-refresh.ts";
 import { requireConnectorActionName } from "./shared.ts";
 
 interface ConnectorSchemaInput {
@@ -21,6 +22,9 @@ export const connectorSchemaCommand: CliCommandDefinition<ConnectorSchemaInput> 
     summaryKey: "commands.connector.schema.summary",
     descriptionKey: "commands.connector.schema.description",
     missingArgumentBehavior: "showHelp",
+    children: [
+        connectorSchemaRefreshCommand,
+    ],
     arguments: [
         {
             name: "serviceName",

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -186,6 +186,10 @@ const commandTelemetryDecisions = {
         properties: ["refresh"],
         reason: "Records whether the user requested a fresh schema lookup without service or action identity.",
     },
+    "connector.schema.refresh": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; cached connector service and action identities are not recorded.",
+    },
     "file": {
         kind: "generic",
         reason: "Command group; child commands record file dimensions where safe.",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -55,6 +55,10 @@ export const enMessages = {
     "commands.connector.search.summary": "Search connector actions",
     "commands.connector.schema.description":
         "Show the schema contract for one connector action.",
+    "commands.connector.schema.refresh.description":
+        "Clear all locally cached connector action schemas.",
+    "commands.connector.schema.refresh.summary":
+        "Clear connector action schema cache",
     "commands.connector.schema.summary": "Show connector action schema",
     "commands.connector.run.description":
         "Validate input data and run one connector action.",
@@ -911,6 +915,8 @@ export const enMessages = {
         "Polling {action} (poll {pollCount}, state {state})",
     "connector.run.progress.waiting":
         "Waiting for async connector result from {action}...",
+    "connector.schema.refresh.success":
+        "Cleared locally cached connector action schemas.",
     "file.cleanup.success":
         "Deleted {deletedCount} expired or stale file transfer records.",
     "file.download.savedTo": "Saved to: {path}",
@@ -988,6 +994,10 @@ export const zhMessages = {
         "搜索 connector action",
     "commands.connector.schema.description":
         "显示一个 connector action 的 schema contract。",
+    "commands.connector.schema.refresh.description":
+        "清除所有本地缓存的 connector action schema。",
+    "commands.connector.schema.refresh.summary":
+        "清除 connector action schema cache",
     "commands.connector.schema.summary":
         "显示 connector action schema",
     "commands.connector.run.description":
@@ -1808,6 +1818,8 @@ export const zhMessages = {
         "正在轮询 {action}（第 {pollCount} 次，状态 {state}）",
     "connector.run.progress.waiting":
         "正在等待 {action} 的异步 connector 结果...",
+    "connector.schema.refresh.success":
+        "已清除本地缓存的 connector action schema。",
     "file.cleanup.success": "已删除 {deletedCount} 条过期或陈旧的文件传输记录。",
     "file.download.savedTo": "已保存到：{path}",
     "file.list.noResults": "未找到任何上传记录。",


### PR DESCRIPTION
Introduce `oo connector schema refresh` to clear all locally cached
connector action schemas. The command requires no authentication and
defers metadata refetching to subsequent `oo connector schema` or
`oo connector run` invocations.

Also override `visibleGlobalOptions` in the localized help renderer so
nested subcommands surface root-level global options (`--debug`,
`--lang`) on their `--help` output, which previously appeared blank.