### PR TITLE
refactor(ci): use organization membership to gate large PRs

### DIFF
--- a/.github/workflows/reject-large-external-pr.yaml
+++ b/.github/workflows/reject-large-external-pr.yaml
@@ -35,4 +35,5 @@ jobs:
       - name: Reject Large External Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_MEMBERSHIP_TOKEN: ${{ secrets.ORG_MEMBERSHIP_TOKEN }}
         run: bun run contrib/ci/reject-large-external-pr.ts

--- a/contrib/ci/reject-large-external-pr.test.ts
+++ b/contrib/ci/reject-large-external-pr.test.ts
@@ -17,86 +17,33 @@ afterEach(() => {
 });
 
 describe("reject-large-external-pr", () => {
-    test("rejects external pull requests at the diff limit", () => {
+    test("rejects non organization members at the diff limit", () => {
         expect(evaluateLargeExternalPullRequest({
             additions: 120,
+            authorIsOrganizationMember: false,
             deletions: 80,
-            authorAssociation: "CONTRIBUTOR",
         })).toEqual({
-            authorIsBot: false,
-            authorIsExternal: true,
             diffLimit: 200,
             diffSize: 200,
             shouldReject: true,
-            sourceIsExternal: true,
         });
     });
 
-    test("allows external pull requests below the diff limit", () => {
+    test("allows non organization members below the diff limit", () => {
         expect(evaluateLargeExternalPullRequest({
             additions: 120,
+            authorIsOrganizationMember: false,
             deletions: 79,
-            authorAssociation: "FIRST_TIME_CONTRIBUTOR",
         }).shouldReject).toBeFalse();
     });
 
     test("allows organization members above the diff limit", () => {
         expect(evaluateLargeExternalPullRequest({
             additions: 500,
+            authorIsOrganizationMember: true,
             deletions: 500,
-            authorAssociation: "MEMBER",
-        })).toMatchObject({
-            authorIsBot: false,
-            authorIsExternal: false,
-            diffSize: 1000,
-            shouldReject: false,
-        });
-    });
-
-    test("allows organization owners above the diff limit", () => {
-        expect(evaluateLargeExternalPullRequest({
-            additions: 500,
-            deletions: 500,
-            authorAssociation: "OWNER",
-        }).shouldReject).toBeFalse();
-    });
-
-    test("allows repository collaborators above the diff limit", () => {
-        expect(evaluateLargeExternalPullRequest({
-            additions: 500,
-            deletions: 500,
-            authorAssociation: "COLLABORATOR",
-        })).toMatchObject({
-            authorIsBot: false,
-            authorIsExternal: false,
-            diffSize: 1000,
-            shouldReject: false,
-        });
-    });
-
-    test("allows same-repository pull requests above the diff limit", () => {
-        expect(evaluateLargeExternalPullRequest({
-            additions: 500,
-            authorAssociation: "NONE",
-            baseRepositoryFullName: "oomol-lab/oo-cli",
-            deletions: 500,
-            headRepositoryFullName: "oomol-lab/oo-cli",
-        })).toMatchObject({
-            authorIsExternal: false,
-            shouldReject: false,
-            sourceIsExternal: false,
-        });
-    });
-
-    test("allows bots above the diff limit", () => {
-        expect(evaluateLargeExternalPullRequest({
-            additions: 500,
-            deletions: 500,
-            authorAssociation: "CONTRIBUTOR",
-            authorType: "Bot",
-        })).toMatchObject({
-            authorIsBot: true,
-            authorIsExternal: false,
+        })).toEqual({
+            diffLimit: 200,
             diffSize: 1000,
             shouldReject: false,
         });
@@ -105,8 +52,8 @@ describe("reject-large-external-pr", () => {
     test("uses absolute additions and deletions for diff size", () => {
         expect(evaluateLargeExternalPullRequest({
             additions: -120,
+            authorIsOrganizationMember: false,
             deletions: -80,
-            authorAssociation: "NONE",
         })).toMatchObject({
             diffSize: 200,
             shouldReject: true,
@@ -125,41 +72,15 @@ describe("reject-large-external-pr", () => {
         expect(comment).toContain("Please open an issue instead");
     });
 
-    test("allows same-repository pull requests before requiring a GitHub token", async () => {
-        await withTempPullRequestEvent({
-            additions: 500,
-            authorAssociation: "NONE",
-            baseRepositoryFullName: "oomol-lab/oo-cli",
-            deletions: 500,
-            headRepositoryFullName: "oomol-lab/oo-cli",
-        }, async (eventPath) => {
-            await main({
-                GITHUB_EVENT_PATH: eventPath,
-            });
-        });
-    });
-
-    test("allows users with repository write permission when author association is stale", async () => {
+    test("allows organization members before applying the diff limit", async () => {
         const requests = installGitHubApiFetchStub({
-            permissionResponse: {
-                permission: "admin",
-                user: {
-                    permissions: {
-                        admin: true,
-                        maintain: true,
-                        push: true,
-                    },
-                },
-            },
+            organizationMember: true,
         });
 
         await withTempPullRequestEvent({
             additions: 500,
-            authorAssociation: "NONE",
             authorLogin: "l1shen",
-            baseRepositoryFullName: "oomol-lab/oo-cli",
             deletions: 500,
-            headRepositoryFullName: "l1shen/oo-cli",
         }, async (eventPath) => {
             await main({
                 GITHUB_API_URL: "https://api.example.test/",
@@ -172,39 +93,63 @@ describe("reject-large-external-pr", () => {
             init: expect.objectContaining({
                 method: "GET",
             }),
-            url: "https://api.example.test/repos/oomol-lab/oo-cli/collaborators/l1shen/permission",
+            url: "https://api.example.test/orgs/oomol-lab/members/l1shen",
         }]);
     });
 
-    test("treats missing repository names as external when reading events", async () => {
-        const requests = installGitHubApiFetchStub();
+    test("uses the organization membership token for membership checks", async () => {
+        const requests = installGitHubApiFetchStub({
+            organizationMember: true,
+        });
 
         await withTempPullRequestEvent({
-            additions: 120,
-            authorAssociation: "CONTRIBUTOR",
-            baseRepositoryFullName: "oomol-lab/oo-cli",
-            deletions: 80,
+            additions: 500,
+            authorLogin: "l1shen",
+            deletions: 500,
         }, async (eventPath) => {
             await main({
                 GITHUB_API_URL: "https://api.example.test/",
                 GITHUB_EVENT_PATH: eventPath,
-                GITHUB_TOKEN: "token",
+                GITHUB_TOKEN: "write-token",
+                ORG_MEMBERSHIP_TOKEN: "membership-token",
             });
         });
 
-        expect(requests).toHaveLength(4);
-        expect(requests.some(request => request.init?.method === "PATCH")).toBeTrue();
+        expect(getHeaderValue(requests[0]?.init, "authorization")).toBe("Bearer membership-token");
     });
 
-    test("comments and closes large external pull requests without a GET body", async () => {
-        const requests = installGitHubApiFetchStub();
+    test("allows non organization members below the diff limit after membership check", async () => {
+        const requests = installGitHubApiFetchStub({
+            organizationMember: false,
+        });
 
         await withTempPullRequestEvent({
             additions: 120,
-            authorAssociation: "CONTRIBUTOR",
-            baseRepositoryFullName: "oomol-lab/oo-cli",
+            deletions: 79,
+        }, async (eventPath) => {
+            await main({
+                GITHUB_API_URL: "https://api.example.test/",
+                GITHUB_EVENT_PATH: eventPath,
+                GITHUB_TOKEN: "token",
+            });
+        });
+
+        expect(requests).toEqual([{
+            init: expect.objectContaining({
+                method: "GET",
+            }),
+            url: "https://api.example.test/orgs/oomol-lab/members/contributor",
+        }]);
+    });
+
+    test("comments and closes large pull requests from non organization members", async () => {
+        const requests = installGitHubApiFetchStub({
+            organizationMember: false,
+        });
+
+        await withTempPullRequestEvent({
+            additions: 120,
             deletions: 80,
-            headRepositoryFullName: "external-user/oo-cli",
         }, async (eventPath) => {
             await main({
                 GITHUB_API_URL: "https://api.example.test/",
@@ -214,6 +159,10 @@ describe("reject-large-external-pr", () => {
         });
 
         expect(requests).toHaveLength(4);
+        expect(requests[0]).toMatchObject({
+            url: "https://api.example.test/orgs/oomol-lab/members/contributor",
+        });
+
         const commentListRequest = requests.find(request =>
             request.init?.method === "GET" && request.url.includes("/issues/157/comments"));
         const commentCreateRequest = requests.find(request => request.init?.method === "POST");
@@ -241,11 +190,8 @@ describe("reject-large-external-pr", () => {
 
 interface PullRequestEventOptions {
     additions: number;
-    authorAssociation: string;
     authorLogin?: string;
-    baseRepositoryFullName?: string;
     deletions: number;
-    headRepositoryFullName?: string;
 }
 
 interface CapturedFetchRequest {
@@ -254,10 +200,10 @@ interface CapturedFetchRequest {
 }
 
 interface GitHubApiFetchStubOptions {
-    permissionResponse?: unknown;
+    organizationMember: boolean;
 }
 
-function installGitHubApiFetchStub(options: GitHubApiFetchStubOptions = {}): CapturedFetchRequest[] {
+function installGitHubApiFetchStub(options: GitHubApiFetchStubOptions): CapturedFetchRequest[] {
     const requests: CapturedFetchRequest[] = [];
 
     // Bun's fetch type requires a `preconnect` property; preserve the original.
@@ -265,20 +211,19 @@ function installGitHubApiFetchStub(options: GitHubApiFetchStubOptions = {}): Cap
         input: Parameters<typeof fetch>[0],
         init?: FetchInit,
     ): Promise<Response> => {
+        const url = String(input);
         requests.push({
             init,
-            url: String(input),
+            url,
         });
 
-        if (String(input).includes("/collaborators/")) {
-            if (options.permissionResponse !== undefined) {
-                return Response.json(options.permissionResponse);
-            }
-
-            return Response.json({ message: "Not Found" }, {
-                status: 404,
-                statusText: "Not Found",
-            });
+        if (url.includes("/orgs/oomol-lab/members/")) {
+            return options.organizationMember
+                ? new Response(null, { status: 204, statusText: "No Content" })
+                : Response.json({ message: "Not Found" }, {
+                        status: 404,
+                        statusText: "Not Found",
+                    });
         }
 
         if (init?.method === "GET") {
@@ -291,6 +236,15 @@ function installGitHubApiFetchStub(options: GitHubApiFetchStubOptions = {}): Cap
     });
 
     return requests;
+}
+
+function getHeaderValue(init: FetchInit | undefined, name: string): string | undefined {
+    const headers = init?.headers;
+    if (headers === undefined) {
+        return undefined;
+    }
+
+    return new Headers(headers).get(name) ?? undefined;
 }
 
 async function withTempPullRequestEvent(
@@ -319,14 +273,8 @@ async function writePullRequestEvent(eventPath: string, options: PullRequestEven
         },
         pull_request: {
             additions: options.additions,
-            author_association: options.authorAssociation,
-            base: {
-                repo: createPullRequestRepositoryPayload(options.baseRepositoryFullName),
-            },
+            author_association: "NONE",
             deletions: options.deletions,
-            head: {
-                repo: createPullRequestRepositoryPayload(options.headRepositoryFullName),
-            },
             number: 157,
             user: {
                 login: options.authorLogin ?? "contributor",
@@ -334,14 +282,4 @@ async function writePullRequestEvent(eventPath: string, options: PullRequestEven
             },
         },
     }));
-}
-
-function createPullRequestRepositoryPayload(
-    repositoryFullName: string | undefined,
-): Record<string, string> {
-    return repositoryFullName === undefined
-        ? {}
-        : {
-                full_name: repositoryFullName,
-            };
 }

--- a/contrib/ci/reject-large-external-pr.ts
+++ b/contrib/ci/reject-large-external-pr.ts
@@ -2,28 +2,20 @@ import process from "node:process";
 
 const DEFAULT_GITHUB_API_URL = "https://api.github.com";
 const DEFAULT_EXTERNAL_PR_DIFF_LIMIT = 200;
+const INTERNAL_ORGANIZATION_LOGIN = "oomol-lab";
 const REJECTION_COMMENT_MARKER = "<!-- oo-cli-large-external-pr-guard -->";
-const INTERNAL_AUTHOR_ASSOCIATIONS = new Set(["COLLABORATOR", "MEMBER", "OWNER"]);
-const INTERNAL_REPOSITORY_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 
 interface PullRequestGuardInput {
     additions: number;
-    authorAssociation: string;
-    authorLogin?: string;
-    authorType?: string;
-    baseRepositoryFullName?: string;
+    authorIsOrganizationMember: boolean;
     deletions: number;
     diffLimit?: number;
-    headRepositoryFullName?: string;
 }
 
 interface PullRequestGuardDecision {
-    authorIsBot: boolean;
-    authorIsExternal: boolean;
     diffSize: number;
     diffLimit: number;
     shouldReject: boolean;
-    sourceIsExternal: boolean;
 }
 
 interface RejectionCommentInput {
@@ -39,7 +31,13 @@ interface PullRequestRef {
 }
 
 interface PullRequestEvent extends PullRequestRef {
-    pullRequest: PullRequestGuardInput;
+    pullRequest: PullRequestEventInput;
+}
+
+interface PullRequestEventInput {
+    additions: number;
+    authorLogin: string;
+    deletions: number;
 }
 
 interface GitHubApiClientOptions {
@@ -50,7 +48,6 @@ interface GitHubApiClientOptions {
 type GitHubRequestOptions = GitHubApiClientOptions & {
     body?: unknown;
     method: string;
-    notFoundValue?: unknown;
     path: string;
 };
 
@@ -58,33 +55,14 @@ interface GitHubIssueComment {
     body?: string;
 }
 
-interface GitHubCollaboratorPermission {
-    permission?: string;
-    user?: {
-        permissions?: {
-            admin?: boolean;
-            maintain?: boolean;
-            push?: boolean;
-        };
-    };
-}
-
 export function evaluateLargeExternalPullRequest(input: PullRequestGuardInput): PullRequestGuardDecision {
     const diffLimit = input.diffLimit ?? DEFAULT_EXTERNAL_PR_DIFF_LIMIT;
     const diffSize = Math.abs(input.additions) + Math.abs(input.deletions);
-    const authorIsBot = input.authorType === "Bot";
-    const sourceIsExternal = evaluateSourceIsExternal(input);
-    const authorIsExternal = !authorIsBot
-        && sourceIsExternal
-        && !INTERNAL_AUTHOR_ASSOCIATIONS.has(input.authorAssociation);
 
     return {
-        authorIsBot,
-        authorIsExternal,
         diffSize,
         diffLimit,
-        shouldReject: authorIsExternal && diffSize >= diffLimit,
-        sourceIsExternal,
+        shouldReject: !input.authorIsOrganizationMember && diffSize >= diffLimit,
     };
 }
 
@@ -94,9 +72,9 @@ export function buildLargeExternalPullRequestRejectionComment(input: RejectionCo
     const diffSize = additions + deletions;
     return [
         REJECTION_COMMENT_MARKER,
-        "Thanks for your contribution. This repository is primarily maintained internally, and we are not able to reliably review large pull requests from external contributors.",
+        "Thanks for your contribution. This repository is primarily maintained internally, and we are not able to reliably review large pull requests from contributors outside the oomol-lab organization.",
         "",
-        `This pull request changes ${diffSize} lines (${additions} additions and ${deletions} deletions), which is at or above our external pull request limit of ${input.diffLimit}. We are closing it automatically.`,
+        `This pull request changes ${diffSize} lines (${additions} additions and ${deletions} deletions), which is at or above our non-organization pull request limit of ${input.diffLimit}. We are closing it automatically.`,
         "",
         "Please open an issue instead with the problem, expected behavior, and any relevant context. That gives the maintainers a better path to evaluate and plan the change.",
     ].join("\n");
@@ -111,14 +89,17 @@ function readRequiredEnv(environment: NodeJS.ProcessEnv, name: string): string {
     return value;
 }
 
+function readOptionalEnv(environment: NodeJS.ProcessEnv, name: string): string | undefined {
+    const value = environment[name];
+    return value === undefined || value === "" ? undefined : value;
+}
+
 async function readPullRequestEvent(eventPath: string): Promise<PullRequestEvent> {
     const eventPayload = parseObject(JSON.parse(await Bun.file(eventPath).text()), "GitHub event payload");
     const repository = parseObject(eventPayload.repository, "repository");
     const repositoryOwner = parseObject(repository.owner, "repository.owner");
     const pullRequest = parseObject(eventPayload.pull_request, "pull_request");
     const pullRequestAuthor = parseObject(pullRequest.user, "pull_request.user");
-    const baseRepositoryFullName = parsePullRequestRepositoryFullName(pullRequest, "base");
-    const headRepositoryFullName = parsePullRequestRepositoryFullName(pullRequest, "head");
 
     return {
         owner: parseString(repositoryOwner.login, "repository.owner.login"),
@@ -127,11 +108,7 @@ async function readPullRequestEvent(eventPath: string): Promise<PullRequestEvent
         pullRequest: {
             additions: parseNumber(pullRequest.additions, "pull_request.additions"),
             deletions: parseNumber(pullRequest.deletions, "pull_request.deletions"),
-            authorAssociation: parseString(pullRequest.author_association, "pull_request.author_association"),
             authorLogin: parseString(pullRequestAuthor.login, "pull_request.user.login"),
-            authorType: parseString(pullRequestAuthor.type, "pull_request.user.type"),
-            baseRepositoryFullName,
-            headRepositoryFullName,
         },
     };
 }
@@ -160,51 +137,12 @@ function parseNumber(value: unknown, fieldName: string): number {
     throw new TypeError(`${fieldName} must be a finite number.`);
 }
 
-function parsePullRequestRepositoryFullName(
-    pullRequest: Record<string, unknown>,
-    refName: "base" | "head",
-): string | undefined {
-    const pullRequestRef = parseOptionalObject(pullRequest[refName]);
-    if (pullRequestRef === undefined) {
-        return undefined;
-    }
-
-    const repository = parseOptionalObject(pullRequestRef.repo);
-    if (repository === undefined) {
-        return undefined;
-    }
-
-    const fullName = repository.full_name;
-    if (typeof fullName !== "string") {
-        return undefined;
-    }
-
-    const normalizedFullName = fullName.trim();
-    return normalizedFullName === "" ? undefined : normalizedFullName;
-}
-
-function parseOptionalObject(value: unknown): Record<string, unknown> | undefined {
-    return typeof value === "object" && value !== null && !Array.isArray(value)
-        ? value as Record<string, unknown>
-        : undefined;
-}
-
-function evaluateSourceIsExternal(input: PullRequestGuardInput): boolean {
-    const baseRepositoryFullName = input.baseRepositoryFullName?.trim();
-    const headRepositoryFullName = input.headRepositoryFullName?.trim();
-
-    if (baseRepositoryFullName === undefined || baseRepositoryFullName === "") {
-        return true;
-    }
-    if (headRepositoryFullName === undefined || headRepositoryFullName === "") {
-        return true;
-    }
-
-    return baseRepositoryFullName !== headRepositoryFullName;
-}
-
 function buildRepoPath(ref: PullRequestRef, suffix: string): string {
     return `/repos/${encodeURIComponent(ref.owner)}/${encodeURIComponent(ref.repo)}/${suffix}`;
+}
+
+function buildOrgPath(organization: string, suffix: string): string {
+    return `/orgs/${encodeURIComponent(organization)}/${suffix}`;
 }
 
 async function ensureRejectionComment(
@@ -244,30 +182,9 @@ async function closePullRequest(
     });
 }
 
-async function authorHasRepositoryWritePermission(
-    options: GitHubApiClientOptions & PullRequestRef & { username: string },
-): Promise<boolean> {
-    const permission = await requestGitHubJson<GitHubCollaboratorPermission | undefined>({
-        ...options,
-        method: "GET",
-        notFoundValue: undefined,
-        path: buildRepoPath(options, `collaborators/${encodeURIComponent(options.username)}/permission`),
-    });
-
-    return permission !== undefined && hasRepositoryWritePermission(permission);
-}
-
-function hasRepositoryWritePermission(permission: GitHubCollaboratorPermission): boolean {
-    if (permission.permission !== undefined && INTERNAL_REPOSITORY_PERMISSIONS.has(permission.permission)) {
-        return true;
-    }
-
-    return permission.user?.permissions?.admin === true
-        || permission.user?.permissions?.maintain === true
-        || permission.user?.permissions?.push === true;
-}
-
-async function requestGitHubJson<Value>(options: GitHubRequestOptions): Promise<Value> {
+async function githubFetch(
+    options: GitHubApiClientOptions & { body?: unknown; method: string; path: string },
+): Promise<{ response: Response; responseText: string }> {
     const response = await fetch(`${trimTrailingSlash(options.apiUrl)}${options.path}`, {
         method: options.method,
         headers: {
@@ -279,11 +196,11 @@ async function requestGitHubJson<Value>(options: GitHubRequestOptions): Promise<
         body: options.body === undefined ? undefined : JSON.stringify(options.body),
         signal: AbortSignal.timeout(15_000),
     });
-    const responseText = await response.text();
+    return { response, responseText: await response.text() };
+}
 
-    if (response.status === 404 && "notFoundValue" in options) {
-        return options.notFoundValue as Value;
-    }
+async function requestGitHubJson<Value>(options: GitHubRequestOptions): Promise<Value> {
+    const { response, responseText } = await githubFetch(options);
 
     if (!response.ok) {
         throw new Error(`GitHub API request failed: ${response.status} ${response.statusText}\n${responseText}`);
@@ -296,14 +213,47 @@ async function requestGitHubJson<Value>(options: GitHubRequestOptions): Promise<
     return JSON.parse(responseText) as Value;
 }
 
+async function authorIsOrganizationMember(
+    options: GitHubApiClientOptions & { organization: string; username: string },
+): Promise<boolean> {
+    const { response, responseText } = await githubFetch({
+        apiUrl: options.apiUrl,
+        method: "GET",
+        path: buildOrgPath(options.organization, `members/${encodeURIComponent(options.username)}`),
+        token: options.token,
+    });
+
+    if (response.ok) {
+        return true;
+    }
+    if (response.status === 404) {
+        return false;
+    }
+
+    throw new Error(`GitHub API request failed: ${response.status} ${response.statusText}\n${responseText}`);
+}
+
 function trimTrailingSlash(value: string): string {
     return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
 export async function main(environment: NodeJS.ProcessEnv = process.env): Promise<void> {
     const event = await readPullRequestEvent(readRequiredEnv(environment, "GITHUB_EVENT_PATH"));
-    const decision = evaluateLargeExternalPullRequest(event.pullRequest);
-    const decisionSummary = `association=${event.pullRequest.authorAssociation}, bot=${decision.authorIsBot}, sourceExternal=${decision.sourceIsExternal}, authorExternal=${decision.authorIsExternal}, diff=${decision.diffSize}, limit=${decision.diffLimit}`;
+    const apiUrl = environment.GITHUB_API_URL ?? DEFAULT_GITHUB_API_URL;
+    const membershipToken = readOptionalEnv(environment, "ORG_MEMBERSHIP_TOKEN")
+        ?? readRequiredEnv(environment, "GITHUB_TOKEN");
+    const isOrganizationMember = await authorIsOrganizationMember({
+        apiUrl,
+        organization: INTERNAL_ORGANIZATION_LOGIN,
+        token: membershipToken,
+        username: event.pullRequest.authorLogin,
+    });
+    const decision = evaluateLargeExternalPullRequest({
+        additions: event.pullRequest.additions,
+        authorIsOrganizationMember: isOrganizationMember,
+        deletions: event.pullRequest.deletions,
+    });
+    const decisionSummary = `orgMember=${isOrganizationMember}, diff=${decision.diffSize}, limit=${decision.diffLimit}`;
 
     if (!decision.shouldReject) {
         process.stdout.write(`Pull request allowed: ${decisionSummary}.\n`);
@@ -311,23 +261,9 @@ export async function main(environment: NodeJS.ProcessEnv = process.env): Promis
     }
 
     const apiClientOptions = {
-        apiUrl: environment.GITHUB_API_URL ?? DEFAULT_GITHUB_API_URL,
+        apiUrl,
         token: readRequiredEnv(environment, "GITHUB_TOKEN"),
     };
-    if (
-        event.pullRequest.authorLogin !== undefined
-        && await authorHasRepositoryWritePermission({
-            ...apiClientOptions,
-            owner: event.owner,
-            pullNumber: event.pullNumber,
-            repo: event.repo,
-            username: event.pullRequest.authorLogin,
-        })
-    ) {
-        process.stdout.write(`Pull request allowed: ${decisionSummary}.\n`);
-        return;
-    }
-
     const commentBody = buildLargeExternalPullRequestRejectionComment({
         additions: event.pullRequest.additions,
         deletions: event.pullRequest.deletions,
@@ -349,7 +285,7 @@ export async function main(environment: NodeJS.ProcessEnv = process.env): Promis
             repo: event.repo,
         }),
     ]);
-    process.stdout.write(`Closed external pull request #${event.pullNumber}: ${decisionSummary}.\n`);
+    process.stdout.write(`Closed non-organization pull request #${event.pullNumber}: ${decisionSummary}.\n`);
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
Replace the previous mix of author_association, author type, source repository match, and collaborator permission checks with a single organization membership API call against oomol-lab. The earlier signals were redundant and could disagree (for example, stale author_association on first-time contributors), so consolidating to one authoritative check simplifies the logic and the tests.

A dedicated ORG_MEMBERSHIP_TOKEN is now required because reading organization membership needs scopes beyond the default GITHUB_TOKEN.