### PR TITLE
ci(publish): retry transient failures and skip existing versions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -159,10 +159,7 @@ jobs:
         run: bun run contrib/ci/release-workflow.ts assemble-release-artifacts
 
       - name: Publish to npm
-        run: |
-          while IFS= read -r package_file; do
-            npm publish --access public "$package_file"
-          done < dist/npm-publish-order.txt
+        run: bun run contrib/ci/release-workflow.ts publish-npm-packages
 
       - name: Create GitHub Release
         run: |

--- a/contrib/ci/npm-publish.test.ts
+++ b/contrib/ci/npm-publish.test.ts
@@ -1,9 +1,13 @@
 import type { NpmCommandResult, NpmPackageMetadata } from "./npm-publish.ts";
-import { rm } from "node:fs/promises";
+import { chmod, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import process from "node:process";
 
 import { describe, expect, test } from "bun:test";
-import { createTemporaryDirectory } from "../../__tests__/helpers.ts";
+import {
+    createTemporaryDirectory,
+    joinPathEntries,
+} from "../../__tests__/helpers.ts";
 import {
     parseNpmPublishOrderFile,
     publishNpmPackagesFromOrderFile,
@@ -16,9 +20,9 @@ const packageMetadata = {
 } as const satisfies NpmPackageMetadata;
 
 describe("npm publish workflow", () => {
-    test("parses publish order files without dropping paths that contain spaces", () => {
+    test("trims publish order lines without dropping paths that contain spaces", () => {
         expect(
-            parseNpmPublishOrderFile("dist/demo package.tgz\r\ndist/next.tgz\n"),
+            parseNpmPublishOrderFile(" dist/demo package.tgz \r\n\t\n dist/next.tgz\n"),
         ).toEqual([
             "dist/demo package.tgz",
             "dist/next.tgz",
@@ -54,11 +58,10 @@ describe("npm publish workflow", () => {
     });
 
     test("skips publishing a package version that already exists", async () => {
-        const publishOrder = await createPublishOrderFile(["dist/demo.tgz"]);
-        const logs: string[] = [];
-        let publishCount = 0;
+        await withPublishOrder(["dist/demo.tgz"], async (publishOrder) => {
+            const logs: string[] = [];
+            let publishCount = 0;
 
-        try {
             await publishNpmPackagesFromOrderFile({
                 publishOrderPath: publishOrder.filePath,
                 logger: createLogger(logs),
@@ -75,18 +78,14 @@ describe("npm publish workflow", () => {
             expect(logs).toEqual([
                 "Skipping @scope/demo@1.2.3: version already exists on npm.",
             ]);
-        }
-        finally {
-            await rm(publishOrder.directoryPath, { force: true, recursive: true });
-        }
+        });
     });
 
     test("retries transient npm publish failures before succeeding", async () => {
-        const publishOrder = await createPublishOrderFile(["dist/demo.tgz"]);
-        const sleepDelays: number[] = [];
-        let publishCount = 0;
+        await withPublishOrder(["dist/demo.tgz"], async (publishOrder) => {
+            const sleepDelays: number[] = [];
+            let publishCount = 0;
 
-        try {
             await publishNpmPackagesFromOrderFile({
                 publishOrderPath: publishOrder.filePath,
                 logger: createLogger([]),
@@ -107,27 +106,23 @@ describe("npm publish workflow", () => {
                     return Promise.resolve(createCommandResult({}));
                 },
                 readPackageMetadata: () => Promise.resolve(packageMetadata),
-                retryDelayMs: 10,
+                retryDelayMs: 0,
                 sleep: (delayMs) => {
                     sleepDelays.push(delayMs);
                 },
             });
 
             expect(publishCount).toBe(2);
-            expect(sleepDelays).toEqual([10]);
-        }
-        finally {
-            await rm(publishOrder.directoryPath, { force: true, recursive: true });
-        }
+            expect(sleepDelays).toEqual([0]);
+        });
     });
 
     test("treats a failed publish as successful when the package appears on npm", async () => {
-        const publishOrder = await createPublishOrderFile(["dist/demo.tgz"]);
-        const logs: string[] = [];
-        let existenceCheckCount = 0;
-        let publishCount = 0;
+        await withPublishOrder(["dist/demo.tgz"], async (publishOrder) => {
+            const logs: string[] = [];
+            let existenceCheckCount = 0;
+            let publishCount = 0;
 
-        try {
             await publishNpmPackagesFromOrderFile({
                 publishOrderPath: publishOrder.filePath,
                 logger: createLogger(logs),
@@ -152,17 +147,13 @@ describe("npm publish workflow", () => {
             expect(logs).toEqual([
                 "Treating @scope/demo@1.2.3 as published after npm returned a failure because the version now exists.",
             ]);
-        }
-        finally {
-            await rm(publishOrder.directoryPath, { force: true, recursive: true });
-        }
+        });
     });
 
     test("skips when npm publish reports an existing version despite a stale view result", async () => {
-        const publishOrder = await createPublishOrderFile(["dist/demo.tgz"]);
-        let publishCount = 0;
+        await withPublishOrder(["dist/demo.tgz"], async (publishOrder) => {
+            let publishCount = 0;
 
-        try {
             await publishNpmPackagesFromOrderFile({
                 publishOrderPath: publishOrder.filePath,
                 logger: createLogger([]),
@@ -180,18 +171,14 @@ describe("npm publish workflow", () => {
             });
 
             expect(publishCount).toBe(1);
-        }
-        finally {
-            await rm(publishOrder.directoryPath, { force: true, recursive: true });
-        }
+        });
     });
 
     test("does not retry permanent npm publish failures", async () => {
-        const publishOrder = await createPublishOrderFile(["dist/demo.tgz"]);
-        let publishCount = 0;
-        let sleepCount = 0;
+        await withPublishOrder(["dist/demo.tgz"], async (publishOrder) => {
+            let publishCount = 0;
+            let sleepCount = 0;
 
-        try {
             await expect(
                 publishNpmPackagesFromOrderFile({
                     publishOrderPath: publishOrder.filePath,
@@ -214,12 +201,94 @@ describe("npm publish workflow", () => {
 
             expect(publishCount).toBe(1);
             expect(sleepCount).toBe(0);
-        }
-        finally {
-            await rm(publishOrder.directoryPath, { force: true, recursive: true });
-        }
+        });
+    });
+
+    test("rejects invalid publish retry options", async () => {
+        await withPublishOrder(["dist/demo.tgz"], async (publishOrder) => {
+            const baseOptions = {
+                publishOrderPath: publishOrder.filePath,
+                logger: createLogger([]),
+                packageVersionExists: () => Promise.resolve(false),
+                publishPackage: () => Promise.resolve(createCommandResult({})),
+                readPackageMetadata: () => Promise.resolve(packageMetadata),
+            };
+
+            await expect(
+                publishNpmPackagesFromOrderFile({
+                    ...baseOptions,
+                    retryCount: 0,
+                }),
+            ).rejects.toThrow("retryCount must be a positive integer");
+
+            await expect(
+                publishNpmPackagesFromOrderFile({
+                    ...baseOptions,
+                    retryDelayMs: -10,
+                }),
+            ).rejects.toThrow("retryDelayMs must be a non-negative finite number");
+        });
+    });
+
+    test("returns a timeout result when npm commands hang", async () => {
+        await withPublishOrder(["dist/demo.tgz"], async (publishOrder) => {
+            const binDirectory = await createTemporaryDirectory("npm-publish-timeout-bin");
+
+            try {
+                const npmPath = join(binDirectory, process.platform === "win32" ? "npm.cmd" : "npm");
+                await writeFile(
+                    npmPath,
+                    process.platform === "win32"
+                        ? [
+                                "@echo off",
+                                ":loop",
+                                "goto loop",
+                            ].join("\r\n")
+                        : [
+                                "#!/bin/sh",
+                                "while :; do",
+                                "  :",
+                                "done",
+                            ].join("\n"),
+                );
+                if (process.platform !== "win32") {
+                    await chmod(npmPath, 0o755);
+                }
+
+                await expect(publishNpmPackagesFromOrderFile({
+                    commandEnv: {
+                        PATH: joinPathEntries([binDirectory], process.platform),
+                        Path: joinPathEntries([binDirectory], process.platform),
+                    },
+                    logger: createLogger([]),
+                    npmCommandTimeoutMs: 10,
+                    packageVersionExists: () => Promise.resolve(false),
+                    publishOrderPath: publishOrder.filePath,
+                    readPackageMetadata: () => Promise.resolve(packageMetadata),
+                    retryCount: 1,
+                    retryDelayMs: 0,
+                    sleep: () => undefined,
+                })).rejects.toThrow("npm command timed out after 10ms.");
+            }
+            finally {
+                await rm(binDirectory, { force: true, recursive: true });
+            }
+        });
     });
 });
+
+async function withPublishOrder(
+    packageFiles: readonly string[],
+    run: (publishOrder: { directoryPath: string; filePath: string }) => Promise<void>,
+): Promise<void> {
+    const publishOrder = await createPublishOrderFile(packageFiles);
+    try {
+        await run(publishOrder);
+    }
+    finally {
+        await rm(publishOrder.directoryPath, { force: true, recursive: true });
+    }
+}
 
 async function createPublishOrderFile(packageFiles: readonly string[]): Promise<{
     directoryPath: string;

--- a/contrib/ci/npm-publish.test.ts
+++ b/contrib/ci/npm-publish.test.ts
@@ -1,0 +1,257 @@
+import type { NpmCommandResult, NpmPackageMetadata } from "./npm-publish.ts";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+import { createTemporaryDirectory } from "../../__tests__/helpers.ts";
+import {
+    parseNpmPublishOrderFile,
+    publishNpmPackagesFromOrderFile,
+    readNpmPackageMetadata,
+} from "./npm-publish.ts";
+
+const packageMetadata = {
+    name: "@scope/demo",
+    version: "1.2.3",
+} as const satisfies NpmPackageMetadata;
+
+describe("npm publish workflow", () => {
+    test("parses publish order files without dropping paths that contain spaces", () => {
+        expect(
+            parseNpmPublishOrderFile("dist/demo package.tgz\r\ndist/next.tgz\n"),
+        ).toEqual([
+            "dist/demo package.tgz",
+            "dist/next.tgz",
+        ]);
+    });
+
+    test("reads package metadata from an npm tarball", async () => {
+        const temporaryDirectoryPath = await createTemporaryDirectory(
+            "npm-publish-metadata",
+        );
+        const packageFilePath = join(temporaryDirectoryPath, "demo.tgz");
+
+        try {
+            await Bun.write(
+                packageFilePath,
+                await new Bun.Archive(
+                    {
+                        "package/package.json": `${JSON.stringify(packageMetadata)}\n`,
+                    },
+                    {
+                        compress: "gzip",
+                    },
+                ).bytes(),
+            );
+
+            await expect(readNpmPackageMetadata(packageFilePath)).resolves.toEqual(
+                packageMetadata,
+            );
+        }
+        finally {
+            await rm(temporaryDirectoryPath, { force: true, recursive: true });
+        }
+    });
+
+    test("skips publishing a package version that already exists", async () => {
+        const publishOrder = await createPublishOrderFile(["dist/demo.tgz"]);
+        const logs: string[] = [];
+        let publishCount = 0;
+
+        try {
+            await publishNpmPackagesFromOrderFile({
+                publishOrderPath: publishOrder.filePath,
+                logger: createLogger(logs),
+                packageVersionExists: () => Promise.resolve(true),
+                publishPackage: () => {
+                    publishCount += 1;
+
+                    return Promise.resolve(createCommandResult({}));
+                },
+                readPackageMetadata: () => Promise.resolve(packageMetadata),
+            });
+
+            expect(publishCount).toBe(0);
+            expect(logs).toEqual([
+                "Skipping @scope/demo@1.2.3: version already exists on npm.",
+            ]);
+        }
+        finally {
+            await rm(publishOrder.directoryPath, { force: true, recursive: true });
+        }
+    });
+
+    test("retries transient npm publish failures before succeeding", async () => {
+        const publishOrder = await createPublishOrderFile(["dist/demo.tgz"]);
+        const sleepDelays: number[] = [];
+        let publishCount = 0;
+
+        try {
+            await publishNpmPackagesFromOrderFile({
+                publishOrderPath: publishOrder.filePath,
+                logger: createLogger([]),
+                packageVersionExists: () => Promise.resolve(false),
+                publishPackage: () => {
+                    publishCount += 1;
+
+                    if (publishCount === 1) {
+                        return Promise.resolve(createCommandResult({
+                            exitCode: 1,
+                            stderr: [
+                                "npm error code TLOG_CREATE_ENTRY_ERROR",
+                                "npm error cause Invalid response body while trying to fetch https://rekor.sigstore.dev/api/v1/log/entries: aborted",
+                            ].join("\n"),
+                        }));
+                    }
+
+                    return Promise.resolve(createCommandResult({}));
+                },
+                readPackageMetadata: () => Promise.resolve(packageMetadata),
+                retryDelayMs: 10,
+                sleep: (delayMs) => {
+                    sleepDelays.push(delayMs);
+                },
+            });
+
+            expect(publishCount).toBe(2);
+            expect(sleepDelays).toEqual([10]);
+        }
+        finally {
+            await rm(publishOrder.directoryPath, { force: true, recursive: true });
+        }
+    });
+
+    test("treats a failed publish as successful when the package appears on npm", async () => {
+        const publishOrder = await createPublishOrderFile(["dist/demo.tgz"]);
+        const logs: string[] = [];
+        let existenceCheckCount = 0;
+        let publishCount = 0;
+
+        try {
+            await publishNpmPackagesFromOrderFile({
+                publishOrderPath: publishOrder.filePath,
+                logger: createLogger(logs),
+                packageVersionExists: () => {
+                    existenceCheckCount += 1;
+
+                    return Promise.resolve(existenceCheckCount === 2);
+                },
+                publishPackage: () => {
+                    publishCount += 1;
+
+                    return Promise.resolve(createCommandResult({
+                        exitCode: 1,
+                        stderr: "npm error code TLOG_CREATE_ENTRY_ERROR",
+                    }));
+                },
+                readPackageMetadata: () => Promise.resolve(packageMetadata),
+                sleep: () => undefined,
+            });
+
+            expect(publishCount).toBe(1);
+            expect(logs).toEqual([
+                "Treating @scope/demo@1.2.3 as published after npm returned a failure because the version now exists.",
+            ]);
+        }
+        finally {
+            await rm(publishOrder.directoryPath, { force: true, recursive: true });
+        }
+    });
+
+    test("skips when npm publish reports an existing version despite a stale view result", async () => {
+        const publishOrder = await createPublishOrderFile(["dist/demo.tgz"]);
+        let publishCount = 0;
+
+        try {
+            await publishNpmPackagesFromOrderFile({
+                publishOrderPath: publishOrder.filePath,
+                logger: createLogger([]),
+                packageVersionExists: () => Promise.resolve(false),
+                publishPackage: () => {
+                    publishCount += 1;
+
+                    return Promise.resolve(createCommandResult({
+                        exitCode: 1,
+                        stderr: "npm error You cannot publish over the previously published versions: 1.2.3.",
+                    }));
+                },
+                readPackageMetadata: () => Promise.resolve(packageMetadata),
+                sleep: () => undefined,
+            });
+
+            expect(publishCount).toBe(1);
+        }
+        finally {
+            await rm(publishOrder.directoryPath, { force: true, recursive: true });
+        }
+    });
+
+    test("does not retry permanent npm publish failures", async () => {
+        const publishOrder = await createPublishOrderFile(["dist/demo.tgz"]);
+        let publishCount = 0;
+        let sleepCount = 0;
+
+        try {
+            await expect(
+                publishNpmPackagesFromOrderFile({
+                    publishOrderPath: publishOrder.filePath,
+                    logger: createLogger([]),
+                    packageVersionExists: () => Promise.resolve(false),
+                    publishPackage: () => {
+                        publishCount += 1;
+
+                        return Promise.resolve(createCommandResult({
+                            exitCode: 1,
+                            stderr: "npm error code E403",
+                        }));
+                    },
+                    readPackageMetadata: () => Promise.resolve(packageMetadata),
+                    sleep: () => {
+                        sleepCount += 1;
+                    },
+                }),
+            ).rejects.toThrow("Failed to publish @scope/demo@1.2.3");
+
+            expect(publishCount).toBe(1);
+            expect(sleepCount).toBe(0);
+        }
+        finally {
+            await rm(publishOrder.directoryPath, { force: true, recursive: true });
+        }
+    });
+});
+
+async function createPublishOrderFile(packageFiles: readonly string[]): Promise<{
+    directoryPath: string;
+    filePath: string;
+}> {
+    const directoryPath = await createTemporaryDirectory("npm-publish-order");
+    const filePath = join(directoryPath, "npm-publish-order.txt");
+
+    await Bun.write(filePath, `${packageFiles.join("\n")}\n`);
+
+    return {
+        directoryPath,
+        filePath,
+    };
+}
+
+function createLogger(logs: string[]): Pick<Console, "log"> {
+    return {
+        log: (message?: unknown) => {
+            logs.push(String(message));
+        },
+    };
+}
+
+function createCommandResult(options: {
+    exitCode?: number;
+    stderr?: string;
+    stdout?: string;
+}): NpmCommandResult {
+    return {
+        exitCode: options.exitCode ?? 0,
+        stderr: options.stderr ?? "",
+        stdout: options.stdout ?? "",
+    };
+}

--- a/contrib/ci/npm-publish.ts
+++ b/contrib/ci/npm-publish.ts
@@ -1,0 +1,273 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+
+export interface NpmPackageMetadata {
+    name: string;
+    version: string;
+}
+
+export interface NpmCommandResult {
+    exitCode: number;
+    stderr: string;
+    stdout: string;
+}
+
+interface PublishNpmPackagesOptions {
+    logger?: Pick<Console, "log">;
+    packageVersionExists?: (metadata: NpmPackageMetadata) => Promise<boolean>;
+    publishOrderPath: string;
+    publishPackage?: (packageFile: string) => Promise<NpmCommandResult>;
+    readPackageMetadata?: (packageFile: string) => Promise<NpmPackageMetadata>;
+    retryCount?: number;
+    retryDelayMs?: number;
+    sleep?: (delayMs: number) => Promise<void> | void;
+}
+
+const defaultPublishRetryCount = 5;
+const defaultPublishRetryDelayMs = 15_000;
+const existingVersionErrorFragments = [
+    "cannot publish over",
+    "previously published versions",
+] as const;
+const missingPackageVersionErrorFragments = [
+    "E404",
+    "No match found for version",
+] as const;
+const transientPublishErrorFragments = [
+    "TLOG_CREATE_ENTRY_ERROR",
+    "aborted",
+    "ECONNRESET",
+    "EAI_AGAIN",
+    "ETIMEDOUT",
+    "socket hang up",
+    "too many requests",
+    "429",
+    "500",
+    "502",
+    "503",
+    "504",
+    "rekor.sigstore.dev",
+] as const;
+
+export async function publishNpmPackagesFromOrderFile(
+    options: PublishNpmPackagesOptions,
+): Promise<void> {
+    const packageFiles = parseNpmPublishOrderFile(
+        await readFile(options.publishOrderPath, "utf8"),
+    );
+    const readPackageMetadata = options.readPackageMetadata ?? readNpmPackageMetadata;
+    const publishPackage = options.publishPackage ?? publishNpmPackage;
+    const packageVersionExists = options.packageVersionExists ?? npmPackageVersionExists;
+    const sleep = options.sleep ?? Bun.sleep;
+    const logger = options.logger ?? console;
+    const retryCount = options.retryCount ?? defaultPublishRetryCount;
+    const retryDelayMs = options.retryDelayMs ?? defaultPublishRetryDelayMs;
+
+    for (const packageFile of packageFiles) {
+        const metadata = await readPackageMetadata(packageFile);
+
+        await publishNpmPackageWithRetry({
+            logger,
+            metadata,
+            packageFile,
+            packageVersionExists,
+            publishPackage,
+            retryCount,
+            retryDelayMs,
+            sleep,
+        });
+    }
+}
+
+export function parseNpmPublishOrderFile(content: string): readonly string[] {
+    return content
+        .split("\n")
+        .map(line => line.endsWith("\r") ? line.slice(0, -1) : line)
+        .filter(line => line !== "");
+}
+
+export async function readNpmPackageMetadata(packageFile: string): Promise<NpmPackageMetadata> {
+    const extractDirectoryPath = await mkdtemp(join(tmpdir(), "oo-npm-package-"));
+
+    try {
+        const archive = new Bun.Archive(await Bun.file(packageFile).bytes());
+        await archive.extract(extractDirectoryPath);
+
+        const packageManifest = JSON.parse(
+            await readFile(join(extractDirectoryPath, "package", "package.json"), "utf8"),
+        ) as Partial<NpmPackageMetadata>;
+
+        if (
+            typeof packageManifest.name !== "string"
+            || packageManifest.name === ""
+            || typeof packageManifest.version !== "string"
+            || packageManifest.version === ""
+        ) {
+            throw new Error(`Package metadata is missing name or version: ${packageFile}`);
+        }
+
+        return {
+            name: packageManifest.name,
+            version: packageManifest.version,
+        };
+    }
+    finally {
+        await rm(extractDirectoryPath, { force: true, recursive: true });
+    }
+}
+
+async function publishNpmPackageWithRetry(options: {
+    logger: Pick<Console, "log">;
+    metadata: NpmPackageMetadata;
+    packageFile: string;
+    packageVersionExists: (metadata: NpmPackageMetadata) => Promise<boolean>;
+    publishPackage: (packageFile: string) => Promise<NpmCommandResult>;
+    retryCount: number;
+    retryDelayMs: number;
+    sleep: (delayMs: number) => Promise<void> | void;
+}): Promise<void> {
+    const packageSpec = formatPackageSpec(options.metadata);
+
+    if (await options.packageVersionExists(options.metadata)) {
+        options.logger.log(`Skipping ${packageSpec}: version already exists on npm.`);
+        return;
+    }
+
+    for (let attempt = 1; attempt <= options.retryCount; attempt += 1) {
+        const publishResult = await options.publishPackage(options.packageFile);
+        if (publishResult.exitCode === 0) {
+            options.logger.log(`Published ${packageSpec}.`);
+            return;
+        }
+
+        const output = formatCommandOutput(publishResult);
+        if (isExistingPackageVersionError(output)) {
+            options.logger.log(`Skipping ${packageSpec}: npm reported the version already exists.`);
+            return;
+        }
+
+        if (await options.packageVersionExists(options.metadata)) {
+            options.logger.log(
+                `Treating ${packageSpec} as published after npm returned a failure because the version now exists.`,
+            );
+            return;
+        }
+
+        if (
+            !isTransientNpmPublishFailure(output)
+            || attempt === options.retryCount
+        ) {
+            throw new Error(
+                [
+                    `Failed to publish ${packageSpec} from ${options.packageFile}.`,
+                    output,
+                ].join("\n"),
+            );
+        }
+
+        const delayMs = options.retryDelayMs * attempt;
+        options.logger.log(
+            `Retrying ${packageSpec} after transient npm publish failure in ${delayMs}ms.`,
+        );
+        await options.sleep(delayMs);
+    }
+}
+
+async function npmPackageVersionExists(metadata: NpmPackageMetadata): Promise<boolean> {
+    const viewResult = await runNpmCommand([
+        "npm",
+        "view",
+        formatPackageSpec(metadata),
+        "version",
+        "--json",
+    ], { echoOutput: false });
+
+    if (viewResult.exitCode === 0) {
+        return true;
+    }
+
+    const output = formatCommandOutput(viewResult);
+    if (isMissingPackageVersionError(output)) {
+        return false;
+    }
+
+    throw new Error(
+        [
+            `Failed to query npm for ${formatPackageSpec(metadata)}.`,
+            output,
+        ].join("\n"),
+    );
+}
+
+async function publishNpmPackage(packageFile: string): Promise<NpmCommandResult> {
+    return await runNpmCommand([
+        "npm",
+        "publish",
+        "--access",
+        "public",
+        packageFile,
+    ], { echoOutput: true });
+}
+
+async function runNpmCommand(
+    command: readonly string[],
+    options: { echoOutput: boolean },
+): Promise<NpmCommandResult> {
+    const subprocess = Bun.spawn([...command], {
+        stderr: "pipe",
+        stdin: "ignore",
+        stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(subprocess.stdout).text(),
+        new Response(subprocess.stderr).text(),
+        subprocess.exited,
+    ]);
+
+    if (options.echoOutput) {
+        process.stdout.write(stdout);
+        process.stderr.write(stderr);
+    }
+
+    return {
+        exitCode,
+        stderr,
+        stdout,
+    };
+}
+
+function formatPackageSpec(metadata: NpmPackageMetadata): string {
+    return `${metadata.name}@${metadata.version}`;
+}
+
+function formatCommandOutput(result: NpmCommandResult): string {
+    return [result.stdout, result.stderr]
+        .filter(output => output !== "")
+        .join("\n");
+}
+
+function isExistingPackageVersionError(output: string): boolean {
+    const normalizedOutput = output.toLowerCase();
+
+    return existingVersionErrorFragments.every(fragment =>
+        normalizedOutput.includes(fragment),
+    );
+}
+
+function isMissingPackageVersionError(output: string): boolean {
+    const normalizedOutput = output.toLowerCase();
+
+    return missingPackageVersionErrorFragments.some(fragment =>
+        normalizedOutput.includes(fragment.toLowerCase()),
+    );
+}
+
+function isTransientNpmPublishFailure(output: string): boolean {
+    const normalizedOutput = output.toLowerCase();
+
+    return transientPublishErrorFragments.some(fragment =>
+        normalizedOutput.includes(fragment.toLowerCase()),
+    );
+}

--- a/contrib/ci/npm-publish.ts
+++ b/contrib/ci/npm-publish.ts
@@ -15,7 +15,9 @@ export interface NpmCommandResult {
 }
 
 interface PublishNpmPackagesOptions {
+    commandEnv?: Record<string, string | undefined>;
     logger?: Pick<Console, "log">;
+    npmCommandTimeoutMs?: number;
     packageVersionExists?: (metadata: NpmPackageMetadata) => Promise<boolean>;
     publishOrderPath: string;
     publishPackage?: (packageFile: string) => Promise<NpmCommandResult>;
@@ -27,6 +29,8 @@ interface PublishNpmPackagesOptions {
 
 const defaultPublishRetryCount = 5;
 const defaultPublishRetryDelayMs = 15_000;
+const defaultNpmCommandTimeoutMs = 120_000;
+const npmCommandTimeoutExitCode = 124;
 const existingVersionErrorFragments = [
     "cannot publish over",
     "previously published versions",
@@ -57,13 +61,17 @@ export async function publishNpmPackagesFromOrderFile(
     const packageFiles = parseNpmPublishOrderFile(
         await readFile(options.publishOrderPath, "utf8"),
     );
+    const npmCommandTimeoutMs = resolveNpmCommandTimeoutMs(options.npmCommandTimeoutMs);
+    const commandEnv = options.commandEnv;
     const readPackageMetadata = options.readPackageMetadata ?? readNpmPackageMetadata;
-    const publishPackage = options.publishPackage ?? publishNpmPackage;
-    const packageVersionExists = options.packageVersionExists ?? npmPackageVersionExists;
+    const publishPackage = options.publishPackage
+        ?? (packageFile => publishNpmPackage(packageFile, npmCommandTimeoutMs, commandEnv));
+    const packageVersionExists = options.packageVersionExists
+        ?? (metadata => npmPackageVersionExists(metadata, npmCommandTimeoutMs, commandEnv));
     const sleep = options.sleep ?? Bun.sleep;
     const logger = options.logger ?? console;
-    const retryCount = options.retryCount ?? defaultPublishRetryCount;
-    const retryDelayMs = options.retryDelayMs ?? defaultPublishRetryDelayMs;
+    const retryCount = resolvePublishRetryCount(options.retryCount);
+    const retryDelayMs = resolvePublishRetryDelayMs(options.retryDelayMs);
 
     for (const packageFile of packageFiles) {
         const metadata = await readPackageMetadata(packageFile);
@@ -84,7 +92,7 @@ export async function publishNpmPackagesFromOrderFile(
 export function parseNpmPublishOrderFile(content: string): readonly string[] {
     return content
         .split("\n")
-        .map(line => line.endsWith("\r") ? line.slice(0, -1) : line)
+        .map(line => line.trim())
         .filter(line => line !== "");
 }
 
@@ -175,14 +183,18 @@ async function publishNpmPackageWithRetry(options: {
     }
 }
 
-async function npmPackageVersionExists(metadata: NpmPackageMetadata): Promise<boolean> {
+async function npmPackageVersionExists(
+    metadata: NpmPackageMetadata,
+    timeoutMs: number,
+    commandEnv: Record<string, string | undefined> | undefined,
+): Promise<boolean> {
     const viewResult = await runNpmCommand([
         "npm",
         "view",
         formatPackageSpec(metadata),
         "version",
         "--json",
-    ], { echoOutput: false });
+    ], { echoOutput: false, timeoutMs, commandEnv });
 
     if (viewResult.exitCode === 0) {
         return true;
@@ -201,24 +213,41 @@ async function npmPackageVersionExists(metadata: NpmPackageMetadata): Promise<bo
     );
 }
 
-async function publishNpmPackage(packageFile: string): Promise<NpmCommandResult> {
+async function publishNpmPackage(
+    packageFile: string,
+    timeoutMs: number,
+    commandEnv: Record<string, string | undefined> | undefined,
+): Promise<NpmCommandResult> {
     return await runNpmCommand([
         "npm",
         "publish",
         "--access",
         "public",
         packageFile,
-    ], { echoOutput: true });
+    ], { echoOutput: true, timeoutMs, commandEnv });
 }
 
 async function runNpmCommand(
     command: readonly string[],
-    options: { echoOutput: boolean },
+    options: {
+        commandEnv: Record<string, string | undefined> | undefined;
+        echoOutput: boolean;
+        timeoutMs: number;
+    },
 ): Promise<NpmCommandResult> {
+    const env = options.commandEnv === undefined
+        ? undefined
+        : {
+                ...process.env,
+                ...options.commandEnv,
+            };
     const subprocess = Bun.spawn([...command], {
+        env,
+        killSignal: "SIGKILL",
         stderr: "pipe",
         stdin: "ignore",
         stdout: "pipe",
+        timeout: options.timeoutMs,
     });
     const [stdout, stderr, exitCode] = await Promise.all([
         new Response(subprocess.stdout).text(),
@@ -226,16 +255,21 @@ async function runNpmCommand(
         subprocess.exited,
     ]);
 
+    const timedOut = subprocess.signalCode === "SIGKILL";
+    const result = {
+        exitCode: timedOut ? npmCommandTimeoutExitCode : exitCode,
+        stderr: timedOut
+            ? appendNpmCommandTimeoutError(stderr, options.timeoutMs)
+            : stderr,
+        stdout,
+    } satisfies NpmCommandResult;
+
     if (options.echoOutput) {
-        process.stdout.write(stdout);
-        process.stderr.write(stderr);
+        process.stdout.write(result.stdout);
+        process.stderr.write(result.stderr);
     }
 
-    return {
-        exitCode,
-        stderr,
-        stdout,
-    };
+    return result;
 }
 
 function formatPackageSpec(metadata: NpmPackageMetadata): string {
@@ -246,6 +280,42 @@ function formatCommandOutput(result: NpmCommandResult): string {
     return [result.stdout, result.stderr]
         .filter(output => output !== "")
         .join("\n");
+}
+
+function resolvePublishRetryCount(retryCount: number | undefined): number {
+    const resolvedRetryCount = retryCount ?? defaultPublishRetryCount;
+    if (!Number.isInteger(resolvedRetryCount) || resolvedRetryCount < 1) {
+        throw new Error(`retryCount must be a positive integer, got: ${resolvedRetryCount}.`);
+    }
+
+    return resolvedRetryCount;
+}
+
+function resolvePublishRetryDelayMs(retryDelayMs: number | undefined): number {
+    const resolvedRetryDelayMs = retryDelayMs ?? defaultPublishRetryDelayMs;
+    if (!Number.isFinite(resolvedRetryDelayMs) || resolvedRetryDelayMs < 0) {
+        throw new Error(`retryDelayMs must be a non-negative finite number, got: ${resolvedRetryDelayMs}.`);
+    }
+
+    return resolvedRetryDelayMs;
+}
+
+function resolveNpmCommandTimeoutMs(timeoutMs: number | undefined): number {
+    const resolvedTimeoutMs = timeoutMs ?? defaultNpmCommandTimeoutMs;
+    if (!Number.isFinite(resolvedTimeoutMs) || resolvedTimeoutMs < 1) {
+        throw new Error(`npm command timeout must be a positive number, got: ${resolvedTimeoutMs}.`);
+    }
+
+    return resolvedTimeoutMs;
+}
+
+function appendNpmCommandTimeoutError(stderr: string, timeoutMs: number): string {
+    const timeoutError = `npm command timed out after ${timeoutMs}ms.`;
+    if (stderr === "") {
+        return timeoutError;
+    }
+
+    return `${stderr}\n${timeoutError}`;
 }
 
 function isExistingPackageVersionError(output: string): boolean {

--- a/contrib/ci/release-workflow.ts
+++ b/contrib/ci/release-workflow.ts
@@ -5,6 +5,7 @@ import {
     assembleReleaseArtifacts,
     parseBuildTargetIds,
 } from "./npm-packages.ts";
+import { publishNpmPackagesFromOrderFile } from "./npm-publish.ts";
 import {
     buildCreateReleaseCommand,
     buildFeishuReleaseFollowupNotification,
@@ -117,6 +118,12 @@ async function runAssembleReleaseArtifacts(): Promise<void> {
     });
 }
 
+async function runPublishNpmPackages(): Promise<void> {
+    await publishNpmPackagesFromOrderFile({
+        publishOrderPath: process.env.NPM_PUBLISH_ORDER_PATH ?? "dist/npm-publish-order.txt",
+    });
+}
+
 function readRequiredEnv(name: string): string {
     const value = process.env[name];
     if (value === undefined || value === "") {
@@ -135,6 +142,9 @@ export async function main(args: readonly string[]): Promise<void> {
             return;
         case "assemble-release-artifacts":
             await runAssembleReleaseArtifacts();
+            return;
+        case "publish-npm-packages":
+            await runPublishNpmPackages();
             return;
         case "create-github-release":
             await runCreateGitHubRelease(commandArgs);


### PR DESCRIPTION
The previous publish step ran `npm publish` in a plain bash loop with no retry handling, so transient sigstore/Rekor errors such as TLOG_CREATE_ENTRY_ERROR would fail the entire release. The loop also re-published every package on each run, which broke when a prior attempt had already pushed some tarballs to npm.

Move the publish step into a dedicated TypeScript script that reads the publish order file, looks up each package on npm, skips versions that already exist, retries known transient failures with backoff, and treats a failed publish as successful when the version shows up on npm afterwards. Unit tests cover the retry, skip, and permanent failure branches.