### PR TITLE
feat(auth): embed user code in device login URL

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -37,9 +37,9 @@ Project overview: [README.md](../README.md)
 Start a device login flow or authenticate with a session token, then save the
 authenticated account.
 
-- Notes: the CLI prints the verification URL and user code, then polls until
-  the device login is verified or times out when `--session-token` is not
-  provided.
+- Notes: the CLI prints the verification URL with the user code in the
+  `user_code` query parameter, then polls until the device login is verified or
+  times out when `--session-token` is not provided.
 - Options:
   - `--session-token <session-token>`: Authenticate with an existing session
     token. The CLI does not print a device-login URL or poll for verification

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -32,8 +32,8 @@
 
 启动 device login 流程，或使用 session token 登录，并保存登录成功后的账号。
 
-- 说明：未传入 `--session-token` 时，CLI 会打印验证地址和用户 code，然后轮询直到
-  device login 验证成功或超时。
+- 说明：未传入 `--session-token` 时，CLI 会打印验证地址，并把用户 code 放在
+  `user_code` query 参数中，然后轮询直到 device login 验证成功或超时。
 - 选项：
   - `--session-token <session-token>`：使用已有 session token 登录。传入后 CLI 不会
     打印 device-login URL，也不会轮询验证结果。

--- a/src/application/auth/login-flow.test.ts
+++ b/src/application/auth/login-flow.test.ts
@@ -34,7 +34,7 @@ describe("startAuthLoginSession", () => {
                             code: "M0KO41",
                             expires_in: 1800,
                             status: "waiting",
-                            verify_code_url: "https://oomol.com/login/device",
+                            verify_code_url: "https://oomol.com/login/device?from=cli",
                         }));
                     }
 
@@ -71,9 +71,10 @@ describe("startAuthLoginSession", () => {
                 stat: string;
             };
 
-            expect(session.code).toBe("M0KO41");
             expect(session.expiresInSeconds).toBe(1800);
-            expect(session.verificationUrl).toBe("https://oomol.com/login/device");
+            expect(session.verificationUrl).toBe(
+                "https://oomol.com/login/device?from=cli&user_code=M0KO41",
+            );
             expect(account).toEqual({
                 apiKey: "secret-1",
                 endpoint: "oomol.com",

--- a/src/application/auth/login-flow.ts
+++ b/src/application/auth/login-flow.ts
@@ -60,7 +60,6 @@ interface AuthLoginRequestOptions {
 }
 
 export interface AuthLoginSession {
-    code: string;
     expiresInSeconds: number;
     verificationUrl: string;
     waitForAccount: () => Promise<AuthAccount>;
@@ -96,9 +95,11 @@ export async function startAuthLoginSession(
     );
 
     return {
-        code: codeResponse.code,
         expiresInSeconds: codeResponse.expires_in,
-        verificationUrl: codeResponse.verify_code_url,
+        verificationUrl: createDeviceLoginVerificationUrl(
+            codeResponse.verify_code_url,
+            codeResponse.code,
+        ),
         waitForAccount: async () => await waitForVerifiedAccount(
             state,
             expiresAt,
@@ -354,6 +355,16 @@ function createDeviceLoginResultUrl(endpoint: string, state: string): URL {
 
     requestUrl.searchParams.set("stat", state);
     return requestUrl;
+}
+
+function createDeviceLoginVerificationUrl(
+    verificationUrl: string,
+    userCode: string,
+): string {
+    const url = new URL(verificationUrl);
+
+    url.searchParams.set("user_code", userCode);
+    return url.toString();
 }
 
 function createFastLoginProfileWithSessionTokenUrl(

--- a/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
@@ -6,7 +6,6 @@ exports[`auth CLI writes auth device login logs without persisting secrets 1`] =
   "stderr": "",
   "stdout": 
 "Open this URL in your browser to continue: <LOGIN_URL>
-Enter this code to continue: M0KO41
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
@@ -75,7 +74,6 @@ exports[`auth CLI supports auth login and updates the existing account without d
     "stderr": "",
     "stdout": 
 "Open this URL in your browser to continue: <LOGIN_URL>
-Enter this code to continue: M0KO41
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
@@ -87,7 +85,6 @@ Waiting for the device login to complete...
     "stderr": "",
     "stdout": 
 "Open this URL in your browser to continue: <LOGIN_URL>
-Enter this code to continue: M0KO41
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
@@ -103,7 +100,6 @@ exports[`auth CLI supports auth login with a custom OOMOL_ENDPOINT 1`] = `
   "stderr": "",
   "stdout": 
 "Open this URL in your browser to continue: <LOGIN_URL>
-Enter this code to continue: M0KO41
 Waiting for the device login to complete...
 ✓ Logged in to staging.oomol.test account Alice
   - Active account: true
@@ -118,7 +114,6 @@ exports[`auth CLI supports login as an alias for auth login 1`] = `
   "stderr": "",
   "stdout": 
 "Open this URL in your browser to continue: <LOGIN_URL>
-Enter this code to continue: M0KO41
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
@@ -133,7 +128,6 @@ exports[`auth CLI renders the auth login url and success block with color stylin
   "stderr": "",
   "stdout": 
 "Open this URL in your browser to continue: <LOGIN_URL>
-Enter this code to continue: M0KO41
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -126,10 +126,16 @@ describe("auth CLI", () => {
             const secondLoginUrl = findLoginUrl(secondLogin.stdout);
 
             expect(firstLogin.exitCode).toBe(0);
+            expect(new URL(firstLoginUrl!).searchParams.get("user_code")).toBe(
+                "M0KO41",
+            );
             expect(firstLoginUrl).toStartWith(
                 readAuthLoginUrlPrefix(defaultAuthEndpoint),
             );
             expect(secondLogin.exitCode).toBe(0);
+            expect(new URL(secondLoginUrl!).searchParams.get("user_code")).toBe(
+                "M0KO41",
+            );
             expect(secondLoginUrl).toStartWith(
                 readAuthLoginUrlPrefix(defaultAuthEndpoint),
             );
@@ -158,6 +164,9 @@ describe("auth CLI", () => {
             const loginUrl = findLoginUrl(result.stdout);
 
             expect(result.exitCode).toBe(0);
+            expect(new URL(loginUrl!).searchParams.get("user_code")).toBe(
+                "M0KO41",
+            );
             expect(loginUrl).toStartWith(
                 readAuthLoginUrlPrefix("staging.oomol.test"),
             );
@@ -178,6 +187,9 @@ describe("auth CLI", () => {
             const loginUrl = findLoginUrl(result.stdout);
 
             expect(result.exitCode).toBe(0);
+            expect(new URL(loginUrl!).searchParams.get("user_code")).toBe(
+                "M0KO41",
+            );
             expect(loginUrl).toStartWith(
                 readAuthLoginUrlPrefix(defaultAuthEndpoint),
             );
@@ -266,13 +278,16 @@ describe("auth CLI", () => {
 
             expect(login.exitCode).toBe(0);
             expect(plainLoginUrl).toBeTruthy();
+            expect(new URL(plainLoginUrl!).searchParams.get("user_code")).toBe(
+                "M0KO41",
+            );
             expect(createAuthLoginSnapshot(login, {
                 stripAnsi: true,
             })).toMatchSnapshot();
             expect(login.stdout).toContain(
                 colors.hex(loginUrlColor)(plainLoginUrl!),
             );
-            expect(login.stdout).toContain(colors.bold("M0KO41"));
+            expect(login.stdout).not.toContain(colors.bold("M0KO41"));
             expect(login.stdout).toContain(colors.green("✓"));
             expect(login.stdout).toContain(colors.bold("oomol.com"));
             expect(login.stdout).toContain(colors.bold("Alice"));

--- a/src/application/commands/auth/login.ts
+++ b/src/application/commands/auth/login.ts
@@ -121,12 +121,6 @@ async function runDeviceLogin(
     );
     writeLine(
         context.stdout,
-        context.translator.t("auth.login.code", {
-            code: colors.bold(session.code),
-        }),
-    );
-    writeLine(
-        context.stdout,
         context.translator.t("auth.login.waiting"),
     );
 

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -2,7 +2,6 @@ import { APP_NAME } from "../application/config/app-config.ts";
 
 export const enMessages = {
     "app.description": `${APP_NAME} is OOMOL's CLI toolkit. Everything can be done in the CLI.`,
-    "auth.login.code": "Enter this code to continue: {code}",
     "auth.login.openManually": "Open this URL in your browser to continue: {url}",
     "auth.account.activeAccountMissing":
         "The active account is missing from the auth store.",
@@ -973,7 +972,6 @@ export const enMessages = {
 
 export const zhMessages = {
     "app.description": `${APP_NAME} 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成`,
-    "auth.login.code": "请输入这个 code 继续登录：{code}",
     "auth.login.openManually": "请在浏览器中打开这个 URL 继续登录：{url}",
     "auth.account.activeAccountMissing": "当前激活账号不存在于认证数据中。",
     "auth.account.loggedIn": "已登录 {endpoint} 账号 {name}",


### PR DESCRIPTION
The device login flow previously printed the verification URL on
one line and required the user to copy a separate code into the
browser. The code is now appended as a `user_code` query parameter
on the verification URL, so opening the printed URL is enough to
proceed.

Also drop the now-unused `code` field from `AuthLoginSession`
since callers only need the prepared verification URL.