### PR TITLE
feat(file): retry upload part requests on network failure

### DIFF
--- a/src/application/commands/file/shared.test.ts
+++ b/src/application/commands/file/shared.test.ts
@@ -48,4 +48,58 @@ describe("uploadFileParts", () => {
             logCapture.close();
         }
     });
+
+    test("retries file upload part network failures before succeeding", async () => {
+        const logCapture = createLogCapture();
+        const originalSleep = Bun.sleep;
+        let fetchCount = 0;
+
+        try {
+            Bun.sleep = (() => Promise.resolve()) as typeof Bun.sleep;
+
+            await uploadFileParts(
+                {
+                    size: 1,
+                    slice: () => new Blob(["a"]),
+                },
+                {
+                    partSize: 1,
+                    presignedUrls: {
+                        1: "https://storage.example.com/upload/1",
+                    },
+                    totalParts: 1,
+                    uploadId: "upload-1",
+                },
+                {
+                    fetcher: async () => {
+                        fetchCount += 1;
+
+                        if (fetchCount === 1) {
+                            throw new Error("socket closed");
+                        }
+
+                        return new Response(null, {
+                            status: 200,
+                        });
+                    },
+                    logger: logCapture.logger,
+                    translator: createTranslator("en"),
+                },
+            );
+
+            const logs = logCapture.read();
+
+            expect(fetchCount).toBe(2);
+            expect(logs).toContain(
+                "\"msg\":\"HTTP request retry scheduled after a network failure.\"",
+            );
+            expect(logs).toContain(
+                "\"msg\":\"File upload part request completed.\"",
+            );
+        }
+        finally {
+            Bun.sleep = originalSleep;
+            logCapture.close();
+        }
+    });
 });

--- a/src/application/commands/file/shared.ts
+++ b/src/application/commands/file/shared.ts
@@ -7,6 +7,7 @@ import type { AuthAccount } from "../../schemas/auth.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
+import { createRetryingFetcher } from "../../shared/retrying-fetcher.ts";
 import { parseEnumOption, parsePositiveIntegerOption } from "../shared/input-parsing.ts";
 import { performLoggedRequest, requestText } from "../shared/request.ts";
 
@@ -59,6 +60,8 @@ const finalFileUploadResponseSchema = z.object({
         url: z.string().min(1),
     }).passthrough(),
 }).passthrough();
+
+const fileUploadPartExtraRetries = 1;
 
 export function parseFileFormat(
     value: string | undefined,
@@ -284,9 +287,18 @@ async function uploadFilePart(
     context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<void> {
     const requestUrl = new URL(presignedUrl);
+    const uploadPartFetcher = createRetryingFetcher({
+        fetcher: context.fetcher,
+        logger: context.logger,
+        maxRetries: fileUploadPartExtraRetries,
+    });
 
     await performLoggedRequest({
-        context,
+        context: {
+            fetcher: uploadPartFetcher,
+            logger: context.logger,
+            translator: context.translator,
+        },
         createRequestFailedError: status => new CliUserError(
             "errors.fileUpload.requestFailed",
             1,


### PR DESCRIPTION
Wrap the file upload part fetcher with createRetryingFetcher so a transient network failure during a multipart upload no longer aborts the entire operation. One extra retry is allowed per part, which matches the resilience profile already used elsewhere for HTTP calls and avoids forcing users to restart large uploads after a single socket hiccup.