### PR TITLE
ci(publish): make GitHub release step idempotent on retry

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -161,7 +161,7 @@ jobs:
       - name: Publish to npm
         run: bun run contrib/ci/release-workflow.ts publish-npm-packages
 
-      - name: Create GitHub Release
+      - name: Ensure GitHub Release
         run: |
           mapfile -t release_assets < dist/github-release-assets.txt
           bun run contrib/ci/release-workflow.ts create-github-release "${release_assets[@]}"

--- a/contrib/ci/release-steps.ts
+++ b/contrib/ci/release-steps.ts
@@ -49,6 +49,28 @@ export function buildCreateReleaseCommand(input: {
     return command;
 }
 
+export function buildUploadReleaseAssetsCommand(input: {
+    releaseTag: string;
+    assets: readonly string[];
+}): string[] {
+    if (input.releaseTag === "") {
+        throw new Error("RELEASE_TAG is required.");
+    }
+
+    if (input.assets.length === 0) {
+        throw new Error("At least one release asset is required.");
+    }
+
+    return [
+        "gh",
+        "release",
+        "upload",
+        input.releaseTag,
+        ...input.assets,
+        "--clobber",
+    ];
+}
+
 export function buildFeishuReleaseNotification(input: {
     releaseVersion: string;
     releaseTag: string;

--- a/contrib/ci/release-workflow.test.ts
+++ b/contrib/ci/release-workflow.test.ts
@@ -1,11 +1,25 @@
-import { describe, expect, test } from "bun:test";
+import process from "node:process";
+
+import { afterEach, describe, expect, test } from "bun:test";
 
 import {
     buildCreateReleaseCommand,
     buildFeishuReleaseFollowupNotification,
     buildFeishuReleaseNotification,
+    buildUploadReleaseAssetsCommand,
     preparePackageManifest,
 } from "./release-steps.ts";
+import { main } from "./release-workflow.ts";
+
+const originalFetch = globalThis.fetch;
+const originalSpawn = Bun.spawn;
+const originalEnv = process.env;
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Bun.spawn = originalSpawn;
+    process.env = originalEnv;
+});
 
 describe("release-workflow", () => {
     test("prepares the package manifest for publishing", () => {
@@ -172,6 +186,126 @@ describe("release-workflow", () => {
             buildFeishuReleaseNotification(createFeishuInput({ releaseTag: "" })),
         ).toThrow("RELEASE_TAG is required.");
     });
+
+    test("builds the gh release upload command with clobber", () => {
+        expect(
+            buildUploadReleaseAssetsCommand({
+                releaseTag: "v1.2.3",
+                assets: [
+                    "dist/oo-1.2.3.tgz",
+                    "dist/oo-binaries.tgz",
+                ],
+            }),
+        ).toEqual([
+            "gh",
+            "release",
+            "upload",
+            "v1.2.3",
+            "dist/oo-1.2.3.tgz",
+            "dist/oo-binaries.tgz",
+            "--clobber",
+        ]);
+    });
+
+    test("creates a GitHub release when the tag does not exist", async () => {
+        const requests = installReleaseFetchStub({ kind: "missing" });
+        const spawnCalls = installSpawnStub();
+        process.env = {
+            GH_TOKEN: "token",
+            GITHUB_REPOSITORY: "oomol-lab/oo-cli",
+            GITHUB_SHA: "abc123",
+            PREVIOUS_TAG: "v1.2.2",
+            RELEASE_TAG: "v1.2.3",
+        } as NodeJS.ProcessEnv;
+
+        await main([
+            "create-github-release",
+            "dist/oo-1.2.3.tgz",
+            "dist/oo-binaries.tgz",
+        ]);
+
+        expect(requests).toEqual([{
+            init: expect.objectContaining({
+                headers: expect.objectContaining({
+                    authorization: "Bearer token",
+                }),
+            }),
+            url: "https://api.github.com/repos/oomol-lab/oo-cli/releases/tags/v1.2.3",
+        }]);
+        expect(spawnCalls).toEqual([[
+            "gh",
+            "release",
+            "create",
+            "v1.2.3",
+            "dist/oo-1.2.3.tgz",
+            "dist/oo-binaries.tgz",
+            "--target",
+            "abc123",
+            "--title",
+            "v1.2.3",
+            "--generate-notes",
+            "--notes-start-tag",
+            "v1.2.2",
+            "--latest",
+        ]]);
+    });
+
+    test("uploads release assets when the tag already exists", async () => {
+        const requests = installReleaseFetchStub({ kind: "exists" });
+        const spawnCalls = installSpawnStub();
+        process.env = {
+            GH_TOKEN: "token",
+            GITHUB_REPOSITORY: "oomol-lab/oo-cli",
+            GITHUB_SHA: "abc123",
+            PREVIOUS_TAG: "v1.2.2",
+            RELEASE_TAG: "v1.2.3",
+        } as NodeJS.ProcessEnv;
+
+        await main([
+            "create-github-release",
+            "dist/oo-1.2.3.tgz",
+            "dist/oo-binaries.tgz",
+        ]);
+
+        expect(requests).toEqual([{
+            init: expect.objectContaining({
+                headers: expect.objectContaining({
+                    authorization: "Bearer token",
+                }),
+            }),
+            url: "https://api.github.com/repos/oomol-lab/oo-cli/releases/tags/v1.2.3",
+        }]);
+        expect(spawnCalls).toEqual([[
+            "gh",
+            "release",
+            "upload",
+            "v1.2.3",
+            "dist/oo-1.2.3.tgz",
+            "dist/oo-binaries.tgz",
+            "--clobber",
+        ]]);
+    });
+
+    test("throws when the GitHub releases lookup fails with a non-404 error", async () => {
+        installReleaseFetchStub({
+            kind: "error",
+            status: 500,
+            statusText: "Internal Server Error",
+        });
+        const spawnCalls = installSpawnStub();
+        process.env = {
+            GH_TOKEN: "token",
+            GITHUB_REPOSITORY: "oomol-lab/oo-cli",
+            GITHUB_SHA: "abc123",
+            RELEASE_TAG: "v1.2.3",
+        } as NodeJS.ProcessEnv;
+
+        await expect(main([
+            "create-github-release",
+            "dist/oo-1.2.3.tgz",
+        ])).rejects.toThrow(/GitHub API request failed: 500/);
+        expect(spawnCalls).toEqual([]);
+    });
 });
 
 function createFeishuInput(overrides: Partial<Parameters<typeof buildFeishuReleaseNotification>[0]> = {}): Parameters<typeof buildFeishuReleaseNotification>[0] {
@@ -183,4 +317,70 @@ function createFeishuInput(overrides: Partial<Parameters<typeof buildFeishuRelea
         runId: "123456789",
         ...overrides,
     };
+}
+
+type FetchInit = Parameters<typeof fetch>[1];
+
+interface CapturedFetchRequest {
+    init: FetchInit;
+    url: string;
+}
+
+type ReleaseFetchStubOptions
+    = | { kind: "exists" }
+        | { kind: "missing" }
+        | { kind: "error"; status: number; statusText: string };
+
+function installReleaseFetchStub(options: ReleaseFetchStubOptions): CapturedFetchRequest[] {
+    const requests: CapturedFetchRequest[] = [];
+
+    globalThis.fetch = Object.assign(async (
+        input: Parameters<typeof fetch>[0],
+        init?: FetchInit,
+    ): Promise<Response> => {
+        const url = String(input);
+        requests.push({
+            init,
+            url,
+        });
+
+        if (url.includes("/releases/tags/v1.2.3")) {
+            switch (options.kind) {
+                case "exists":
+                    return Response.json({ tag_name: "v1.2.3" });
+                case "missing":
+                    return Response.json({ message: "Not Found" }, {
+                        status: 404,
+                        statusText: "Not Found",
+                    });
+                case "error":
+                    return Response.json({ message: "boom" }, {
+                        status: options.status,
+                        statusText: options.statusText,
+                    });
+            }
+        }
+
+        return Response.json({});
+    }, {
+        preconnect: originalFetch.preconnect,
+    });
+
+    return requests;
+}
+
+function installSpawnStub(): string[][] {
+    const spawnCalls: string[][] = [];
+
+    Bun.spawn = ((command: string[]) => {
+        spawnCalls.push(command);
+
+        return {
+            exited: Promise.resolve(0),
+            kill: () => 0,
+            unref: () => {},
+        } as unknown as ReturnType<typeof Bun.spawn>;
+    }) as typeof Bun.spawn;
+
+    return spawnCalls;
 }

--- a/contrib/ci/release-workflow.ts
+++ b/contrib/ci/release-workflow.ts
@@ -10,8 +10,12 @@ import {
     buildCreateReleaseCommand,
     buildFeishuReleaseFollowupNotification,
     buildFeishuReleaseNotification,
+    buildUploadReleaseAssetsCommand,
     preparePackageManifest,
 } from "./release-steps.ts";
+
+const defaultGitHubApiUrl = "https://api.github.com";
+const githubApiVersion = "2022-11-28";
 
 async function runPrepareManifest(): Promise<void> {
     const releaseVersion = readRequiredEnv("RELEASE_VERSION");
@@ -22,12 +26,19 @@ async function runPrepareManifest(): Promise<void> {
 }
 
 async function runCreateGitHubRelease(assets: readonly string[]): Promise<void> {
-    const command = buildCreateReleaseCommand({
-        releaseTag: readRequiredEnv("RELEASE_TAG"),
-        previousTag: process.env.PREVIOUS_TAG ?? "",
-        target: readRequiredEnv("GITHUB_SHA"),
-        assets,
-    });
+    const releaseTag = readRequiredEnv("RELEASE_TAG");
+    const releaseExists = await doesGitHubReleaseExist(releaseTag);
+    const command = releaseExists
+        ? buildUploadReleaseAssetsCommand({
+                assets,
+                releaseTag,
+            })
+        : buildCreateReleaseCommand({
+                assets,
+                previousTag: process.env.PREVIOUS_TAG ?? "",
+                releaseTag,
+                target: readRequiredEnv("GITHUB_SHA"),
+            });
 
     const processResult = Bun.spawn(command, {
         cwd: process.cwd(),
@@ -40,6 +51,47 @@ async function runCreateGitHubRelease(assets: readonly string[]): Promise<void> 
     if (exitCode !== 0) {
         process.exit(exitCode);
     }
+}
+
+async function doesGitHubReleaseExist(releaseTag: string): Promise<boolean> {
+    const githubRepository = readRequiredEnv("GITHUB_REPOSITORY");
+    const apiUrl = process.env.GITHUB_API_URL ?? defaultGitHubApiUrl;
+    const token = readGitHubToken();
+    const response = await fetch(
+        `${trimTrailingSlash(apiUrl)}/repos/${githubRepository}/releases/tags/${encodeURIComponent(releaseTag)}`,
+        {
+            headers: {
+                "accept": "application/vnd.github+json",
+                "authorization": `Bearer ${token}`,
+                "x-github-api-version": githubApiVersion,
+            },
+            signal: AbortSignal.timeout(15_000),
+        },
+    );
+
+    if (response.status === 404) {
+        return false;
+    }
+
+    if (!response.ok) {
+        const responseText = await response.text();
+        throw new Error(`GitHub API request failed: ${response.status} ${response.statusText}\n${responseText}`);
+    }
+
+    return true;
+}
+
+function readGitHubToken(): string {
+    const token = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
+    if (token === undefined || token === "") {
+        throw new Error("GH_TOKEN or GITHUB_TOKEN is required.");
+    }
+
+    return token;
+}
+
+function trimTrailingSlash(value: string): string {
+    return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
 async function runNotifyFeishuRelease(): Promise<void> {


### PR DESCRIPTION
When the publish workflow retried after a partial failure, the GitHub release step would fail because `gh release create` rejects an existing tag. Pre-check the release via the GitHub API and either create it or upload assets with `gh release upload --clobber` so reruns converge on the same final state.