### PR TITLE
feat(connector): accept --json flag on schema for compatibility

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -367,6 +367,7 @@ Show the stable schema contract for one connector action.
 - Arguments: `<serviceName>` is the service name.
 - Options: `-a, --action <action>` selects the action name and is required.
 - Options: `--refresh` fetches fresh metadata from the connector metadata API.
+- Options: `--json` is accepted for compatibility and does not change output.
 - Output: the command always prints a JSON object with the stable CLI fields
   `service`, `name`, `description`, `inputSchema`, and `outputSchema`.
 - Notes: `--refresh` forces a fresh schema fetch for the selected action.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -315,6 +315,7 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 参数：`<serviceName>` 为服务名。
 - 选项：`-a, --action <action>` 用于指定 action 名称，且为必填。
 - 选项：`--refresh` 会直接从 connector metadata API 获取最新 schema。
+- 选项：`--json` 作为兼容性选项被接受，不会改变输出。
 - 输出：命令默认输出 JSON 对象，包含稳定 CLI 字段 `service`、`name`、
   `description`、`inputSchema` 和 `outputSchema`。
 - 说明：`--refresh` 会强制为选中的 action 重新获取 schema。

--- a/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
@@ -99,7 +99,7 @@ Global Options:
 }
 `;
 
-exports[`connectorCommand CLI renders connector schema help without json options 1`] = `
+exports[`connectorCommand CLI renders connector schema help with the json compatibility option 1`] = `
 {
   "exitCode": 0,
   "stderr": "",
@@ -112,6 +112,7 @@ Arguments:
 Options:
   -a, --action <action>  Specify the target action name
   --refresh              Bypass any cached response and fetch fresh data
+  --json                 Accepted for compatibility; output is always JSON
   -h, --help             Show help for command
 
 Global Options:

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -411,7 +411,7 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("renders connector schema help without json options", async () => {
+    test("renders connector schema help with the json compatibility option", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -419,7 +419,7 @@ describe("connectorCommand CLI", () => {
 
             expect(createCliSnapshot(result)).toMatchSnapshot();
             expect(result.stdout).not.toContain("--format");
-            expect(result.stdout).not.toContain("--json");
+            expect(result.stdout).toContain("--json");
         }
         finally {
             await sandbox.cleanup();
@@ -1423,7 +1423,7 @@ describe("connectorCommand CLI", () => {
                 )[0]!,
             );
             const cachedResult = await sandbox.run(
-                ["connector", "schema", "gmail", "--action", "send_mail"],
+                ["connector", "schema", "gmail", "--action", "send_mail", "--json"],
                 {
                     fetcher: async () => {
                         throw new Error("Unexpected schema metadata request");

--- a/src/application/commands/connector/schema.ts
+++ b/src/application/commands/connector/schema.ts
@@ -45,6 +45,11 @@ export const connectorSchemaCommand: CliCommandDefinition<ConnectorSchemaInput> 
             longFlag: "--refresh",
             descriptionKey: "options.refresh",
         },
+        {
+            name: "json",
+            longFlag: "--json",
+            descriptionKey: "options.connectorSchemaJson",
+        },
     ],
     inputSchema: z.object({
         action: z.string().optional(),

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -669,6 +669,8 @@ export const enMessages = {
     "options.format": "Specify output format (use json for structured output)",
     "options.input": "Provide LLM input JSON or @path to a JSON file",
     "options.json": "Alias for --format=json",
+    "options.connectorSchemaJson":
+        "Accepted for compatibility; output is always JSON",
     "options.keywords":
         "Specify comma-separated keywords to refine the skill search",
     "options.maxRetries": "Maximum retry count",
@@ -1578,6 +1580,8 @@ export const zhMessages = {
     "options.format": "指定输出格式（使用 json 返回结构化内容）",
     "options.input": "提供 LLM 输入 JSON，或使用 @路径 读取 JSON 文件",
     "options.json": "--format=json 的别名",
+    "options.connectorSchemaJson":
+        "兼容性选项；输出始终是 JSON",
     "options.keywords":
         "指定用于细化 skill 搜索的逗号分隔关键词",
     "options.maxRetries": "最大重试次数",


### PR DESCRIPTION
The `connector schema` command always emits JSON, but external callers and scripts often pass `--json` defensively. Accept the flag as a no-op so those invocations no longer fail with an unknown option error, and document it as a compatibility shim in the CLI docs and i18n catalog.