### PR TITLE
fix(skills): preserve same-version legacy targets during auto-sync

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -436,7 +436,8 @@ supported host directory that already exists.
   Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, OpenClaw, and QoderWork host.
   Existing oo-managed bundled skill targets are refreshed to the current `oo`
   version, except that `0.0.0-development` startup runs do not refresh
-  existing copied bundled targets.
+  existing bundled targets, and installed `0.0.0-development` bundled targets
+  are left untouched.
 - Published skills: when a published skill already has a local canonical copy
   under `<config-dir>/skills/registry/<skill-id>`, `oo` publishes that copy to
   any newly detected supported host that is missing it.
@@ -445,8 +446,11 @@ supported host directory that already exists.
   detected supported host that is missing it. Existing same-name local copies
   with different `SKILL.md` content are left untouched during silent startup
   synchronization; run `oo skills add` to refresh them explicitly.
-- Migration: existing oo-managed symlink targets from older releases are
-  replaced with copied directories during startup synchronization.
+- Migration: startup synchronization does not rewrite same-version legacy
+  symlink targets. Use `oo skills add` for bundled and local skills, and
+  `oo skills update` for registry skills, to replace legacy symlinks
+  explicitly. Successful `oo install` and `oo update` workflows run both
+  maintenance steps.
 - Safety: startup synchronization does not fetch registry data, does not
   require authentication, does not print additional command output, and does
   not overwrite same-name targets that are not managed by `oo`.
@@ -793,7 +797,7 @@ Install bundled or published skills into supported local skill directories.
 - Installation mode: bundled, published, and refreshed local skills are copied
   into every target skills directory. Existing oo-managed symlink targets from
   older releases are replaced with copied directories when the skill is
-  synchronized, installed, or updated.
+  installed, refreshed, or updated explicitly.
 - Local refresh: for local skills, the canonical source wins. Existing
   oo-managed local copies are overwritten from the canonical source; if their
   `SKILL.md` content differs, the command prints a warning before overwriting

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -381,8 +381,8 @@ skills。
   CodeBuddy、WorkBuddy、Trae、Trae CN、OpenClaw 和 QoderWork Agent 都安装了 `oo`、
   `oo-find-skills`、`oo-create-skill` 与 `oo-publish-skill`。已经由 oo 管理的
   内置 skill 目标会刷新到当前 `oo` 版本；
-  但当启动中的当前版本为 `0.0.0-development` 时，不会刷新已存在的复制版内置
-  skill 目标。
+  但当启动中的当前版本为 `0.0.0-development` 时，不会刷新已存在的内置 skill
+  目标；已安装版本为 `0.0.0-development` 的内置 skill 目标也会保持不变。
 - 已发布 skill：如果某个已发布 skill 已经有本地 canonical 副本
   `<config-dir>/skills/registry/<skill-id>`，`oo` 会把该副本发布到任何新检测
   到且尚未安装它的受支持 Agent。
@@ -390,7 +390,9 @@ skills。
   `<config-dir>/skills/local/<skill-id>`，`oo` 会把该副本发布到任何新检测到且尚未
   安装它的受支持 Agent。静默启动同步不会覆盖 `SKILL.md` 内容不同的同名本地副本；
   如需显式刷新，请运行 `oo skills add`。
-- 迁移：旧版本留下的 oo-managed 软链接目标，会在启动同步期间替换为复制目录。
+- 迁移：启动同步不会改写同版本的历史软链接目标。请用 `oo skills add` 刷新内置
+  和本地 skill，用 `oo skills update` 刷新 registry skill，从而显式替换历史软链接。
+  成功的 `oo install` / `oo update` 会运行这两个维护步骤。
 - 安全规则：启动同步不会请求 registry，不要求登录，不会产生额外命令输出，也
   不会覆盖不由 `oo` 管理的同名目标。
 
@@ -670,8 +672,8 @@ skills。
 - 目标目录：当已存在的受支持 Agent 缺少 `skills` 根目录时，命令会先创建该目录，
   再发布所选 skill。
 - 安装方式：内置、已发布以及被刷新的 local skill 会复制到每个目标 skills 目录。
-  旧版本留下的 oo-managed 软链接目标，会在同步、安装或更新该 skill 时替换为复制
-  目录。
+  旧版本留下的 oo-managed 软链接目标，会在显式安装、刷新或更新该 skill 时替换为
+  复制目录。
 - local 刷新：对 local skill 来说，canonical 来源优先。已有的 oo-managed local
   副本会被 canonical 来源覆盖；如果其 `SKILL.md` 内容不同，命令会先打印 warning。
   没有 metadata 的同名目标只有在 `SKILL.md` 内容已经与 canonical local 来源一致时

--- a/src/application/commands/skills/auto-sync.ts
+++ b/src/application/commands/skills/auto-sync.ts
@@ -49,9 +49,6 @@ import {
     resolveLocalSkillCanonicalRootDirectoryPath,
     resolveManagedSkillCanonicalRootDirectoryPath,
 } from "./managed-skill-paths.ts";
-import {
-    isManagedSkillPublicationCurrent,
-} from "./managed-skill-publication.ts";
 import { publishManagedBundledSkill } from "./shared.ts";
 
 interface ManagedSkillTargetState<Metadata> {
@@ -140,22 +137,32 @@ async function synchronizeBundledSkill(
             return;
         }
 
-        const publicationCurrent = targetState.kind === "managed"
-            ? await isManagedSkillPublicationCurrent(installation.installedSkillDirectoryPath)
-            : false;
-
         if (
             targetState.kind === "managed"
             && targetState.metadata?.version === context.version
-            && publicationCurrent
         ) {
             return;
         }
 
         if (
             targetState.kind === "managed"
+            && targetState.metadata?.version === bundledSkillDevelopmentVersion
+        ) {
+            context.logger.info(
+                {
+                    agentName: host.agentName,
+                    path: installation.installedSkillDirectoryPath,
+                    skillName,
+                    version: context.version,
+                },
+                "Bundled skill startup synchronization skipped because the installed skill is a development version.",
+            );
+            return;
+        }
+
+        if (
+            targetState.kind === "managed"
             && context.version === bundledSkillDevelopmentVersion
-            && publicationCurrent
         ) {
             context.logger.info(
                 {
@@ -325,13 +332,7 @@ async function synchronizeRegistrySkill(
                 return;
             }
 
-            if (
-                await isManagedSkillPublicationCurrent(
-                    installation.installedSkillDirectoryPath,
-                )
-            ) {
-                return;
-            }
+            return;
         }
 
         await publishBundledSkillInstallation({
@@ -471,18 +472,11 @@ async function synchronizeLocalSkill(
                 return;
             }
             else if (metadataState.metadata?.kind === "local") {
-                if (
-                    await isManagedSkillPublicationCurrent(
-                        installation.installedSkillDirectoryPath,
-                    )
-                ) {
-                    return;
-                }
+                return;
             }
 
             if (
-                targetMatchesCanonical
-                && metadataState.metadata === undefined
+                metadataState.metadata === undefined
                 && !metadataState.exists
             ) {
                 context.logger.info(
@@ -491,8 +485,13 @@ async function synchronizeLocalSkill(
                         path: installation.installedSkillDirectoryPath,
                         skillName: skill.name,
                     },
-                    "Local skill startup synchronization adopted a legacy matching copy.",
+                    "Local skill startup synchronization adopted a legacy matching target.",
                 );
+                await Promise.all([
+                    writeLocalSkillMetadata(skill.path),
+                    writeLocalSkillMetadata(installation.installedSkillDirectoryPath),
+                ]);
+                return;
             }
         }
 

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -198,6 +198,64 @@ describe("skills CLI", () => {
         }
     });
 
+    test("does not auto-refresh development-version bundled skills during release-version cli startup", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const skillTargets = availableBundledSkillNames.map(skillName => ({
+            directoryPath: join(codexHomeDirectory, "skills", skillName),
+            name: skillName,
+        }));
+
+        try {
+            for (const skillTarget of skillTargets) {
+                await mkdir(skillTarget.directoryPath, { recursive: true });
+                await Bun.write(
+                    resolveBundledSkillMetadataFilePath(skillTarget.directoryPath),
+                    renderSkillMetadataJson({
+                        version: bundledSkillDevelopmentVersion,
+                    }),
+                );
+                await Bun.write(
+                    join(skillTarget.directoryPath, "SKILL.md"),
+                    `# Local ${skillTarget.name}\n`,
+                );
+            }
+
+            const result = await sandbox.run(["--help"], {
+                version: "9.9.9",
+            });
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain("Options:");
+            for (const skillTarget of skillTargets) {
+                expect(
+                    await readFile(join(skillTarget.directoryPath, "SKILL.md"), "utf8"),
+                ).toBe(
+                    `# Local ${skillTarget.name}\n`,
+                );
+                expect(
+                    await readFile(
+                        resolveBundledSkillMetadataFilePath(skillTarget.directoryPath),
+                        "utf8",
+                    ),
+                ).toBe(renderSkillMetadataJson({
+                    version: bundledSkillDevelopmentVersion,
+                }));
+            }
+            expect(content).toContain(
+                `"msg":"Bundled skill startup synchronization skipped because the installed skill is a development version."`,
+            );
+            expect(content).not.toContain(
+                `"msg":"Bundled skill synchronized during CLI startup."`,
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("publishes canonical registry skills during cli startup", async () => {
         const sandbox = await createCliSandbox();
         const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
@@ -250,7 +308,7 @@ describe("skills CLI", () => {
         }
     });
 
-    test("converts synchronized registry symlink targets to copies", async () => {
+    test("leaves synchronized registry symlink targets unchanged during cli startup", async () => {
         const sandbox = await createCliSandbox();
         const codeBuddyHomeDirectory = resolveCodeBuddyHomeDirectory(sandbox.env);
         const codeBuddySkillsDirectory = join(codeBuddyHomeDirectory, "skills");
@@ -295,14 +353,14 @@ describe("skills CLI", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(result.stdout).toContain("Options:");
-            expect(await realpath(codeBuddySkillDirectoryPath)).not.toBe(
+            expect(await realpath(codeBuddySkillDirectoryPath)).toBe(
                 await realpath(canonicalSkillDirectoryPath),
             );
-            expect((await lstat(codeBuddySkillDirectoryPath)).isSymbolicLink()).toBeFalse();
+            expect((await lstat(codeBuddySkillDirectoryPath)).isSymbolicLink()).toBeTrue();
             expect(await readFile(join(codeBuddySkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
                 "# ChatGPT\n",
             );
-            expect(content).toContain(
+            expect(content).not.toContain(
                 `"msg":"Registry skill synchronized during CLI startup."`,
             );
         }
@@ -311,7 +369,7 @@ describe("skills CLI", () => {
         }
     });
 
-    test("converts synchronized local symlink targets to copies", async () => {
+    test("leaves synchronized local symlink targets unchanged during cli startup", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
         const codexSkillsDirectory = join(codexHomeDirectory, "skills");
@@ -349,14 +407,14 @@ describe("skills CLI", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(result.stdout).toContain("Options:");
-            expect(await realpath(codexSkillDirectoryPath)).not.toBe(
+            expect(await realpath(codexSkillDirectoryPath)).toBe(
                 await realpath(canonicalSkillDirectoryPath),
             );
-            expect((await lstat(codexSkillDirectoryPath)).isSymbolicLink()).toBeFalse();
+            expect((await lstat(codexSkillDirectoryPath)).isSymbolicLink()).toBeTrue();
             expect(await readFile(join(codexSkillDirectoryPath, "SKILL.md"), "utf8")).toBe(
                 "# Campaign Writer\n",
             );
-            expect(content).toContain(
+            expect(content).not.toContain(
                 `"msg":"Local skill synchronized during CLI startup."`,
             );
         }


### PR DESCRIPTION
Startup synchronization previously rewrote oo-managed legacy symlink targets and re-published skills whenever the publication state was considered stale, even when the installed version already matched the running CLI. This produced unexpected churn for users who had not asked to migrate legacy installations.

Auto-sync now leaves same-version targets alone and only adopts legacy matching local copies by writing metadata in place. Bundled skill targets installed at the development version are also skipped so local development copies stay untouched across release-version startups. Use `oo skills add` for bundled and local skills, and `oo skills update` for registry skills, to migrate legacy symlinks explicitly.