### PR TITLE
refactor(self-update): use active markers instead of lifetime locks

### DIFF
--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -42,7 +42,7 @@ import {
 import { CliUserError } from "../contracts/cli.ts";
 import { logCategory } from "../logging/log-categories.ts";
 import { withCategory, withErrorKey, withStorePath } from "../logging/log-fields.ts";
-import { initializeCurrentVersionProcessLock } from "../self-update/core.ts";
+import { initializeCurrentVersionActiveMarker } from "../self-update/core.ts";
 import { createRetryingFetcher } from "../shared/retrying-fetcher.ts";
 import {
     telemetryInternalCommand,
@@ -164,8 +164,8 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
     let fileDownloadSessionStore: FileDownloadSessionStore | undefined;
     let fileUploadStore: FileUploadRecordStore | undefined;
     let settingsForTelemetry: AppSettings | undefined;
-    let currentVersionLockResource:
-        | Awaited<ReturnType<typeof initializeCurrentVersionProcessLock>>
+    let currentVersionActiveMarkerResource:
+        | Awaited<ReturnType<typeof initializeCurrentVersionActiveMarker>>
         | undefined;
     const loggerHandle = createCliLogger({
         appName: APP_NAME,
@@ -235,7 +235,7 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
             "CLI invocation started.",
         );
 
-        currentVersionLockResource = await initializeCurrentVersionProcessLock({
+        currentVersionActiveMarkerResource = await initializeCurrentVersionActiveMarker({
             currentVersion: version,
             runtime: {
                 env: invocation.env,
@@ -316,7 +316,7 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
                 cacheStore,
                 fileUploadStore,
                 fileDownloadSessionStore,
-                currentVersionLockResource,
+                currentVersionActiveMarkerResource,
             ],
             exitCode,
             logger,

--- a/src/application/self-update/core.test.ts
+++ b/src/application/self-update/core.test.ts
@@ -1,7 +1,7 @@
 import type { SelfUpdateCommandRunOptions } from "../contracts/self-update.ts";
 import type { SelfUpdateProgressEvent } from "./progress.ts";
 import { chmodSync, rmSync, symlinkSync } from "node:fs";
-import { chmod, mkdir, readlink, realpath, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readdir, readlink, realpath, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import process from "node:process";
 import { describe, expect, test } from "bun:test";
@@ -15,11 +15,13 @@ import {
 } from "../../../__tests__/helpers.ts";
 import { createTranslator } from "../../i18n/translator.ts";
 import {
+    initializeCurrentVersionActiveMarker,
     performSelfUpdateOperation,
     renderSelfUpdateLockBusyMessage,
 } from "./core.ts";
 import {
-    resolveSelfUpdateLockFilePath,
+    resolveActiveVersionMarkerPath,
+    resolveLegacyVersionLockPath,
     resolveSelfUpdatePaths,
     resolveSelfUpdateVersionDirectoryPath,
     resolveSelfUpdateVersionExecutablePath,
@@ -38,6 +40,66 @@ describe("performSelfUpdateOperation", () => {
         expect(renderSelfUpdateLockBusyMessage({
             translator,
         })).toBe("另一个更新已在进行中，请稍后再试。");
+    });
+
+    test("initializes a current-version active marker without waiting on a legacy lock", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-self-update-current-marker");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const currentVersionPath = resolveSelfUpdateVersionExecutablePath(
+            paths,
+            "1.2.3",
+        );
+        const logCapture = createLogCapture();
+
+        trackDirectory(rootDirectory);
+        await Promise.all([
+            mkdir(paths.locksDirectory, { recursive: true }),
+            writeManagedVersion(currentVersionPath),
+        ]);
+        await writeFile(
+            resolveLegacyVersionLockPath(paths, "1.2.3"),
+            `${JSON.stringify({
+                acquiredAt: new Date().toISOString(),
+                execPath: process.execPath,
+                pid: process.pid,
+                version: "1.2.3",
+            })}\n`,
+        );
+
+        try {
+            const resource = await initializeCurrentVersionActiveMarker({
+                currentVersion: "1.2.3",
+                runtime: {
+                    env,
+                    execPath: process.execPath,
+                    logger: logCapture.logger,
+                    platform: process.platform,
+                    processId: process.pid,
+                },
+            });
+
+            expect(resource).toBeDefined();
+            const markerDirectory = resolveActiveVersionMarkerDirectoryPath(
+                paths,
+                "1.2.3",
+            );
+            const markerEntries = await readdir(markerDirectory);
+
+            expect(markerEntries).toHaveLength(1);
+            expect(logCapture.read()).not.toContain("lifetime lock");
+
+            await resource?.close();
+            await expect(
+                Bun.file(join(markerDirectory, markerEntries[0] ?? "")).exists(),
+            ).resolves.toBeFalse();
+        }
+        finally {
+            logCapture.close();
+        }
     });
 
     test("re-activates an existing target version without downloading again", async () => {
@@ -265,6 +327,9 @@ describe("performSelfUpdateOperation", () => {
 
         trackDirectory(rootDirectory);
         await Promise.all([
+            mkdir(resolveActiveVersionMarkerDirectoryPath(paths, "9.9.9"), {
+                recursive: true,
+            }),
             mkdir(paths.locksDirectory, { recursive: true }),
             mkdir(paths.versionsDirectory, { recursive: true }),
         ]);
@@ -274,10 +339,17 @@ describe("performSelfUpdateOperation", () => {
             writeManagedVersion(resolveSelfUpdateVersionExecutablePath(paths, "9.9.9")),
             writeManagedVersion(resolveSelfUpdateVersionExecutablePath(paths, "0.5.0")),
             writeFile(
-                resolveSelfUpdateLockFilePath(paths, "9.9.9"),
+                resolveActiveVersionMarkerPath(
+                    paths,
+                    "9.9.9",
+                    process.pid,
+                    "marker",
+                ),
                 `${JSON.stringify({
                     acquiredAt: new Date().toISOString(),
                     execPath: process.execPath,
+                    kind: "active",
+                    markerId: "marker",
                     pid: process.pid,
                     version: "9.9.9",
                 })}\n`,
@@ -316,6 +388,134 @@ describe("performSelfUpdateOperation", () => {
             await expect(
                 Bun.file(resolveSelfUpdateVersionExecutablePath(paths, "0.5.0")).exists(),
             ).resolves.toBeFalse();
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("returns busy before replacing a target version used by another process", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-self-update-active-target");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
+            paths,
+            "2.0.0",
+        );
+        const activeMarkerPath = resolveActiveVersionMarkerPath(
+            paths,
+            "2.0.0",
+            process.pid,
+            "other",
+        );
+        const logCapture = createLogCapture();
+
+        trackDirectory(rootDirectory);
+        await Promise.all([
+            mkdir(resolveActiveVersionMarkerDirectoryPath(paths, "2.0.0"), {
+                recursive: true,
+            }),
+            writeManagedVersion(targetVersionPath),
+        ]);
+        await writeFile(
+            activeMarkerPath,
+            `${JSON.stringify({
+                acquiredAt: new Date().toISOString(),
+                execPath: process.execPath,
+                kind: "active",
+                markerId: "other",
+                pid: process.pid,
+                version: "2.0.0",
+            })}\n`,
+        );
+
+        try {
+            const result = await performSelfUpdateOperation({
+                currentVersion: "1.0.0",
+                forceReinstall: true,
+                runtime: {
+                    arch: process.arch,
+                    env,
+                    execPath: process.execPath,
+                    fetcher: async () => new Response("new-binary"),
+                    logger: logCapture.logger,
+                    platform: process.platform,
+                    processId: process.pid + 1,
+                },
+                targetVersion: "2.0.0",
+            });
+
+            expect(result).toEqual({
+                ownerPid: process.pid,
+                status: "busy",
+            });
+            expect(await Bun.file(targetVersionPath).text()).toBe("binary");
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("allows replacing a target version when only the current process marker is active", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-self-update-own-active-target");
+        const env = createSelfUpdateEnv(rootDirectory);
+        const paths = resolveSelfUpdatePaths({
+            env,
+            platform: process.platform,
+        });
+        const targetVersionPath = resolveSelfUpdateVersionExecutablePath(
+            paths,
+            "2.0.0",
+        );
+        const activeMarkerPath = resolveActiveVersionMarkerPath(
+            paths,
+            "2.0.0",
+            process.pid,
+            "self",
+        );
+        const logCapture = createLogCapture();
+
+        trackDirectory(rootDirectory);
+        await Promise.all([
+            mkdir(resolveActiveVersionMarkerDirectoryPath(paths, "2.0.0"), {
+                recursive: true,
+            }),
+            writeManagedVersion(targetVersionPath),
+        ]);
+        await writeFile(
+            activeMarkerPath,
+            `${JSON.stringify({
+                acquiredAt: new Date().toISOString(),
+                execPath: process.execPath,
+                kind: "active",
+                markerId: "self",
+                pid: process.pid,
+                version: "2.0.0",
+            })}\n`,
+        );
+
+        try {
+            const result = await performSelfUpdateOperation({
+                currentVersion: "2.0.0",
+                forceReinstall: true,
+                runtime: {
+                    arch: process.arch,
+                    env,
+                    execPath: process.execPath,
+                    fetcher: async () => new Response("new-binary"),
+                    logger: logCapture.logger,
+                    platform: process.platform,
+                    processId: process.pid,
+                    runCommand: createSuccessfulSelfUpdateCommandRunner(),
+                },
+                targetVersion: "2.0.0",
+            });
+
+            expect(result.status).toBe("installed");
+            expect(await Bun.file(targetVersionPath).text()).toBe("new-binary");
         }
         finally {
             logCapture.close();
@@ -979,6 +1179,18 @@ function createSelfUpdateEnv(rootDirectory: string): Record<string, string | und
         XDG_DATA_HOME: join(rootDirectory, "data"),
         XDG_RUNTIME_DIR: join(rootDirectory, "runtime"),
     };
+}
+
+function resolveActiveVersionMarkerDirectoryPath(
+    paths: ReturnType<typeof resolveSelfUpdatePaths>,
+    version: string,
+): string {
+    return dirname(resolveActiveVersionMarkerPath(
+        paths,
+        version,
+        process.pid,
+        "marker",
+    ));
 }
 
 async function writeManagedVersion(path: string): Promise<void> {

--- a/src/application/self-update/core.ts
+++ b/src/application/self-update/core.ts
@@ -26,14 +26,16 @@ import {
 import { resolveSelfUpdateCommandResolution } from "./command-resolution.ts";
 import { attemptLegacyPackageManagerUninstall } from "./legacy-installation.ts";
 import {
-    acquireProcessLifetimeVersionLock,
-    acquireVersionLock,
+    acquireActiveVersionMarker,
+    acquireInstallVersionLock,
     cleanupStaleVersionLocks,
+    findActiveVersionOwner,
     listActiveVersionLocks,
 } from "./lock.ts";
 import { ensureExecutableDirectoryOnPath } from "./path-configuration.ts";
 import {
-    resolveSelfUpdateLockFilePath,
+    resolveActiveVersionMarkerPath,
+    resolveInstallVersionLockPath,
     resolveSelfUpdatePaths,
     resolveSelfUpdateStagingBinaryPath,
     resolveSelfUpdateStagingDirectory,
@@ -79,7 +81,7 @@ export type SelfUpdateOperationOutcome
             status: "busy";
         };
 
-export interface ProcessLifetimeVersionLockResource {
+export interface CurrentVersionActiveMarkerResource {
     close: () => Promise<void>;
 }
 
@@ -87,6 +89,13 @@ interface TargetVersionMaterialization {
     backupPath?: string;
     targetVersionDirectoryPath: string;
 }
+
+type TargetVersionMaterializationOutcome
+    = TargetVersionMaterialization
+        | {
+            ownerPid?: number;
+            status: "busy";
+        };
 
 export async function resolveLatestSelfUpdateVersion(options: {
     currentVersion: string;
@@ -134,9 +143,9 @@ export async function performSelfUpdateOperation(options: {
         platform: options.runtime.platform,
     });
 
-    const lockResult = await acquireVersionLock({
+    const lockResult = await acquireInstallVersionLock({
         execPath: options.runtime.execPath,
-        lockFilePath: resolveSelfUpdateLockFilePath(paths, options.targetVersion),
+        lockFilePath: resolveInstallVersionLockPath(paths, options.targetVersion),
         now: options.runtime.now,
         platform: options.runtime.platform,
         processId: options.runtime.processId,
@@ -161,6 +170,11 @@ export async function performSelfUpdateOperation(options: {
             runtime: options.runtime,
             targetVersion: options.targetVersion,
         });
+
+        if ("status" in materialization) {
+            return materialization;
+        }
+
         options.reportStage?.({
             stage: "activate",
             version: options.targetVersion,
@@ -270,10 +284,10 @@ export async function ensureSelfUpdateExecutableDirectoryOnPath(options: {
     };
 }
 
-export async function initializeCurrentVersionProcessLock(options: {
+export async function initializeCurrentVersionActiveMarker(options: {
     currentVersion: string;
-    runtime: Pick<SelfUpdateRuntime, "env" | "execPath" | "logger" | "platform" | "processId">;
-}): Promise<ProcessLifetimeVersionLockResource | undefined> {
+    runtime: Pick<SelfUpdateRuntime, "env" | "execPath" | "logger" | "now" | "platform" | "processId">;
+}): Promise<CurrentVersionActiveMarkerResource | undefined> {
     const paths = resolveSelfUpdatePaths({
         env: options.runtime.env,
         platform: options.runtime.platform,
@@ -299,26 +313,33 @@ export async function initializeCurrentVersionProcessLock(options: {
     }
 
     try {
-        const lockHandle = await acquireProcessLifetimeVersionLock({
+        const markerId = Bun.randomUUIDv7();
+        const markerHandle = await acquireActiveVersionMarker({
             execPath: options.runtime.execPath,
-            lockFilePath: resolveSelfUpdateLockFilePath(paths, options.currentVersion),
-            platform: options.runtime.platform,
+            markerFilePath: resolveActiveVersionMarkerPath(
+                paths,
+                options.currentVersion,
+                options.runtime.processId,
+                markerId,
+            ),
+            markerId,
+            now: options.runtime.now,
             processId: options.runtime.processId,
             version: options.currentVersion,
         });
 
-        if (!lockHandle) {
+        if (!markerHandle) {
             options.runtime.logger.warn(
                 {
                     currentVersion: options.currentVersion,
                 },
-                "Current CLI version lifetime lock could not be acquired.",
+                "Current CLI version active marker could not be created; continuing without lifecycle marker.",
             );
             return undefined;
         }
 
         const closeOnExit = () => {
-            lockHandle.closeSync();
+            markerHandle.closeSync();
         };
 
         process.once("exit", closeOnExit);
@@ -326,7 +347,7 @@ export async function initializeCurrentVersionProcessLock(options: {
         return {
             close: async () => {
                 process.off("exit", closeOnExit);
-                await lockHandle.close();
+                await markerHandle.close();
             },
         };
     }
@@ -336,7 +357,7 @@ export async function initializeCurrentVersionProcessLock(options: {
                 currentVersion: options.currentVersion,
                 err: error,
             },
-            "Current CLI version lifetime lock acquisition failed.",
+            "Current CLI version active marker creation failed; continuing without lifecycle marker.",
         );
         return undefined;
     }
@@ -394,7 +415,7 @@ async function materializeTargetVersion(options: {
     reportStage?: (event: SelfUpdateProgressEvent) => void;
     runtime: SelfUpdateRuntime;
     targetVersion: string;
-}): Promise<TargetVersionMaterialization> {
+}): Promise<TargetVersionMaterializationOutcome> {
     const targetVersionDirectoryPath = resolveSelfUpdateVersionDirectoryPath(
         options.paths,
         options.targetVersion,
@@ -476,6 +497,20 @@ async function materializeTargetVersion(options: {
 
         if (options.runtime.platform !== "win32") {
             await chmod(versionTempExecutablePath, 0o755);
+        }
+
+        const activeOwner = await findActiveVersionOwner({
+            excludeProcessId: options.runtime.processId,
+            locksDirectory: options.paths.locksDirectory,
+            platform: options.runtime.platform,
+            version: options.targetVersion,
+        });
+
+        if (activeOwner !== undefined) {
+            return {
+                ownerPid: activeOwner.ownerPid,
+                status: "busy",
+            };
         }
 
         return await replaceTargetVersionDirectory({

--- a/src/application/self-update/lock.test.ts
+++ b/src/application/self-update/lock.test.ts
@@ -6,31 +6,119 @@ import {
     createTemporaryDirectory,
     useTemporaryDirectoryCleanup,
 } from "../../../__tests__/helpers.ts";
-import { acquireVersionLock, cleanupStaleVersionLocks } from "./lock.ts";
+import {
+    acquireActiveVersionMarker,
+    acquireInstallVersionLock,
+    cleanupStaleVersionLocks,
+    findActiveVersionOwner,
+    listActiveVersionLocks,
+} from "./lock.ts";
 
 const { track: trackDirectory } = useTemporaryDirectoryCleanup();
 
 describe("self-update version locks", () => {
-    test("removes stale and malformed lock entries", async () => {
-        const rootDirectory = await createTemporaryDirectory("oo-self-update-lock");
+    test("creates same-version active markers without serializing owners", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-self-update-active-marker");
         const locksDirectory = join(rootDirectory, "locks");
+        const firstMarkerPath = join(
+            locksDirectory,
+            "active",
+            "1.2.3",
+            `${process.pid}.marker-a.lock`,
+        );
+        const secondMarkerPath = join(
+            locksDirectory,
+            "active",
+            "1.2.3",
+            `${process.pid + 1}.marker-b.lock`,
+        );
 
         trackDirectory(rootDirectory);
-        await mkdir(join(locksDirectory, "legacy.lock"), { recursive: true });
+
+        const firstMarker = await acquireActiveVersionMarker({
+            execPath: process.execPath,
+            markerFilePath: firstMarkerPath,
+            markerId: "marker-a",
+            now: () => 1_700_000_000_000,
+            processId: process.pid,
+            version: "1.2.3",
+        });
+        const secondMarker = await acquireActiveVersionMarker({
+            execPath: process.execPath,
+            markerFilePath: secondMarkerPath,
+            markerId: "marker-b",
+            now: () => 1_700_000_001_000,
+            processId: process.pid + 1,
+            version: "1.2.3",
+        });
+
+        expect(firstMarker?.data).toEqual({
+            acquiredAt: "2023-11-14T22:13:20.000Z",
+            execPath: process.execPath,
+            markerId: "marker-a",
+            pid: process.pid,
+            version: "1.2.3",
+        });
+        expect(secondMarker?.data.markerId).toBe("marker-b");
+        await expect(Bun.file(firstMarkerPath).exists()).resolves.toBeTrue();
+        await expect(Bun.file(secondMarkerPath).exists()).resolves.toBeTrue();
+
         await Promise.all([
-            writeFile(
-                join(locksDirectory, "stale.lock"),
-                JSON.stringify({
-                    acquiredAt: new Date().toISOString(),
-                    execPath: process.execPath,
-                    pid: 999_999_999,
-                    version: "1.2.3",
-                }),
-            ),
-            writeFile(
-                join(locksDirectory, "invalid.lock"),
-                "not-json",
-            ),
+            firstMarker?.close(),
+            secondMarker?.close(),
+        ]);
+        await expect(Bun.file(firstMarkerPath).exists()).resolves.toBeFalse();
+        await expect(Bun.file(secondMarkerPath).exists()).resolves.toBeFalse();
+    });
+
+    test("removes stale active, install, legacy, and malformed lock entries", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-self-update-lock-cleanup");
+        const locksDirectory = join(rootDirectory, "locks");
+        const staleActiveMarkerPath = join(
+            locksDirectory,
+            "active",
+            "1.2.3",
+            "999999999.marker.lock",
+        );
+        const malformedActiveMarkerPath = join(
+            locksDirectory,
+            "active",
+            "1.2.3",
+            "malformed.lock",
+        );
+        const staleInstallLockPath = join(locksDirectory, "install", "2.0.0.lock");
+        const staleLegacyLockPath = join(locksDirectory, "3.0.0.lock");
+        const unexpectedDirectory = join(locksDirectory, "unexpected");
+
+        trackDirectory(rootDirectory);
+        await Promise.all([
+            mkdir(join(locksDirectory, "active", "1.2.3"), { recursive: true }),
+            mkdir(join(locksDirectory, "install"), { recursive: true }),
+            mkdir(unexpectedDirectory, { recursive: true }),
+        ]);
+        await Promise.all([
+            writeJsonFile(staleActiveMarkerPath, {
+                acquiredAt: new Date().toISOString(),
+                execPath: process.execPath,
+                kind: "active",
+                markerId: "marker",
+                pid: 999_999_999,
+                version: "1.2.3",
+            }),
+            writeFile(malformedActiveMarkerPath, "not-json"),
+            writeJsonFile(staleInstallLockPath, {
+                acquiredAt: new Date().toISOString(),
+                execPath: process.execPath,
+                kind: "install",
+                pid: 999_999_999,
+                version: "2.0.0",
+            }),
+            writeJsonFile(staleLegacyLockPath, {
+                acquiredAt: new Date().toISOString(),
+                execPath: process.execPath,
+                pid: 999_999_999,
+                version: "3.0.0",
+            }),
         ]);
 
         await cleanupStaleVersionLocks({
@@ -38,33 +126,93 @@ describe("self-update version locks", () => {
             platform: process.platform,
         });
 
-        await expect(Bun.file(join(locksDirectory, "stale.lock")).exists()).resolves.toBeFalse();
-        await expect(Bun.file(join(locksDirectory, "invalid.lock")).exists()).resolves.toBeFalse();
-        await expect(Bun.file(join(locksDirectory, "legacy.lock")).exists()).resolves.toBeFalse();
+        await expect(Bun.file(staleActiveMarkerPath).exists()).resolves.toBeFalse();
+        await expect(Bun.file(malformedActiveMarkerPath).exists()).resolves.toBeFalse();
+        await expect(Bun.file(join(locksDirectory, "active", "1.2.3")).exists()).resolves.toBeFalse();
+        await expect(Bun.file(staleInstallLockPath).exists()).resolves.toBeFalse();
+        await expect(Bun.file(staleLegacyLockPath).exists()).resolves.toBeFalse();
+        await expect(Bun.file(unexpectedDirectory).exists()).resolves.toBeFalse();
     });
 
-    test("returns a busy result with the owner pid when the lock is active", async () => {
-        const rootDirectory = await createTemporaryDirectory("oo-self-update-lock-busy");
-        const lockFilePath = join(rootDirectory, "1.2.3.lock");
+    test("lists live active markers and legacy locks without treating install locks as active", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-self-update-lock-list");
+        const locksDirectory = join(rootDirectory, "locks");
+        const activeMarkerPath = join(
+            locksDirectory,
+            "active",
+            "4.0.0",
+            `${process.pid}.marker.lock`,
+        );
+        const installLockPath = join(locksDirectory, "install", "5.0.0.lock");
+        const legacyLockPath = join(locksDirectory, "6.0.0.lock");
 
         trackDirectory(rootDirectory);
-        await mkdir(rootDirectory, { recursive: true });
-        await writeFile(
-            lockFilePath,
-            `${JSON.stringify({
+        await Promise.all([
+            mkdir(join(locksDirectory, "active", "4.0.0"), { recursive: true }),
+            mkdir(join(locksDirectory, "install"), { recursive: true }),
+        ]);
+        await Promise.all([
+            writeJsonFile(activeMarkerPath, {
+                acquiredAt: new Date().toISOString(),
+                execPath: process.execPath,
+                kind: "active",
+                markerId: "marker",
+                pid: process.pid,
+                version: "4.0.0",
+            }),
+            writeJsonFile(installLockPath, {
+                acquiredAt: new Date().toISOString(),
+                execPath: process.execPath,
+                kind: "install",
+                pid: process.pid,
+                version: "5.0.0",
+            }),
+            writeJsonFile(legacyLockPath, {
                 acquiredAt: new Date().toISOString(),
                 execPath: process.execPath,
                 pid: process.pid,
-                version: "1.2.3",
-            })}\n`,
-        );
+                version: "6.0.0",
+            }),
+        ]);
 
-        const result = await acquireVersionLock({
+        await cleanupStaleVersionLocks({
+            locksDirectory,
+            platform: process.platform,
+        });
+        const activeVersions = await listActiveVersionLocks({
+            locksDirectory,
+            platform: process.platform,
+        });
+
+        await expect(Bun.file(activeMarkerPath).exists()).resolves.toBeTrue();
+        await expect(Bun.file(installLockPath).exists()).resolves.toBeTrue();
+        await expect(Bun.file(legacyLockPath).exists()).resolves.toBeTrue();
+        expect(activeVersions).toEqual(new Set(["4.0.0", "6.0.0"]));
+    });
+
+    test("returns a busy result with the owner pid when the install lock is active", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-self-update-lock-busy");
+        const lockFilePath = join(rootDirectory, "locks", "install", "1.2.3.lock");
+        const delays: number[] = [];
+
+        trackDirectory(rootDirectory);
+        await mkdir(join(rootDirectory, "locks", "install"), { recursive: true });
+        await writeJsonFile(lockFilePath, {
+            acquiredAt: new Date().toISOString(),
+            execPath: process.execPath,
+            kind: "install",
+            pid: process.pid,
+            version: "1.2.3",
+        });
+
+        const result = await acquireInstallVersionLock({
             execPath: "/tmp/oo-other",
             lockFilePath,
             platform: process.platform,
             processId: process.pid + 1,
-            sleep: async () => {},
+            sleep: async (ms) => {
+                delays.push(ms);
+            },
             version: "1.2.3",
         });
 
@@ -72,26 +220,61 @@ describe("self-update version locks", () => {
             ownerPid: process.pid,
             status: "busy",
         });
+        expect(delays).toEqual([1000, 2000, 4000]);
+    });
+
+    test("finds active version owners and ignores the excluded process id", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-self-update-owner");
+        const locksDirectory = join(rootDirectory, "locks");
+        const markerPath = join(
+            locksDirectory,
+            "active",
+            "1.2.3",
+            `${process.pid}.marker.lock`,
+        );
+
+        trackDirectory(rootDirectory);
+        await mkdir(join(locksDirectory, "active", "1.2.3"), { recursive: true });
+        await writeJsonFile(markerPath, {
+            acquiredAt: new Date().toISOString(),
+            execPath: process.execPath,
+            kind: "active",
+            markerId: "marker",
+            pid: process.pid,
+            version: "1.2.3",
+        });
+
+        await expect(findActiveVersionOwner({
+            excludeProcessId: process.pid,
+            locksDirectory,
+            platform: process.platform,
+            version: "1.2.3",
+        })).resolves.toBeUndefined();
+        await expect(findActiveVersionOwner({
+            locksDirectory,
+            platform: process.platform,
+            version: "1.2.3",
+        })).resolves.toEqual({
+            ownerPid: process.pid,
+        });
     });
 
     if (process.platform === "win32") {
         test("treats a live pid as active when process command lines are unavailable", async () => {
             const rootDirectory = await createTemporaryDirectory("oo-self-update-lock-substring");
-            const lockFilePath = join(rootDirectory, "1.2.3.lock");
+            const lockFilePath = join(rootDirectory, "locks", "install", "1.2.3.lock");
 
             trackDirectory(rootDirectory);
-            await mkdir(rootDirectory, { recursive: true });
-            await writeFile(
-                lockFilePath,
-                `${JSON.stringify({
-                    acquiredAt: new Date().toISOString(),
-                    execPath: "/tmp/b",
-                    pid: process.pid,
-                    version: "1.2.3",
-                })}\n`,
-            );
+            await mkdir(join(rootDirectory, "locks", "install"), { recursive: true });
+            await writeJsonFile(lockFilePath, {
+                acquiredAt: new Date().toISOString(),
+                execPath: "/tmp/b",
+                kind: "install",
+                pid: process.pid,
+                version: "1.2.3",
+            });
 
-            const result = await acquireVersionLock({
+            const result = await acquireInstallVersionLock({
                 execPath: process.execPath,
                 lockFilePath,
                 platform: process.platform,
@@ -107,23 +290,21 @@ describe("self-update version locks", () => {
         });
     }
     else {
-        test("does not treat basename substring matches as an active lock owner", async () => {
+        test("does not treat basename substring matches as an active install lock owner", async () => {
             const rootDirectory = await createTemporaryDirectory("oo-self-update-lock-substring");
-            const lockFilePath = join(rootDirectory, "1.2.3.lock");
+            const lockFilePath = join(rootDirectory, "locks", "install", "1.2.3.lock");
 
             trackDirectory(rootDirectory);
-            await mkdir(rootDirectory, { recursive: true });
-            await writeFile(
-                lockFilePath,
-                `${JSON.stringify({
-                    acquiredAt: new Date().toISOString(),
-                    execPath: "/tmp/b",
-                    pid: process.pid,
-                    version: "1.2.3",
-                })}\n`,
-            );
+            await mkdir(join(rootDirectory, "locks", "install"), { recursive: true });
+            await writeJsonFile(lockFilePath, {
+                acquiredAt: new Date().toISOString(),
+                execPath: "/tmp/b",
+                kind: "install",
+                pid: process.pid,
+                version: "1.2.3",
+            });
 
-            const result = await acquireVersionLock({
+            const result = await acquireInstallVersionLock({
                 execPath: process.execPath,
                 lockFilePath,
                 platform: process.platform,
@@ -136,3 +317,7 @@ describe("self-update version locks", () => {
         });
     }
 });
+
+async function writeJsonFile(path: string, value: object): Promise<void> {
+    await writeFile(path, `${JSON.stringify(value)}\n`);
+}

--- a/src/application/self-update/lock.ts
+++ b/src/application/self-update/lock.ts
@@ -1,37 +1,49 @@
 import { unlinkSync } from "node:fs";
-import { open, readdir, readFile, rm } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, open, readdir, readFile, rm, rmdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { z } from "zod";
 import {
     isDirectoryReadError,
     isFileAlreadyExistsError,
-    isFileMissingError,
+    isPathMissingError,
 } from "../shared/fs-errors.ts";
 import { isProcessLockOwnerActive } from "../shared/process-owner.ts";
+import { resolveLegacyVersionLockPath } from "./paths.ts";
 
-const versionLockSchema = z.object({
+const versionOwnerSchema = z.object({
     acquiredAt: z.string().trim().min(1),
     execPath: z.string().trim().min(1),
     pid: z.number().int().positive(),
     version: z.string().trim().min(1),
 });
 
-const ownedVersionLocks = new Map<string, {
-    lock: VersionLockData;
+const activeVersionMarkerSchema = versionOwnerSchema.extend({
+    markerId: z.string().trim().min(1),
+});
+
+const ownedInstallVersionLocks = new Map<string, {
+    lock: VersionOwner;
     referenceCount: number;
 }>();
 
-export type VersionLockData = z.infer<typeof versionLockSchema>;
+export type ActiveVersionMarker = z.infer<typeof activeVersionMarkerSchema>;
+export type VersionOwner = z.infer<typeof versionOwnerSchema>;
 
-export interface VersionLockHandle {
+export interface ActiveVersionMarkerHandle {
     close: () => Promise<void>;
     closeSync: () => void;
-    data: VersionLockData;
+    data: ActiveVersionMarker;
 }
 
-export type VersionLockAcquisitionResult
+export interface InstallVersionLockHandle {
+    close: () => Promise<void>;
+    closeSync: () => void;
+    data: VersionOwner;
+}
+
+export type InstallVersionLockAcquisitionResult
     = | {
-        handle: VersionLockHandle;
+        handle: InstallVersionLockHandle;
         status: "acquired";
     }
     | {
@@ -39,7 +51,46 @@ export type VersionLockAcquisitionResult
         status: "busy";
     };
 
-export async function acquireVersionLock(options: {
+export async function acquireActiveVersionMarker(options: {
+    execPath: string;
+    markerFilePath: string;
+    markerId: string;
+    now?: () => number;
+    processId: number;
+    version: string;
+}): Promise<ActiveVersionMarkerHandle | undefined> {
+    const marker: ActiveVersionMarker = {
+        acquiredAt: new Date((options.now ?? Date.now)()).toISOString(),
+        execPath: options.execPath,
+        markerId: options.markerId,
+        pid: options.processId,
+        version: options.version,
+    };
+
+    await mkdir(dirname(options.markerFilePath), { recursive: true });
+
+    try {
+        const fileHandle = await open(options.markerFilePath, "wx");
+
+        try {
+            await fileHandle.writeFile(`${JSON.stringify(marker)}\n`, "utf8");
+        }
+        finally {
+            await fileHandle.close();
+        }
+    }
+    catch (error) {
+        if (isFileAlreadyExistsError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
+
+    return createActiveVersionMarkerHandle(options.markerFilePath, marker);
+}
+
+export async function acquireInstallVersionLock(options: {
     execPath: string;
     lockFilePath: string;
     now?: () => number;
@@ -47,20 +98,22 @@ export async function acquireVersionLock(options: {
     processId: number;
     sleep?: (ms: number) => Promise<void>;
     version: string;
-}): Promise<VersionLockAcquisitionResult> {
+}): Promise<InstallVersionLockAcquisitionResult> {
     const sleep = options.sleep ?? Bun.sleep;
     const now = options.now ?? Date.now;
 
-    if (ownedVersionLocks.has(options.lockFilePath)) {
-        incrementOwnedVersionLockReferenceCount(options.lockFilePath);
+    await mkdir(dirname(options.lockFilePath), { recursive: true });
+
+    if (ownedInstallVersionLocks.has(options.lockFilePath)) {
+        incrementOwnedInstallVersionLockReferenceCount(options.lockFilePath);
 
         return {
-            handle: createVersionLockHandle(options.lockFilePath),
+            handle: createInstallVersionLockHandle(options.lockFilePath),
             status: "acquired",
         };
     }
 
-    const lockData: VersionLockData = {
+    const lockData: VersionOwner = {
         acquiredAt: new Date(now()).toISOString(),
         execPath: options.execPath,
         pid: options.processId,
@@ -68,7 +121,7 @@ export async function acquireVersionLock(options: {
     };
 
     for (let attempt = 0; attempt <= 3; attempt += 1) {
-        const result = await tryAcquireVersionLock(
+        const result = await tryAcquireInstallVersionLock(
             options.lockFilePath,
             lockData,
             options.platform,
@@ -92,21 +145,6 @@ export async function acquireVersionLock(options: {
     };
 }
 
-export async function acquireProcessLifetimeVersionLock(options: {
-    execPath: string;
-    lockFilePath: string;
-    now?: () => number;
-    platform: NodeJS.Platform;
-    processId: number;
-    version: string;
-}): Promise<VersionLockHandle | undefined> {
-    const result = await acquireVersionLock(options);
-
-    return result.status === "acquired"
-        ? result.handle
-        : undefined;
-}
-
 export async function cleanupStaleVersionLocks(options: {
     locksDirectory: string;
     platform: NodeJS.Platform;
@@ -116,22 +154,25 @@ export async function cleanupStaleVersionLocks(options: {
     await Promise.all(entries.map(async (entry) => {
         const entryPath = join(options.locksDirectory, entry);
 
-        if (!entry.endsWith(".lock")) {
-            await rm(entryPath, {
-                force: true,
-                recursive: true,
-            });
+        if (entry === "active") {
+            await cleanupStaleActiveVersionMarkers(entryPath, options.platform);
             return;
         }
 
-        const lockData = await readVersionLockData(entryPath);
-
-        if (!lockData || !isVersionLockActive(lockData, options.platform)) {
-            await rm(entryPath, {
-                force: true,
-                recursive: true,
-            });
+        if (entry === "install") {
+            await cleanupStaleInstallVersionLocks(entryPath, options.platform);
+            return;
         }
+
+        if (entry.endsWith(".lock")) {
+            await cleanupLegacyVersionLock(entryPath, options.platform);
+            return;
+        }
+
+        await rm(entryPath, {
+            force: true,
+            recursive: true,
+        });
     }));
 }
 
@@ -140,50 +181,86 @@ export async function listActiveVersionLocks(options: {
     platform: NodeJS.Platform;
 }): Promise<Set<string>> {
     const versions = new Set<string>();
-    const entries = await readDirectoryEntries(options.locksDirectory);
 
-    for (const entry of entries) {
-        if (!entry.endsWith(".lock")) {
-            continue;
-        }
-
-        const lockData = await readVersionLockData(
-            join(options.locksDirectory, entry),
-        );
-
-        if (!lockData || !isVersionLockActive(lockData, options.platform)) {
-            continue;
-        }
-
-        versions.add(lockData.version);
-    }
+    await Promise.all([
+        addActiveMarkerVersions(versions, options),
+        addLegacyLockVersions(versions, options),
+    ]);
 
     return versions;
 }
 
-function createVersionLockHandle(lockFilePath: string): VersionLockHandle {
-    const ownedLock = ownedVersionLocks.get(lockFilePath);
+export async function findActiveVersionOwner(options: {
+    excludeProcessId?: number;
+    locksDirectory: string;
+    platform: NodeJS.Platform;
+    version: string;
+}): Promise<{ ownerPid: number } | undefined> {
+    const activeMarkerOwner = await findActiveMarkerOwner(
+        join(options.locksDirectory, "active", options.version),
+        options,
+    );
+
+    if (activeMarkerOwner !== undefined) {
+        return activeMarkerOwner;
+    }
+
+    const legacyLock = await readVersionOwner(
+        resolveLegacyVersionLockPath(options, options.version),
+    );
+
+    if (!isLiveOwner(legacyLock, options)) {
+        return undefined;
+    }
+
+    return {
+        ownerPid: legacyLock.pid,
+    };
+}
+
+function createActiveVersionMarkerHandle(
+    markerFilePath: string,
+    marker: ActiveVersionMarker,
+): ActiveVersionMarkerHandle {
+    return {
+        close: async () => {
+            await rm(markerFilePath, { force: true });
+        },
+        closeSync: () => {
+            try {
+                unlinkSync(markerFilePath);
+            }
+            catch {}
+        },
+        data: marker,
+    };
+}
+
+function createInstallVersionLockHandle(
+    lockFilePath: string,
+): InstallVersionLockHandle {
+    const ownedLock = ownedInstallVersionLocks.get(lockFilePath);
 
     if (!ownedLock) {
-        throw new Error(`Expected to own version lock: ${lockFilePath}`);
+        throw new Error(`Expected to own install version lock: ${lockFilePath}`);
     }
 
     return {
         close: async () => {
-            await releaseVersionLock(lockFilePath);
+            await releaseInstallVersionLock(lockFilePath);
         },
         closeSync: () => {
-            releaseVersionLockSync(lockFilePath);
+            releaseInstallVersionLockSync(lockFilePath);
         },
         data: ownedLock.lock,
     };
 }
 
-async function tryAcquireVersionLock(
+async function tryAcquireInstallVersionLock(
     lockFilePath: string,
-    lockData: VersionLockData,
+    lockData: VersionOwner,
     platform: NodeJS.Platform,
-): Promise<VersionLockAcquisitionResult> {
+): Promise<InstallVersionLockAcquisitionResult> {
     try {
         const fileHandle = await open(lockFilePath, "wx");
 
@@ -199,21 +276,28 @@ async function tryAcquireVersionLock(
             throw error;
         }
 
-        const existingLockData = await readVersionLockData(lockFilePath);
+        const existingLockData = await readVersionOwner(lockFilePath);
 
         if (existingLockData?.pid === lockData.pid) {
-            incrementOwnedVersionLockReferenceCount(
+            incrementOwnedInstallVersionLockReferenceCount(
                 lockFilePath,
                 existingLockData,
             );
 
             return {
-                handle: createVersionLockHandle(lockFilePath),
+                handle: createInstallVersionLockHandle(lockFilePath),
                 status: "acquired",
             };
         }
 
-        if (existingLockData && isVersionLockActive(existingLockData, platform)) {
+        if (
+            existingLockData
+            && isProcessLockOwnerActive(
+                existingLockData.pid,
+                existingLockData.execPath,
+                platform,
+            )
+        ) {
             return {
                 ownerPid: existingLockData.pid,
                 status: "busy",
@@ -228,7 +312,7 @@ async function tryAcquireVersionLock(
         };
     }
 
-    const confirmedLockData = await readVersionLockData(lockFilePath);
+    const confirmedLockData = await readVersionOwner(lockFilePath);
 
     if (confirmedLockData?.pid !== lockData.pid) {
         await rm(lockFilePath, { force: true });
@@ -239,19 +323,19 @@ async function tryAcquireVersionLock(
         };
     }
 
-    ownedVersionLocks.set(lockFilePath, {
+    ownedInstallVersionLocks.set(lockFilePath, {
         lock: confirmedLockData,
         referenceCount: 1,
     });
 
     return {
-        handle: createVersionLockHandle(lockFilePath),
+        handle: createInstallVersionLockHandle(lockFilePath),
         status: "acquired",
     };
 }
 
-async function releaseVersionLock(lockFilePath: string): Promise<void> {
-    const ownedLock = ownedVersionLocks.get(lockFilePath);
+async function releaseInstallVersionLock(lockFilePath: string): Promise<void> {
+    const ownedLock = ownedInstallVersionLocks.get(lockFilePath);
 
     if (!ownedLock) {
         return;
@@ -262,12 +346,12 @@ async function releaseVersionLock(lockFilePath: string): Promise<void> {
         return;
     }
 
-    ownedVersionLocks.delete(lockFilePath);
+    ownedInstallVersionLocks.delete(lockFilePath);
     await rm(lockFilePath, { force: true });
 }
 
-function releaseVersionLockSync(lockFilePath: string): void {
-    const ownedLock = ownedVersionLocks.get(lockFilePath);
+function releaseInstallVersionLockSync(lockFilePath: string): void {
+    const ownedLock = ownedInstallVersionLocks.get(lockFilePath);
 
     if (!ownedLock) {
         return;
@@ -278,7 +362,7 @@ function releaseVersionLockSync(lockFilePath: string): void {
         return;
     }
 
-    ownedVersionLocks.delete(lockFilePath);
+    ownedInstallVersionLocks.delete(lockFilePath);
 
     try {
         unlinkSync(lockFilePath);
@@ -286,11 +370,11 @@ function releaseVersionLockSync(lockFilePath: string): void {
     catch {}
 }
 
-function incrementOwnedVersionLockReferenceCount(
+function incrementOwnedInstallVersionLockReferenceCount(
     lockFilePath: string,
-    lockData?: VersionLockData,
+    lockData?: VersionOwner,
 ): void {
-    const ownedLock = ownedVersionLocks.get(lockFilePath);
+    const ownedLock = ownedInstallVersionLocks.get(lockFilePath);
 
     if (ownedLock) {
         ownedLock.referenceCount += 1;
@@ -298,25 +382,203 @@ function incrementOwnedVersionLockReferenceCount(
     }
 
     if (!lockData) {
-        throw new Error(`Expected existing version lock data: ${lockFilePath}`);
+        throw new Error(`Expected existing install version lock data: ${lockFilePath}`);
     }
 
-    ownedVersionLocks.set(lockFilePath, {
+    ownedInstallVersionLocks.set(lockFilePath, {
         lock: lockData,
         referenceCount: 1,
     });
 }
 
-async function readVersionLockData(
+async function cleanupStaleActiveVersionMarkers(
+    activeDirectory: string,
+    platform: NodeJS.Platform,
+): Promise<void> {
+    const versionEntries = await readDirectoryEntries(activeDirectory);
+
+    await Promise.all(versionEntries.map(async (versionEntry) => {
+        const versionDirectory = join(activeDirectory, versionEntry);
+        const markerEntries = await readDirectoryEntries(versionDirectory);
+
+        await Promise.all(markerEntries.map(async (markerEntry) => {
+            const markerPath = join(versionDirectory, markerEntry);
+
+            if (!markerEntry.endsWith(".lock")) {
+                await rm(markerPath, {
+                    force: true,
+                    recursive: true,
+                });
+                return;
+            }
+
+            const marker = await readActiveVersionMarker(markerPath);
+
+            if (!isVersionOwnerActive(marker, platform)) {
+                await rm(markerPath, { force: true });
+            }
+        }));
+
+        await rmdir(versionDirectory).catch(() => undefined);
+    }));
+
+    await rmdir(activeDirectory).catch(() => undefined);
+}
+
+async function cleanupStaleInstallVersionLocks(
+    installDirectory: string,
+    platform: NodeJS.Platform,
+): Promise<void> {
+    const entries = await readDirectoryEntries(installDirectory);
+
+    await Promise.all(entries.map(async (entry) => {
+        const entryPath = join(installDirectory, entry);
+
+        if (!entry.endsWith(".lock")) {
+            await rm(entryPath, {
+                force: true,
+                recursive: true,
+            });
+            return;
+        }
+
+        const lock = await readVersionOwner(entryPath);
+
+        if (!isVersionOwnerActive(lock, platform)) {
+            await rm(entryPath, { force: true });
+        }
+    }));
+
+    await rmdir(installDirectory).catch(() => undefined);
+}
+
+async function cleanupLegacyVersionLock(
     lockFilePath: string,
-): Promise<VersionLockData | undefined> {
+    platform: NodeJS.Platform,
+): Promise<void> {
+    const lock = await readVersionOwner(lockFilePath);
+
+    if (isVersionOwnerActive(lock, platform)) {
+        return;
+    }
+
+    await rm(lockFilePath, {
+        force: true,
+        recursive: true,
+    });
+}
+
+async function addActiveMarkerVersions(
+    versions: Set<string>,
+    options: {
+        locksDirectory: string;
+        platform: NodeJS.Platform;
+    },
+): Promise<void> {
+    const activeDirectory = join(options.locksDirectory, "active");
+    const versionEntries = await readDirectoryEntries(activeDirectory);
+
+    await Promise.all(versionEntries.map(async (versionEntry) => {
+        const versionDirectory = join(activeDirectory, versionEntry);
+        const markerEntries = await readDirectoryEntries(versionDirectory);
+
+        await Promise.all(markerEntries.map(async (markerEntry) => {
+            if (!markerEntry.endsWith(".lock")) {
+                return;
+            }
+
+            const marker = await readActiveVersionMarker(
+                join(versionDirectory, markerEntry),
+            );
+
+            if (!isVersionOwnerActive(marker, options.platform)) {
+                return;
+            }
+
+            versions.add(marker.version);
+        }));
+    }));
+}
+
+async function addLegacyLockVersions(
+    versions: Set<string>,
+    options: {
+        locksDirectory: string;
+        platform: NodeJS.Platform;
+    },
+): Promise<void> {
+    const entries = await readDirectoryEntries(options.locksDirectory);
+
+    await Promise.all(entries.map(async (entry) => {
+        if (!entry.endsWith(".lock")) {
+            return;
+        }
+
+        const lock = await readVersionOwner(
+            join(options.locksDirectory, entry),
+        );
+
+        if (!isVersionOwnerActive(lock, options.platform)) {
+            return;
+        }
+
+        versions.add(lock.version);
+    }));
+}
+
+async function findActiveMarkerOwner(
+    versionDirectory: string,
+    options: {
+        excludeProcessId?: number;
+        platform: NodeJS.Platform;
+    },
+): Promise<{ ownerPid: number } | undefined> {
+    const markerEntries = await readDirectoryEntries(versionDirectory);
+
+    for (const markerEntry of markerEntries) {
+        if (!markerEntry.endsWith(".lock")) {
+            continue;
+        }
+
+        const marker = await readActiveVersionMarker(
+            join(versionDirectory, markerEntry),
+        );
+
+        if (!isLiveOwner(marker, options)) {
+            continue;
+        }
+
+        return {
+            ownerPid: marker.pid,
+        };
+    }
+
+    return undefined;
+}
+
+async function readActiveVersionMarker(
+    markerFilePath: string,
+): Promise<ActiveVersionMarker | undefined> {
+    return readJsonFile(markerFilePath, activeVersionMarkerSchema);
+}
+
+async function readVersionOwner(
+    filePath: string,
+): Promise<VersionOwner | undefined> {
+    return readJsonFile(filePath, versionOwnerSchema);
+}
+
+async function readJsonFile<Schema extends z.ZodType>(
+    filePath: string,
+    schema: Schema,
+): Promise<z.infer<Schema> | undefined> {
     let content: string;
 
     try {
-        content = await readFile(lockFilePath, "utf8");
+        content = await readFile(filePath, "utf8");
     }
     catch (error) {
-        if (isFileMissingError(error) || isDirectoryReadError(error)) {
+        if (isPathMissingError(error) || isDirectoryReadError(error)) {
             return undefined;
         }
 
@@ -332,15 +594,33 @@ async function readVersionLockData(
         return undefined;
     }
 
-    const result = versionLockSchema.safeParse(parsedContent);
+    const result = schema.safeParse(parsedContent);
 
     return result.success ? result.data : undefined;
 }
 
-function isVersionLockActive(
-    lockData: VersionLockData,
+function isLiveOwner<Owner extends VersionOwner>(
+    lockData: Owner | undefined,
+    options: {
+        excludeProcessId?: number;
+        platform: NodeJS.Platform;
+    },
+): lockData is Owner {
+    if (lockData === undefined || lockData.pid === options.excludeProcessId) {
+        return false;
+    }
+
+    return isVersionOwnerActive(lockData, options.platform);
+}
+
+function isVersionOwnerActive<Owner extends VersionOwner>(
+    lockData: Owner | undefined,
     platform: NodeJS.Platform,
-): boolean {
+): lockData is Owner {
+    if (lockData === undefined) {
+        return false;
+    }
+
     return isProcessLockOwnerActive(lockData.pid, lockData.execPath, platform);
 }
 
@@ -349,7 +629,7 @@ async function readDirectoryEntries(path: string): Promise<string[]> {
         return await readdir(path);
     }
     catch (error) {
-        if (isFileMissingError(error)) {
+        if (isPathMissingError(error)) {
             return [];
         }
 

--- a/src/application/self-update/paths.test.ts
+++ b/src/application/self-update/paths.test.ts
@@ -1,7 +1,9 @@
 import { posix, win32 } from "node:path";
 import { describe, expect, test } from "bun:test";
 import {
-    resolveSelfUpdateLockFilePath,
+    resolveActiveVersionMarkerPath,
+    resolveInstallVersionLockPath,
+    resolveLegacyVersionLockPath,
     resolveSelfUpdatePaths,
     resolveSelfUpdateStagingBinaryPath,
     resolveSelfUpdateStagingDirectory,
@@ -91,7 +93,13 @@ describe("resolveSelfUpdatePaths", () => {
             platform: "linux",
         });
 
-        expect(resolveSelfUpdateLockFilePath(paths, "1.2.3")).toBe(
+        expect(resolveActiveVersionMarkerPath(paths, "1.2.3", 123, "marker")).toBe(
+            posix.join(paths.locksDirectory, "active", "1.2.3", "123.marker.lock"),
+        );
+        expect(resolveInstallVersionLockPath(paths, "1.2.3")).toBe(
+            posix.join(paths.locksDirectory, "install", "1.2.3.lock"),
+        );
+        expect(resolveLegacyVersionLockPath(paths, "1.2.3")).toBe(
             posix.join(paths.locksDirectory, "1.2.3.lock"),
         );
         expect(resolveSelfUpdateVersionDirectoryPath(paths, "1.2.3")).toBe(
@@ -145,7 +153,13 @@ describe("resolveSelfUpdatePaths", () => {
             version: "1.2.3",
         });
 
-        expect(resolveSelfUpdateLockFilePath(paths, "1.2.3")).toBe(
+        expect(resolveActiveVersionMarkerPath(paths, "1.2.3", 123, "marker")).toBe(
+            win32.join(paths.locksDirectory, "active", "1.2.3", "123.marker.lock"),
+        );
+        expect(resolveInstallVersionLockPath(paths, "1.2.3")).toBe(
+            win32.join(paths.locksDirectory, "install", "1.2.3.lock"),
+        );
+        expect(resolveLegacyVersionLockPath(paths, "1.2.3")).toBe(
             win32.join(paths.locksDirectory, "1.2.3.lock"),
         );
         expect(resolveSelfUpdateVersionDirectoryPath(paths, "1.2.3")).toBe(

--- a/src/application/self-update/paths.ts
+++ b/src/application/self-update/paths.ts
@@ -89,7 +89,32 @@ export function resolveSelfUpdatePaths(options: {
     }
 }
 
-export function resolveSelfUpdateLockFilePath(
+export function resolveActiveVersionMarkerPath(
+    paths: Pick<SelfUpdatePaths, "locksDirectory" | "platform">,
+    version: string,
+    pid: number,
+    markerId: string,
+): string {
+    return readPathModule(paths.platform).join(
+        paths.locksDirectory,
+        "active",
+        version,
+        `${pid}.${markerId}.lock`,
+    );
+}
+
+export function resolveInstallVersionLockPath(
+    paths: Pick<SelfUpdatePaths, "locksDirectory" | "platform">,
+    version: string,
+): string {
+    return readPathModule(paths.platform).join(
+        paths.locksDirectory,
+        "install",
+        `${version}.lock`,
+    );
+}
+
+export function resolveLegacyVersionLockPath(
     paths: Pick<SelfUpdatePaths, "locksDirectory" | "platform">,
     version: string,
 ): string {


### PR DESCRIPTION
The previous process-lifetime version lock prevented concurrent CLI invocations on the same version from coexisting, because each process held an exclusive lock on the version lock file for its entire run.

Split the lock into two concerns: install locks guard mutation of a version directory, while per-process active markers advertise which versions are currently in use. Multiple processes can now run the same version simultaneously, and a self-update that targets a version held by another process now returns a busy outcome before clobbering its on-disk binary.