### PR TITLE
ci: cache install deps and parallelize npm package packing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,27 +84,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
-          fetch-depth: 0
-          fetch-tags: true
+          fetch-depth: 1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: .bun-version
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6.4.0
+      - name: Configure Bun install cache directory
+        shell: bash
+        run: |
+          # Keep BUN_INSTALL_CACHE_DIR explicit for all platforms so actions/cache restores Bun's install cache before `bun install`; it also works around a Bun Windows x64 install-cache bug fixed upstream in oven-sh/bun#28339.
+          echo "BUN_INSTALL_CACHE_DIR=${{ github.workspace }}/.bun-install-cache" >> "$GITHUB_ENV"
+
+      - name: Cache Bun install dependencies
+        uses: actions/cache@v4
         with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
+          path: .bun-install-cache
+          key: bun-install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock', '.bun-version') }}
+          restore-keys: |
+            bun-install-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install
         run: bun install --frozen-lockfile
-
-      # See: https://github.com/oven-sh/bun/pull/28339
-      - name: Use workspace Bun cache for Win32 x64 baseline builds
-        if: matrix.platform_name == 'Win32 x64'
-        run: echo "BUN_INSTALL_CACHE_DIR=${{ github.workspace }}\\.bun-install\\cache" >> $env:GITHUB_ENV
 
       - name: Stage platform packages
         run: bun run "${{ matrix.build_script }}"
@@ -191,7 +193,6 @@ jobs:
     needs:
       - compute-version
       - publish
-      - upload-release-binaries-to-oss
     uses: ./.github/workflows/deploy-install-worker.yaml
     with:
       tag: ${{ needs.compute-version.outputs.tag_name }}

--- a/.github/workflows/upload-release-binaries-to-oss.yaml
+++ b/.github/workflows/upload-release-binaries-to-oss.yaml
@@ -22,6 +22,7 @@ on:
         type: string
 
 env:
+  RCLONE_VERSION: v1.69.1
   RELEASE_ARCHIVE_NAME: oo-binaries.tgz
   RELEASE_ARCHIVE_PATH: dist/oo-binaries.tgz
   RELEASE_EXTRACT_DIR: dist/oo-binaries
@@ -96,17 +97,32 @@ jobs:
           role-session-expiration: 1800
           audience: https://github.com/oomol-lab
 
+      - name: Cache rclone
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/rclone
+          key: rclone-${{ runner.os }}-${{ env.RCLONE_VERSION }}
+
       - name: Setup rclone
+        run: |
+          set -euo pipefail
+
+          if [ ! -x "$HOME/.local/bin/rclone" ]; then
+            mkdir -p "$HOME/.local/bin"
+            curl -fsSL "https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-amd64.zip" -o /tmp/rclone.zip
+            unzip -j /tmp/rclone.zip "rclone-${RCLONE_VERSION}-linux-amd64/rclone" -d "$HOME/.local/bin"
+            chmod +x "$HOME/.local/bin/rclone"
+          fi
+
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Configure rclone for OSS
         env:
           ALICLOUD_ACCESS_KEY_ID: ${{ steps.aliyun_credentials.outputs.aliyun-access-key-id }}
           ALICLOUD_ACCESS_KEY_SECRET: ${{ steps.aliyun_credentials.outputs.aliyun-access-key-secret }}
           ALICLOUD_SECURITY_TOKEN: ${{ steps.aliyun_credentials.outputs.aliyun-security-token }}
         run: |
           set -euo pipefail
-
-          if ! command -v rclone >/dev/null 2>&1; then
-            curl -fsSL https://rclone.org/install.sh | sudo bash
-          fi
 
           mkdir -p ~/.config/rclone
           cat > ~/.config/rclone/rclone.conf <<EOF

--- a/.github/workflows/upload-skill-install-guide-to-oss.yaml
+++ b/.github/workflows/upload-skill-install-guide-to-oss.yaml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 
 env:
+  RCLONE_VERSION: v1.69.1
   OSS_BUCKET: oomol-static-oversea-prod
   OSS_ENDPOINT: https://oss-ap-southeast-1.aliyuncs.com
   OSS_PREFIX: oo-cli/
@@ -38,17 +39,32 @@ jobs:
           role-session-expiration: 1800
           audience: https://github.com/oomol-lab
 
+      - name: Cache rclone
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/rclone
+          key: rclone-${{ runner.os }}-${{ env.RCLONE_VERSION }}
+
       - name: Setup rclone
+        run: |
+          set -euo pipefail
+
+          if [ ! -x "$HOME/.local/bin/rclone" ]; then
+            mkdir -p "$HOME/.local/bin"
+            curl -fsSL "https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-amd64.zip" -o /tmp/rclone.zip
+            unzip -j /tmp/rclone.zip "rclone-${RCLONE_VERSION}-linux-amd64/rclone" -d "$HOME/.local/bin"
+            chmod +x "$HOME/.local/bin/rclone"
+          fi
+
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Configure rclone for OSS
         env:
           ALICLOUD_ACCESS_KEY_ID: ${{ steps.aliyun_credentials.outputs.aliyun-access-key-id }}
           ALICLOUD_ACCESS_KEY_SECRET: ${{ steps.aliyun_credentials.outputs.aliyun-access-key-secret }}
           ALICLOUD_SECURITY_TOKEN: ${{ steps.aliyun_credentials.outputs.aliyun-security-token }}
         run: |
           set -euo pipefail
-
-          if ! command -v rclone >/dev/null 2>&1; then
-            curl -fsSL https://rclone.org/install.sh | sudo bash
-          fi
 
           mkdir -p ~/.config/rclone
           cat > ~/.config/rclone/rclone.conf <<EOF

--- a/contrib/ci/npm-packages.test.ts
+++ b/contrib/ci/npm-packages.test.ts
@@ -1,7 +1,7 @@
 import type { CompileSpawnResult } from "./npm-packages.ts";
-import { chmod, mkdir, readFile, rm } from "node:fs/promises";
+import { chmod, mkdir, readdir, readFile, rm } from "node:fs/promises";
 
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 import { createTemporaryDirectory } from "../../__tests__/helpers.ts";
@@ -364,6 +364,16 @@ describe("npm-packages", () => {
             expect(tarballPaths[0]).toContain("darwin-arm64");
             expect(tarballPaths[1]).toContain("win32-x64");
             expect(tarballPaths[2]).toContain("oo-cli-1.2.3.tgz");
+            expect(
+                tarballPaths.every(tarballPath =>
+                    dirname(tarballPath) === outDirectoryPath,
+                ),
+            ).toBeTrue();
+            expect(
+                (await readdir(outDirectoryPath)).some(entry =>
+                    entry.startsWith(".pack-"),
+                ),
+            ).toBeFalse();
 
             expect(
                 await readFile(join(outDirectoryPath, "npm-publish-order.txt"), "utf8"),

--- a/contrib/ci/npm-packages.ts
+++ b/contrib/ci/npm-packages.ts
@@ -1,5 +1,6 @@
 import { chmodSync, copyFileSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { mkdtemp, rename, rm } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import process from "node:process";
 
 import platformTargetsData from "../npm/platform-targets.json";
@@ -224,21 +225,11 @@ export async function assembleReleaseArtifacts(options: {
         releaseBuildOptions.stagingDir,
         options.targetIds,
     );
-    const tarballPaths: string[] = [];
 
     clearReleaseOutputDirectory(
         releaseBuildOptions.outDir,
         releaseBuildOptions.stagingDir,
     );
-
-    for (const target of selectedTargets) {
-        tarballPaths.push(
-            packPackage(
-                join(releaseBuildOptions.stagingDir, target.id),
-                releaseBuildOptions.outDir,
-            ),
-        );
-    }
 
     const wrapperDir = stageWrapperPackage({
         packageManifestContent: releaseBuildOptions.packageManifestContent,
@@ -246,7 +237,17 @@ export async function assembleReleaseArtifacts(options: {
         rootDir: releaseBuildOptions.rootDir,
         stagingDir: releaseBuildOptions.stagingDir,
     });
-    tarballPaths.push(packPackage(wrapperDir, releaseBuildOptions.outDir));
+    const packageDirs = [
+        ...selectedTargets.map(target =>
+            join(releaseBuildOptions.stagingDir, target.id),
+        ),
+        wrapperDir,
+    ];
+    const tarballPaths = unwrapPackResults(await Promise.allSettled(
+        packageDirs.map(packageDir =>
+            packPackage(packageDir, releaseBuildOptions.outDir),
+        ),
+    ));
 
     const releaseBundlePath = await createGitHubReleaseBundle({
         outDir: releaseBuildOptions.outDir,
@@ -589,27 +590,77 @@ export function buildCompileDefineArgs(
     ];
 }
 
-function packPackage(packageDir: string, outDir: string): string {
-    const packResult = Bun.spawnSync(
-        ["bun", "pm", "pack", "--destination", outDir, "--quiet"],
-        {
-            cwd: packageDir,
-            stderr: "pipe",
-            stdin: "ignore",
-            stdout: "pipe",
-        },
-    );
+async function packPackage(packageDir: string, outDir: string): Promise<string> {
+    const temporaryOutDir = await mkdtemp(join(outDir, ".pack-"));
 
-    if (packResult.exitCode !== 0) {
-        throw new Error(
-            [
-                `Failed to pack ${packageDir}.`,
-                decodeOutput(packResult.stderr),
-            ].join("\n"),
+    try {
+        const packResult = Bun.spawn(
+            ["bun", "pm", "pack", "--destination", temporaryOutDir, "--quiet"],
+            {
+                cwd: packageDir,
+                stderr: "pipe",
+                stdin: "ignore",
+                stdout: "pipe",
+            },
         );
+        const [exitCode, stdout, stderr] = await Promise.all([
+            packResult.exited,
+            new Response(packResult.stdout).text(),
+            new Response(packResult.stderr).text(),
+        ]);
+
+        if (exitCode !== 0) {
+            throw new Error(
+                [
+                    `Failed to pack ${packageDir}.`,
+                    stderr,
+                ].join("\n"),
+            );
+        }
+
+        const packedTarballPath = resolvePackedTarballPath(
+            stdout.trim(),
+            temporaryOutDir,
+            packageDir,
+        );
+        const tarballPath = join(outDir, basename(packedTarballPath));
+        await rename(packedTarballPath, tarballPath);
+
+        return tarballPath;
+    }
+    finally {
+        await rm(temporaryOutDir, { force: true, recursive: true });
+    }
+}
+
+function unwrapPackResults(
+    packResults: readonly PromiseSettledResult<string>[],
+): readonly string[] {
+    const tarballPaths: string[] = [];
+
+    for (const packResult of packResults) {
+        if (packResult.status === "rejected") {
+            throw packResult.reason;
+        }
+
+        tarballPaths.push(packResult.value);
     }
 
-    return decodeOutput(packResult.stdout).trim();
+    return tarballPaths;
+}
+
+function resolvePackedTarballPath(
+    packOutput: string,
+    temporaryOutDir: string,
+    packageDir: string,
+): string {
+    if (packOutput === "") {
+        throw new Error(`Failed to resolve packed tarball path for ${packageDir}.`);
+    }
+
+    return isAbsolute(packOutput)
+        ? packOutput
+        : join(temporaryOutDir, packOutput);
 }
 
 export function decodeOutput(


### PR DESCRIPTION
Replace the Win32-only Bun cache workaround and the unused Node.js setup in publish.yaml with a unified actions/cache keyed on OS, arch, bun.lock, and .bun-version; reduce checkout to fetch-depth: 1 and let deploy-install-worker run alongside upload-release-binaries instead of after it.

Pin rclone to v1.69.1 and cache the binary in both OSS upload workflows so the curl/unzip cost is paid once per cache key.

Rewrite packPackage to spawn `bun pm pack` asynchronously into a per-pack temp directory and use fs/promises throughout, so the Promise.allSettled over all platform packages plus the wrapper actually runs in parallel and concurrent packs cannot race on the shared destination.