### PR TITLE
feat(auth): print device login URL on its own line

### DIFF
--- a/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
@@ -5,7 +5,8 @@ exports[`auth CLI writes auth device login logs without persisting secrets 1`] =
   "exitCode": 0,
   "stderr": "",
   "stdout": 
-"Open this URL in your browser to continue: <LOGIN_URL>
+"Open this login URL in your browser:
+<LOGIN_URL>
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
@@ -73,7 +74,8 @@ exports[`auth CLI supports auth login and updates the existing account without d
     "exitCode": 0,
     "stderr": "",
     "stdout": 
-"Open this URL in your browser to continue: <LOGIN_URL>
+"Open this login URL in your browser:
+<LOGIN_URL>
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
@@ -84,7 +86,8 @@ Waiting for the device login to complete...
     "exitCode": 0,
     "stderr": "",
     "stdout": 
-"Open this URL in your browser to continue: <LOGIN_URL>
+"Open this login URL in your browser:
+<LOGIN_URL>
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
@@ -99,7 +102,8 @@ exports[`auth CLI supports auth login with a custom OOMOL_ENDPOINT 1`] = `
   "exitCode": 0,
   "stderr": "",
   "stdout": 
-"Open this URL in your browser to continue: <LOGIN_URL>
+"Open this login URL in your browser:
+<LOGIN_URL>
 Waiting for the device login to complete...
 ✓ Logged in to staging.oomol.test account Alice
   - Active account: true
@@ -113,7 +117,8 @@ exports[`auth CLI supports login as an alias for auth login 1`] = `
   "exitCode": 0,
   "stderr": "",
   "stdout": 
-"Open this URL in your browser to continue: <LOGIN_URL>
+"Open this login URL in your browser:
+<LOGIN_URL>
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
@@ -127,7 +132,8 @@ exports[`auth CLI renders the auth login url and success block with color stylin
   "exitCode": 0,
   "stderr": "",
   "stdout": 
-"Open this URL in your browser to continue: <LOGIN_URL>
+"Open this login URL in your browser:
+<LOGIN_URL>
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -152,6 +152,56 @@ describe("auth CLI", () => {
         }
     });
 
+    test("renders device login instructions with a standalone URL", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await runPrintedAuthLogin(sandbox, "secret-1");
+            const plainOutput = createTerminalColors(true).strip(result.stdout);
+            const outputLines = plainOutput.split("\n");
+            const loginUrl = findLoginUrl(result.stdout);
+
+            expect(result.exitCode).toBe(0);
+            expect(loginUrl).toBeTruthy();
+            expect(outputLines[0]).toBe("Open this login URL in your browser:");
+            expect(outputLines[1]).toBe(loginUrl);
+            expect(outputLines[2]).toBe("Waiting for the device login to complete...");
+            expect(new URL(loginUrl!).searchParams.get("user_code")).toBe(
+                "M0KO41",
+            );
+            expectForbiddenDeviceLoginPhrases(plainOutput);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders localized device login instructions with a standalone URL", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
+                argv: ["--lang", "zh", "auth", "login"],
+            });
+            const plainOutput = createTerminalColors(true).strip(result.stdout);
+            const outputLines = plainOutput.split("\n");
+            const loginUrl = findLoginUrl(result.stdout);
+
+            expect(result.exitCode).toBe(0);
+            expect(loginUrl).toBeTruthy();
+            expect(outputLines[0]).toBe("请在你的浏览器中打开此登录 URL：");
+            expect(outputLines[1]).toBe(loginUrl);
+            expect(outputLines[2]).toBe("正在等待 device login 完成...");
+            expect(new URL(loginUrl!).searchParams.get("user_code")).toBe(
+                "M0KO41",
+            );
+            expectForbiddenDeviceLoginPhrases(plainOutput);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("supports auth login with a custom OOMOL_ENDPOINT", async () => {
         const sandbox = await createCliSandbox();
 
@@ -243,7 +293,7 @@ describe("auth CLI", () => {
 
             expect(result.exitCode).toBe(0);
             expect(requests).toHaveLength(1);
-            expect(result.stdout).not.toContain("Open this URL");
+            expect(result.stdout).not.toContain("Open this login URL");
             expect(result.stdout).not.toContain("Enter this code");
             expect(result.stdout).not.toContain("Waiting for the device login");
             expect(createCliSnapshot(result)).toEqual({
@@ -670,4 +720,18 @@ function createAuthLoginSnapshot(
                 ],
         stripAnsi: options.stripAnsi,
     });
+}
+
+function expectForbiddenDeviceLoginPhrases(output: string): void {
+    for (const phrase of [
+        "AI agents",
+        "sandbox",
+        "automation",
+        "do not open",
+        "must be logged in",
+        "不要代为打开",
+        "必须已登录",
+    ]) {
+        expect(output).not.toContain(phrase);
+    }
 }

--- a/src/application/commands/auth/login.ts
+++ b/src/application/commands/auth/login.ts
@@ -115,9 +115,11 @@ async function runDeviceLogin(
     );
     writeLine(
         context.stdout,
-        context.translator.t("auth.login.openManually", {
-            url: colors.hex(loginUrlColor)(session.verificationUrl),
-        }),
+        context.translator.t("auth.login.openManually"),
+    );
+    writeLine(
+        context.stdout,
+        colors.hex(loginUrlColor)(session.verificationUrl),
     );
     writeLine(
         context.stdout,

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -2,7 +2,7 @@ import { APP_NAME } from "../application/config/app-config.ts";
 
 export const enMessages = {
     "app.description": `${APP_NAME} is OOMOL's CLI toolkit. Everything can be done in the CLI.`,
-    "auth.login.openManually": "Open this URL in your browser to continue: {url}",
+    "auth.login.openManually": "Open this login URL in your browser:",
     "auth.account.activeAccountMissing":
         "The active account is missing from the auth store.",
     "auth.account.loggedIn": "Logged in to {endpoint} account {name}",
@@ -975,7 +975,7 @@ export const enMessages = {
 
 export const zhMessages = {
     "app.description": `${APP_NAME} 是 OOMOL 的 CLI 工具集，一切均可在 CLI 中完成`,
-    "auth.login.openManually": "请在浏览器中打开这个 URL 继续登录：{url}",
+    "auth.login.openManually": "请在你的浏览器中打开此登录 URL：",
     "auth.account.activeAccountMissing": "当前激活账号不存在于认证数据中。",
     "auth.account.loggedIn": "已登录 {endpoint} 账号 {name}",
     "auth.login.waiting": "正在等待 device login 完成...",


### PR DESCRIPTION
Previously the login URL was appended inline to the instruction text, which made it harder to spot and prevented many terminals from auto-linking it as a clickable target. Moving the URL onto its own line keeps the instruction concise and lets terminal emulators detect the URL for one-click opening or copying.