### PR TITLE
fix(file): normalize signed download URLs to URI-safe form

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -567,21 +567,40 @@ export function toRequest(input: string | URL | Request, init?: RequestInit): Re
     return new Request(String(input), init);
 }
 
-export async function expectCliUserError(
-    operation: Promise<unknown>,
-): Promise<CliUserError> {
-    try {
-        await operation;
-    }
-    catch (error) {
-        if (error instanceof CliUserError) {
-            return error;
+export function expectCliUserError(operation: () => unknown): CliUserError;
+export function expectCliUserError(operation: Promise<unknown>): Promise<CliUserError>;
+export function expectCliUserError(
+    operation: Promise<unknown> | (() => unknown),
+): CliUserError | Promise<CliUserError> {
+    if (typeof operation === "function") {
+        try {
+            operation();
+        }
+        catch (error) {
+            if (error instanceof CliUserError) {
+                return error;
+            }
+
+            throw error;
         }
 
-        throw error;
+        throw new Error("Expected a CliUserError to be thrown.");
     }
 
-    throw new Error("Expected a CliUserError to be thrown.");
+    return (async () => {
+        try {
+            await operation;
+        }
+        catch (error) {
+            if (error instanceof CliUserError) {
+                return error;
+            }
+
+            throw error;
+        }
+
+        throw new Error("Expected a CliUserError to be thrown.");
+    })();
 }
 
 export function findLoginUrl(output: string): string | undefined {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -998,6 +998,8 @@ Upload one file to the temporary file cache.
 - Notes: files larger than `500 MiB` are rejected.
 - Notes: successful uploads persist a local sqlite record with the upload time,
   file name, file size, signed download URL, expiry time, and a UUID v7 id.
+- Notes: JSON and text output return `downloadUrl` as a URI-safe signed URL.
+  The `fileName` field keeps the original uploaded file name.
 
 ### `oo file list`
 
@@ -1011,6 +1013,8 @@ List previously uploaded files from the local sqlite store.
   `json`.
 - Options: `--json` is an alias for `--format=json`.
 - Notes: the command does not delete expired records implicitly.
+- Notes: output normalizes legacy signed download URLs when possible, while
+  leaving `fileName` unchanged.
 
 ### `oo file cleanup`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -846,6 +846,8 @@ skills。
 - 说明：文件大小超过 `500 MiB` 时会被拒绝。
 - 说明：上传成功后，CLI 会在本地 sqlite 中记录上传时间、文件名、文件大小、
   带签名的下载 URL、过期时间，以及一个 UUID v7 格式的主键。
+- 说明：JSON 和文本输出中的 `downloadUrl` 会是 URI-safe 的带签名 URL；
+  `fileName` 字段仍保留原始上传文件名。
 
 ### `oo file list`
 
@@ -856,6 +858,8 @@ skills。
 - 选项：`--format <format>` 返回结构化输出，目前仅支持 `json`。
 - 选项：`--json` 是 `--format=json` 的别名。
 - 说明：命令不会隐式删除已过期记录。
+- 说明：输出时会尽量规范化历史记录中的带签名下载 URL，同时保持 `fileName`
+  不变。
 
 ### `oo file cleanup`
 

--- a/src/application/commands/cloud-task/validation.test.ts
+++ b/src/application/commands/cloud-task/validation.test.ts
@@ -2,8 +2,8 @@ import type { PackageInfoResponse } from "../package/shared.ts";
 
 import { describe, expect, test } from "bun:test";
 
+import { expectCliUserError } from "../../../../__tests__/helpers.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
-import { CliUserError } from "../../contracts/cli.ts";
 import { validateCloudTaskInputValues } from "./validation.ts";
 
 const englishTranslator = createTranslator("en");
@@ -232,19 +232,4 @@ function createBlock(
         outputHandle: {},
         title: "Main",
     };
-}
-
-function expectCliUserError(callback: () => void): CliUserError {
-    try {
-        callback();
-    }
-    catch (error) {
-        if (error instanceof CliUserError) {
-            return error;
-        }
-
-        throw error;
-    }
-
-    throw new Error("Expected a CliUserError to be thrown.");
 }

--- a/src/application/commands/connector/validation.test.ts
+++ b/src/application/commands/connector/validation.test.ts
@@ -17,6 +17,21 @@ describe("validateConnectorActionInput", () => {
             )).not.toThrow();
     });
 
+    test("accepts normalized file upload download URLs as uri-formatted image input", () => {
+        expect(() =>
+            validateConnectorActionInput(
+                {
+                    images: [
+                        {
+                            image_url: "https://download.example.com/files/%E5%8C%851.jpg",
+                        },
+                    ],
+                },
+                createImageInputSchema(),
+                englishTranslator,
+            )).not.toThrow();
+    });
+
     test("rejects invalid payloads with the connector invalid-payload error", () => {
         expect(() =>
             validateConnectorActionInput(
@@ -51,6 +66,36 @@ function createEmailSchema(): Record<string, unknown> {
             },
         },
         required: ["to"],
+        type: "object",
+    };
+}
+
+function createImageInputSchema(): Record<string, unknown> {
+    return {
+        properties: {
+            images: {
+                items: {
+                    properties: {
+                        image_url: {
+                            anyOf: [
+                                {
+                                    format: "uri",
+                                    type: "string",
+                                },
+                                {
+                                    pattern: "^data:image/[^;,]+;base64,.*",
+                                    type: "string",
+                                },
+                            ],
+                        },
+                    },
+                    required: ["image_url"],
+                    type: "object",
+                },
+                type: "array",
+            },
+        },
+        required: ["images"],
         type: "object",
     };
 }

--- a/src/application/commands/file/download.cli.test.ts
+++ b/src/application/commands/file/download.cli.test.ts
@@ -194,6 +194,40 @@ describe("file download CLI", () => {
         }
     });
 
+    test("infers a non-ASCII file name from an encoded download URL", async () => {
+        const sandbox = await createCliSandbox();
+        const outputDirectoryPath = join(sandbox.env.HOME!, "downloads");
+        const inferredFileName = "\u53051.jpg";
+
+        try {
+            const result = await sandbox.run(
+                [
+                    "file",
+                    "download",
+                    "https://download.example.com/%E5%8C%851.jpg",
+                    outputDirectoryPath,
+                ],
+                {
+                    fetcher: async () => new Response("image bytes", {
+                        headers: {
+                            "Content-Length": "11",
+                            "Content-Type": "image/jpeg",
+                        },
+                        status: 200,
+                    }),
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            await expect(Bun.file(join(outputDirectoryPath, inferredFileName)).text()).resolves.toBe(
+                "image bytes",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("uses the configured file download output directory and expands a leading tilde", async () => {
         const sandbox = await createCliSandbox();
         const outputDirectoryPath = join(sandbox.env.HOME!, "Downloads", "reports");

--- a/src/application/commands/file/download/input.test.ts
+++ b/src/application/commands/file/download/input.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { CliUserError } from "../../../contracts/cli.ts";
+import { expectCliUserError } from "../../../../../__tests__/helpers.ts";
 import {
     parseFileDownloadExtensionOption,
     parseFileDownloadNameOption,
+    parseFileDownloadUrl,
 } from "./input.ts";
 
 describe("parseFileDownloadNameOption", () => {
@@ -55,17 +56,12 @@ describe("parseFileDownloadExtensionOption", () => {
     });
 });
 
-function expectCliUserError(callback: () => unknown): CliUserError {
-    try {
-        callback();
-    }
-    catch (error) {
-        if (error instanceof CliUserError) {
-            return error;
-        }
+describe("parseFileDownloadUrl", () => {
+    test("normalizes raw non-ASCII URL input", () => {
+        const fileName = "\u53051.jpg";
 
-        throw error;
-    }
-
-    throw new Error("Expected a CliUserError to be thrown.");
-}
+        expect(
+            parseFileDownloadUrl(`https://download.example.com/${fileName}`).toString(),
+        ).toBe("https://download.example.com/%E5%8C%851.jpg");
+    });
+});

--- a/src/application/commands/file/list-cleanup.cli.test.ts
+++ b/src/application/commands/file/list-cleanup.cli.test.ts
@@ -16,6 +16,8 @@ describe("file list and cleanup CLI", () => {
             env: sandbox.env,
             platform: process.platform,
         }).uploadsFilePath;
+        const legacyFileName = "\u53051.jpg";
+        const legacyDownloadUrl = `https://download.example.com/${legacyFileName}`;
 
         try {
             await mkdir(
@@ -52,7 +54,7 @@ describe("file list and cleanup CLI", () => {
                         "INSERT INTO uploaded_files (",
                         "id, file_name, file_size, download_url, uploaded_at_ms, expires_at_ms",
                         ") VALUES",
-                        "('0195f5fe-ec27-7000-8000-000000000008', 'expired.txt', 10, 'https://download.example.com/expired', 1000, 2000),",
+                        `('0195f5fe-ec27-7000-8000-000000000008', '${legacyFileName}', 10, '${legacyDownloadUrl}', 1000, 2000),`,
                         "('0195f5fe-ec28-7000-8000-000000000009', 'active.txt', 11, 'https://download.example.com/active', 3000, 32503680000000)",
                     ].join(" "),
                 );
@@ -80,9 +82,9 @@ describe("file list and cleanup CLI", () => {
             expect(listJsonResult.exitCode).toBe(0);
             expect(JSON.parse(listJsonResult.stdout)).toEqual([
                 {
-                    downloadUrl: "https://download.example.com/expired",
+                    downloadUrl: "https://download.example.com/%E5%8C%851.jpg",
                     expiresAt: new Date(2000).toISOString(),
-                    fileName: "expired.txt",
+                    fileName: legacyFileName,
                     fileSize: 10,
                     id: "0195f5fe-ec27-7000-8000-000000000008",
                     status: "expired",

--- a/src/application/commands/file/list.ts
+++ b/src/application/commands/file/list.ts
@@ -53,7 +53,7 @@ export const fileListCommand: CliCommandDefinition<FileListInput> = {
                 now,
                 status,
             })
-            .map(record => serializeFileUploadRecord(record, now));
+            .map(record => serializeFileUploadRecord(record, now, context.logger));
 
         if (format === "json") {
             writeJsonOutput(context.stdout, records);

--- a/src/application/commands/file/shared.test.ts
+++ b/src/application/commands/file/shared.test.ts
@@ -1,8 +1,84 @@
 import { describe, expect, test } from "bun:test";
 
-import { createLogCapture } from "../../../../__tests__/helpers.ts";
+import { createLogCapture, expectCliUserError } from "../../../../__tests__/helpers.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
-import { uploadFileParts } from "./shared.ts";
+import {
+    normalizeFileUploadDownloadUrl,
+    normalizeFileUploadDownloadUrlForDisplay,
+    uploadFileParts,
+} from "./shared.ts";
+
+describe("normalizeFileUploadDownloadUrl", () => {
+    test("normalizes non-ASCII paths, spaces, and IDN hosts", () => {
+        expect(
+            normalizeFileUploadDownloadUrl("https://download.example.com/files/\u5305 1.jpg"),
+        ).toBe("https://download.example.com/files/%E5%8C%85%201.jpg");
+        expect(
+            normalizeFileUploadDownloadUrl(
+                "https://download.example.com/files/\u65E5\u672C\u8A9E/\uD55C\uAE00/caf\u00E9.jpg",
+            ),
+        ).toBe(
+            "https://download.example.com/files/%E6%97%A5%E6%9C%AC%E8%AA%9E/%ED%95%9C%EA%B8%80/caf%C3%A9.jpg",
+        );
+        expect(
+            normalizeFileUploadDownloadUrl("https://\u4F8B\u3048.example.com/files/archive.txt"),
+        ).toBe("https://xn--r8jz45g.example.com/files/archive.txt");
+    });
+
+    test("preserves existing escapes and query signature characters", () => {
+        const normalizedUrl
+            = "https://download.example.com/files/%E5%8C%85%201.jpg?signature=a+b%2Fc&label=%E5%8C%85";
+
+        expect(
+            normalizeFileUploadDownloadUrl(
+                "https://download.example.com/files/\u5305 1.jpg?signature=a+b%2Fc&label=\u5305",
+            ),
+        ).toBe(normalizedUrl);
+        expect(normalizeFileUploadDownloadUrl(normalizedUrl)).toBe(normalizedUrl);
+    });
+
+    test("rejects invalid server download URLs", () => {
+        expect(expectCliUserError(() =>
+            normalizeFileUploadDownloadUrl("not a url"),
+        )).toMatchObject({
+            key: "errors.fileUpload.invalidResponse",
+        });
+    });
+});
+
+describe("normalizeFileUploadDownloadUrlForDisplay", () => {
+    test("normalizes parseable legacy download URLs", () => {
+        expect(
+            normalizeFileUploadDownloadUrlForDisplay(
+                "https://download.example.com/files/\u53051.jpg",
+            ),
+        ).toBe("https://download.example.com/files/%E5%8C%851.jpg");
+    });
+
+    test("keeps unparseable legacy download URLs and logs only sanitized fields", () => {
+        const logCapture = createLogCapture();
+        const rawUrl = "not a url with secret-token";
+
+        try {
+            expect(
+                normalizeFileUploadDownloadUrlForDisplay(rawUrl, logCapture.logger),
+            ).toBe(rawUrl);
+
+            const logs = logCapture.read();
+
+            expect(logs).toContain(
+                "Skipping URL normalization for unparseable legacy file upload record.",
+            );
+            expect(logs).toContain("\"errorName\":\"TypeError\"");
+            expect(logs).toContain(`"rawUrlLength":${rawUrl.length}`);
+            expect(logs).not.toContain(rawUrl);
+            expect(logs).not.toContain("secret-token");
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+});
 
 describe("uploadFileParts", () => {
     test("keeps the request method in unexpected error logs", async () => {

--- a/src/application/commands/file/shared.ts
+++ b/src/application/commands/file/shared.ts
@@ -1,3 +1,4 @@
+import type { Logger } from "pino";
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type {
     FileUploadRecord,
@@ -115,9 +116,13 @@ export function parseFileStatus(
 export function serializeFileUploadRecord(
     record: FileUploadRecord,
     now: number,
+    logger?: Logger,
 ): FileUploadRecordView {
     return {
-        downloadUrl: record.downloadUrl,
+        downloadUrl: normalizeFileUploadDownloadUrlForDisplay(
+            record.downloadUrl,
+            logger,
+        ),
         expiresAt: new Date(record.expiresAtMs).toISOString(),
         fileName: record.fileName,
         fileSize: record.fileSize,
@@ -125,6 +130,34 @@ export function serializeFileUploadRecord(
         status: readFileUploadStatus(record.expiresAtMs, now),
         uploadedAt: new Date(record.uploadedAtMs).toISOString(),
     };
+}
+
+export function normalizeFileUploadDownloadUrl(rawUrl: string): string {
+    try {
+        return normalizeFileUploadDownloadUrlValue(rawUrl);
+    }
+    catch {
+        throw new CliUserError("errors.fileUpload.invalidResponse", 1);
+    }
+}
+
+export function normalizeFileUploadDownloadUrlForDisplay(
+    rawUrl: string,
+    logger?: Logger,
+): string {
+    try {
+        return normalizeFileUploadDownloadUrlValue(rawUrl);
+    }
+    catch (error) {
+        logger?.debug(
+            {
+                errorName: error instanceof Error ? error.name : typeof error,
+                rawUrlLength: rawUrl.length,
+            },
+            "Skipping URL normalization for unparseable legacy file upload record.",
+        );
+        return rawUrl;
+    }
 }
 
 export async function createMultipartFileUpload(
@@ -265,7 +298,7 @@ export async function completeMultipartFileUpload(
         );
 
         return {
-            downloadUrl: response.data.downloadURL,
+            downloadUrl: normalizeFileUploadDownloadUrl(response.data.downloadURL),
         };
     }
     catch {
@@ -287,6 +320,10 @@ function createFileUploadRequestUrl(
     return new URL(
         `https://fusion-api.${endpoint}/v1/file-upload/action/${actionName}`,
     );
+}
+
+function normalizeFileUploadDownloadUrlValue(rawUrl: string): string {
+    return new URL(rawUrl).href;
 }
 
 async function requestFileUpload(

--- a/src/application/commands/file/upload.cli.test.ts
+++ b/src/application/commands/file/upload.cli.test.ts
@@ -384,6 +384,99 @@ describe("file upload CLI", () => {
         }
     });
 
+    test("stores normalized download URLs before persisting uploaded records", async () => {
+        const sandbox = await createCliSandbox();
+        const uploadsFilePath = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        }).uploadsFilePath;
+        const uploadedFileName = "\u53051.jpg";
+        const localFilePath = join(sandbox.env.HOME!, uploadedFileName);
+
+        try {
+            await writeAuthFile(sandbox);
+            await Bun.write(localFilePath, "persist me");
+
+            const result = await sandbox.run(
+                ["file", "upload", localFilePath, "--json"],
+                {
+                    fetcher: createSinglePartUploadFetcher({
+                        downloadURL: `https://download.example.com/files/${uploadedFileName}`,
+                        key: `file-upload/user-1/file-1/${uploadedFileName}`,
+                    }),
+                },
+            );
+            const database = new Database(uploadsFilePath, {
+                strict: true,
+            });
+
+            try {
+                expect(result.exitCode).toBe(0);
+                expect(JSON.parse(result.stdout)).toMatchObject({
+                    downloadUrl: "https://download.example.com/files/%E5%8C%851.jpg",
+                    fileName: uploadedFileName,
+                });
+                expect(
+                    database.query(
+                        [
+                            "SELECT",
+                            "download_url AS downloadUrl",
+                            "FROM uploaded_files",
+                        ].join(" "),
+                    ).all(),
+                ).toEqual([
+                    {
+                        downloadUrl: "https://download.example.com/files/%E5%8C%851.jpg",
+                    },
+                ]);
+            }
+            finally {
+                database.close();
+            }
+        }
+        finally {
+            await Bun.file(localFilePath).delete();
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects invalid complete upload download URLs without persisting records", async () => {
+        const sandbox = await createCliSandbox();
+        const uploadsFilePath = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        }).uploadsFilePath;
+        const localFilePath = join(sandbox.env.HOME!, "invalid-download-url.txt");
+
+        try {
+            await writeAuthFile(sandbox);
+            await Bun.write(localFilePath, "invalid response");
+
+            const result = await sandbox.run(
+                ["file", "upload", localFilePath, "--json"],
+                {
+                    fetcher: createSinglePartUploadFetcher({
+                        downloadURL: "not a url with secret-token",
+                        key: "file-upload/user-1/file-1/invalid-download-url.txt",
+                    }),
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toContain(
+                "The file upload service returned an unsupported response body.",
+            );
+            await expect(Bun.file(uploadsFilePath).exists()).resolves.toBeFalse();
+        }
+        finally {
+            await Bun.file(localFilePath).delete();
+            await sandbox.cleanup();
+        }
+    });
+
     test("records rejected too large telemetry without file identity", async () => {
         const sandbox = await createCliSandbox();
         const localFilePath = join(sandbox.env.HOME!, "large-upload.bin");
@@ -431,6 +524,61 @@ describe("file upload CLI", () => {
         }
     });
 });
+
+function createSinglePartUploadFetcher(options: {
+    readonly downloadURL: string;
+    readonly key: string;
+}): (input: string | URL | Request, init?: RequestInit) => Promise<Response> {
+    return async (input, init) => {
+        const request = toRequest(input, init);
+
+        if (request.url.endsWith("/create-multipart-upload")) {
+            return new Response(JSON.stringify({
+                success: true,
+                data: {
+                    key: options.key,
+                    partSize: 64,
+                    totalParts: 1,
+                    uploadID: "upload-1",
+                },
+            }));
+        }
+
+        if (request.url.endsWith("/generate-presigned-urls")) {
+            return new Response(JSON.stringify({
+                success: true,
+                data: [
+                    {
+                        partNumber: 1,
+                        uploadURL: "https://storage.example.com/upload/1",
+                    },
+                ],
+            }));
+        }
+
+        if (request.url.startsWith("https://storage.example.com/upload/")) {
+            return new Response(null, {
+                headers: {
+                    ETag: "\"etag-1\"",
+                },
+                status: 200,
+            });
+        }
+
+        if (request.url.endsWith("/complete-multipart-upload")) {
+            return new Response(JSON.stringify({
+                success: true,
+                data: {
+                    downloadURL: options.downloadURL,
+                },
+            }));
+        }
+
+        return new Response(null, {
+            status: 200,
+        });
+    };
+}
 
 function createFileUploadSnapshot(
     result: {

--- a/src/application/commands/file/upload.ts
+++ b/src/application/commands/file/upload.ts
@@ -102,7 +102,7 @@ export const fileUploadCommand: CliCommandDefinition<FileUploadInput> = {
 
         context.fileUploadStore.save(record);
 
-        const view = serializeFileUploadRecord(record, uploadedAtMs);
+        const view = serializeFileUploadRecord(record, uploadedAtMs, context.logger);
 
         if (format === "json") {
             writeJsonOutput(context.stdout, view);


### PR DESCRIPTION
The file upload service can return signed download URLs that contain raw non-ASCII characters, spaces, or non-ASCII hosts. These URLs round-trip through the CLI into connector inputs that validate strict URI format and were rejected there.

Normalize the URL at upload completion before persisting, and also normalize legacy records on read so existing rows surface the URI-safe form without a migration. Unparseable legacy URLs are returned unchanged so the list command keeps working.

Also consolidate the duplicated synchronous expectCliUserError test helper into the shared helpers module per project rule.

fixed: #199