### PR TITLE
feat(cli): add --input as alias for --data option

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -389,6 +389,7 @@ Validate input data and run one connector action.
 - Arguments: `<serviceName>` is the service name.
 - Options: `-a, --action <action>` selects the action name and is required.
 - Options: `-d, --data <data>` accepts inline JSON or `@path` to a JSON file.
+  `--input <data>` is an alias for `--data <data>`.
 - Options: `--dry-run` validates the payload without executing the action.
 - Options: `--format=json` and `--json` print a JSON object.
 - Output: non-dry-run JSON output mirrors the stable response shape
@@ -1057,7 +1058,7 @@ Validate input values and create a cloud task for a package block.
 - Options: `-b, --block-id <block-id>` selects the target block. This option is
   required.
 - Options: `-d, --data <data>` provides input values as a JSON object string or
-  `@path/to/file.json`.
+  `@path/to/file.json`. `--input <data>` is an alias for `--data <data>`.
 - Options: `--dry-run` validates the request without creating a task.
 - Options: `--format <format>` returns structured output. Supported value:
   `json`.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -337,6 +337,7 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 参数：`<serviceName>` 为服务名。
 - 选项：`-a, --action <action>` 用于指定 action 名称，且为必填。
 - 选项：`-d, --data <data>` 支持直接传入 JSON，或使用 `@路径` 读取 JSON 文件。
+  `--input <data>` 是 `--data <data>` 的 alias。
 - 选项：`--dry-run` 只做 payload 校验，不真正执行 action。
 - 选项：`--format=json` 和 `--json` 会输出 JSON 对象。
 - 输出：非 dry-run 的 JSON 输出会保持稳定结构
@@ -896,7 +897,7 @@ skills。
   例如 `foo/bar@1.2.3`。
 - 选项：`-b, --block-id <block-id>` 指定目标 block。该选项必填。
 - 选项：`-d, --data <data>` 提供输入值，可以是 JSON 对象字符串，也可以是
-  `@path/to/file.json`。
+  `@path/to/file.json`。`--input <data>` 是 `--data <data>` 的 alias。
 - 选项：`--dry-run` 仅校验请求，不真正创建任务。
 - 选项：`--format <format>` 返回结构化输出，目前仅支持 `json`。
 - 选项：`--json` 是 `--format=json` 的别名。

--- a/src/adapters/commander/commander-cli-adapter.test.ts
+++ b/src/adapters/commander/commander-cli-adapter.test.ts
@@ -132,6 +132,52 @@ describe("CommanderCliAdapter", () => {
             },
         ]);
     });
+
+    test("maps option alias flags to the primary option name", async () => {
+        const adapter = new CommanderCliAdapter();
+        const stdout = createTextBuffer();
+        const stderr = createTextBuffer();
+        const handledInputs: Array<{ data?: string }> = [];
+        const catalog: CliCatalog = {
+            commands: [
+                {
+                    handler: (input) => {
+                        handledInputs.push(input as { data?: string });
+                    },
+                    inputSchema: z.object({
+                        data: z.string().optional(),
+                    }),
+                    name: "demo",
+                    options: [
+                        {
+                            aliasFlags: ["--input"],
+                            descriptionKey: "options.help",
+                            longFlag: "--data",
+                            name: "data",
+                            valueName: "data",
+                        },
+                    ],
+                    summaryKey: "commands.help.summary",
+                },
+            ],
+            descriptionKey: "app.description",
+            globalOptions: [],
+            name: "oo",
+        };
+
+        const exitCode = await adapter.run({
+            argv: ["demo", "--input", "{\"value\":1}"],
+            catalog,
+            context: createCommanderContext(catalog, stdout.writer, stderr.writer),
+        });
+
+        expect(exitCode).toBe(0);
+        expect(handledInputs).toEqual([
+            {
+                data: "{\"value\":1}",
+            },
+        ]);
+    });
 });
 
 function createCommanderContext(

--- a/src/adapters/commander/commander-cli-adapter.ts
+++ b/src/adapters/commander/commander-cli-adapter.ts
@@ -94,7 +94,9 @@ export class CommanderCliAdapter {
             .exitOverride();
 
         for (const option of catalog.globalOptions) {
-            program.addOption(createOption(option, context.translator));
+            for (const commanderOption of createOptions(option, context.translator)) {
+                program.addOption(commanderOption);
+            }
         }
 
         for (const command of catalog.commands) {
@@ -237,7 +239,9 @@ function configureCommand(
     }
 
     for (const option of definition.options ?? []) {
-        command.addOption(createOption(option, translator));
+        for (const commanderOption of createOptions(option, translator)) {
+            command.addOption(commanderOption);
+        }
     }
 
     for (const argument of definition.arguments ?? []) {
@@ -301,6 +305,34 @@ function formatOptionFlags(option: {
         : longFlag;
 }
 
+function createOptions(
+    option: {
+        aliasFlags?: readonly string[];
+        descriptionKey: string;
+        implies?: Record<string, unknown>;
+        longFlag: string;
+        name: string;
+        shortFlag?: string;
+        valueName?: string;
+    },
+    translator: Translator,
+): Option[] {
+    return [
+        createOption(option, translator),
+        ...(option.aliasFlags ?? []).map(aliasFlag =>
+            createOption(
+                {
+                    ...option,
+                    longFlag: aliasFlag,
+                    shortFlag: undefined,
+                },
+                translator,
+                option.name,
+            ),
+        ),
+    ];
+}
+
 function createOption(
     option: {
         descriptionKey: string;
@@ -310,11 +342,16 @@ function createOption(
         valueName?: string;
     },
     translator: Translator,
+    attributeName?: string,
 ): Option {
     const commanderOption = new Option(
         formatOptionFlags(option),
         translator.t(option.descriptionKey),
     );
+
+    if (attributeName !== undefined) {
+        commanderOption.attributeName = () => attributeName;
+    }
 
     if (option.implies !== undefined) {
         commanderOption.implies(option.implies);

--- a/src/adapters/completion/static-completion-renderer.ts
+++ b/src/adapters/completion/static-completion-renderer.ts
@@ -101,15 +101,16 @@ function buildCompletionNodes(
 
 function flattenOptionFlags(
     options: readonly {
+        aliasFlags?: readonly string[];
         longFlag: string;
         shortFlag?: string;
     }[],
 ): string[] {
-    return options.flatMap(option =>
-        option.shortFlag
-            ? [option.shortFlag, option.longFlag]
-            : [option.longFlag],
-    );
+    return options.flatMap(option => [
+        ...(option.shortFlag ? [option.shortFlag] : []),
+        option.longFlag,
+        ...(option.aliasFlags ?? []),
+    ]);
 }
 
 function renderBashCompletion(

--- a/src/application/commands/cloud-task/index.cli.test.ts
+++ b/src/application/commands/cloud-task/index.cli.test.ts
@@ -118,7 +118,7 @@ describe("cloudTaskCommand CLI", () => {
                     "qrcode@1.0.4",
                     "-b",
                     "Exist",
-                    "-d",
+                    "--input",
                     "{\"count\":3}",
                     "--json",
                 ],

--- a/src/application/commands/cloud-task/run.ts
+++ b/src/application/commands/cloud-task/run.ts
@@ -56,6 +56,7 @@ export const cloudTaskRunCommand: CliCommandDefinition<CloudTaskRunInput> = {
             name: "data",
             longFlag: "--data",
             shortFlag: "-d",
+            aliasFlags: ["--input"],
             valueName: "data",
             descriptionKey: "options.data",
         },

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -528,7 +528,7 @@ describe("connectorCommand CLI", () => {
                     "gmail",
                     "-a",
                     "send_mail",
-                    "-d",
+                    "--input",
                     "{\"to\":\"foo@bar.com\"}",
                     "--json",
                 ],

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -74,6 +74,7 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             name: "data",
             longFlag: "--data",
             shortFlag: "-d",
+            aliasFlags: ["--input"],
             valueName: "data",
             descriptionKey: "options.data",
         },

--- a/src/application/contracts/cli.ts
+++ b/src/application/contracts/cli.ts
@@ -39,6 +39,7 @@ export interface CliOptionDefinition {
     name: string;
     longFlag: string;
     shortFlag?: string;
+    aliasFlags?: readonly string[];
     valueName?: string;
     descriptionKey: string;
     global?: boolean;


### PR DESCRIPTION
Introduce an `aliasFlags` field on CLI option definitions so a single option can be exposed under multiple long flags while sharing one attribute name. Wire the commander adapter and static completion renderer through the new field, and apply it to `--data` on the `connector run` and `cloud-task create` commands so `--input` works as a drop-in alias. This improves ergonomics for users coming from tools that name the equivalent option `--input`.