### PR TITLE
fix(connector): surface failing action name + safe diagnostics on HTTP errors

### DIFF
--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -975,7 +975,7 @@ describe("connectorCommand CLI", () => {
 
             expect(runResult.exitCode).toBe(1);
             expect(runResult.stderr).toContain(
-                "The connector action run request returned HTTP 404 (errorCode: action_not_found).",
+                "Connector action openai_image_async_result returned HTTP 404 (errorCode: action_not_found).",
             );
             expect(metadataRequestCount).toBe(1);
             expect(JSON.parse(schemaResult.stdout)).toMatchObject({
@@ -1396,7 +1396,7 @@ describe("connectorCommand CLI", () => {
             expect(result.exitCode).toBe(1);
             expect(result.stdout).toBe("");
             expect(result.stderr).toContain(
-                "The connector action run request returned HTTP 400 (errorCode: invalid_input): Invalid id value",
+                "Connector action get_message returned HTTP 400 (errorCode: invalid_input): Invalid id value",
             );
             expect(content).toContain(
                 "\"msg\":\"Connector action run request returned a non-success status.\"",
@@ -1405,6 +1405,10 @@ describe("connectorCommand CLI", () => {
             expect(content).toContain("\"errorCode\":\"invalid_input\"");
             expect(content).toContain("\"executionId\":\"exec-1\"");
             expect(content).not.toContain("\"responseBody\":");
+            // Always-on diagnostics are present even when structured fields exist.
+            expect(content).toContain("\"responseBodyLength\":");
+            // Preview is NOT included when structured fields are present.
+            expect(content).not.toContain("\"rawResponsePreview\":");
             expect(telemetryPayload).toMatchObject({
                 properties: {
                     action: "get_message",
@@ -1416,6 +1420,297 @@ describe("connectorCommand CLI", () => {
                     service: "gmail",
                 },
             });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("surfaces failing async poll action name and html body diagnostics on non-standard 500", async () => {
+        const sandbox = await createCliSandbox();
+        const originalSleep = Bun.sleep;
+
+        try {
+            Bun.sleep = ((_durationMs: number) => Promise.resolve()) as typeof Bun.sleep;
+
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(
+                sandbox,
+                {
+                    asyncLifecycle: {
+                        defaultRunMode: "wait",
+                        kind: "poll",
+                        poll: {
+                            action: "openai_image_async_result",
+                            handleInputField: "sessionID",
+                            handleOutputField: "sessionId",
+                            intervalSeconds: 3,
+                        },
+                        resultField: "data",
+                        state: {
+                            failure: ["not_found"],
+                            field: "state",
+                            running: ["processing"],
+                            success: ["completed"],
+                        },
+                    },
+                    description: "Submit OpenAI image generation.",
+                    inputSchema: {
+                        type: "object",
+                    },
+                    name: "openai_image_async_submit",
+                    outputSchema: {
+                        type: "object",
+                    },
+                    service: "fusion-api",
+                },
+            );
+
+            const result = await sandbox.run(
+                [
+                    "--debug",
+                    "connector",
+                    "run",
+                    "fusion-api",
+                    "-a",
+                    "openai_image_async_submit",
+                    "-d",
+                    "{\"prompt\":\"a cat\"}",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.endsWith("openai_image_async_submit")) {
+                            return new Response(JSON.stringify({
+                                data: {
+                                    sessionId: "session-1",
+                                },
+                                meta: {
+                                    executionId: "submit-exec",
+                                },
+                            }));
+                        }
+
+                        // Simulate a non-standard upstream 500: HTML body + trace headers,
+                        // no JSON failure schema match.
+                        return new Response(
+                            "<html><body>Internal Server Error</body></html>",
+                            {
+                                headers: {
+                                    "cf-ray": "abcdef1234-SJC",
+                                    "content-type": "text/html; charset=utf-8",
+                                    "x-request-id": "req-abc-123",
+                                },
+                                status: 500,
+                            },
+                        );
+                    },
+                },
+            );
+
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(1);
+            // The failing action is the poll action, not the submit action that the user typed.
+            expect(result.stderr).toContain(
+                "Connector action openai_image_async_result returned HTTP 500.",
+            );
+            // Debug log records the failing poll action.
+            expect(content).toContain("\"actionName\":\"openai_image_async_result\"");
+            // Safe bounded diagnostics:
+            expect(content).toContain("\"responseBodyLength\":");
+            expect(content).toContain("\"responseContentType\":\"text/html; charset=utf-8\"");
+            expect(content).toContain("\"x-request-id\":\"req-abc-123\"");
+            expect(content).toContain("\"cf-ray\":\"abcdef1234-SJC\"");
+            // No structured failure fields → preview IS included.
+            expect(content).toContain("\"rawResponsePreview\":");
+            expect(content).toContain("Internal Server Error");
+            // Full response body field never appears (legacy guarantee preserved).
+            expect(content).not.toContain("\"responseBody\":");
+        }
+        finally {
+            Bun.sleep = originalSleep;
+            await sandbox.cleanup();
+        }
+    });
+
+    test("emits responseBodyLength but no preview for empty 500 body", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(
+                sandbox,
+                {
+                    description: "Send a Gmail message.",
+                    inputSchema: {
+                        type: "object",
+                    },
+                    name: "send_mail",
+                    outputSchema: {
+                        type: "object",
+                    },
+                    service: "gmail",
+                },
+            );
+
+            const result = await sandbox.run(
+                [
+                    "--debug",
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{}",
+                ],
+                {
+                    fetcher: async () => new Response("", { status: 500 }),
+                },
+            );
+
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain(
+                "Connector action send_mail returned HTTP 500.",
+            );
+            expect(content).toContain("\"responseBodyLength\":0");
+            // Preview MUST NOT be emitted for empty bodies, even though there are
+            // no structured failure fields.
+            expect(content).not.toContain("\"rawResponsePreview\":");
+            expect(content).not.toContain("\"responseBody\":");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("emits truncated preview for non-schema JSON 500 body", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(
+                sandbox,
+                {
+                    description: "Send a Gmail message.",
+                    inputSchema: {
+                        type: "object",
+                    },
+                    name: "send_mail",
+                    outputSchema: {
+                        type: "object",
+                    },
+                    service: "gmail",
+                },
+            );
+
+            const oversizedDetail = "x".repeat(2000);
+            const result = await sandbox.run(
+                [
+                    "--debug",
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{}",
+                ],
+                {
+                    fetcher: async () => new Response(
+                        JSON.stringify({
+                            // Not the connector failure schema shape: no message /
+                            // errorCode / meta.executionId.
+                            detail: oversizedDetail,
+                            something: "else",
+                        }),
+                        {
+                            headers: {
+                                "content-type": "application/json",
+                            },
+                            status: 500,
+                        },
+                    ),
+                },
+            );
+
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain(
+                "Connector action send_mail returned HTTP 500.",
+            );
+            expect(content).toContain("\"responseBodyLength\":");
+            expect(content).toContain("\"responseContentType\":\"application/json\"");
+            expect(content).toContain("\"rawResponsePreview\":");
+            // The preview is truncated with a marker — full 2000-char body should not be in the log.
+            expect(content).not.toContain(oversizedDetail);
+            // Ensure the truncation marker is present.
+            expect(content).toContain("...\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("emits preview for empty-object failure body that matches the schema but has no useful fields", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(
+                sandbox,
+                {
+                    description: "Send a Gmail message.",
+                    inputSchema: {
+                        type: "object",
+                    },
+                    name: "send_mail",
+                    outputSchema: {
+                        type: "object",
+                    },
+                    service: "gmail",
+                },
+            );
+
+            const result = await sandbox.run(
+                [
+                    "--debug",
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{}",
+                ],
+                {
+                    fetcher: async () => new Response(
+                        JSON.stringify({}),
+                        {
+                            headers: {
+                                "content-type": "application/json",
+                            },
+                            status: 500,
+                        },
+                    ),
+                },
+            );
+
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain(
+                "Connector action send_mail returned HTTP 500.",
+            );
+            // Schema parsed successfully but no useful fields → still include preview.
+            expect(content).toContain("\"rawResponsePreview\":\"{}\"");
+            expect(content).toContain("\"responseBodyLength\":2");
         }
         finally {
             await sandbox.cleanup();
@@ -1829,7 +2124,7 @@ describe("connectorCommand CLI", () => {
 
             expect(runResult.exitCode).toBe(1);
             expect(runResult.stderr).toContain(
-                "The connector action run request returned HTTP 404 (errorCode: action_not_found).",
+                "Connector action send_mail returned HTTP 404 (errorCode: action_not_found).",
             );
             expect(metadataRequestCount).toBe(1);
             expect(JSON.parse(schemaResult.stdout)).toMatchObject({

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -210,6 +210,7 @@ describe("connector shared requests", () => {
 
         expect(error.key).toBe("errors.connectorRun.requestFailedWithCode");
         expect(error.params).toEqual({
+            action: "send_mail",
             errorCode: "invalid_input",
             status: 400,
         });

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -1,5 +1,6 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 
+import { Buffer } from "node:buffer";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { withRequestTarget } from "../../logging/log-fields.ts";
@@ -322,10 +323,16 @@ export async function runConnectorAction(
 
         if (!response.ok) {
             const failureResponse = parseConnectorFailureResponse(rawResponse);
+            const responseDiagnostics = collectSafeConnectorFailureDiagnostics(
+                response,
+                rawResponse,
+                failureResponse,
+            );
 
             context.logger.warn(
                 {
                     ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+                    ...responseDiagnostics,
                     actionName: options.actionName,
                     durationMs,
                     errorCode: failureResponse?.errorCode,
@@ -340,10 +347,11 @@ export async function runConnectorAction(
                 "Connector action run request returned a non-success status.",
             );
 
-            throw createConnectorRunRequestFailedError(
-                response.status,
+            throw createConnectorRunRequestFailedError({
+                actionName: options.actionName,
                 failureResponse,
-            );
+                status: response.status,
+            });
         }
 
         context.logger.debug(
@@ -416,6 +424,102 @@ function parseConnectorFailureResponse(
     }
 }
 
+const safeResponseHeaderNames = [
+    "x-request-id",
+    "x-amzn-requestid",
+    "x-amzn-trace-id",
+    "x-correlation-id",
+    "cf-ray",
+    "trace-id",
+    "x-trace-id",
+] as const;
+
+const rawResponsePreviewMaxLength = 1000;
+
+const responsePreviewWhitespacePattern = /[\r\n\t]/g;
+// eslint-disable-next-line no-control-regex
+const responsePreviewControlCharsPattern = /[\x00-\x08\x0B-\x1F\x7F]/g;
+
+interface SafeConnectorFailureDiagnostics {
+    rawResponsePreview?: string;
+    responseBodyLength: number;
+    responseContentType?: string;
+    responseHeaders?: Record<string, string>;
+}
+
+/**
+ * Returns safe, bounded diagnostics for a non-success connector response.
+ *
+ * Always-on fields:
+ * - `responseBodyLength` (UTF-8 byte count of the response body)
+ * - `responseContentType` (when the response has a `Content-Type` header)
+ * - `responseHeaders` (a whitelisted subset of trace / request-id headers)
+ *
+ * Conditional `rawResponsePreview`:
+ * - Only emitted when the structured `connectorActionFailureResponseSchema`
+ *   yielded no usable fields (all of `message`, `errorCode`,
+ *   `meta.executionId` are absent or empty) AND the body is non-empty.
+ * - Bounded to {@link rawResponsePreviewMaxLength} characters with a `...`
+ *   marker; CR / LF / tab are folded to spaces and other ASCII control
+ *   characters are stripped to keep log output single-line and readable.
+ *
+ * Why preview is conditional: when the failure body matches the structured
+ * schema, `message` / `errorCode` / `executionId` already carry the safe
+ * subset of the response. Logging the raw preview anyway would expand the
+ * sensitive surface (prompts, signed URLs, payload echoes) without adding
+ * diagnostic value.
+ */
+function collectSafeConnectorFailureDiagnostics(
+    response: Response,
+    rawResponse: string,
+    failureResponse: ConnectorActionFailureResponse | undefined,
+): SafeConnectorFailureDiagnostics {
+    const diagnostics: SafeConnectorFailureDiagnostics = {
+        responseBodyLength: Buffer.byteLength(rawResponse, "utf8"),
+    };
+
+    const contentType = response.headers.get("content-type");
+    if (contentType !== null && contentType !== "") {
+        diagnostics.responseContentType = contentType;
+    }
+
+    const responseHeaders: Record<string, string> = {};
+    for (const headerName of safeResponseHeaderNames) {
+        const value = response.headers.get(headerName);
+        if (value !== null && value !== "") {
+            responseHeaders[headerName] = value;
+        }
+    }
+    if (Object.keys(responseHeaders).length > 0) {
+        diagnostics.responseHeaders = responseHeaders;
+    }
+
+    const hasStructuredFailureFields = isNonEmptyString(failureResponse?.message)
+        || isNonEmptyString(failureResponse?.errorCode)
+        || isNonEmptyString(failureResponse?.meta?.executionId);
+
+    if (rawResponse.length > 0 && !hasStructuredFailureFields) {
+        diagnostics.rawResponsePreview = createBoundedResponsePreview(rawResponse);
+    }
+
+    return diagnostics;
+}
+
+function createBoundedResponsePreview(rawResponse: string): string {
+    const flattened = rawResponse.replaceAll(responsePreviewWhitespacePattern, " ");
+    const stripped = flattened.replaceAll(responsePreviewControlCharsPattern, "");
+
+    if (stripped.length <= rawResponsePreviewMaxLength) {
+        return stripped;
+    }
+
+    return `${stripped.slice(0, rawResponsePreviewMaxLength)}...`;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+    return typeof value === "string" && value.length > 0;
+}
+
 function sanitizeConnectorFailureMessage(
     message: string | undefined,
 ): string | undefined {
@@ -433,17 +537,18 @@ function sanitizeConnectorFailureMessage(
     return `${singleLineMessage.slice(0, maxLength)}...`;
 }
 
-function createConnectorRunRequestFailedError(
-    status: number,
-    failureResponse: ConnectorActionFailureResponse | undefined,
-): CliUserError {
-    const responseMessage = failureResponse?.message;
-    const errorCode = failureResponse?.errorCode;
+function createConnectorRunRequestFailedError(options: {
+    actionName: string;
+    failureResponse: ConnectorActionFailureResponse | undefined;
+    status: number;
+}): CliUserError {
+    const responseMessage = options.failureResponse?.message;
+    const errorCode = options.failureResponse?.errorCode;
 
     if (isInsufficientCreditFailure({
         errorCode,
         message: responseMessage,
-        status,
+        status: options.status,
     })) {
         return createInsufficientCreditError();
     }
@@ -454,9 +559,10 @@ function createConnectorRunRequestFailedError(
                 "errors.connectorRun.requestFailedWithMessageAndCode",
                 1,
                 {
+                    action: options.actionName,
                     errorCode,
                     message: responseMessage,
-                    status,
+                    status: options.status,
                 },
             );
         }
@@ -465,8 +571,9 @@ function createConnectorRunRequestFailedError(
             "errors.connectorRun.requestFailedWithMessage",
             1,
             {
+                action: options.actionName,
                 message: responseMessage,
-                status,
+                status: options.status,
             },
         );
     }
@@ -476,13 +583,15 @@ function createConnectorRunRequestFailedError(
             "errors.connectorRun.requestFailedWithCode",
             1,
             {
+                action: options.actionName,
                 errorCode,
-                status,
+                status: options.status,
             },
         );
     }
 
     return new CliUserError("errors.connectorRun.requestFailed", 1, {
-        status,
+        action: options.actionName,
+        status: options.status,
     });
 }

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -328,13 +328,13 @@ export const enMessages = {
     "errors.connectorRun.requestError":
         "The connector action run request failed: {message}",
     "errors.connectorRun.requestFailed":
-        "The connector action run request returned HTTP {status}.",
+        "Connector action {action} returned HTTP {status}.",
     "errors.connectorRun.requestFailedWithCode":
-        "The connector action run request returned HTTP {status} (errorCode: {errorCode}).",
+        "Connector action {action} returned HTTP {status} (errorCode: {errorCode}).",
     "errors.connectorRun.requestFailedWithMessage":
-        "The connector action run request returned HTTP {status}: {message}",
+        "Connector action {action} returned HTTP {status}: {message}",
     "errors.connectorRun.requestFailedWithMessageAndCode":
-        "The connector action run request returned HTTP {status} (errorCode: {errorCode}): {message}",
+        "Connector action {action} returned HTTP {status} (errorCode: {errorCode}): {message}",
     "errors.connectorSchema.asyncPollSchemaMissing":
         "The async connector action poll schema is missing for action {action}.",
     "errors.connectorSchema.asyncResultSchemaMissing":
@@ -1272,13 +1272,13 @@ export const zhMessages = {
     "errors.connectorRun.requestError":
         "运行 connector action 失败：{message}",
     "errors.connectorRun.requestFailed":
-        "运行 connector action 返回了 HTTP {status}。",
+        "Connector action {action} 返回了 HTTP {status}。",
     "errors.connectorRun.requestFailedWithCode":
-        "运行 connector action 返回了 HTTP {status}（errorCode: {errorCode}）。",
+        "Connector action {action} 返回了 HTTP {status}（errorCode: {errorCode}）。",
     "errors.connectorRun.requestFailedWithMessage":
-        "运行 connector action 返回了 HTTP {status}：{message}",
+        "Connector action {action} 返回了 HTTP {status}：{message}",
     "errors.connectorRun.requestFailedWithMessageAndCode":
-        "运行 connector action 返回了 HTTP {status}（errorCode: {errorCode}）：{message}",
+        "Connector action {action} 返回了 HTTP {status}（errorCode: {errorCode}）：{message}",
     "errors.connectorSchema.asyncPollSchemaMissing":
         "异步 connector action 缺少 action {action} 的轮询 schema。",
     "errors.connectorSchema.asyncResultSchemaMissing":


### PR DESCRIPTION
Fixes #214.

## Summary

When an async connector lifecycle polling action fails with a non-success HTTP status, the user-facing error previously collapsed to a generic `"The connector action run request returned HTTP {status}"`, giving no signal which action actually failed. For async lifecycles the user types the submit action name (e.g. `openai_image_async_submit`) but the poll action (`openai_image_async_result`) is what fails — stderr lost this distinction.

The debug log also lost all diagnostic value when the failure body did not match the structured `connectorActionFailureResponseSchema` (empty body, HTML error pages, nginx / cloudflare passthroughs, non-schema JSON): `errorCode` / `responseMessage` / `executionId` were all undefined and no response metadata was recorded.

## Changes (no service-side changes)

### Part A: User-facing error includes action name

- `createConnectorRunRequestFailedError(options: { actionName, status, failureResponse })` threads `action` into all four i18n params.
- 4 i18n keys (EN + ZH) rewritten to lead with the action name:
  ```
  Connector action {action} returned HTTP {status}.
  Connector action {action} returned HTTP {status} (errorCode: {errorCode}).
  Connector action {action} returned HTTP {status}: {message}
  Connector action {action} returned HTTP {status} (errorCode: {errorCode}): {message}
  ```

Async lifecycle calls already pass `lifecycle.poll.action` into `runConnectorAction` — no wrapper layer needed; submit, poll, and future follow-up actions all surface their own names.

### Part B: Safe bounded debug diagnostics

New `collectSafeConnectorFailureDiagnostics(response, rawResponse, failureResponse)` helper returns:

| Field | When emitted |
| --- | --- |
| `responseBodyLength` (UTF-8 byte count) | always |
| `responseContentType` | always (when header present) |
| `responseHeaders` | always (whitelist of 7 lower-case trace/request-id headers: `x-request-id`, `x-amzn-requestid`, `x-amzn-trace-id`, `x-correlation-id`, `cf-ray`, `trace-id`, `x-trace-id`; only emitted when ≥1 matches) |
| `rawResponsePreview` | only when `!hasStructuredFailureFields` AND `rawResponse.length > 0`; bounded to 1000 chars + `...`; CR/LF/\t folded to spaces; other ASCII control chars stripped |

`hasStructuredFailureFields` is true when any of `failureResponse.message`, `failureResponse.errorCode`, `failureResponse.meta.executionId` is a non-empty string.

**Why preview is conditional**: when the schema matched and yielded usable fields, those fields already carry the safe subset of the response. Logging the raw preview anyway would expand the sensitive surface (prompts, signed URLs, payload echoes) without adding diagnostic value. Full `responseBody` is still never logged, preserving the existing privacy contract.

## Test plan

- [x] Updated 3 existing CLI assertions (line 978 / 1399 / 1832) to include the action name in the user-facing error.
- [x] Enhanced existing structured-400 test: asserts `responseBodyLength` is always present and `rawResponsePreview` is omitted when `message`/`errorCode`/`executionId` are populated.
- [x] **Added 4 new CLI tests**:
  - **async poll 500 + text/html body + trace headers** — stderr names the **poll** action; log records content-type, body length, `x-request-id`, `cf-ray`, and a preview containing "Internal Server Error". This is the exact issue #214 scenario.
  - **empty 500 body** — `responseBodyLength=0` and NO preview.
  - **non-schema JSON 500 body (oversized detail field)** — preview is truncated with `...` marker; full body never appears.
  - **empty-object `{}` body that matches the schema but has no useful fields** — preview IS emitted (covers the conditional-preview gating criterion).
- [x] `shared.test.ts`: structured 400 error params updated to include `action`.
- [x] Full repo `bun test`: 1051 passed / 4 skipped / 0 failed.
- [x] `bun run lint` clean.
- [x] `bunx tsc --noEmit` clean.

## Convergence

Plan converged with @codex-coder in a cross-review pass before implementation. Key design points (preview conditional gating, header whitelist of 7, Buffer.byteLength for UTF-8 byte count, lower-case header normalization) were jointly signed off.

## Out of scope

- `searchConnectorActions` / `getConnectorActionMetadata` / `listAuthenticatedConnectorServices` — not the issue's report path, avoided scope creep.
- Telemetry payload — kept minimal (no body/preview).
- Env-flag to log full body — issue explicitly wants bounded-by-default.