### PR TITLE
feat(install): block installation inside TRAE sandbox

### DIFF
--- a/contrib/install/install-unix.test.ts
+++ b/contrib/install/install-unix.test.ts
@@ -9,6 +9,7 @@ import { createTemporaryDirectory, useTemporaryDirectoryCleanup } from "../../__
 const installScriptPath = join(import.meta.dir, "install.sh");
 const { track: trackDirectory } = useTemporaryDirectoryCleanup();
 const unixInstallDescribe = process.platform === "win32" ? describe.skip : describe;
+const traeSandboxInstallError = "Installing oo inside the TRAE sandbox is not supported yet. Please run the install script from the host terminal.";
 
 unixInstallDescribe("install.sh", () => {
     test("uses ~/.config/oo/downloads as the default Linux download directory", async () => {
@@ -106,6 +107,37 @@ unixInstallDescribe("install.sh", () => {
             "install stable --force\n",
         );
         expect(await readdir(downloadDirectory)).toEqual([]);
+    });
+
+    test("fails before downloading in Trae local VM", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-install-script");
+
+        trackDirectory(rootDirectory);
+        const result = await runInstaller(rootDirectory, {
+            TRAE_RUNTIME: "local_vm",
+        });
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toBe(`${traeSandboxInstallError}\n`);
+    });
+
+    test("fails before downloading when the Trae sandbox binary exists", async () => {
+        const result = await runBashCommand([
+            "[() {",
+            "  if test \"$1\" = \"-e\" && test \"$2\" = \"/mnt/appmodules/bin/trae-sandbox\"; then",
+            "    return 0",
+            "  fi",
+            "  command [ \"$@\"",
+            "}",
+            "TRAE_RUNTIME=''",
+            `source "${installScriptPath}"`,
+            "main",
+        ].join("\n"));
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout).toBe("");
+        expect(result.stderr).toBe(`${traeSandboxInstallError}\n`);
     });
 
     test("fails when latest.json does not include a version", async () => {
@@ -226,6 +258,7 @@ async function runInstallerFromStdin(
         cwd: sandboxDirectory,
         env: {
             ...process.env,
+            TRAE_RUNTIME: "",
             ...env,
             PATH: buildPath(env.PATH, sandboxDirectory),
         },
@@ -262,6 +295,7 @@ async function runCommand(
         cwd,
         env: {
             ...process.env,
+            TRAE_RUNTIME: "",
             ...env,
             PATH: buildPath(env.PATH, cwd),
         },

--- a/contrib/install/install.sh
+++ b/contrib/install/install.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 readonly DEFAULT_DOWNLOAD_BASE_URL="https://static.oomol.com/release/apps/oo-cli"
+readonly TRAE_SANDBOX_BINARY_PATH="/mnt/appmodules/bin/trae-sandbox"
+readonly TRAE_SANDBOX_INSTALL_ERROR="Installing oo inside the TRAE sandbox is not supported yet. Please run the install script from the host terminal."
 
 DOWNLOAD_BASE_URL="${OO_INSTALL_DOWNLOAD_BASE_URL:-$DEFAULT_DOWNLOAD_BASE_URL}"
 DOWNLOAD_DIR="${OO_INSTALL_DOWNLOAD_DIR:-}"
@@ -17,6 +19,16 @@ fail() {
 cleanup() {
     if [ -n "${DOWNLOADED_BINARY_PATH:-}" ]; then
         rm -f "$DOWNLOADED_BINARY_PATH"
+    fi
+}
+
+is_trae_sandbox() {
+    [ -e "$TRAE_SANDBOX_BINARY_PATH" ] || [ "${TRAE_RUNTIME:-}" = "local_vm" ]
+}
+
+assert_supported_install_environment() {
+    if is_trae_sandbox; then
+        fail "$TRAE_SANDBOX_INSTALL_ERROR"
     fi
 }
 
@@ -190,6 +202,7 @@ run_install_command() {
 main() {
     local version platform binary_url
 
+    assert_supported_install_environment
     trap cleanup EXIT
 
     if [ -z "$DOWNLOAD_DIR" ]; then


### PR DESCRIPTION
Installing oo inside the TRAE sandbox is not currently supported, and silently proceeding ends up downloading binaries that cannot run there. Detect the sandbox via the trae-sandbox binary path or the TRAE_RUNTIME=local_vm environment variable, and fail fast with a clear message directing the user to run the script from the host terminal instead.