### PR TITLE
ci: bump actions/cache and wrangler-action off Node.js 20

### DIFF
--- a/.github/workflows/deploy-install-worker.yaml
+++ b/.github/workflows/deploy-install-worker.yaml
@@ -52,7 +52,7 @@ jobs:
           cp contrib/install/install.sh "${asset_directory}/install.sh"
 
       - name: Deploy install worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -98,7 +98,7 @@ jobs:
           echo "BUN_INSTALL_CACHE_DIR=${{ github.workspace }}/.bun-install-cache" >> "$GITHUB_ENV"
 
       - name: Cache Bun install dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .bun-install-cache
           key: bun-install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock', '.bun-version') }}

--- a/.github/workflows/upload-release-binaries-to-oss.yaml
+++ b/.github/workflows/upload-release-binaries-to-oss.yaml
@@ -98,7 +98,7 @@ jobs:
           audience: https://github.com/oomol-lab
 
       - name: Cache rclone
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/bin/rclone
           key: rclone-${{ runner.os }}-${{ env.PINNED_RCLONE_VERSION }}

--- a/.github/workflows/upload-skill-install-guide-to-oss.yaml
+++ b/.github/workflows/upload-skill-install-guide-to-oss.yaml
@@ -40,7 +40,7 @@ jobs:
           audience: https://github.com/oomol-lab
 
       - name: Cache rclone
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/bin/rclone
           key: rclone-${{ runner.os }}-${{ env.PINNED_RCLONE_VERSION }}

--- a/contrib/ci/npm-publish.test.ts
+++ b/contrib/ci/npm-publish.test.ts
@@ -211,7 +211,10 @@ describe("npm publish workflow", () => {
                     readPackageMetadata: () => Promise.resolve(packageMetadata),
                 });
 
-                expect((await readFile(npmArgsPath, "utf8")).split("\n")).toEqual([
+                const recordedArgs = (await readFile(npmArgsPath, "utf8"))
+                    .replaceAll("\r\n", "\n")
+                    .split("\n");
+                expect(recordedArgs).toEqual([
                     "publish",
                     resolve("dist/demo.tgz"),
                     "--access",

--- a/contrib/cloudflare/oo-cli/deploy-install-worker.test.ts
+++ b/contrib/cloudflare/oo-cli/deploy-install-worker.test.ts
@@ -38,7 +38,7 @@ describe("install worker deployment", () => {
         expect(workflow).toContain("cp contrib/install/install.cmd");
         expect(workflow).toContain("cp contrib/install/install.ps1");
         expect(workflow).toContain("cp contrib/install/install.sh");
-        expect(workflow).toContain("uses: cloudflare/wrangler-action@v3");
+        expect(workflow).toContain("uses: cloudflare/wrangler-action@v4");
         expect(workflow).toContain("workingDirectory: contrib/cloudflare/oo-cli");
         expect(workflow).toContain("command: deploy");
     });


### PR DESCRIPTION
GitHub deprecated the Node.js 20 actions runtime: actions will be forced onto Node.js 24 on 2026-06-02 and Node.js 20 will be removed from the runner on 2026-09-16.

Upgrade actions/cache from v4 to v5 and cloudflare/wrangler-action from v3 to v4; both new majors run on node24. The wrangler-action v4 breaking change only flips the default wranglerVersion to 4, which the deploy-install-worker workflow already pins explicitly.