### PR TITLE
feat(skills): add DeepSeek TUI as a supported agent

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -434,7 +434,8 @@ for every supported host directory that already exists.
 
 - Bundled skills: `oo` ensures `oo`, `oo-find-skills`, `oo-create-skill`, and
   `oo-publish-skill` are installed for each detected Codex, Claude Code,
-  Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, OpenClaw, and QoderWork host.
+  Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, OpenClaw, QoderWork, and
+  DeepSeek TUI host.
   Existing oo-managed bundled skill targets are refreshed to the current `oo`
   version, except that `0.0.0-development` startup runs do not refresh
   existing bundled targets, and installed `0.0.0-development` bundled targets
@@ -461,15 +462,15 @@ requested.
   `bundled`, `registry`, or `local`.
 - Options: `--agent <agent>` narrows the scan to one supported agent:
   `codex`, `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `trae-cn`,
-  `openclaw`, or `qoderwork`.
+  `openclaw`, `qoderwork`, or `deepseek-tui`.
 - Managed ownership rule: the command scans each existing supported local skill root:
   `${CODEX_HOME:-~/.codex}/skills`, `~/.claude/skills`,
   `${HERMES_HOME:-~/.hermes}/skills`, `~/.codebuddy/skills`,
   `~/.workbuddy/skills`, `~/.trae/skills`, `~/.trae-cn/skills`,
-  `${OPENCLAW_HOME:-~/.openclaw}/skills`, and `~/.qoderwork/skills`. It keeps
-  only child directories whose `.oo-metadata.json` identifies an oo-managed
-  bundled, registry, or local skill. Existing legacy bundled and registry
-  metadata remains readable.
+  `${OPENCLAW_HOME:-~/.openclaw}/skills`, `~/.qoderwork/skills`, and
+  `~/.deepseek/skills`. It keeps only child directories whose
+  `.oo-metadata.json` identifies an oo-managed bundled, registry, or local
+  skill. Existing legacy bundled and registry metadata remains readable.
 - Local source rule: `--source local` lists oo-managed local skills from agent
   skill directories. `--source local --agent <agent>` lists only that agent's
   local skills. Local entries are kept distinct by agent and path, even when
@@ -482,7 +483,7 @@ requested.
   `oo-find-skills` before `oo-create-skill` before `oo-publish-skill`; the
   remaining skills are ordered by skill name. Host names within a managed block
   follow `Codex`, `Claude Code`, `Hermes`, `CodeBuddy`, `WorkBuddy`, `Trae`,
-  `Trae CN`, `OpenClaw`, `QoderWork` order.
+  `Trae CN`, `OpenClaw`, `QoderWork`, `DeepSeek TUI` order.
 - Output: each skill block shows the skill name plus `Host`, `Source`, and
   `Version`. `Source` is `bundled`, `registry`, or `local`. Registry and local
   blocks also show `Package`; local blocks also show `Path`. `Host` lists
@@ -497,7 +498,7 @@ agent.
 
 - Options: `--agent <agent>` is required and selects one supported agent:
   `codex`, `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `trae-cn`,
-  `openclaw`, or `qoderwork`.
+  `openclaw`, `qoderwork`, or `deepseek-tui`.
 - Host check: the selected agent home directory must already exist.
 - Storage check: the command creates the selected agent's skills root, such as
   `<agent-home>/skills`, when needed. It writes and removes a temporary probe
@@ -514,7 +515,8 @@ Initialize one local skill in the selected agent's own skill directory.
   skill id, target directory name, and frontmatter `name`.
 - Options: `--agent <agent>` is required and selects the agent skill directory
   to write. Accepted values are `codex`, `claude`, `hermes`, `codebuddy`,
-  `workbuddy`, `trae`, `trae-cn`, `openclaw`, and `qoderwork`.
+  `workbuddy`, `trae`, `trae-cn`, `openclaw`, `qoderwork`, and
+  `deepseek-tui`.
 - Options: `--description <text>` is required and writes the generated
   `SKILL.md` frontmatter description.
 - Generated `SKILL.md` frontmatter includes `compatibility: "Requires the oo
@@ -567,7 +569,7 @@ Convert one skill into an OOMOL package and run the publish step.
 - Options: `--agent <agent>` selects one agent-native local skill when the same
   local skill id exists in multiple agents. Accepted values are `codex`,
   `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `trae-cn`, `openclaw`,
-  and `qoderwork`.
+  `qoderwork`, and `deepseek-tui`.
 - Options: `-y, --yes` answers publish confirmation prompts with yes.
 - Options: `--force` is accepted for compatibility with older workflows.
 - Source resolution: skill ids first match oo-managed local skills in supported
@@ -732,8 +734,8 @@ Install bundled or published skills into supported local skill directories.
 - Canonical directory: bundled skills are materialized under
   `<config-dir>/skills/bundled/<agent>/<skill-id>`, where `<config-dir>` is the
   directory that contains `settings.toml` and `<agent>` is `codex`, `claude`,
-  `hermes`, `codebuddy`, `workbuddy`, `trae`, `trae-cn`, `openclaw`, or
-  `qoderwork`.
+  `hermes`, `codebuddy`, `workbuddy`, `trae`, `trae-cn`, `openclaw`,
+  `qoderwork`, or `deepseek-tui`.
 - Canonical directory: published skills are materialized to
   `<config-dir>/skills/registry/<skill-id>`.
 - Migration: on first run after upgrading, `oo skills install` removes legacy
@@ -751,8 +753,9 @@ Install bundled or published skills into supported local skill directories.
   `~/.workbuddy/skills/<skill-id>`,
   `~/.trae/skills/<skill-id>`,
   `~/.trae-cn/skills/<skill-id>`,
-  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`, and
-  `~/.qoderwork/skills/<skill-id>`.
+  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`,
+  `~/.qoderwork/skills/<skill-id>`, and
+  `~/.deepseek/skills/<skill-id>`.
 - Target directory: if an existing supported host is missing its `skills` root,
   the command creates that root before publishing the selected skill.
 - Path rule: published skill names are accepted only when their resolved
@@ -778,8 +781,8 @@ Install bundled or published skills into supported local skill directories.
 - Notes: in the interactive picker, conflicting skills are marked in the list;
   selecting one means it will be overwritten.
 - Notes: the command exits with an error when none of the supported Codex,
-  Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, OpenClaw, or
-  QoderWork home directories exists.
+  Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, OpenClaw,
+  QoderWork, or DeepSeek TUI home directories exist.
 - Notes: an existing bundled or registry skill installation is considered
   managed by `oo` only when its `.oo-metadata.json` identifies that source.
   Otherwise `oo` treats it as a different skill and will not overwrite it.
@@ -879,9 +882,9 @@ Remove oo-managed skills from supported local skill directories.
   `~/.codebuddy/skills/<skill>`, `~/.workbuddy/skills/<skill>`,
   `~/.trae/skills/<skill>`,
   `~/.trae-cn/skills/<skill>`,
-  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`, and
-  `~/.qoderwork/skills/<skill>`. Local skills remove only the selected
-  agent-native local directory.
+  `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`,
+  `~/.qoderwork/skills/<skill>`, and `~/.deepseek/skills/<skill>`. Local skills
+  remove only the selected agent-native local directory.
 - Path rule: `[skill]` must resolve to child directories under those local
   `skills` roots. Names that escape those roots are rejected.
 - Notes: when no supported target has a managed installation and no matching

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -379,9 +379,9 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 registry skills。
 
 - 内置 skill：`oo` 会确保每个检测到的 Codex、Claude Code、Hermes、
-  CodeBuddy、WorkBuddy、Trae、Trae CN、OpenClaw 和 QoderWork Agent 都安装了 `oo`、
-  `oo-find-skills`、`oo-create-skill` 与 `oo-publish-skill`。已经由 oo 管理的
-  内置 skill 目标会刷新到当前 `oo` 版本；
+  CodeBuddy、WorkBuddy、Trae、Trae CN、OpenClaw、QoderWork 和 DeepSeek TUI
+  Agent 都安装了 `oo`、`oo-find-skills`、`oo-create-skill` 与 `oo-publish-skill`。
+  已经由 oo 管理的内置 skill 目标会刷新到当前 `oo` 版本；
   但当启动中的当前版本为 `0.0.0-development` 时，不会刷新已存在的内置 skill
   目标；已安装版本为 `0.0.0-development` 的内置 skill 目标也会保持不变。
 - Registry skill：如果某个已发布 skill 已经有本地 canonical 副本
@@ -402,15 +402,16 @@ registry skills。
 - 选项：`--source <source>`、`-s <source>` 将列表过滤为一个来源：
   `bundled`、`registry` 或 `local`。
 - 选项：`--agent <agent>` 将扫描范围限制为一个受支持 Agent：`codex`、`claude`、
-  `hermes`、`codebuddy`、`workbuddy`、`trae`、`trae-cn`、`openclaw` 或
-  `qoderwork`。
+  `hermes`、`codebuddy`、`workbuddy`、`trae`、`trae-cn`、`openclaw`、
+  `qoderwork` 或 `deepseek-tui`。
 - managed 所有权规则：命令会扫描每个已存在的受支持本地 skill 根目录：
   `${CODEX_HOME:-~/.codex}/skills`、`~/.claude/skills`，以及
   `${HERMES_HOME:-~/.hermes}/skills`、`~/.codebuddy/skills`、
   `~/.workbuddy/skills`、`~/.trae/skills`、`~/.trae-cn/skills`、
-  `${OPENCLAW_HOME:-~/.openclaw}/skills`、`~/.qoderwork/skills`。只保留
-  `.oo-metadata.json` 能识别为由 oo 管理的 bundled、registry 或 local skill 的
-  子目录；已有的 legacy bundled 和 registry metadata 仍可读取。
+  `${OPENCLAW_HOME:-~/.openclaw}/skills`、`~/.qoderwork/skills`、
+  `~/.deepseek/skills`。只保留 `.oo-metadata.json` 能识别为由 oo 管理的
+  bundled、registry 或 local skill 的子目录；已有的 legacy bundled 和 registry
+  metadata 仍可读取。
 - local 来源规则：`--source local` 会列出 Agent skill 目录中的 oo-managed local
   skill。`--source local --agent <agent>` 只列出该 Agent 的 local skill。即使多个
   Agent 中存在同名 local skill，也会按 Agent 和路径分别显示，不会合并。
@@ -421,7 +422,7 @@ registry skills。
   `oo-find-skills`，再其次 `oo-create-skill`，再其次 `oo-publish-skill`；其余
   skill 按名称排序。managed 块内的 Agent 名称按 `Codex`、`Claude Code`、
   `Hermes`、`CodeBuddy`、`WorkBuddy`、`Trae`、`Trae CN`、`OpenClaw`、
-  `QoderWork` 顺序显示。
+  `QoderWork`、`DeepSeek TUI` 顺序显示。
 - 输出：每个 skill 块会显示 skill 名称，以及 `Host`、`Source` 和 `Version`。
   `Source` 为 `bundled`、`registry` 或 `local`。registry 和 local 块还会显示
   `Package`；local 块还会显示 `Path`。`Host` 会列出匹配的受支持 Agent。local
@@ -435,7 +436,7 @@ registry skills。
 
 - 选项：`--agent <agent>` 为必填项，并选择一个受支持 Agent：`codex`、
   `claude`、`hermes`、`codebuddy`、`workbuddy`、`trae`、`trae-cn`、
-  `openclaw` 或 `qoderwork`。
+  `openclaw`、`qoderwork` 或 `deepseek-tui`。
 - Agent 检查：所选 Agent home 目录必须存在。
 - 存储检查：命令会在需要时创建所选 Agent 的 skills 根目录（如
   `<agent-home>/skills`），并在其中写入再移除临时探针文件。
@@ -450,7 +451,7 @@ registry skills。
   frontmatter `name`。
 - 选项：`--agent <agent>` 为必填项，并选择要写入的 Agent skill 目录。可选值为
   `codex`、`claude`、`hermes`、`codebuddy`、`workbuddy`、`trae`、`trae-cn`、
-  `openclaw` 和 `qoderwork`。
+  `openclaw`、`qoderwork` 和 `deepseek-tui`。
 - 选项：`--description <text>` 为必填项，并写入生成的 `SKILL.md`
   frontmatter description。
 - 生成的 `SKILL.md` frontmatter 包含 `compatibility: "Requires the oo CLI."`。
@@ -492,7 +493,7 @@ registry skills。
   已有可见性，交互式终端会询问发布为 `private` 还是 `public`。
 - 选项：`--agent <agent>` 用于当多个 Agent 中存在同名 local skill 时选择其中一个。
   可选值为 `codex`、`claude`、`hermes`、`codebuddy`、`workbuddy`、`trae`、
-  `trae-cn`、`openclaw` 和 `qoderwork`。
+  `trae-cn`、`openclaw`、`qoderwork` 和 `deepseek-tui`。
 - 选项：`-y, --yes` 会对发布过程中的确认提示自动回答 yes。
 - 选项：`--force` 为兼容旧流程保留。
 - 来源解析：skill id 会先匹配受支持 Agent skill 目录中的 oo-managed local skill。
@@ -625,8 +626,8 @@ registry skills。
 - canonical 目录：内置 skill 会先释放到
   `<config-dir>/skills/bundled/<agent>/<skill-id>`，其中 `<config-dir>` 是
   `settings.toml` 所在目录，`<agent>` 为 `codex`、`claude`、`hermes`、
-  `codebuddy`、`workbuddy`、`trae`、`trae-cn`、`openclaw` 或
-  `qoderwork`。
+  `codebuddy`、`workbuddy`、`trae`、`trae-cn`、`openclaw`、`qoderwork` 或
+  `deepseek-tui`。
 - canonical 目录：已发布 skill 会先释放到
   `<config-dir>/skills/registry/<skill-id>`。
 - 迁移：升级后首次运行 `oo skills install` 时，命令会清理历史遗留的 canonical
@@ -642,7 +643,8 @@ registry skills。
   `~/.trae/skills/<skill-id>`、
   `~/.trae-cn/skills/<skill-id>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill-id>`、
-  `~/.qoderwork/skills/<skill-id>`。
+  `~/.qoderwork/skills/<skill-id>`、
+  `~/.deepseek/skills/<skill-id>`。
 - 目标目录：当已存在的受支持 Agent 缺少 `skills` 根目录时，命令会先创建该目录，
   再发布所选 skill。
 - 安装方式：内置和已发布 skill 会复制到每个目标 skills 目录。旧版本留下的
@@ -662,7 +664,7 @@ registry skills。
 - 说明：在交互选择页面中，存在重名冲突的 skill 会在列表中显示状态标记；
   只要用户仍然选择该项，就会执行覆盖。
 - 说明：当 Codex、Claude Code、Hermes、CodeBuddy、WorkBuddy、Trae、Trae CN、
-  OpenClaw 和 QoderWork 的受支持根目录都不存在时，命令会直接报错退出。
+  OpenClaw、QoderWork 和 DeepSeek TUI 的受支持根目录都不存在时，命令会直接报错退出。
 - 说明：只有当 bundled 或 registry skill 的 `.oo-metadata.json` 能识别对应来源
   时，`oo` 才会认为这是自己管理的安装；否则会视为其他 skill，并拒绝覆盖。
 
@@ -747,7 +749,8 @@ registry skills。
   `~/.trae/skills/<skill>`、
   `~/.trae-cn/skills/<skill>`、
   `${OPENCLAW_HOME:-~/.openclaw}/skills/<skill>`、
-  `~/.qoderwork/skills/<skill>`。local skill 只移除所选 agent-native local 目录。
+  `~/.qoderwork/skills/<skill>`、
+  `~/.deepseek/skills/<skill>`。local skill 只移除所选 agent-native local 目录。
 - 路径规则：`[skill]` 解析后必须仍然落在这些本地 `skills` 根目录的子目录中。
   任何会逃出这些根目录的名称都会被拒绝。
 - 说明：如果请求的 skill 在任何受支持目标中都不存在受管理安装，且不存在同名

--- a/src/application/commands/skills/bundled-skill-observation.test.ts
+++ b/src/application/commands/skills/bundled-skill-observation.test.ts
@@ -14,6 +14,7 @@ import {
     writeInstalledBundledSkillMetadata,
 } from "./bundled-skill-observation.ts";
 import {
+    resolveDeepSeekTuiHomeDirectory,
     resolveTraeCnHomeDirectory,
     resolveTraeHomeDirectory,
 } from "./bundled-skill-paths.ts";
@@ -270,6 +271,33 @@ describe("bundled skill observation", () => {
             expect(await requireBundledSkillHomeDirectory({ env }, "qoderwork")).toBe(
                 qoderWorkHomeDirectory,
             );
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("requires the resolved DeepSeek TUI home directory to exist", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
+        const deepSeekTuiHomeDirectory = join(rootDirectory, ".deepseek");
+        const env = {
+            HOME: rootDirectory,
+        };
+
+        try {
+            await expect(
+                requireBundledSkillHomeDirectory({ env }, "deepseek-tui"),
+            ).rejects.toMatchObject({
+                exitCode: 1,
+                key: "errors.skills.deepseekTuiNotInstalled",
+            });
+
+            await mkdir(deepSeekTuiHomeDirectory, { recursive: true });
+
+            expect(await requireBundledSkillHomeDirectory({ env }, "deepseek-tui")).toBe(
+                deepSeekTuiHomeDirectory,
+            );
+            expect(resolveDeepSeekTuiHomeDirectory(env)).toBe(deepSeekTuiHomeDirectory);
         }
         finally {
             await rm(rootDirectory, { force: true, recursive: true });

--- a/src/application/commands/skills/bundled-skill-paths.ts
+++ b/src/application/commands/skills/bundled-skill-paths.ts
@@ -6,6 +6,7 @@ import { resolveHomeDirectory } from "../../path/home-directory.ts";
 const codexDirectoryName = ".codex";
 const claudeDirectoryName = ".claude";
 const codeBuddyDirectoryName = ".codebuddy";
+const deepSeekTuiDirectoryName = ".deepseek";
 const hermesDirectoryName = ".hermes";
 const openClawDirectoryName = ".openclaw";
 const qoderWorkDirectoryName = ".qoderwork";
@@ -41,6 +42,12 @@ export function resolveCodeBuddyHomeDirectory(
     env: Record<string, string | undefined>,
 ): string {
     return join(resolveHomeDirectory(env), codeBuddyDirectoryName);
+}
+
+export function resolveDeepSeekTuiHomeDirectory(
+    env: Record<string, string | undefined>,
+): string {
+    return join(resolveHomeDirectory(env), deepSeekTuiDirectoryName);
 }
 
 export function resolveHermesHomeDirectory(
@@ -100,6 +107,8 @@ export function resolveBundledSkillHomeDirectory(
             return resolveClaudeHomeDirectory(env);
         case "codebuddy":
             return resolveCodeBuddyHomeDirectory(env);
+        case "deepseek-tui":
+            return resolveDeepSeekTuiHomeDirectory(env);
         case "codex":
             return resolveCodexHomeDirectory(env);
         case "hermes":

--- a/src/application/commands/skills/check.test.ts
+++ b/src/application/commands/skills/check.test.ts
@@ -8,6 +8,7 @@ import {
     resolveClaudeHomeDirectory,
     resolveCodeBuddyHomeDirectory,
     resolveCodexHomeDirectory,
+    resolveDeepSeekTuiHomeDirectory,
     resolveHermesHomeDirectory,
     resolveQoderWorkHomeDirectory,
     resolveTraeCnHomeDirectory,
@@ -30,7 +31,7 @@ describe("skills preflight command", () => {
             expect(result.exitCode).toBe(1);
             expect(result.stdout).toBe("");
             expect(result.stderr).toBe(
-                "Missing required --agent. Choose codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, or qoderwork.\n",
+                "Missing required --agent. Choose codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.\n",
             );
         }
         finally {
@@ -158,6 +159,35 @@ describe("skills preflight command", () => {
                 "preflight",
                 "--agent",
                 "codebuddy",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Local skill editing is ready. Writable storage: ${skillsDirectoryPath}. Supported hosts: 1.\n`,
+            );
+            expect(await readDirectoryWithoutBundledSkills(skillsDirectoryPath)).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("checks DeepSeek TUI as a requested agent", async () => {
+        const sandbox = await createCliSandbox();
+        const deepSeekTuiHomeDirectory = resolveDeepSeekTuiHomeDirectory(sandbox.env);
+        const skillsDirectoryPath = resolveManagedSkillsDirectoryPath(
+            deepSeekTuiHomeDirectory,
+        );
+
+        try {
+            await mkdir(deepSeekTuiHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "preflight",
+                "--agent",
+                "deepseek-tui",
             ]);
 
             expect(result.exitCode).toBe(0);

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -105,6 +105,16 @@ describe("embedded skill assets", () => {
             "references/file-transfer.md",
             "references/task-lifecycle.md",
         ]);
+        expect(getBundledSkillFiles("oo", "deepseek-tui").map(file => file.relativePath)).toEqual([
+            "SKILL.md",
+            "references/auth-and-billing.md",
+            "references/llm-client.md",
+            "references/search-and-selection.md",
+            "references/package-execution.md",
+            "references/connector-execution.md",
+            "references/file-transfer.md",
+            "references/task-lifecycle.md",
+        ]);
         expect(
             getBundledSkillFiles("oo-find-skills", "codex").map(
                 file => file.relativePath,
@@ -179,6 +189,14 @@ describe("embedded skill assets", () => {
             "references/oo-cli-contract.md",
         ]);
         expect(
+            getBundledSkillFiles("oo-find-skills", "deepseek-tui").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+            "references/oo-cli-contract.md",
+        ]);
+        expect(
             getBundledSkillFiles("oo-create-skill", "codex").map(
                 file => file.relativePath,
             ),
@@ -237,6 +255,13 @@ describe("embedded skill assets", () => {
         ]);
         expect(
             getBundledSkillFiles("oo-create-skill", "qoderwork").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
+        expect(
+            getBundledSkillFiles("oo-create-skill", "deepseek-tui").map(
                 file => file.relativePath,
             ),
         ).toEqual([
@@ -306,6 +331,13 @@ describe("embedded skill assets", () => {
         ).toEqual([
             "SKILL.md",
         ]);
+        expect(
+            getBundledSkillFiles("oo-publish-skill", "deepseek-tui").map(
+                file => file.relativePath,
+            ),
+        ).toEqual([
+            "SKILL.md",
+        ]);
     });
 
     test("maps bundled skills to contrib/skills/<agent>/<skill> source directories", () => {
@@ -319,6 +351,7 @@ describe("embedded skill assets", () => {
             "trae-cn",
             "openclaw",
             "qoderwork",
+            "deepseek-tui",
         ]);
 
         for (const skillName of availableBundledSkillNames) {
@@ -940,7 +973,7 @@ describe("embedded skill assets", () => {
     });
 
     test("keeps non-Claude skill frontmatter free of Claude allowed tools", async () => {
-        for (const agentName of ["qoderwork", "trae", "trae-cn", "workbuddy"] as const) {
+        for (const agentName of ["deepseek-tui", "qoderwork", "trae", "trae-cn", "workbuddy"] as const) {
             for (const skillName of availableBundledSkillNames) {
                 const skillFile = getBundledSkillFiles(skillName, agentName)
                     .find(file => file.relativePath === "SKILL.md");
@@ -983,6 +1016,7 @@ function readBundledSkillSourceAgentName(
         case "trae":
         case "trae-cn":
         case "workbuddy":
+        case "deepseek-tui":
             return "codebuddy";
         default:
             return agentName;

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -63,7 +63,7 @@ import ooQoderWorkSearchAndSelectionReferencePath from "../../../../contrib/skil
 import ooQoderWorkTaskLifecycleReferencePath from "../../../../contrib/skills/qoderwork/oo/references/task-lifecycle.md" with { type: "file" };
 import ooQoderWorkSkillPath from "../../../../contrib/skills/qoderwork/oo/SKILL.md" with { type: "file" };
 
-export const availableBundledSkillAgentNames = ["codex", "claude", "hermes", "codebuddy", "workbuddy", "trae", "trae-cn", "openclaw", "qoderwork"] as const;
+export const availableBundledSkillAgentNames = ["codex", "claude", "hermes", "codebuddy", "workbuddy", "trae", "trae-cn", "openclaw", "qoderwork", "deepseek-tui"] as const;
 export type BundledSkillAgentName = (typeof availableBundledSkillAgentNames)[number];
 
 export const availableBundledSkillNames = ["oo", "oo-find-skills", "oo-create-skill", "oo-publish-skill"] as const;
@@ -217,6 +217,15 @@ const bundledSkillRegistry = {
                 ...ooQoderWorkReferenceFiles,
             ],
         },
+        "deepseek-tui": {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCodeBuddySkillPath,
+                },
+                ...ooCodeBuddyReferenceFiles,
+            ],
+        },
     },
     "oo-find-skills": {
         "codex": {
@@ -331,6 +340,18 @@ const bundledSkillRegistry = {
                 },
             ],
         },
+        "deepseek-tui": {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooFindSkillsCodeBuddySkillPath,
+                },
+                {
+                    relativePath: "references/oo-cli-contract.md",
+                    sourcePath: ooFindSkillsCodeBuddyCliContractPath,
+                },
+            ],
+        },
     },
     "oo-create-skill": {
         "codex": {
@@ -409,6 +430,14 @@ const bundledSkillRegistry = {
                 },
             ],
         },
+        "deepseek-tui": {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooCreateSkillCodeBuddySkillPath,
+                },
+            ],
+        },
     },
     "oo-publish-skill": {
         "codex": {
@@ -484,6 +513,14 @@ const bundledSkillRegistry = {
                 {
                     relativePath: "SKILL.md",
                     sourcePath: ooPublishSkillQoderWorkSkillPath,
+                },
+            ],
+        },
+        "deepseek-tui": {
+            files: [
+                {
+                    relativePath: "SKILL.md",
+                    sourcePath: ooPublishSkillCodeBuddySkillPath,
                 },
             ],
         },

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -31,6 +31,7 @@ import {
     resolveClaudeHomeDirectory,
     resolveCodeBuddyHomeDirectory,
     resolveCodexHomeDirectory,
+    resolveDeepSeekTuiHomeDirectory,
     resolveHermesHomeDirectory,
     resolveOpenClawHomeDirectory,
     resolveQoderWorkHomeDirectory,
@@ -978,6 +979,66 @@ describe("skills commands", () => {
         }
     });
 
+    test("installs bundled skills into DeepSeek TUI using the CodeBuddy skill template", async () => {
+        const sandbox = await createCliSandbox();
+        const deepSeekTuiHomeDirectory = resolveDeepSeekTuiHomeDirectory(sandbox.env);
+        const deepSeekTuiSkillsDirectoryPath = join(deepSeekTuiHomeDirectory, "skills");
+        const skillDirectoryPath = join(deepSeekTuiHomeDirectory, "skills", "oo");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+            "deepseek-tui",
+        );
+        const metadataFilePath = resolveBundledSkillMetadataFilePath(skillDirectoryPath);
+        const skillFilePath = join(skillDirectoryPath, "SKILL.md");
+        const deepSeekTuiSkillFile = getBundledSkillFiles("oo", "deepseek-tui")
+            .find(file => file.relativePath === "SKILL.md");
+
+        try {
+            if (deepSeekTuiSkillFile === undefined) {
+                throw new Error("Missing DeepSeek TUI oo SKILL.md fixture");
+            }
+
+            await mkdir(deepSeekTuiHomeDirectory, { recursive: true });
+            await expect(stat(deepSeekTuiSkillsDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+
+            const result = await sandbox.run(["skills", "install", "oo"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Installed skill oo to ${skillDirectoryPath}.\n`,
+            );
+            expect((await stat(deepSeekTuiSkillsDirectoryPath)).isDirectory()).toBeTrue();
+            expect(await realpath(skillDirectoryPath)).not.toBe(
+                await realpath(canonicalSkillDirectoryPath),
+            );
+            expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
+            expect(await readFile(metadataFilePath, "utf8")).toBe(
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
+            );
+            expect(await readFile(skillFilePath, "utf8")).toBe(
+                await Bun.file(deepSeekTuiSkillFile.sourcePath).text(),
+            );
+            await expect(
+                stat(join(skillDirectoryPath, "agents", "openai.yaml")),
+            ).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("installs bundled skills into WorkBuddy", async () => {
         const sandbox = await createCliSandbox();
         const workBuddyHomeDirectory = resolveWorkBuddyHomeDirectory(sandbox.env);
@@ -1321,6 +1382,7 @@ describe("skills commands", () => {
         const traeCnHomeDirectory = resolveTraeCnHomeDirectory(sandbox.env);
         const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
         const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
+        const deepSeekTuiHomeDirectory = resolveDeepSeekTuiHomeDirectory(sandbox.env);
         const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
         const claudeSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
         const hermesSkillDirectoryPath = join(hermesHomeDirectory, "skills", "chatgpt");
@@ -1330,6 +1392,7 @@ describe("skills commands", () => {
         const traeCnSkillDirectoryPath = join(traeCnHomeDirectory, "skills", "chatgpt");
         const openClawSkillDirectoryPath = join(openClawHomeDirectory, "skills", "chatgpt");
         const qoderWorkSkillDirectoryPath = join(qoderWorkHomeDirectory, "skills", "chatgpt");
+        const deepSeekTuiSkillDirectoryPath = join(deepSeekTuiHomeDirectory, "skills", "chatgpt");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
@@ -1350,7 +1413,6 @@ describe("skills commands", () => {
                 traeSkillDirectoryPath,
                 traeCnSkillDirectoryPath,
                 openClawSkillDirectoryPath,
-                qoderWorkSkillDirectoryPath,
             ]) {
                 await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
             }
@@ -1367,6 +1429,7 @@ describe("skills commands", () => {
                 traeCnSkillDirectoryPath,
                 openClawSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
+                deepSeekTuiSkillDirectoryPath,
             ]) {
                 await Bun.write(
                     resolveManagedSkillMetadataFilePath(skillDirectoryPath),
@@ -1390,6 +1453,7 @@ describe("skills commands", () => {
                     `Removed skill chatgpt from ${traeCnSkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${openClawSkillDirectoryPath}.`,
                     `Removed skill chatgpt from ${qoderWorkSkillDirectoryPath}.`,
+                    `Removed skill chatgpt from ${deepSeekTuiSkillDirectoryPath}.`,
                     "",
                 ].join("\n"),
             );
@@ -1404,6 +1468,7 @@ describe("skills commands", () => {
                 traeCnSkillDirectoryPath,
                 openClawSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
+                deepSeekTuiSkillDirectoryPath,
             ]) {
                 await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
                     code: "ENOENT",
@@ -2536,6 +2601,7 @@ describe("skills commands", () => {
         const traeCnHomeDirectory = resolveTraeCnHomeDirectory(sandbox.env);
         const openClawHomeDirectory = resolveOpenClawHomeDirectory(sandbox.env);
         const qoderWorkHomeDirectory = resolveQoderWorkHomeDirectory(sandbox.env);
+        const deepSeekTuiHomeDirectory = resolveDeepSeekTuiHomeDirectory(sandbox.env);
         const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
         const claudeSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
         const hermesSkillDirectoryPath = join(hermesHomeDirectory, "skills", "chatgpt");
@@ -2545,6 +2611,7 @@ describe("skills commands", () => {
         const traeCnSkillDirectoryPath = join(traeCnHomeDirectory, "skills", "chatgpt");
         const openClawSkillDirectoryPath = join(openClawHomeDirectory, "skills", "chatgpt");
         const qoderWorkSkillDirectoryPath = join(qoderWorkHomeDirectory, "skills", "chatgpt");
+        const deepSeekTuiSkillDirectoryPath = join(deepSeekTuiHomeDirectory, "skills", "chatgpt");
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
@@ -2566,6 +2633,7 @@ describe("skills commands", () => {
                 mkdir(traeCnHomeDirectory, { recursive: true }),
                 mkdir(openClawHomeDirectory, { recursive: true }),
                 mkdir(qoderWorkHomeDirectory, { recursive: true }),
+                mkdir(deepSeekTuiHomeDirectory, { recursive: true }),
             ]);
             await writeAuthFile(sandbox);
 
@@ -2603,7 +2671,7 @@ describe("skills commands", () => {
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(result.stdout).toBe(
-                "Installed skill chatgpt to 9 agents: Codex, Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, OpenClaw, QoderWork.\n",
+                "Installed skill chatgpt to 10 agents: Codex, Claude Code, Hermes, CodeBuddy, WorkBuddy, Trae, Trae CN, OpenClaw, QoderWork, DeepSeek TUI.\n",
             );
             const canonicalSkillRealPath = await realpath(canonicalSkillDirectoryPath);
 
@@ -2611,6 +2679,7 @@ describe("skills commands", () => {
                 codexSkillDirectoryPath,
                 claudeSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
+                deepSeekTuiSkillDirectoryPath,
             ]) {
                 expect(await realpath(copiedSkillDirectoryPath)).not.toBe(
                     canonicalSkillRealPath,
@@ -2642,6 +2711,7 @@ describe("skills commands", () => {
                 traeCnSkillDirectoryPath,
                 openClawSkillDirectoryPath,
                 qoderWorkSkillDirectoryPath,
+                deepSeekTuiSkillDirectoryPath,
             ]) {
                 expect(await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8")).toContain(
                     "# ChatGPT",

--- a/src/application/commands/skills/init.test.ts
+++ b/src/application/commands/skills/init.test.ts
@@ -7,6 +7,7 @@ import { createCliSandbox } from "../../../../__tests__/helpers.ts";
 import {
     resolveCodeBuddyHomeDirectory,
     resolveCodexHomeDirectory,
+    resolveDeepSeekTuiHomeDirectory,
     resolveTraeCnHomeDirectory,
     resolveTraeHomeDirectory,
 } from "./bundled-skill-paths.ts";
@@ -196,6 +197,38 @@ describe("skills init command", () => {
         }
     });
 
+    test("initializes a local skill for DeepSeek TUI", async () => {
+        const sandbox = await createCliSandbox();
+        const deepSeekTuiHomeDirectory = resolveDeepSeekTuiHomeDirectory(sandbox.env);
+        const skillDirectoryPath = resolveManagedSkillDirectoryPath(
+            deepSeekTuiHomeDirectory,
+            "deepseek-tui-skill",
+        );
+
+        try {
+            await mkdir(deepSeekTuiHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "init",
+                "deepseek-tui-skill",
+                "--agent",
+                "deepseek-tui",
+                "--description",
+                "Use a known package workflow.",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Initialized skill deepseek-tui-skill at ${skillDirectoryPath}.\n`,
+            );
+            expect((await lstat(skillDirectoryPath)).isSymbolicLink()).toBeFalse();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("initializes a local skill for Trae", async () => {
         const sandbox = await createCliSandbox();
         const traeHomeDirectory = resolveTraeHomeDirectory(sandbox.env);
@@ -282,7 +315,7 @@ describe("skills init command", () => {
             expect(result.exitCode).toBe(1);
             expect(result.stdout).toBe("");
             expect(result.stderr).toBe(
-                "Missing required --agent. Choose codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, or qoderwork.\n",
+                "Missing required --agent. Choose codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.\n",
             );
             await expect(stat(skillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -15,6 +15,7 @@ import {
     resolveClaudeHomeDirectory,
     resolveCodeBuddyHomeDirectory,
     resolveCodexHomeDirectory,
+    resolveDeepSeekTuiHomeDirectory,
     resolveHermesHomeDirectory,
     resolveOpenClawHomeDirectory,
     resolveQoderWorkHomeDirectory,
@@ -430,6 +431,35 @@ describe("skills list CLI", () => {
                     "✓ Found 4 skills.",
                     "",
                     ...createExpectedBundledSkillLines("CodeBuddy"),
+                ].join("\n"),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("lists startup-synchronized DeepSeek TUI bundled installs when Codex is not installed", async () => {
+        const sandbox = await createCliSandbox();
+        const deepSeekTuiHomeDirectory = resolveDeepSeekTuiHomeDirectory(sandbox.env);
+
+        try {
+            await mkdir(deepSeekTuiHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install", "oo"], {
+                version: "9.9.9",
+            });
+
+            const result = await sandbox.run(["skills", "list"], {
+                version: "9.9.9",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    "✓ Found 4 skills.",
+                    "",
+                    ...createExpectedBundledSkillLines("DeepSeek TUI"),
                 ].join("\n"),
             );
         }

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -64,6 +64,7 @@ const managedSkillHostOrder = {
     "trae-cn": 6,
     "openclaw": 7,
     "qoderwork": 8,
+    "deepseek-tui": 9,
 } as const satisfies Record<BundledSkillAgentName, number>;
 
 type SkillListSource = (typeof skillListSourceValues)[number];

--- a/src/application/commands/skills/managed-skill-host-errors.ts
+++ b/src/application/commands/skills/managed-skill-host-errors.ts
@@ -4,6 +4,7 @@ export type ManagedSkillHostMissingErrorKey
     = | "errors.skills.claudeNotInstalled"
         | "errors.skills.codebuddyNotInstalled"
         | "errors.skills.codexNotInstalled"
+        | "errors.skills.deepseekTuiNotInstalled"
         | "errors.skills.hermesNotInstalled"
         | "errors.skills.openclawNotInstalled"
         | "errors.skills.qoderworkNotInstalled"
@@ -21,6 +22,8 @@ export function resolveManagedSkillHostMissingErrorKey(
             return "errors.skills.codebuddyNotInstalled";
         case "codex":
             return "errors.skills.codexNotInstalled";
+        case "deepseek-tui":
+            return "errors.skills.deepseekTuiNotInstalled";
         case "hermes":
             return "errors.skills.hermesNotInstalled";
         case "openclaw":

--- a/src/application/commands/skills/managed-skill-host-labels.ts
+++ b/src/application/commands/skills/managed-skill-host-labels.ts
@@ -14,6 +14,8 @@ export function readManagedSkillHostLabel(
             return translator.t("skills.list.host.codebuddy");
         case "codex":
             return translator.t("skills.list.host.codex");
+        case "deepseek-tui":
+            return translator.t("skills.list.host.deepseekTui");
         case "hermes":
             return translator.t("skills.list.host.hermes");
         case "openclaw":

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -870,7 +870,7 @@ describe("skills publish command", () => {
 
             expect(result.exitCode).toBe(2);
             expect(result.stderr).toBe(
-                "Unsupported skill agent: unknown. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, or qoderwork.\n",
+                "Unsupported skill agent: unknown. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.\n",
             );
         }
         finally {

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -404,9 +404,9 @@ export const enMessages = {
     "errors.skills.init.invalidIcon":
         "Invalid value for --icon. Use a non-empty icon reference.",
     "errors.skills.init.agentRequired":
-        "Missing required --agent. Choose codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, or qoderwork.",
+        "Missing required --agent. Choose codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.",
     "errors.skills.init.invalidAgent":
-        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, or qoderwork.",
+        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.",
     "errors.skills.init.invalidTitle":
         "Invalid value for --title. Use a non-empty display title.",
     "errors.skills.init.descriptionRequired":
@@ -414,13 +414,13 @@ export const enMessages = {
     "errors.skills.init.invalidName":
         "Invalid skill name: {value}. Use a name that can be normalized to lowercase hyphen-case.",
     "errors.skills.check.agentRequired":
-        "Missing required --agent. Choose codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, or qoderwork.",
+        "Missing required --agent. Choose codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.",
     "errors.skills.check.invalidAgent":
-        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, or qoderwork.",
+        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.",
     "errors.skills.publish.invalidPackageMetadata":
         "Invalid skill package metadata: {message}",
     "errors.skills.publish.invalidAgent":
-        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, or qoderwork.",
+        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.",
     "errors.skills.publish.invalidSkillFile":
         "Cannot publish the skill at {path}: {message}",
     "errors.skills.publish.invalidVisibility":
@@ -452,9 +452,9 @@ export const enMessages = {
     "errors.skills.publish.visibilityRequired":
         "Package {packageName} does not have an existing visibility to preserve. Run in an interactive terminal or pass --visibility private or --visibility public.",
     "errors.skills.list.invalidAgent":
-        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, or qoderwork.",
+        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.",
     "errors.skills.uninstall.invalidAgent":
-        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, or qoderwork.",
+        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.",
     "errors.skills.share.cancelled":
         "Share cancelled for skill {name}.",
     "errors.skills.share.confirmationRequired":
@@ -529,6 +529,8 @@ export const enMessages = {
         "Claude Code is not installed. Expected the Claude home directory at {path}.",
     "errors.skills.codebuddyNotInstalled":
         "CodeBuddy is not installed. Expected the CodeBuddy home directory at {path}.",
+    "errors.skills.deepseekTuiNotInstalled":
+        "DeepSeek TUI is not installed. Expected the DeepSeek TUI home directory at {path}.",
     "errors.skills.hermesNotInstalled":
         "Hermes is not installed. Expected the Hermes home directory at {path}.",
     "errors.skills.openclawNotInstalled":
@@ -763,6 +765,7 @@ export const enMessages = {
     "skills.list.host.claude": "Claude Code",
     "skills.list.host.codebuddy": "CodeBuddy",
     "skills.list.host.codex": "Codex",
+    "skills.list.host.deepseekTui": "DeepSeek TUI",
     "skills.list.host.hermes": "Hermes",
     "skills.list.host.openclaw": "OpenClaw",
     "skills.list.host.qoderwork": "QoderWork",
@@ -1345,9 +1348,9 @@ export const zhMessages = {
     "errors.skills.init.invalidIcon":
         "--icon 的值无效。请使用非空 icon 引用。",
     "errors.skills.init.agentRequired":
-        "缺少必填的 --agent。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw 或 qoderwork。",
+        "缺少必填的 --agent。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw、qoderwork 或 deepseek-tui。",
     "errors.skills.init.invalidAgent":
-        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw 或 qoderwork。",
+        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw、qoderwork 或 deepseek-tui。",
     "errors.skills.init.invalidTitle":
         "--title 的值无效。请使用非空显示标题。",
     "errors.skills.init.descriptionRequired":
@@ -1355,13 +1358,13 @@ export const zhMessages = {
     "errors.skills.init.invalidName":
         "无效的 skill 名称：{value}。请使用可规范化为小写短横线格式的名称。",
     "errors.skills.check.agentRequired":
-        "缺少必填的 --agent。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw 或 qoderwork。",
+        "缺少必填的 --agent。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw、qoderwork 或 deepseek-tui。",
     "errors.skills.check.invalidAgent":
-        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw 或 qoderwork。",
+        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw、qoderwork 或 deepseek-tui。",
     "errors.skills.publish.invalidPackageMetadata":
         "skill 包元数据无效：{message}",
     "errors.skills.publish.invalidAgent":
-        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw 或 qoderwork。",
+        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw、qoderwork 或 deepseek-tui。",
     "errors.skills.publish.invalidSkillFile":
         "无法发布 {path} 中的 skill：{message}",
     "errors.skills.publish.invalidVisibility":
@@ -1391,9 +1394,9 @@ export const zhMessages = {
     "errors.skills.publish.visibilityRequired":
         "包 {packageName} 没有可沿用的已有可见性。请在交互式终端中运行，或传入 --visibility private / --visibility public。",
     "errors.skills.list.invalidAgent":
-        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw 或 qoderwork。",
+        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw、qoderwork 或 deepseek-tui。",
     "errors.skills.uninstall.invalidAgent":
-        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw 或 qoderwork。",
+        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw、qoderwork 或 deepseek-tui。",
     "errors.skills.publish.skillNotFound":
         "无法在 local、bundled、registry、指定 Agent 或路径来源中找到 skill {name}。",
     "errors.skills.share.cancelled":
@@ -1470,6 +1473,8 @@ export const zhMessages = {
         "未检测到 Claude Code 安装。期望的 Claude 根目录为 {path}。",
     "errors.skills.codebuddyNotInstalled":
         "未检测到 CodeBuddy 安装。期望的 CodeBuddy 根目录为 {path}。",
+    "errors.skills.deepseekTuiNotInstalled":
+        "未检测到 DeepSeek TUI 安装。期望的 DeepSeek TUI 根目录为 {path}。",
     "errors.skills.hermesNotInstalled":
         "未检测到 Hermes 安装。期望的 Hermes 根目录为 {path}。",
     "errors.skills.openclawNotInstalled":
@@ -1696,6 +1701,7 @@ export const zhMessages = {
     "skills.list.host.claude": "Claude Code",
     "skills.list.host.codebuddy": "CodeBuddy",
     "skills.list.host.codex": "Codex",
+    "skills.list.host.deepseekTui": "DeepSeek TUI",
     "skills.list.host.hermes": "Hermes",
     "skills.list.host.openclaw": "OpenClaw",
     "skills.list.host.qoderwork": "QoderWork",


### PR DESCRIPTION
Extend bundled, registry, and local skill workflows to recognize a new DeepSeek TUI host rooted at ~/.deepseek. The agent reuses the CodeBuddy-shaped SKILL.md frontmatter so existing non-Claude skill assets apply without per-host duplication, and is wired through path resolution, preflight checks, list/init/publish flows, host labels, error messages, and i18n catalog entries.