### PR TITLE
docs(install): add install guide for oo cli

### DIFF
--- a/.github/workflows/deploy-install-worker.yaml
+++ b/.github/workflows/deploy-install-worker.yaml
@@ -48,6 +48,7 @@ jobs:
           mkdir -p "${asset_directory}"
 
           cp contrib/install/install.cmd "${asset_directory}/install.cmd"
+          cp contrib/install/install-guide.md "${asset_directory}/install-guide.md"
           cp contrib/install/install.ps1 "${asset_directory}/install.ps1"
           cp contrib/install/install.sh "${asset_directory}/install.sh"
 

--- a/contrib/cloudflare/oo-cli/deploy-install-worker.test.ts
+++ b/contrib/cloudflare/oo-cli/deploy-install-worker.test.ts
@@ -7,7 +7,7 @@ const workflowPath = join(workerDirectoryPath, "..", "..", "..", ".github", "wor
 const wranglerConfigPath = join(workerDirectoryPath, "wrangler.jsonc");
 
 describe("install worker deployment", () => {
-    test("deploys the install scripts through the expected worker endpoints", async () => {
+    test("deploys the install assets through the expected worker endpoints", async () => {
         const wranglerConfig = await readFile(wranglerConfigPath, "utf8");
 
         expect(wranglerConfig).toContain("\"name\": \"oo-cli\"");
@@ -36,6 +36,7 @@ describe("install worker deployment", () => {
         expect(workflow).toContain("Prepare install worker assets");
         expect(workflow).toContain("asset_directory=\"dist/install-worker-assets\"");
         expect(workflow).toContain("cp contrib/install/install.cmd");
+        expect(workflow).toContain("cp contrib/install/install-guide.md");
         expect(workflow).toContain("cp contrib/install/install.ps1");
         expect(workflow).toContain("cp contrib/install/install.sh");
         expect(workflow).toContain("uses: cloudflare/wrangler-action@v4");

--- a/contrib/install/install-guide.md
+++ b/contrib/install/install-guide.md
@@ -1,0 +1,47 @@
+# OO CLI Install Guide
+
+Use this guide before running any `oo` command. It helps confirm whether the OO CLI is already available and provides the correct installation command for the current platform when needed.
+
+## 1. Check Whether OO CLI Is Available
+
+Run:
+
+```bash
+oo --version
+```
+
+If the command prints a version number, OO CLI is already installed and available. No additional installation is required.
+
+If the command is missing or cannot be found, install OO CLI using the command for the current platform.
+
+## 2. Install OO CLI
+
+### macOS / Linux
+
+```bash
+curl -fsSL https://cli.oomol.com/install.sh | bash
+```
+
+### Windows PowerShell
+
+```powershell
+irm https://cli.oomol.com/install.ps1 | iex
+```
+
+### Windows CMD
+
+```cmd
+curl -fsSL https://cli.oomol.com/install.cmd -o install.cmd && install.cmd && del install.cmd
+```
+
+If the installer updates `PATH` but `oo` is still unavailable in the current shell, open a new terminal and try again.
+
+## 3. Verify the Installation
+
+After installation, run:
+
+```bash
+oo --version
+```
+
+If the command prints a version number, OO CLI has been installed successfully.


### PR DESCRIPTION
Provide a short guide that explains how to verify whether the OO CLI is already installed and which installation command to use on each platform. Deploy the guide alongside the existing install scripts so it can be fetched from cli.oomol.com and referenced before running any oo command.