### PR TITLE
feat(auth): enforce 10-minute timeout on device login wait

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -38,8 +38,9 @@ Start a device login flow or authenticate with a session token, then save the
 authenticated account.
 
 - Notes: the CLI prints the verification URL with the user code in the
-  `user_code` query parameter, then polls until the device login is verified or
-  times out when `--session-token` is not provided.
+  `user_code` query parameter, then waits up to 10 minutes for the device login
+  to be verified when `--session-token` is not provided. It exits with a
+  timeout error if verification does not complete within that window.
 - Options:
   - `--session-token <session-token>`: Authenticate with an existing session
     token. The CLI does not print a device-login URL or poll for verification

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -33,7 +33,8 @@
 启动 device login 流程，或使用 session token 登录，并保存登录成功后的账号。
 
 - 说明：未传入 `--session-token` 时，CLI 会打印验证地址，并把用户 code 放在
-  `user_code` query 参数中，然后轮询直到 device login 验证成功或超时。
+  `user_code` query 参数中，然后最多等待 10 分钟，直到 device login 验证成功；
+  如果超过该时间仍未完成验证，会以超时错误退出。
 - 选项：
   - `--session-token <session-token>`：使用已有 session token 登录。传入后 CLI 不会
     打印 device-login URL，也不会轮询验证结果。

--- a/src/application/auth/login-flow.test.ts
+++ b/src/application/auth/login-flow.test.ts
@@ -20,7 +20,7 @@ describe("startAuthLoginSession", () => {
         try {
             const session = await startAuthLoginSession({
                 endpoint: "oomol.com",
-                fetcher: async (input, init) => {
+                fetcher: (input, init) => {
                     const request = toRequest(input, init);
                     const requestUrl = new URL(request.url);
 
@@ -30,12 +30,12 @@ describe("startAuthLoginSession", () => {
                         request.method === "POST"
                         && requestUrl.pathname === "/v1/auth/device_login/code"
                     ) {
-                        return new Response(JSON.stringify({
+                        return Promise.resolve(new Response(JSON.stringify({
                             code: "M0KO41",
                             expires_in: 1800,
                             status: "waiting",
                             verify_code_url: "https://oomol.com/login/device?from=cli",
-                        }));
+                        })));
                     }
 
                     if (
@@ -44,7 +44,7 @@ describe("startAuthLoginSession", () => {
                     ) {
                         resultRequestCount += 1;
 
-                        return new Response(JSON.stringify(resultRequestCount === 1
+                        return Promise.resolve(new Response(JSON.stringify(resultRequestCount === 1
                             ? {
                                     status: "waiting",
                                 }
@@ -54,7 +54,7 @@ describe("startAuthLoginSession", () => {
                                     id: "user-1",
                                     name: "Alice",
                                     status: "verified",
-                                }));
+                                })));
                     }
 
                     throw new Error(`Unexpected request: ${request.method} ${requestUrl}`);
@@ -126,11 +126,12 @@ describe("startAuthLoginSession", () => {
     test("times out when the device login result never becomes verified", async () => {
         const logCapture = createLogCapture();
         let nowMs = 0;
+        let resultRequestCount = 0;
 
         try {
             const session = await startAuthLoginSession({
                 endpoint: "oomol.com",
-                fetcher: async (input, init) => {
+                fetcher: (input, init) => {
                     const request = toRequest(input, init);
                     const requestUrl = new URL(request.url);
 
@@ -138,28 +139,30 @@ describe("startAuthLoginSession", () => {
                         request.method === "POST"
                         && requestUrl.pathname === "/v1/auth/device_login/code"
                     ) {
-                        return new Response(JSON.stringify({
+                        return Promise.resolve(new Response(JSON.stringify({
                             code: "M0KO41",
                             expires_in: 2,
                             status: "waiting",
                             verify_code_url: "https://oomol.com/login/device",
-                        }));
+                        })));
                     }
 
                     if (
                         request.method === "GET"
                         && requestUrl.pathname === "/v1/auth/device_login/result"
                     ) {
-                        return new Response(JSON.stringify({
+                        resultRequestCount += 1;
+
+                        return Promise.resolve(new Response(JSON.stringify({
                             status: "waiting",
-                        }));
+                        })));
                     }
 
                     throw new Error(`Unexpected request: ${request.method} ${requestUrl}`);
                 },
                 logger: logCapture.logger,
                 now: () => nowMs,
-                pollIntervalMs: 1_000,
+                pollIntervalMs: 600_000,
                 sleep: async (ms) => {
                     nowMs += ms;
                 },
@@ -168,6 +171,62 @@ describe("startAuthLoginSession", () => {
 
             await expect(session.waitForAccount()).rejects.toMatchObject({
                 key: "errors.auth.loginTimeout",
+                params: {
+                    timeout: "10m",
+                },
+            });
+            expect(nowMs).toBe(600_000);
+            expect(resultRequestCount).toBe(1);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("times out a pending device login poll at the CLI wait timeout", async () => {
+        const logCapture = createLogCapture();
+        let nowMs = 0;
+
+        try {
+            const session = await startAuthLoginSession({
+                endpoint: "oomol.com",
+                fetcher: (input, init) => {
+                    const request = toRequest(input, init);
+                    const requestUrl = new URL(request.url);
+
+                    if (
+                        request.method === "POST"
+                        && requestUrl.pathname === "/v1/auth/device_login/code"
+                    ) {
+                        return Promise.resolve(new Response(JSON.stringify({
+                            code: "M0KO41",
+                            expires_in: 1800,
+                            status: "waiting",
+                            verify_code_url: "https://oomol.com/login/device",
+                        })));
+                    }
+
+                    if (
+                        request.method === "GET"
+                        && requestUrl.pathname === "/v1/auth/device_login/result"
+                    ) {
+                        return new Promise<Response>(() => {});
+                    }
+
+                    throw new Error(`Unexpected request: ${request.method} ${requestUrl}`);
+                },
+                logger: logCapture.logger,
+                now: () => nowMs,
+                translator: createTranslator("en"),
+            });
+
+            nowMs = 599_999;
+
+            await expect(session.waitForAccount()).rejects.toMatchObject({
+                key: "errors.auth.loginTimeout",
+                params: {
+                    timeout: "10m",
+                },
             });
         }
         finally {

--- a/src/application/auth/login-flow.ts
+++ b/src/application/auth/login-flow.ts
@@ -11,6 +11,9 @@ import {
 } from "../logging/log-fields.ts";
 
 const deviceLoginPollIntervalMs = 2_000;
+const deviceLoginWaitTimeoutMinutes = 10;
+const deviceLoginWaitTimeoutMs = deviceLoginWaitTimeoutMinutes * 60 * 1_000;
+const deviceLoginWaitTimeoutLabel = `${deviceLoginWaitTimeoutMinutes}m`;
 
 const deviceLoginCodeResponseSchema = z.object({
     code: z.string().min(1),
@@ -84,12 +87,17 @@ export async function startAuthLoginSession(
     const sleep = options.sleep ?? Bun.sleep;
     const pollIntervalMs = options.pollIntervalMs ?? deviceLoginPollIntervalMs;
     const state = Bun.randomUUIDv7();
-    const codeResponse = await requestDeviceLoginCode(state, options);
-    const expiresAt = now() + (codeResponse.expires_in * 1000);
+    const waitTimeoutAt = now() + deviceLoginWaitTimeoutMs;
+    const codeResponse = await requestDeviceLoginCode(
+        state,
+        options,
+        deviceLoginWaitTimeoutMs,
+    );
 
     options.logger.info(
         {
             expiresInSeconds: codeResponse.expires_in,
+            waitTimeoutMs: deviceLoginWaitTimeoutMs,
         },
         "Auth device login code created.",
     );
@@ -102,7 +110,7 @@ export async function startAuthLoginSession(
         ),
         waitForAccount: async () => await waitForVerifiedAccount(
             state,
-            expiresAt,
+            waitTimeoutAt,
             options,
             { now, sleep, pollIntervalMs },
         ),
@@ -144,7 +152,7 @@ export async function requestAuthAccountWithSessionToken(
 
 async function waitForVerifiedAccount(
     state: string,
-    expiresAt: number,
+    waitTimeoutAt: number,
     options: Pick<
         StartAuthLoginSessionOptions,
         "endpoint" | "fetcher" | "logger" | "translator"
@@ -155,8 +163,18 @@ async function waitForVerifiedAccount(
         sleep: (ms: number) => Promise<void>;
     },
 ): Promise<AuthAccount> {
-    while (resolved.now() < expiresAt) {
-        const result = await requestDeviceLoginResult(state, options);
+    while (true) {
+        const requestTimeoutMs = waitTimeoutAt - resolved.now();
+
+        if (requestTimeoutMs <= 0) {
+            break;
+        }
+
+        const result = await requestDeviceLoginResult(
+            state,
+            options,
+            requestTimeoutMs,
+        );
 
         if (result.status === "verified") {
             options.logger.info(
@@ -170,7 +188,7 @@ async function waitForVerifiedAccount(
             return createAuthAccount(result);
         }
 
-        const remainingMs = expiresAt - resolved.now();
+        const remainingMs = waitTimeoutAt - resolved.now();
 
         if (remainingMs <= 0) {
             break;
@@ -181,16 +199,17 @@ async function waitForVerifiedAccount(
 
     options.logger.warn(
         {
-            timeoutMs: expiresAt - resolved.now(),
+            timeoutMs: deviceLoginWaitTimeoutMs,
         },
         "Auth device login timed out.",
     );
-    throw new CliUserError("errors.auth.loginTimeout", 1);
+    throw createDeviceLoginTimeoutError();
 }
 
 async function requestDeviceLoginCode(
     state: string,
     options: StartAuthLoginSessionOptions,
+    timeoutMs: number,
 ): Promise<DeviceLoginCodeResponse> {
     const rawResponse = await requestAuthLogin(
         createDeviceLoginCodeUrl(options.endpoint),
@@ -202,6 +221,7 @@ async function requestDeviceLoginCode(
             kind: "code",
             method: "POST",
             requestDescription: "device login",
+            timeoutMs,
         },
     );
 
@@ -214,6 +234,7 @@ async function requestDeviceLoginCode(
 async function requestDeviceLoginResult(
     state: string,
     options: StartAuthLoginSessionOptions,
+    timeoutMs: number,
 ): Promise<DeviceLoginResultResponse> {
     const requestUrl = createDeviceLoginResultUrl(options.endpoint, state);
     const rawResponse = await requestAuthLogin(
@@ -223,6 +244,7 @@ async function requestDeviceLoginResult(
             kind: "result",
             method: "GET",
             requestDescription: "device login",
+            timeoutMs,
         },
     );
 
@@ -241,10 +263,31 @@ async function requestAuthLogin(
         method: "GET" | "POST";
         redactedValues?: readonly string[];
         requestDescription: "device login" | "fast login";
+        timeoutMs?: number;
     },
 ): Promise<string> {
     const redactedValues = requestOptions.redactedValues ?? [];
     const requestStartedAt = Date.now();
+    const abortController = requestOptions.timeoutMs === undefined
+        ? undefined
+        : new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = abortController === undefined
+        || requestOptions.timeoutMs === undefined
+        ? undefined
+        : new Promise<never>((_, reject) => {
+                timeoutId = setTimeout(() => {
+                    abortController.abort();
+                    reject(new Error("Request timed out."));
+                }, requestOptions.timeoutMs);
+            });
+    const withTimeout = async <TValue>(operation: Promise<TValue>): Promise<TValue> => {
+        if (timeoutPromise === undefined) {
+            return await operation;
+        }
+
+        return await Promise.race([operation, timeoutPromise]);
+    };
 
     options.logger.debug(
         {
@@ -258,7 +301,7 @@ async function requestAuthLogin(
     );
 
     try {
-        const response = await options.fetcher(requestUrl, {
+        const response = await withTimeout(options.fetcher(requestUrl, {
             body: requestOptions.body,
             headers: requestOptions.body === undefined
                 ? undefined
@@ -266,7 +309,8 @@ async function requestAuthLogin(
                         "Content-Type": "application/json",
                     },
             method: requestOptions.method,
-        });
+            signal: abortController?.signal,
+        }));
         const durationMs = Date.now() - requestStartedAt;
 
         if (!response.ok) {
@@ -303,6 +347,21 @@ async function requestAuthLogin(
             throw error;
         }
 
+        if (abortController?.signal.aborted ?? false) {
+            options.logger.warn(
+                {
+                    durationMs: Date.now() - requestStartedAt,
+                    kind: requestOptions.kind,
+                    method: requestOptions.method,
+                    timeoutMs: requestOptions.timeoutMs,
+                    ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+                },
+                `Auth ${requestOptions.requestDescription} request timed out.`,
+            );
+
+            throw createDeviceLoginTimeoutError();
+        }
+
         options.logger.warn(
             {
                 durationMs: Date.now() - requestStartedAt,
@@ -320,6 +379,11 @@ async function requestAuthLogin(
                 redactedValues,
             ),
         });
+    }
+    finally {
+        if (timeoutId !== undefined) {
+            clearTimeout(timeoutId);
+        }
     }
 }
 
@@ -342,6 +406,12 @@ function createAuthAccount(response: AuthAccountResponse): AuthAccount {
         id: response.id,
         name: response.name,
     };
+}
+
+function createDeviceLoginTimeoutError(): CliUserError {
+    return new CliUserError("errors.auth.loginTimeout", 1, {
+        timeout: deviceLoginWaitTimeoutLabel,
+    });
 }
 
 function createDeviceLoginCodeUrl(endpoint: string): URL {

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -214,7 +214,7 @@ export const enMessages = {
     "errors.auth.loginRequestFailed":
         "The auth login request returned HTTP {status}.",
     "errors.auth.loginTimeout":
-        "Timed out waiting for the device login to complete.",
+        "Timed out after {timeout} waiting for the device login to complete.",
     "errors.auth.noSavedAccounts":
         "There are no auth accounts to switch to.",
     "errors.auth.required":
@@ -1161,7 +1161,7 @@ export const zhMessages = {
     "errors.auth.loginInvalidResponse": "auth login 服务返回了不受支持的响应内容。",
     "errors.auth.loginRequestError": "auth login 请求失败：{message}",
     "errors.auth.loginRequestFailed": "auth login 请求返回了 HTTP {status}。",
-    "errors.auth.loginTimeout": "等待 device login 完成超时。",
+    "errors.auth.loginTimeout": "等待 device login 完成超过 {timeout}，已超时。",
     "errors.auth.noSavedAccounts": "没有可切换的认证账号。",
     "errors.auth.required":
         "使用此命令前请先登录。",


### PR DESCRIPTION
Previously the CLI waited for the server-provided expires_in (typically 30 minutes) and could block indefinitely if a poll request hung, since no per-request timeout was set. Cap the total wait at 10 minutes and abort each fetch when that deadline is reached so users get a prompt timeout error instead of an apparent hang. Surface the duration in the error message so the limit is visible.