### PR TITLE
feat(ci): publish npm packages concurrently before the wrapper

### DIFF
--- a/contrib/ci/npm-publish.test.ts
+++ b/contrib/ci/npm-publish.test.ts
@@ -117,6 +117,74 @@ describe("npm publish workflow", () => {
         });
     });
 
+    test("publishes package files concurrently before the final package", async () => {
+        await withPublishOrder([
+            "dist/platform-a.tgz",
+            "dist/platform-b.tgz",
+            "dist/wrapper.tgz",
+        ], async (publishOrder) => {
+            const activePackageFiles = new Set<string>();
+            const publishCompletions = new Map<string, (result: NpmCommandResult) => void>();
+            const startedPackageFiles: string[] = [];
+            const firstTwoPublishesStarted = Promise.withResolvers<void>();
+            const finalPublishStarted = Promise.withResolvers<void>();
+            let maxConcurrentPublishes = 0;
+
+            const publishPromise = publishNpmPackagesFromOrderFile({
+                publishOrderPath: publishOrder.filePath,
+                logger: createLogger([]),
+                packageVersionExists: () => Promise.resolve(false),
+                publishConcurrency: 2,
+                publishPackage: (packageFile) => {
+                    startedPackageFiles.push(packageFile);
+                    activePackageFiles.add(packageFile);
+                    maxConcurrentPublishes = Math.max(
+                        maxConcurrentPublishes,
+                        activePackageFiles.size,
+                    );
+
+                    const publishCompletion = Promise.withResolvers<NpmCommandResult>();
+                    publishCompletions.set(packageFile, publishCompletion.resolve);
+
+                    if (startedPackageFiles.length === 2) {
+                        firstTwoPublishesStarted.resolve(undefined);
+                    }
+                    if (packageFile === "dist/wrapper.tgz") {
+                        finalPublishStarted.resolve(undefined);
+                    }
+
+                    return publishCompletion.promise.finally(() => {
+                        activePackageFiles.delete(packageFile);
+                    });
+                },
+                readPackageMetadata: packageFile => Promise.resolve(
+                    readMetadataFixture(packageFile),
+                ),
+            });
+
+            await firstTwoPublishesStarted.promise;
+
+            expect(startedPackageFiles).toEqual([
+                "dist/platform-a.tgz",
+                "dist/platform-b.tgz",
+            ]);
+            expect(maxConcurrentPublishes).toBe(2);
+
+            completePublish(publishCompletions, "dist/platform-a.tgz");
+            completePublish(publishCompletions, "dist/platform-b.tgz");
+            await finalPublishStarted.promise;
+
+            expect(startedPackageFiles).toEqual([
+                "dist/platform-a.tgz",
+                "dist/platform-b.tgz",
+                "dist/wrapper.tgz",
+            ]);
+
+            completePublish(publishCompletions, "dist/wrapper.tgz");
+            await publishPromise;
+        });
+    });
+
     test("treats a failed publish as successful when the package appears on npm", async () => {
         await withPublishOrder(["dist/demo.tgz"], async (publishOrder) => {
             const logs: string[] = [];
@@ -227,6 +295,13 @@ describe("npm publish workflow", () => {
                     retryDelayMs: -10,
                 }),
             ).rejects.toThrow("retryDelayMs must be a non-negative finite number");
+
+            await expect(
+                publishNpmPackagesFromOrderFile({
+                    ...baseOptions,
+                    publishConcurrency: 0,
+                }),
+            ).rejects.toThrow("publishConcurrency must be a positive integer");
         });
     });
 
@@ -313,6 +388,18 @@ function createLogger(logs: string[]): Pick<Console, "log"> {
     };
 }
 
+function completePublish(
+    publishCompletions: Map<string, (result: NpmCommandResult) => void>,
+    packageFile: string,
+): void {
+    const complete = publishCompletions.get(packageFile);
+    if (complete === undefined) {
+        throw new Error(`Missing publish completion for ${packageFile}.`);
+    }
+
+    complete(createCommandResult({}));
+}
+
 function createCommandResult(options: {
     exitCode?: number;
     stderr?: string;
@@ -323,4 +410,26 @@ function createCommandResult(options: {
         stderr: options.stderr ?? "",
         stdout: options.stdout ?? "",
     };
+}
+
+function readMetadataFixture(packageFile: string): NpmPackageMetadata {
+    switch (packageFile) {
+        case "dist/platform-a.tgz":
+            return {
+                name: "@scope/platform-a",
+                version: "1.2.3",
+            };
+        case "dist/platform-b.tgz":
+            return {
+                name: "@scope/platform-b",
+                version: "1.2.3",
+            };
+        case "dist/wrapper.tgz":
+            return {
+                name: "@scope/wrapper",
+                version: "1.2.3",
+            };
+        default:
+            throw new Error(`Unexpected package file: ${packageFile}.`);
+    }
 }

--- a/contrib/ci/npm-publish.ts
+++ b/contrib/ci/npm-publish.ts
@@ -19,6 +19,7 @@ interface PublishNpmPackagesOptions {
     logger?: Pick<Console, "log">;
     npmCommandTimeoutMs?: number;
     packageVersionExists?: (metadata: NpmPackageMetadata) => Promise<boolean>;
+    publishConcurrency?: number;
     publishOrderPath: string;
     publishPackage?: (packageFile: string) => Promise<NpmCommandResult>;
     readPackageMetadata?: (packageFile: string) => Promise<NpmPackageMetadata>;
@@ -29,6 +30,7 @@ interface PublishNpmPackagesOptions {
 
 const defaultPublishRetryCount = 5;
 const defaultPublishRetryDelayMs = 15_000;
+const defaultPublishConcurrency = 8;
 const defaultNpmCommandTimeoutMs = 120_000;
 const npmCommandTimeoutExitCode = 124;
 const existingVersionErrorFragments = [
@@ -72,8 +74,9 @@ export async function publishNpmPackagesFromOrderFile(
     const logger = options.logger ?? console;
     const retryCount = resolvePublishRetryCount(options.retryCount);
     const retryDelayMs = resolvePublishRetryDelayMs(options.retryDelayMs);
+    const publishConcurrency = resolvePublishConcurrency(options.publishConcurrency);
 
-    for (const packageFile of packageFiles) {
+    const publishPackageFile = async (packageFile: string): Promise<void> => {
         const metadata = await readPackageMetadata(packageFile);
 
         await publishNpmPackageWithRetry({
@@ -86,7 +89,22 @@ export async function publishNpmPackagesFromOrderFile(
             retryDelayMs,
             sleep,
         });
+    };
+
+    const finalPackageFile = packageFiles.at(-1);
+    if (finalPackageFile === undefined) {
+        return;
     }
+
+    // The publish order file lists the wrapper package last (see npm-packages.ts).
+    // The wrapper depends on the platform packages being installable from npm, so
+    // it must be published only after every earlier package has succeeded.
+    await publishNpmPackageFilesWithConcurrency(
+        packageFiles.slice(0, -1),
+        publishConcurrency,
+        publishPackageFile,
+    );
+    await publishPackageFile(finalPackageFile);
 }
 
 export function parseNpmPublishOrderFile(content: string): readonly string[] {
@@ -180,6 +198,39 @@ async function publishNpmPackageWithRetry(options: {
             `Retrying ${packageSpec} after transient npm publish failure in ${delayMs}ms.`,
         );
         await options.sleep(delayMs);
+    }
+}
+
+async function publishNpmPackageFilesWithConcurrency(
+    packageFiles: readonly string[],
+    publishConcurrency: number,
+    publishPackageFile: (packageFile: string) => Promise<void>,
+): Promise<void> {
+    let nextPackageIndex = 0;
+    let firstError: unknown;
+    const workerCount = Math.min(publishConcurrency, packageFiles.length);
+
+    await Promise.all(Array.from({ length: workerCount }, async () => {
+        while (firstError === undefined) {
+            const packageIndex = nextPackageIndex;
+            nextPackageIndex += 1;
+            const packageFile = packageFiles[packageIndex];
+
+            if (packageFile === undefined) {
+                return;
+            }
+
+            try {
+                await publishPackageFile(packageFile);
+            }
+            catch (error) {
+                firstError ??= error;
+            }
+        }
+    }));
+
+    if (firstError !== undefined) {
+        throw firstError;
     }
 }
 
@@ -298,6 +349,15 @@ function resolvePublishRetryDelayMs(retryDelayMs: number | undefined): number {
     }
 
     return resolvedRetryDelayMs;
+}
+
+function resolvePublishConcurrency(publishConcurrency: number | undefined): number {
+    const resolvedPublishConcurrency = publishConcurrency ?? defaultPublishConcurrency;
+    if (!Number.isInteger(resolvedPublishConcurrency) || resolvedPublishConcurrency < 1) {
+        throw new Error(`publishConcurrency must be a positive integer, got: ${resolvedPublishConcurrency}.`);
+    }
+
+    return resolvedPublishConcurrency;
 }
 
 function resolveNpmCommandTimeoutMs(timeoutMs: number | undefined): number {


### PR DESCRIPTION
Releases previously published every package sequentially, even though the platform packages have no inter-dependencies. Publish them with a configurable worker pool (default 8) and keep the wrapper package sequential at the tail, since it depends on platform packages being installable from npm.