### PR TITLE
refactor: skill publishing and sharing commands

### DIFF
--- a/contrib/skills/claude/oo-publish-skill/SKILL.md
+++ b/contrib/skills/claude/oo-publish-skill/SKILL.md
@@ -46,18 +46,16 @@ Ask for the missing skill id or skill directory path only when needed:
 
 - skill id or path to a skill directory
 
-Choose the command shape from the source:
+Publish accepts a concrete path:
 
 ```bash
-oo skills publish <skill-id> --agent <agent>
-oo skills publish <path-to-skill-directory>
+oo skills publish <path-to-skill-directory-or-SKILL.md>
 ```
 
-When publishing by skill id, include `--agent <agent>`. Choose `<agent>`
-yourself from the supported ids according to the current host: `codex`,
-`claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`, or
-`qoderwork`. Do not ask the user just to choose this source agent. When
-publishing by filesystem path, pass the path directly and omit `--agent`.
+If the user gives only a skill id, `oo skills locate <skill-id> --agent <agent>`
+can help resolve the local path. Choose `<agent>` yourself from the supported
+ids according to the current host. Use locate when it is helpful, but do not
+force an extra locate step when the path is already clear from context.
 
 The publish command performs its own environment, authentication, and account
 checks, so run it directly.
@@ -73,14 +71,10 @@ resolves the account and asks any necessary ownership questions itself.
 Run the publish command directly:
 
 ```bash
-oo skills publish my-skill --agent claude
 oo skills publish ./my-skill
-oo skills publish my-skill --agent claude --visibility public
+oo skills publish /path/to/my-skill/SKILL.md
+oo skills publish ./my-skill --visibility public
 ```
-
-If this shared skill file is running in Hermes, CodeBuddy, WorkBuddy, Trae,
-OpenClaw, QoderWork, or Codex instead of Claude Code, replace `claude` with that
-host id from the supported list.
 
 If the command prompts about publishing a registry-installed skill under the
 active account or overwriting an existing remote package, let that prompt drive

--- a/contrib/skills/codebuddy/oo-publish-skill/SKILL.md
+++ b/contrib/skills/codebuddy/oo-publish-skill/SKILL.md
@@ -45,18 +45,16 @@ Ask for the missing skill id or skill directory path only when needed:
 
 - skill id or path to a skill directory
 
-Choose the command shape from the source:
+Publish accepts a concrete path:
 
 ```bash
-oo skills publish <skill-id> --agent <agent>
-oo skills publish <path-to-skill-directory>
+oo skills publish <path-to-skill-directory-or-SKILL.md>
 ```
 
-When publishing by skill id, include `--agent <agent>`. Choose `<agent>`
-yourself from the supported ids according to the current host: `codex`,
-`claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`, or
-`qoderwork`. Do not ask the user just to choose this source agent. When
-publishing by filesystem path, pass the path directly and omit `--agent`.
+If the user gives only a skill id, `oo skills locate <skill-id> --agent <agent>`
+can help resolve the local path. Choose `<agent>` yourself from the supported
+ids according to the current host. Use locate when it is helpful, but do not
+force an extra locate step when the path is already clear from context.
 
 The publish command performs its own environment, authentication, and account
 checks, so run it directly.
@@ -72,14 +70,10 @@ resolves the account and asks any necessary ownership questions itself.
 Run the publish command directly:
 
 ```bash
-oo skills publish my-skill --agent codebuddy
 oo skills publish ./my-skill
-oo skills publish my-skill --agent codebuddy --visibility public
+oo skills publish /path/to/my-skill/SKILL.md
+oo skills publish ./my-skill --visibility public
 ```
-
-If this shared skill file is running in WorkBuddy or Trae, replace `codebuddy`
-with `workbuddy` or `trae`. If it is running in another supported host, choose
-that host id from the supported list.
 
 If the command prompts about publishing a registry-installed skill under the
 active account or overwriting an existing remote package, let that prompt drive

--- a/contrib/skills/codex/oo-publish-skill/SKILL.md
+++ b/contrib/skills/codex/oo-publish-skill/SKILL.md
@@ -45,15 +45,15 @@ Ask for the missing skill id or skill directory path only when needed:
 
 - skill id or path to a skill directory
 
-Choose the command shape from the source:
+Publish accepts a concrete path:
 
 ```bash
-oo skills publish <skill-id> --agent codex
-oo skills publish <path-to-skill-directory>
+oo skills publish <path-to-skill-directory-or-SKILL.md>
 ```
 
-When publishing by skill id from Codex, include `--agent codex`. When publishing
-by filesystem path, pass the path directly and omit `--agent`.
+If the user gives only a skill id, `oo skills locate <skill-id> --agent codex`
+can help resolve the local path. Use it when it is helpful, but do not force an
+extra locate step when the path is already clear from context.
 
 The publish command performs its own environment, authentication, and account
 checks, so run it directly.
@@ -69,9 +69,9 @@ resolves the account and asks any necessary ownership questions itself.
 Run the publish command directly:
 
 ```bash
-oo skills publish my-skill --agent codex
 oo skills publish ./my-skill
-oo skills publish my-skill --agent codex --visibility public
+oo skills publish /path/to/my-skill/SKILL.md
+oo skills publish ./my-skill --visibility public
 ```
 
 If the command prompts about publishing a registry-installed skill under the

--- a/contrib/skills/openclaw/oo-publish-skill/SKILL.md
+++ b/contrib/skills/openclaw/oo-publish-skill/SKILL.md
@@ -45,18 +45,16 @@ Ask for the missing skill id or skill directory path only when needed:
 
 - skill id or path to a skill directory
 
-Choose the command shape from the source:
+Publish accepts a concrete path:
 
 ```bash
-oo skills publish <skill-id> --agent <agent>
-oo skills publish <path-to-skill-directory>
+oo skills publish <path-to-skill-directory-or-SKILL.md>
 ```
 
-When publishing by skill id, include `--agent <agent>`. Choose `<agent>`
-yourself from the supported ids according to the current host: `codex`,
-`claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`, or
-`qoderwork`. Do not ask the user just to choose this source agent. When
-publishing by filesystem path, pass the path directly and omit `--agent`.
+If the user gives only a skill id, `oo skills locate <skill-id> --agent <agent>`
+can help resolve the local path. Choose `<agent>` yourself from the supported
+ids according to the current host. Use locate when it is helpful, but do not
+force an extra locate step when the path is already clear from context.
 
 The publish command performs its own environment, authentication, and account
 checks, so run it directly.
@@ -72,9 +70,9 @@ resolves the account and asks any necessary ownership questions itself.
 Run the publish command directly:
 
 ```bash
-oo skills publish my-skill --agent openclaw
 oo skills publish ./my-skill
-oo skills publish my-skill --agent openclaw --visibility public
+oo skills publish /path/to/my-skill/SKILL.md
+oo skills publish ./my-skill --visibility public
 ```
 
 If this shared skill file is running in another supported host, replace

--- a/contrib/skills/qoderwork/oo-publish-skill/SKILL.md
+++ b/contrib/skills/qoderwork/oo-publish-skill/SKILL.md
@@ -45,18 +45,16 @@ Ask for the missing skill id or skill directory path only when needed:
 
 - skill id or path to a skill directory
 
-Choose the command shape from the source:
+Publish accepts a concrete path:
 
 ```bash
-oo skills publish <skill-id> --agent <agent>
-oo skills publish <path-to-skill-directory>
+oo skills publish <path-to-skill-directory-or-SKILL.md>
 ```
 
-When publishing by skill id, include `--agent <agent>`. Choose `<agent>`
-yourself from the supported ids according to the current host: `codex`,
-`claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `openclaw`, or
-`qoderwork`. Do not ask the user just to choose this source agent. When
-publishing by filesystem path, pass the path directly and omit `--agent`.
+If the user gives only a skill id, `oo skills locate <skill-id> --agent <agent>`
+can help resolve the local path. Choose `<agent>` yourself from the supported
+ids according to the current host. Use locate when it is helpful, but do not
+force an extra locate step when the path is already clear from context.
 
 The publish command performs its own environment, authentication, and account
 checks, so run it directly.
@@ -72,9 +70,9 @@ resolves the account and asks any necessary ownership questions itself.
 Run the publish command directly:
 
 ```bash
-oo skills publish my-skill --agent qoderwork
 oo skills publish ./my-skill
-oo skills publish my-skill --agent qoderwork --visibility public
+oo skills publish /path/to/my-skill/SKILL.md
+oo skills publish ./my-skill --visibility public
 ```
 
 If this shared skill file is running in another supported host, replace

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -491,6 +491,28 @@ requested.
 - Notes: when a folded skill is installed in multiple supported hosts, the
   `Host` field lists all matching hosts.
 
+### `oo skills locate <skill-id>`
+
+Print the local path for an installed skill.
+
+- Arguments: `<skill-id>` is the directory name to locate under supported
+  skill roots. Path-shaped values are rejected; pass paths directly to
+  `oo skills publish`.
+- Options: `--agent <agent>` narrows the scan to one supported agent:
+  `codex`, `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `trae-cn`,
+  `openclaw`, `qoderwork`, or `deepseek-tui`.
+- Resolution: with `--agent`, the command checks only that agent's
+  `<agent-home>/skills/<skill-id>` path. Without `--agent`, it checks all
+  available supported agent skill roots plus canonical registry storage under
+  `<config-dir>/skills/registry/<skill-id>`.
+- Match rule: a candidate matches when it contains `SKILL.md`. The command does
+  not validate skill frontmatter or `.oo-metadata.json`; publish performs that
+  validation.
+- Output: when exactly one candidate matches, stdout is that path plus a
+  newline. When no candidates match, or multiple candidates match, the command
+  exits non-zero. Ambiguous errors list the candidate paths and tell callers to
+  pass `--agent` or publish one path directly.
+
 ### `oo skills preflight`
 
 Check whether this environment has permission to author local skills for one
@@ -555,39 +577,29 @@ Validate a local skill directory against the generic skill contract.
 - Output: on success, the command prints a concise success message. On failure,
   it prints the validation error and exits non-zero.
 
-### `oo skills publish <skill-id>`
+### `oo skills publish <path>`
 
 Convert one skill into an OOMOL package and run the publish step.
 
-- Arguments: `<skill-id>` is normally a skill id. When no managed skill matches,
-  it may also be a path to a skill directory containing `SKILL.md`. Relative
-  paths resolve from the current working directory.
+- Arguments: `<path>` must be a skill directory containing `SKILL.md`, or the
+  `SKILL.md` file itself. Relative paths resolve from the current working
+  directory. Bare skill ids are not resolved by this command; use
+  `oo skills locate <skill-id>` first when needed.
 - Options: `--visibility <visibility>` sets the registry package visibility.
   Accepted values are `private` and `public`. When omitted, an existing package
   keeps its current registry visibility. If no existing visibility can be read,
   an interactive terminal prompts for `private` or `public`.
-- Options: `--agent <agent>` selects one agent-native local skill when the same
-  local skill id exists in multiple agents. Accepted values are `codex`,
-  `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`, `trae-cn`, `openclaw`,
-  `qoderwork`, and `deepseek-tui`.
 - Options: `-y, --yes` answers publish confirmation prompts with yes.
 - Options: `--force` is accepted for compatibility with older workflows.
-- Source resolution: skill ids first match oo-managed local skills in supported
-  agent skill directories. If exactly one local match exists, that directory is
-  published in place. If multiple local matches exist, the command exits
-  non-zero and requires `--agent`.
-- Source resolution: bundled skills are rejected because they are managed by the
-  oo CLI release.
-- Source resolution: registry skills under
-  `<config-dir>/skills/registry/<skill-id>` can be published. When the installed
-  metadata contains a scoped package name, that package name is used as the
-  target. If no scoped package name is available and the installed metadata
-  package name differs from the target package name, an interactive `[y/N]`
-  confirmation is required before publishing under the current account scope
-  unless `-y, --yes` is provided.
-- Source resolution: when no local, bundled, or registry source matched, the
-  argument is resolved as a filesystem path. A matching skill directory is
-  published in place.
+- Source resolution: `.oo-metadata.json` determines whether the path is an
+  oo-managed local skill, an oo-managed registry skill, or an unmanaged path
+  source. Invalid oo metadata fails before publishing. Bundled skills are
+  rejected because they are managed by the oo CLI release.
+- Registry source resolution: when the path has registry metadata with a scoped
+  package name, that package name is used as the target. If no scoped package
+  name is available and the installed metadata package name differs from the
+  target package name, an interactive `[y/N]` confirmation is required before
+  publishing under the current account scope unless `-y, --yes` is provided.
 - Authentication: the command requires the current OOMOL account. If the source
   has an existing scoped `metadata.packageName`, that package name is preserved;
   otherwise the package name is `@<lowercase-account.name>/<lowercase-skill-id>`.
@@ -617,9 +629,13 @@ Convert one skill into an OOMOL package and run the publish step.
 - Version resolution: if the requested version is not greater than the latest
   remote package version, the command publishes the next patch version.
 - Writeback: after the publish step succeeds, `SKILL.md` frontmatter is updated
-  with the final `metadata.packageName` and `metadata.version`. Agent-native
-  local sources keep local ownership metadata; registry sources keep registry
-  ownership metadata.
+  with the final `metadata.packageName` and `metadata.version`.
+- Registry writeback: after publishing an oo-managed registry skill, the command
+  updates registry ownership metadata. If the source path is not canonical
+  registry storage, it replaces `<config-dir>/skills/registry/<skill-id>` with
+  the published source, then copies canonical storage to every available
+  supported agent. If no supported agent home is available, publish and
+  canonical writeback still succeed.
 - Output: on success, text output prints the skill id, final package specifier,
   selected visibility (`private` or `public`), and the Hub package URL
   for the current account endpoint, for example

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -430,6 +430,25 @@ registry skills。
 - 说明：如果折叠后的 skill 安装在多个受支持 Agent 中，`Host` 字段会列出所有匹配的
   Agent。
 
+### `oo skills locate <skill-id>`
+
+输出已安装 skill 的本地路径。
+
+- 参数：`<skill-id>` 是要在受支持 skill 根目录下定位的目录名。路径形式的值会被拒绝；
+  如需传路径，请直接传给 `oo skills publish`。
+- 选项：`--agent <agent>` 将扫描范围限制为一个受支持 Agent：`codex`、
+  `claude`、`hermes`、`codebuddy`、`workbuddy`、`trae`、`trae-cn`、
+  `openclaw`、`qoderwork` 或 `deepseek-tui`。
+- 解析：传入 `--agent` 时，命令只检查该 Agent 的
+  `<agent-home>/skills/<skill-id>`。未传入 `--agent` 时，命令会检查所有可用的受
+  支持 Agent skill 根目录，以及 `<config-dir>/skills/registry/<skill-id>` 下的
+  canonical registry 存储。
+- 匹配规则：候选目录只要包含 `SKILL.md` 就视为匹配。命令不会校验 skill
+  frontmatter 或 `.oo-metadata.json`；这些校验由 publish 负责。
+- 输出：恰好匹配一个候选时，stdout 输出该路径并换行。没有候选或匹配多个候选时，
+  命令以非零状态退出。歧义错误会列出候选路径，并提示调用方传入 `--agent` 或直接
+  发布某个路径。
+
 ### `oo skills preflight`
 
 检查当前环境是否有权限为一个 Agent 创建本地 skills。
@@ -482,31 +501,25 @@ registry skills。
 - 警告：缺少 `metadata.icon` 或 `metadata.title` 会打印 warning，但不会导致校验失败。
 - 输出：成功时命令会打印简短成功消息。失败时打印校验错误并以非零状态退出。
 
-### `oo skills publish <skill-id>`
+### `oo skills publish <path>`
 
 将一个 skill 转换为 OOMOL 包，并执行发布步骤。
 
-- 参数：`<skill-id>` 通常是 skill id。当没有匹配到由 oo 管理的 skill 时，也可以
-  是包含 `SKILL.md` 的 skill 目录路径。相对路径会从当前工作目录解析。
+- 参数：`<path>` 必须是包含 `SKILL.md` 的 skill 目录，或 `SKILL.md` 文件本身。
+  相对路径会从当前工作目录解析。该命令不解析裸 skill id；需要时请先使用
+  `oo skills locate <skill-id>`。
 - 选项：`--visibility <visibility>` 设置 registry 包可见性。可选值为
   `private` 和 `public`。省略时，已有包会沿用当前 registry 可见性。如果无法读取
   已有可见性，交互式终端会询问发布为 `private` 还是 `public`。
-- 选项：`--agent <agent>` 用于当多个 Agent 中存在同名 local skill 时选择其中一个。
-  可选值为 `codex`、`claude`、`hermes`、`codebuddy`、`workbuddy`、`trae`、
-  `trae-cn`、`openclaw`、`qoderwork` 和 `deepseek-tui`。
 - 选项：`-y, --yes` 会对发布过程中的确认提示自动回答 yes。
 - 选项：`--force` 为兼容旧流程保留。
-- 来源解析：skill id 会先匹配受支持 Agent skill 目录中的 oo-managed local skill。
-  如果恰好匹配一个 local skill，则原地发布该目录；如果匹配多个，则命令以非零状态
-  退出并要求传入 `--agent`。
-- 来源解析：内置 skill 会被拒绝发布，因为它们由 oo CLI 版本管理。
-- 来源解析：可以发布 `<config-dir>/skills/registry/<skill-id>` 下的 registry
-  skill。如果已安装元数据中包含带 scope 的包名，命令会使用该包名作为目标。
-  如果没有可用的带 scope 包名，且已安装元数据中的包名和目标包名不同，命令会使用
-  交互式 `[y/N]` 确认，再将它发布到当前账号 scope 下；提供 `-y, --yes` 时会跳过
-  该确认。
-- 来源解析：如果没有匹配到 local、bundled 或 registry 来源，参数会按文件系统路径
-  解析。匹配到的 skill 目录会原地发布。
+- 来源解析：`.oo-metadata.json` 决定该路径是 oo-managed local skill、
+  oo-managed registry skill，还是 unmanaged path 来源。无效的 oo metadata 会在发布
+  前失败。内置 skill 会被拒绝发布，因为它们由 oo CLI 版本管理。
+- Registry 来源解析：如果路径的 registry metadata 中包含带 scope 的包名，命令会
+  使用该包名作为目标。如果没有可用的带 scope 包名，且已安装元数据中的包名和目标包
+  名不同，命令会使用交互式 `[y/N]` 确认，再将它发布到当前账号 scope 下；提供
+  `-y, --yes` 时会跳过该确认。
 - 认证：命令要求存在当前 OOMOL 账号。如果来源已有带 scope 的
   `metadata.packageName`，会保留该包名；否则包名为
   `@<小写 account.name>/<小写 skill-id>`。
@@ -530,8 +543,11 @@ registry skills。
   非交互式运行必须传入 `--visibility`。
 - 版本解析：如果请求版本不大于远端 latest 包版本，命令会发布下一个 patch 版本。
 - 回写：发布步骤成功后，命令会把最终的 `metadata.packageName` 和
-  `metadata.version` 写回 `SKILL.md` frontmatter。agent-native local 来源会保留
-  local 所有权 metadata；registry 来源会保留 registry 所有权 metadata。
+  `metadata.version` 写回 `SKILL.md` frontmatter。
+- Registry 回写：发布 oo-managed registry skill 后，命令会更新 registry 所有权
+  metadata。如果来源路径不是 canonical registry 存储，会先用已发布来源替换
+  `<config-dir>/skills/registry/<skill-id>`，然后将 canonical 存储复制到每个可用的
+  受支持 Agent。即使没有可用的受支持 Agent home，发布和 canonical 回写仍会成功。
 - 输出：成功时，文本输出会打印 skill id、最终包标识、所选可见性（`private`
   或 `public`）以及当前账号 endpoint 对应的 Hub 包页面 URL，例如生产账号使用
   `https://hub.oomol.com/package/<packageName>`。失败时命令以非零状态退出，并保持

--- a/docs/path-first-skill-publish-plan.md
+++ b/docs/path-first-skill-publish-plan.md
@@ -1,0 +1,64 @@
+# Path-First Skill Publish Plan
+
+## Summary
+
+`oo skills publish` should publish a concrete skill directory instead of resolving
+skill ids through hidden local, registry, and agent fallback rules.
+
+The primary flow becomes:
+
+```bash
+oo skills locate <skill-id> --agent codex
+oo skills publish <path>
+```
+
+`--agent` is optional for `locate`. Without it, `locate` searches all available
+agent skill directories and canonical registry storage, and succeeds only when
+there is one matching path.
+
+## Behavior
+
+| Command | Behavior |
+| --- | --- |
+| `oo skills locate <skill-id>` | Print the only matching skill path from available agents plus canonical registry storage. If zero or multiple matches exist, fail with a clear error. |
+| `oo skills locate <skill-id> --agent <agent>` | Print `<agent>`'s matching skill path only. |
+| `oo skills publish <path>` | Publish the skill directory, or the directory containing the provided `SKILL.md`. |
+
+`locate` only finds candidate paths. It does not validate frontmatter or package
+metadata. `publish` owns validation. Because `locate` accepts a skill id rather
+than a path, path-shaped values such as `../skill` are rejected with guidance to
+pass paths directly to `oo skills publish`.
+
+## Registry Publish Writeback
+
+When `publish <path>` publishes an oo-managed registry skill:
+
+1. Validate all available agent targets before the remote publish request.
+2. Publish from the requested path.
+3. Update the source `SKILL.md` frontmatter and registry metadata with the final
+   package name and version.
+4. If the source is not canonical registry storage, replace the canonical
+   registry skill with the updated source.
+5. Copy canonical registry storage to every available supported agent.
+
+If no supported agent home is available, publish and canonical writeback still
+succeed.
+
+## Simplifications
+
+- `oo skills publish --agent` is removed.
+- `publish` no longer accepts a bare skill id.
+- `locate` has plain text output only: one path plus a newline on success.
+- `locate` includes unmanaged agent directories when they contain `SKILL.md`;
+  unmanaged sources remain valid path publish inputs.
+- `publish` rejects oo-managed bundled metadata and invalid `.oo-metadata.json`.
+
+## Required Updates
+
+- Add a `skills locate` command and telemetry decision.
+- Simplify `skills publish` source resolution to path-only.
+- Update command docs in English and Chinese.
+- Update bundled `oo-publish-skill` instructions to mention `oo skills locate`
+  as an optional helper, without requiring agents to use it.
+- Add focused tests for locate, path publish, registry writeback, and registry
+  copy-to-agents behavior.

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -956,8 +956,8 @@ describe("embedded skill assets", () => {
             expect(content).toContain("existing AI agent skill");
             expect(content).toContain("it does not need to be an oo-specific skill");
             expect(content).toContain("oo skills publish");
-            expect(content).toContain("When publishing by skill id");
-            expect(content).toContain("include `--agent");
+            expect(content).toContain("oo skills locate <skill-id>");
+            expect(content).toContain("extra locate step");
             expect(content).toContain("Pass `--visibility` only");
             expect(content).toContain("The publish command performs its own");
             expect(content).toContain("Do not ask whether to publish to the current account");
@@ -968,6 +968,7 @@ describe("embedded skill assets", () => {
             expect(content).not.toContain("--visibility private");
             expect(content).not.toContain("OOMOL/oo skill");
             expect(content).not.toContain("oo skills preflight");
+            expect(content).not.toContain("oo skills publish <skill-id> --agent");
             expect(content).not.toContain("Use `--agent` only as a source hint");
         }
     });

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -4,6 +4,7 @@ import { skillsCheckCommand } from "./check.ts";
 import { skillsInitCommand } from "./init.ts";
 import { skillsInstallCommand } from "./install.ts";
 import { skillsListCommand } from "./list.ts";
+import { skillsLocateCommand } from "./locate.ts";
 import { skillsPublishCommand } from "./publish.ts";
 import { skillsSearchCommand } from "./search.ts";
 import { skillsShareCommand } from "./share.ts";
@@ -19,6 +20,7 @@ export const skillsCommand: CliCommandDefinition = {
     children: [
         skillsSearchCommand,
         skillsListCommand,
+        skillsLocateCommand,
         skillsSyncCommand,
         skillsCheckCommand,
         skillsInitCommand,

--- a/src/application/commands/skills/locate.test.ts
+++ b/src/application/commands/skills/locate.test.ts
@@ -1,0 +1,187 @@
+import { mkdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+    createCliSandbox,
+} from "../../../../__tests__/helpers.ts";
+import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../../telemetry/outbox.ts";
+import { resolveCodexHomeDirectory } from "./bundled-skill-paths.ts";
+import {
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillDirectoryPath,
+} from "./managed-skill-paths.ts";
+
+describe("skills locate command", () => {
+    test("prints the selected agent skill path", async () => {
+        const sandbox = await createCliSandbox();
+        const skillDirectoryPath = resolveManagedSkillDirectoryPath(
+            resolveCodexHomeDirectory(sandbox.env),
+            "agent-skill",
+        );
+
+        try {
+            await writeSkillFile(skillDirectoryPath);
+
+            const result = await sandbox.run([
+                "skills",
+                "locate",
+                "agent-skill",
+                "--agent",
+                "codex",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(`${skillDirectoryPath}\n`);
+            expect(result.stderr).toBe("");
+
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
+
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    command_full: "skills.locate",
+                    has_agent_filter: true,
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("prints a unique canonical registry skill path without an agent", async () => {
+        const sandbox = await createCliSandbox();
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const skillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "registry-skill",
+        );
+
+        try {
+            await writeSkillFile(skillDirectoryPath);
+
+            const result = await sandbox.run([
+                "skills",
+                "locate",
+                "registry-skill",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(`${skillDirectoryPath}\n`);
+            expect(result.stderr).toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports ambiguous matches without an agent", async () => {
+        const sandbox = await createCliSandbox();
+        const codexSkillDirectoryPath = resolveManagedSkillDirectoryPath(
+            resolveCodexHomeDirectory(sandbox.env),
+            "shared-skill",
+        );
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "shared-skill",
+        );
+
+        try {
+            await Promise.all([
+                writeSkillFile(codexSkillDirectoryPath),
+                writeSkillFile(canonicalSkillDirectoryPath),
+            ]);
+
+            const result = await sandbox.run([
+                "skills",
+                "locate",
+                "shared-skill",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toContain(
+                "Skill shared-skill matches multiple local paths.",
+            );
+            expect(result.stderr).toContain(`- codex: ${codexSkillDirectoryPath}`);
+            expect(result.stderr).toContain(`- registry: ${canonicalSkillDirectoryPath}`);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects path-shaped skill ids", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "locate",
+                "../demo-skill",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Invalid skill id ../demo-skill. Pass a skill id to locate, or pass a path directly to oo skills publish.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects unsupported agents", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "locate",
+                "demo-skill",
+                "--agent",
+                "unknown",
+            ]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toBe(
+                "Unsupported skill agent: unknown. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});
+
+async function writeSkillFile(directoryPath: string): Promise<void> {
+    await mkdir(directoryPath, { recursive: true });
+    await Bun.write(
+        join(directoryPath, "SKILL.md"),
+        [
+            "---",
+            `name: ${basename(directoryPath)}`,
+            "description: Use this located skill.",
+            "---",
+            "",
+        ].join("\n"),
+    );
+}

--- a/src/application/commands/skills/locate.ts
+++ b/src/application/commands/skills/locate.ts
@@ -1,0 +1,194 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+import type { BundledSkillAgentName } from "./embedded-assets.ts";
+
+import { join } from "node:path";
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { parseEnumOption } from "../shared/input-parsing.ts";
+import { writeLine } from "../shared/output.ts";
+import { fileExists } from "./bundled-skill-observation.ts";
+import { resolveBundledSkillHomeDirectory } from "./bundled-skill-paths.ts";
+import { availableBundledSkillAgentNames } from "./embedded-assets.ts";
+import {
+    resolveAvailableManagedSkillHosts,
+} from "./managed-skill-hosts.ts";
+import {
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillDirectoryPath,
+} from "./managed-skill-paths.ts";
+import { isSkillIdReference } from "./skill-id.ts";
+
+interface SkillsLocateInput {
+    agent?: string;
+    skill: string;
+}
+
+interface SkillLocation {
+    label: string;
+    path: string;
+}
+
+export const skillsLocateCommand: CliCommandDefinition<SkillsLocateInput> = {
+    name: "locate",
+    summaryKey: "commands.skills.locate.summary",
+    descriptionKey: "commands.skills.locate.description",
+    arguments: [
+        {
+            name: "skill",
+            descriptionKey: "arguments.skill",
+            required: true,
+        },
+    ],
+    options: [
+        {
+            name: "agent",
+            longFlag: "--agent",
+            valueName: "agent",
+            descriptionKey: "options.agent",
+        },
+    ],
+    inputSchema: z.object({
+        agent: z.string().optional(),
+        skill: z.string(),
+    }),
+    handler: async (input, context) => {
+        const agentName = parseSkillLocateAgent(input.agent);
+
+        context.telemetry?.recordProperties({
+            has_agent_filter: agentName !== undefined,
+        });
+
+        writeLine(
+            context.stdout,
+            await locateSkillPath(input.skill, context, { agentName }),
+        );
+    },
+};
+
+export async function locateSkillPath(
+    skillName: string,
+    context: Pick<CliExecutionContext, "env" | "settingsStore">,
+    options: {
+        agentName?: BundledSkillAgentName;
+    } = {},
+): Promise<string> {
+    const trimmedSkillName = skillName.trim();
+
+    if (!isSkillIdReference(trimmedSkillName)) {
+        throw new CliUserError("errors.skills.locate.invalidSkillId", 1, {
+            name: skillName,
+        });
+    }
+
+    const locations = options.agentName === undefined
+        ? await findAllSkillLocations(trimmedSkillName, context)
+        : await findAgentSkillLocations(trimmedSkillName, context.env, [
+                options.agentName,
+            ]);
+
+    if (locations.length === 1) {
+        return locations[0]!.path;
+    }
+
+    if (locations.length === 0) {
+        throw new CliUserError("errors.skills.locate.notFound", 1, {
+            name: skillName,
+        });
+    }
+
+    throw new CliUserError("errors.skills.locate.ambiguous", 1, {
+        name: skillName,
+        paths: formatSkillLocationCandidates(locations),
+    });
+}
+
+function parseSkillLocateAgent(
+    value: string | undefined,
+): BundledSkillAgentName | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    return parseEnumOption(
+        value,
+        availableBundledSkillAgentNames,
+        "errors.skills.locate.invalidAgent",
+    );
+}
+
+async function findAllSkillLocations(
+    skillName: string,
+    context: Pick<CliExecutionContext, "env" | "settingsStore">,
+): Promise<SkillLocation[]> {
+    const hosts = await resolveAvailableManagedSkillHosts(context.env);
+    const agentLocations = await findAgentSkillLocations(
+        skillName,
+        context.env,
+        hosts.map(host => host.agentName),
+    );
+    const canonicalLocation = await findCanonicalRegistrySkillLocation(
+        skillName,
+        context.settingsStore.getFilePath(),
+    );
+
+    return canonicalLocation === undefined
+        ? agentLocations
+        : [...agentLocations, canonicalLocation];
+}
+
+async function findAgentSkillLocations(
+    skillName: string,
+    env: Record<string, string | undefined>,
+    agentNames: readonly BundledSkillAgentName[],
+): Promise<SkillLocation[]> {
+    const locations = await Promise.all(
+        agentNames.map(async (agentName) => {
+            const skillDirectoryPath = resolveManagedSkillDirectoryPath(
+                resolveBundledSkillHomeDirectory(env, agentName),
+                skillName,
+            );
+
+            if (!(await hasSkillFile(skillDirectoryPath))) {
+                return undefined;
+            }
+
+            return {
+                label: agentName,
+                path: skillDirectoryPath,
+            } satisfies SkillLocation;
+        }),
+    );
+
+    return locations.filter(location => location !== undefined);
+}
+
+async function findCanonicalRegistrySkillLocation(
+    skillName: string,
+    settingsFilePath: string,
+): Promise<SkillLocation | undefined> {
+    const skillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+        settingsFilePath,
+        skillName,
+    );
+
+    if (!(await hasSkillFile(skillDirectoryPath))) {
+        return undefined;
+    }
+
+    return {
+        label: "registry",
+        path: skillDirectoryPath,
+    };
+}
+
+async function hasSkillFile(skillDirectoryPath: string): Promise<boolean> {
+    return await fileExists(join(skillDirectoryPath, "SKILL.md"));
+}
+
+function formatSkillLocationCandidates(
+    locations: readonly SkillLocation[],
+): string {
+    return locations
+        .map(location => `- ${location.label}: ${location.path}`)
+        .join("\n");
+}

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -1,11 +1,9 @@
-import type { CliCatalog, CliExecutionContext, Fetcher } from "../../contracts/cli.ts";
+import type { CliCatalog, CliExecutionContext } from "../../contracts/cli.ts";
 
-import { mkdir, readFile, stat } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { describe, expect, test } from "bun:test";
-
 import pino from "pino";
-
 import {
     createAuthStore,
     createCacheStore,
@@ -29,6 +27,7 @@ import {
     readTelemetryRowsForTest,
 } from "../../telemetry/outbox.ts";
 import {
+    resolveClaudeHomeDirectory,
     resolveCodexHomeDirectory,
 } from "./bundled-skill-paths.ts";
 import {
@@ -36,10 +35,11 @@ import {
     resolveManagedSkillDirectoryPath,
     resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
-import { publishLocalSkillPackage, publishSkillPackage } from "./publish.ts";
+import { publishSkillPackage } from "./publish.ts";
 import { parseSkillMarkdownMatter } from "./skill-frontmatter.ts";
 import {
     createLocalSkillMetadata,
+    createRegistrySkillMetadata,
     renderSkillMetadataJson,
 } from "./skill-metadata.ts";
 
@@ -53,26 +53,24 @@ const emptyCatalog: CliCatalog = {
 describe("skills publish command", () => {
     const cleanup = useTemporaryDirectoryCleanup();
 
-    test("publishes an agent-native local skill through the CLI", async () => {
-        const { sandbox, skillDirectoryPath } = await createCliPublishSkillSandbox(
+    test("publishes a local skill directory path through the CLI", async () => {
+        const sandbox = await createCliSandbox();
+        const skillDirectoryPath = resolveManagedSkillDirectoryPath(
+            resolveCodexHomeDirectory(sandbox.env),
             "demo-skill",
-            [
-                "---",
-                "name: demo-skill",
-                "description: Use a known package workflow.",
-                "---",
-                "",
-                "# Demo Skill",
-                "",
-            ].join("\n"),
         );
 
         try {
-            const stdin = createInteractiveInput();
+            await mkdir(resolveCodexHomeDirectory(sandbox.env), { recursive: true });
+            await writeAuthFile(sandbox);
+            await writeLocalSkillFile(skillDirectoryPath, createSkillMarkdown(
+                "demo-skill",
+                "Use a known package workflow.",
+            ));
+
             const requests: Request[] = [];
-            stdin.feed("private\n");
             const result = await sandbox.run(
-                ["skills", "publish", "demo-skill"],
+                ["skills", "publish", skillDirectoryPath, "--visibility", "private"],
                 {
                     fetcher: async (input, init) => {
                         const request = toRequest(input, init);
@@ -85,23 +83,17 @@ describe("skills publish command", () => {
 
                         return new Response("", { status: 201 });
                     },
-                    stdin,
                 },
             );
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toBe(
-                "Publish skill demo-skill as package @alice/demo-skill with which visibility? [private/public] Published skill demo-skill as private package @alice/demo-skill@0.0.1. View it at https://hub.oomol.com/package/@alice/demo-skill.\n",
+                "Published skill demo-skill as private package @alice/demo-skill@0.0.1. View it at https://hub.oomol.com/package/@alice/demo-skill.\n",
             );
-            expect(result.stderr).toBe("");
             expect(requests.map(request => `${request.method} ${request.url}`)).toEqual([
                 "GET https://registry.oomol.com/-/oomol/package-info/%40alice%2Fdemo-skill/latest?lang=en",
                 "PUT https://registry.oomol.com/@alice%2fdemo-skill",
             ]);
-            expect(requests[1]?.headers.get("Authorization")).toBe("secret-1");
-            await expect(requests[1]!.json()).resolves.toMatchObject({
-                access: "restricted",
-            });
 
             const parsed = parseSkillMarkdownMatter(
                 await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8"),
@@ -111,6 +103,7 @@ describe("skills publish command", () => {
                 packageName: "@alice/demo-skill",
                 version: "0.0.1",
             });
+
             const telemetryPayload = parseTelemetryRowPayload(
                 readTelemetryRowsForTest(
                     join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
@@ -133,152 +126,24 @@ describe("skills publish command", () => {
         }
     });
 
-    test("preserves a local skill package scope from frontmatter", async () => {
-        const { sandbox, skillDirectoryPath } = await createCliPublishSkillSandbox(
-            "scoped-skill",
-            [
-                "---",
-                "name: scoped-skill",
-                "description: Use a package with an existing scope.",
-                "metadata:",
-                "  packageName: '@bob/scoped-skill'",
-                "---",
-                "",
-            ].join("\n"),
-        );
-
-        try {
-            const requests: Request[] = [];
-            const result = await sandbox.run(
-                ["skills", "publish", "scoped-skill", "--visibility", "private"],
-                {
-                    fetcher: async (input, init) => {
-                        const request = toRequest(input, init);
-
-                        requests.push(request);
-
-                        if (request.url.includes("/-/oomol/package-info/")) {
-                            return new Response("not found", { status: 404 });
-                        }
-
-                        return new Response("", { status: 201 });
-                    },
-                },
-            );
-
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(
-                "Published skill scoped-skill as private package @bob/scoped-skill@0.0.1. View it at https://hub.oomol.com/package/@bob/scoped-skill.\n",
-            );
-            expect(requests.map(request => `${request.method} ${request.url}`)).toEqual([
-                "GET https://registry.oomol.com/-/oomol/package-info/%40bob%2Fscoped-skill/latest?lang=en",
-                "PUT https://registry.oomol.com/@bob%2fscoped-skill",
-            ]);
-
-            const parsed = parseSkillMarkdownMatter(
-                await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8"),
-            );
-
-            expect(parsed.data.metadata).toMatchObject({
-                packageName: "@bob/scoped-skill",
-                version: "0.0.1",
-            });
-
-            const telemetryPayload = parseTelemetryRowPayload(
-                readTelemetryRowsForTest(
-                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
-                )[0]!,
-            );
-
-            expect(telemetryPayload).toMatchObject({
-                properties: {
-                    force: false,
-                    source_kind: "local",
-                },
-            });
-            expect(telemetryPayload?.properties).not.toHaveProperty("package_name");
-            expect(telemetryPayload?.properties).not.toHaveProperty("skill_id");
-        }
-        finally {
-            await sandbox.cleanup();
-        }
-    });
-
-    test("requires an agent when local skill ids are ambiguous across agents", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-ambiguous-config");
+    test("publishes when the path points directly to SKILL.md", async () => {
+        const configRootDirectoryPath = await createTemporaryDirectory("publish-skill-file-config");
         const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
         const context = createPublishContext(settingsFilePath);
-        const skillId = "ambiguous-skill";
-        const codexSkillDirectoryPath = resolveManagedSkillDirectoryPath(
-            resolveCodexHomeDirectory(context.env),
-            skillId,
-        );
-        const claudeSkillDirectoryPath = resolveManagedSkillDirectoryPath(
-            join(configRootDirectoryPath, ".claude"),
-            skillId,
-        );
+        const skillDirectoryPath = join(configRootDirectoryPath, "file-skill");
 
         cleanup.track(configRootDirectoryPath);
 
-        await Promise.all([
-            writeLocalSkillFile(codexSkillDirectoryPath, createSkillMarkdown(
-                skillId,
-                "Use the Codex workflow.",
-            )),
-            writeLocalSkillFile(claudeSkillDirectoryPath, createSkillMarkdown(
-                skillId,
-                "Use the Claude workflow.",
-            )),
-        ]);
+        await writeSkillFile(skillDirectoryPath, createSkillMarkdown(
+            "file-skill",
+            "Use a path-local workflow.",
+        ));
 
-        await expect(publishSkillPackage(
-            skillId,
+        const result = await publishSkillPackage(
+            join(skillDirectoryPath, "SKILL.md"),
             context,
             "private",
             {},
-            {
-                convertSkillDirectoryToPackage: () => {
-                    throw new Error("Conversion should not run.");
-                },
-                publishConvertedSkillPackage: () => Promise.resolve(),
-            },
-        )).rejects.toMatchObject({
-            key: "errors.skills.publish.localSkillAmbiguous",
-        });
-    });
-
-    test("publishes the selected agent-native local skill when an agent is provided", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-selected-agent-config");
-        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
-        const context = createPublishContext(settingsFilePath);
-        const skillId = "selected-local-skill";
-        const codexSkillDirectoryPath = resolveManagedSkillDirectoryPath(
-            resolveCodexHomeDirectory(context.env),
-            skillId,
-        );
-        const claudeSkillDirectoryPath = resolveManagedSkillDirectoryPath(
-            join(configRootDirectoryPath, ".claude"),
-            skillId,
-        );
-
-        cleanup.track(configRootDirectoryPath);
-
-        await Promise.all([
-            writeLocalSkillFile(codexSkillDirectoryPath, createSkillMarkdown(
-                skillId,
-                "Use the Codex workflow.",
-            )),
-            writeLocalSkillFile(claudeSkillDirectoryPath, createSkillMarkdown(
-                skillId,
-                "Use the Claude workflow.",
-            )),
-        ]);
-
-        const result = await publishSkillPackage(
-            skillId,
-            context,
-            "private",
-            { agentName: "codex" },
             {
                 publishConvertedSkillPackage: () => Promise.resolve(),
                 resolveFinalPublishVersion: request => Promise.resolve(request.requestedVersion),
@@ -286,138 +151,40 @@ describe("skills publish command", () => {
         );
 
         expect(result).toMatchObject({
-            packageName: "@alice/selected-local-skill",
-            skillDirectoryPath: codexSkillDirectoryPath,
-            skillId,
+            packageName: "@alice/file-skill",
+            skillDirectoryPath,
+            skillId: "file-skill",
             version: "0.0.1",
         });
-        expect(await readFile(join(claudeSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
-            "Use the Claude workflow.",
-        );
     });
 
-    test("publishes public package metadata when visibility is public", async () => {
-        const { sandbox } = await createCliPublishSkillSandbox(
-            "public-skill",
-            [
-                "---",
-                "name: public-skill",
-                "description: Use a known package workflow.",
-                "---",
-                "",
-            ].join("\n"),
-            {
-                auth: {
-                    accounts: [
-                        {
-                            apiKey: "secret-1",
-                            endpoint: "example.test",
-                            id: "user-1",
-                            name: "Alice",
-                        },
-                    ],
-                },
-            },
-        );
-
-        try {
-            const requests: Request[] = [];
-            const result = await sandbox.run(
-                ["skills", "publish", "public-skill", "--visibility", "public"],
-                {
-                    fetcher: async (input, init) => {
-                        const request = toRequest(input, init);
-
-                        requests.push(request);
-
-                        if (request.url.includes("/-/oomol/package-info/")) {
-                            return new Response("not found", { status: 404 });
-                        }
-
-                        return new Response("", { status: 201 });
-                    },
-                },
-            );
-
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(
-                "Published skill public-skill as public package @alice/public-skill@0.0.1. View it at https://hub.example.test/package/@alice/public-skill.\n",
-            );
-            await expect(requests[1]!.json()).resolves.toMatchObject({
-                access: "public",
-            });
-        }
-        finally {
-            await sandbox.cleanup();
-        }
-    });
-
-    test("preserves public visibility from an existing package", async () => {
-        const { sandbox } = await createCliPublishSkillSandbox(
-            "existing-public-skill",
-            [
-                "---",
-                "name: existing-public-skill",
-                "description: Use a known package workflow.",
-                "---",
-                "",
-            ].join("\n"),
-        );
-
-        try {
-            const requests: Request[] = [];
-            const result = await sandbox.run(
-                ["skills", "publish", "existing-public-skill"],
-                {
-                    fetcher: async (input, init) => {
-                        const request = toRequest(input, init);
-
-                        requests.push(request);
-
-                        if (request.url.includes("/-/oomol/package-info/")) {
-                            return new Response(JSON.stringify({
-                                access: "public",
-                                blocks: [],
-                                description: "Existing public skill package.",
-                                packageName: "@alice/existing-public-skill",
-                                packageVersion: "0.0.3",
-                                title: "Existing Public Skill",
-                            }));
-                        }
-
-                        return new Response("", { status: 201 });
-                    },
-                },
-            );
-
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(
-                "Published skill existing-public-skill as public package @alice/existing-public-skill@0.0.4. View it at https://hub.oomol.com/package/@alice/existing-public-skill.\n",
-            );
-            await expect(requests[1]!.json()).resolves.toMatchObject({
-                access: "public",
-            });
-        }
-        finally {
-            await sandbox.cleanup();
-        }
-    });
-
-    test("publishes a registry skill when the installed package matches the target package", async () => {
+    test("publishes a registry skill path and syncs canonical storage to agents", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
+        const skillDirectoryPath = resolveManagedSkillDirectoryPath(
+            codexHomeDirectory,
+            "registry-skill",
+        );
         const storePaths = resolveStorePaths({
             appName: APP_NAME,
             env: sandbox.env,
             platform: process.platform,
         });
-        const skillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+        const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
             storePaths.settingsFilePath,
+            "registry-skill",
+        );
+        const claudeSkillDirectoryPath = resolveManagedSkillDirectoryPath(
+            claudeHomeDirectory,
             "registry-skill",
         );
 
         try {
-            await mkdir(codexHomeDirectory, { recursive: true });
+            await Promise.all([
+                mkdir(codexHomeDirectory, { recursive: true }),
+                mkdir(claudeHomeDirectory, { recursive: true }),
+            ]);
             await writeAuthFile(sandbox);
             await writeSkillFile(skillDirectoryPath, [
                 "---",
@@ -427,6 +194,8 @@ describe("skills publish command", () => {
                 "  version: '0.2.0'",
                 "---",
                 "",
+                "# Edited from agent",
+                "",
             ].join("\n"));
             await writeRegistrySkillMetadata(
                 skillDirectoryPath,
@@ -434,14 +203,11 @@ describe("skills publish command", () => {
                 "0.1.0",
             );
 
-            const requests: Request[] = [];
             const result = await sandbox.run(
-                ["skills", "publish", "registry-skill", "--visibility", "private"],
+                ["skills", "publish", skillDirectoryPath, "--visibility", "private"],
                 {
                     fetcher: async (input, init) => {
                         const request = toRequest(input, init);
-
-                        requests.push(request);
 
                         if (request.url.includes("/-/oomol/package-info/")) {
                             return new Response("not found", { status: 404 });
@@ -456,575 +222,74 @@ describe("skills publish command", () => {
             expect(result.stdout).toBe(
                 "Published skill registry-skill as private package @alice/registry-skill@0.2.0. View it at https://hub.oomol.com/package/@alice/registry-skill.\n",
             );
-            expect(requests.map(request => `${request.method} ${request.url}`)).toEqual([
-                "GET https://registry.oomol.com/-/oomol/package-info/%40alice%2Fregistry-skill/latest?lang=en",
-                "PUT https://registry.oomol.com/@alice%2fregistry-skill",
-            ]);
-
-            const parsed = parseSkillMarkdownMatter(
-                await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8"),
+            expect(await readFile(join(canonicalSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
+                "# Edited from agent",
             );
-
-            expect(parsed.data.metadata).toMatchObject({
-                packageName: "@alice/registry-skill",
-                version: "0.2.0",
-            });
+            expect(await readFile(join(claudeSkillDirectoryPath, "SKILL.md"), "utf8")).toContain(
+                "# Edited from agent",
+            );
+            expect(await readFile(resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath), "utf8")).toBe(
+                renderSkillMetadataJson(createRegistrySkillMetadata({
+                    packageName: "@alice/registry-skill",
+                    version: "0.2.0",
+                })),
+            );
+            expect(await readFile(resolveManagedSkillMetadataFilePath(claudeSkillDirectoryPath), "utf8")).toBe(
+                renderSkillMetadataJson(createRegistrySkillMetadata({
+                    packageName: "@alice/registry-skill",
+                    version: "0.2.0",
+                })),
+            );
         }
         finally {
             await sandbox.cleanup();
         }
     });
 
-    test("publishes a registry skill using its installed package name", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-registry-package-config");
-        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
-        const context = createPublishContext(settingsFilePath);
-        const skillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
-            settingsFilePath,
-            "registry-owned-skill",
-        );
-
-        cleanup.track(configRootDirectoryPath);
-
-        await writeSkillFile(skillDirectoryPath, [
-            "---",
-            "name: registry-owned-skill",
-            "description: Use a registry package workflow.",
-            "---",
-            "",
-        ].join("\n"));
-        await writeRegistrySkillMetadata(
-            skillDirectoryPath,
-            "@bob/registry-owned-skill",
-            "0.1.0",
-        );
-
-        const result = await publishSkillPackage(
-            "registry-owned-skill",
-            context,
-            "private",
-            {},
-            {
-                publishConvertedSkillPackage: () => Promise.resolve(),
-                resolveFinalPublishVersion: request => Promise.resolve(request.requestedVersion),
-            },
-        );
-
-        expect(result.packageName).toBe("@bob/registry-owned-skill");
-    });
-
-    test("falls back when registry skill metadata has an invalid scoped package name", async () => {
-        const invalidPackageNames = [
-            "@bob/registry-owned-skill/extra",
-            "@/registry-owned-skill",
-            "@bob/",
-        ];
-
-        for (const invalidPackageName of invalidPackageNames) {
-            const configRootDirectoryPath = await createTemporaryDirectory("publish-invalid-registry-package-config");
-            const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
-            const context = createPublishContext(settingsFilePath);
-            const skillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
-                settingsFilePath,
-                "registry-owned-skill",
-            );
-
-            cleanup.track(configRootDirectoryPath);
-
-            await writeSkillFile(skillDirectoryPath, [
-                "---",
-                "name: registry-owned-skill",
-                "description: Use a registry package workflow.",
-                "---",
-                "",
-            ].join("\n"));
-            await writeRegistrySkillMetadata(
-                skillDirectoryPath,
-                invalidPackageName,
-                "0.1.0",
-            );
-
-            const result = await publishSkillPackage(
-                "registry-owned-skill",
-                context,
-                "private",
-                { yes: true },
-                {
-                    publishConvertedSkillPackage: () => Promise.resolve(),
-                    resolveFinalPublishVersion: request => Promise.resolve(request.requestedVersion),
-                },
-            );
-
-            expect(result.packageName).toBe("@alice/registry-owned-skill");
-        }
-    });
-
-    test("ignores registry skill share ids when preserving scoped package names", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-registry-share-config");
-        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
-        const context = createPublishContext(settingsFilePath);
-        const skillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
-            settingsFilePath,
-            "shared-registry-skill",
-        );
-
-        cleanup.track(configRootDirectoryPath);
-
-        await writeSkillFile(skillDirectoryPath, [
-            "---",
-            "name: shared-registry-skill",
-            "description: Use a registry package workflow.",
-            "---",
-            "",
-        ].join("\n"));
-        await writeRegistrySkillMetadata(
-            skillDirectoryPath,
-            "@bob/shared-registry-skill#share-1",
-            "0.1.0",
-        );
-
-        const result = await publishSkillPackage(
-            "shared-registry-skill",
-            context,
-            "private",
-            {},
-            {
-                publishConvertedSkillPackage: () => Promise.resolve(),
-                resolveFinalPublishVersion: request => Promise.resolve(request.requestedVersion),
-            },
-        );
-
-        expect(result.packageName).toBe("@bob/shared-registry-skill");
-    });
-
-    test("publishes a registry skill using its installed package name when --yes is passed", async () => {
+    test("rejects a registry publish before PUT when another agent target is unmanaged", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-        const storePaths = resolveStorePaths({
-            appName: APP_NAME,
-            env: sandbox.env,
-            platform: process.platform,
-        });
-        const skillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
-            storePaths.settingsFilePath,
-            "forked-skill",
-        );
-
-        try {
-            await mkdir(codexHomeDirectory, { recursive: true });
-            await writeAuthFile(sandbox);
-            await writeSkillFile(skillDirectoryPath, [
-                "---",
-                "name: forked-skill",
-                "description: Use a registry package workflow.",
-                "---",
-                "",
-            ].join("\n"));
-            await writeRegistrySkillMetadata(
-                skillDirectoryPath,
-                "@bob/forked-skill",
-                "0.1.0",
-            );
-
-            const result = await sandbox.run(
-                ["skills", "publish", "forked-skill", "--yes", "--visibility", "private"],
-                {
-                    fetcher: async (input, init) => {
-                        const request = toRequest(input, init);
-
-                        if (request.url.includes("/-/oomol/package-info/")) {
-                            return new Response("not found", { status: 404 });
-                        }
-
-                        return new Response("", { status: 201 });
-                    },
-                },
-            );
-
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toBe(
-                "Published skill forked-skill as private package @bob/forked-skill@0.0.1. View it at https://hub.oomol.com/package/@bob/forked-skill.\n",
-            );
-        }
-        finally {
-            await sandbox.cleanup();
-        }
-    });
-
-    test("publishes an agent-native local skill in place", async () => {
-        const { sandbox, skillDirectoryPath } = await createCliPublishSkillSandbox(
-            "agent-skill",
-            [
-                "---",
-                "name: agent-skill",
-                "description: Use an agent-local workflow.",
-                "metadata:",
-                "  icon: ':sparkles:'",
-                "  packageName: '@bob/agent-skill'",
-                "  version: '0.3.0'",
-                "---",
-                "",
-            ].join("\n"),
-        );
-
-        try {
-            const result = await sandbox.run(
-                ["skills", "publish", "agent-skill", "--agent", "codex", "--visibility", "private"],
-                {
-                    fetcher: async (input, init) => {
-                        const request = toRequest(input, init);
-
-                        if (request.url.includes("/-/oomol/package-info/")) {
-                            return new Response("not found", { status: 404 });
-                        }
-
-                        return new Response("", { status: 201 });
-                    },
-                },
-            );
-
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(
-                "Published skill agent-skill as private package @bob/agent-skill@0.3.0. View it at https://hub.oomol.com/package/@bob/agent-skill.\n",
-            );
-            expect(await readFile(resolveManagedSkillMetadataFilePath(skillDirectoryPath), "utf8")).toBe(
-                renderSkillMetadataJson(createLocalSkillMetadata()),
-            );
-
-            const parsed = parseSkillMarkdownMatter(
-                await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8"),
-            );
-
-            expect(parsed.data.metadata).toMatchObject({
-                icon: ":sparkles:",
-                packageName: "@bob/agent-skill",
-                version: "0.3.0",
-            });
-            const telemetryPayload = parseTelemetryRowPayload(
-                readTelemetryRowsForTest(
-                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
-                )[0]!,
-            );
-
-            expect(telemetryPayload).toMatchObject({
-                properties: {
-                    command_full: "skills.publish",
-                    force: false,
-                    source_kind: "local",
-                    visibility: "private",
-                },
-            });
-            expect(telemetryPayload?.properties).not.toHaveProperty("package_name");
-            expect(telemetryPayload?.properties).not.toHaveProperty("skill_id");
-        }
-        finally {
-            await sandbox.cleanup();
-        }
-    });
-
-    test("publishes a skill from a relative path in place", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-path-config");
-        const cwd = await createTemporaryDirectory("publish-path-cwd");
-        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
-        const stdin = createInteractiveInput();
-        const context = createPublishContext(settingsFilePath, { stdin });
-        const sourceSkillDirectoryPath = join(cwd, "path-skill");
-
-        cleanup.track(configRootDirectoryPath);
-        cleanup.track(cwd);
-
-        context.cwd = cwd;
-
-        await writeSkillFile(sourceSkillDirectoryPath, [
-            "---",
-            "name: path-skill",
-            "description: Use a path-local workflow.",
-            "---",
-            "",
-        ].join("\n"));
-
-        stdin.feed("yes\n");
-
-        const result = await publishSkillPackage(
-            "./path-skill",
-            context,
-            "private",
-            {},
-            {
-                publishConvertedSkillPackage: () => Promise.resolve(),
-                resolveFinalPublishVersion: request => Promise.resolve(request.requestedVersion),
-            },
-        );
-
-        expect(result).toMatchObject({
-            packageName: "@alice/path-skill",
-            skillDirectoryPath: sourceSkillDirectoryPath,
-            skillId: "path-skill",
-            version: "0.0.1",
-        });
-        await expect(stat(sourceSkillDirectoryPath)).resolves.toMatchObject({
-            isDirectory: expect.any(Function),
-        });
-    });
-
-    test("does not modify an invalid path skill", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-invalid-path-config");
-        const cwd = await createTemporaryDirectory("publish-invalid-path-cwd");
-        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
-        const stdin = createInteractiveInput();
-        const context = createPublishContext(settingsFilePath, { stdin });
-        const sourceSkillDirectoryPath = join(cwd, "invalid-path-skill");
-
-        cleanup.track(configRootDirectoryPath);
-        cleanup.track(cwd);
-
-        context.cwd = cwd;
-
-        await writeSkillFile(sourceSkillDirectoryPath, [
-            "---",
-            "name: other-skill",
-            "description: Use a path-local workflow.",
-            "---",
-            "",
-        ].join("\n"));
-
-        stdin.feed("yes\n");
-
-        await expect(publishSkillPackage(
-            "./invalid-path-skill",
-            context,
-            "private",
-            {},
-            {
-                convertSkillDirectoryToPackage: () => {
-                    throw new Error("Conversion should not run.");
-                },
-                publishConvertedSkillPackage: () => Promise.resolve(),
-            },
-        )).rejects.toMatchObject({
-            key: "errors.skills.publish.invalidSkillFile",
-        });
-
-        await expect(stat(sourceSkillDirectoryPath)).resolves.toMatchObject({
-            isDirectory: expect.any(Function),
-        });
-    });
-
-    test("rejects publishing bundled skills directly", async () => {
-        const sandbox = await createCliSandbox();
-        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-
-        try {
-            await mkdir(codexHomeDirectory, { recursive: true });
-            await writeAuthFile(sandbox);
-
-            const result = await sandbox.run(["skills", "publish", "oo"]);
-
-            expect(result.exitCode).toBe(1);
-            expect(result.stderr).toBe(
-                "Bundled skill oo cannot be published directly because it is managed by the oo CLI release. Create a local skill before publishing.\n",
-            );
-        }
-        finally {
-            await sandbox.cleanup();
-        }
-    });
-
-    test("rejects publishing bundled skills by installed target path", async () => {
-        const sandbox = await createCliSandbox();
-        const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
+        const claudeHomeDirectory = resolveClaudeHomeDirectory(sandbox.env);
         const skillDirectoryPath = resolveManagedSkillDirectoryPath(
             codexHomeDirectory,
-            "oo",
+            "conflict-skill",
         );
+        const claudeSkillDirectoryPath = resolveManagedSkillDirectoryPath(
+            claudeHomeDirectory,
+            "conflict-skill",
+        );
+        const requests: Request[] = [];
 
         try {
-            await mkdir(codexHomeDirectory, { recursive: true });
-            const installResult = await sandbox.run(["skills", "install", "oo"]);
-            expect(installResult.exitCode).toBe(0);
-
-            const result = await sandbox.run(["skills", "publish", skillDirectoryPath]);
-
-            expect(result.exitCode).toBe(1);
-            expect(result.stderr).toBe(
-                "Bundled skill oo cannot be published directly because it is managed by the oo CLI release. Create a local skill before publishing.\n",
-            );
-        }
-        finally {
-            await sandbox.cleanup();
-        }
-    });
-
-    test("rejects an unsupported publish agent", async () => {
-        const sandbox = await createCliSandbox();
-
-        try {
-            const result = await sandbox.run([
-                "skills",
-                "publish",
-                "demo-skill",
-                "--agent",
-                "unknown",
+            await Promise.all([
+                mkdir(codexHomeDirectory, { recursive: true }),
+                mkdir(claudeHomeDirectory, { recursive: true }),
             ]);
-
-            expect(result.exitCode).toBe(2);
-            expect(result.stderr).toBe(
-                "Unsupported skill agent: unknown. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.\n",
+            await writeAuthFile(sandbox);
+            await writeSkillFile(skillDirectoryPath, createSkillMarkdown(
+                "conflict-skill",
+                "Use a registry package workflow.",
+            ));
+            await writeRegistrySkillMetadata(
+                skillDirectoryPath,
+                "@alice/conflict-skill",
+                "0.1.0",
             );
-        }
-        finally {
-            await sandbox.cleanup();
-        }
-    });
+            await writeSkillFile(claudeSkillDirectoryPath, createSkillMarkdown(
+                "conflict-skill",
+                "Use an unmanaged conflicting workflow.",
+            ));
 
-    test("increments the final version from latest package info", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-remote-config");
-        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
-        const context = createPublishContext(settingsFilePath, {
-            fetcher: async () => new Response(JSON.stringify({
-                blocks: [],
-                description: "Previous skill package",
-                packageName: "@alice/versioned-skill",
-                packageVersion: "0.0.3",
-                title: "Versioned Skill",
-            })),
-        });
-        const skillDirectoryPath = resolveCodexSkillDirectoryPath(context.env, "versioned-skill");
-
-        cleanup.track(configRootDirectoryPath);
-
-        await writeLocalSkillFile(skillDirectoryPath, [
-            "---",
-            "name: versioned-skill",
-            "description: Use a known package workflow.",
-            "metadata:",
-            "  version: '0.0.2'",
-            "---",
-            "",
-        ].join("\n"));
-
-        const result = await publishLocalSkillPackage(
-            "versioned-skill",
-            context,
-            "private",
-            {
-                publishConvertedSkillPackage: () => Promise.resolve(),
-            },
-        );
-
-        expect(result.version).toBe("0.0.4");
-
-        const parsed = parseSkillMarkdownMatter(
-            await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8"),
-        );
-
-        expect(parsed.data.metadata).toMatchObject({
-            packageName: "@alice/versioned-skill",
-            version: "0.0.4",
-        });
-    });
-
-    test("continues publishing over a remote package with blocks after confirmation", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-blocks-confirm-config");
-        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
-        const stdin = createInteractiveInput();
-        const promptOutput = createTextBuffer();
-        const context = createPublishContext(settingsFilePath, {
-            fetcher: async () => new Response(JSON.stringify({
-                blocks: [
-                    {
-                        blockName: "main",
-                        inputHandleDefs: [],
-                        outputHandleDefs: [],
-                    },
-                ],
-                description: "Remote block package",
-                packageName: "@alice/blocked-skill",
-                packageVersion: "1.2.3",
-                title: "Blocked Skill",
-            })),
-            stdin,
-            stdout: promptOutput.writer,
-        });
-        const skillDirectoryPath = resolveCodexSkillDirectoryPath(context.env, "blocked-skill");
-        let publishCalled = false;
-
-        cleanup.track(configRootDirectoryPath);
-
-        await writeLocalSkillFile(skillDirectoryPath, [
-            "---",
-            "name: blocked-skill",
-            "description: Use a known package workflow.",
-            "---",
-            "",
-        ].join("\n"));
-
-        stdin.feed("yes\n");
-
-        const result = await publishLocalSkillPackage(
-            "blocked-skill",
-            context,
-            "private",
-            {
-                publishConvertedSkillPackage: () => {
-                    publishCalled = true;
-
-                    return Promise.resolve();
-                },
-            },
-        );
-
-        expect(result.version).toBe("1.2.4");
-        expect(publishCalled).toBeTrue();
-        expect(promptOutput.read()).toBe(
-            "Remote package @alice/blocked-skill@1.2.3 contains blocks. Continue publishing skill blocked-skill as @alice/blocked-skill? [y/N] ",
-        );
-
-        const parsed = parseSkillMarkdownMatter(
-            await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8"),
-        );
-
-        expect(parsed.data.metadata).toMatchObject({
-            packageName: "@alice/blocked-skill",
-            version: "1.2.4",
-        });
-    });
-
-    test("publishes over a remote package with blocks when -y is passed", async () => {
-        const { sandbox, skillDirectoryPath } = await createCliPublishSkillSandbox(
-            "blocked-skill",
-            [
-                "---",
-                "name: blocked-skill",
-                "description: Use a known package workflow.",
-                "---",
-                "",
-            ].join("\n"),
-        );
-
-        try {
             const result = await sandbox.run(
-                ["skills", "publish", "blocked-skill", "-y"],
+                ["skills", "publish", skillDirectoryPath, "--visibility", "private"],
                 {
                     fetcher: async (input, init) => {
                         const request = toRequest(input, init);
 
+                        requests.push(request);
+
                         if (request.url.includes("/-/oomol/package-info/")) {
-                            return new Response(JSON.stringify({
-                                access: "restricted",
-                                blocks: [
-                                    {
-                                        blockName: "main",
-                                        inputHandleDefs: [],
-                                        outputHandleDefs: [],
-                                    },
-                                ],
-                                description: "Remote block package",
-                                packageName: "@alice/blocked-skill",
-                                packageVersion: "1.2.3",
-                                title: "Blocked Skill",
-                            }));
+                            return new Response("not found", { status: 404 });
                         }
 
                         return new Response("", { status: 201 });
@@ -1032,288 +297,76 @@ describe("skills publish command", () => {
                 },
             );
 
-            expect(result.exitCode).toBe(0);
-            expect(result.stderr).toBe("");
-            expect(result.stdout).toBe(
-                "Published skill blocked-skill as private package @alice/blocked-skill@1.2.4. View it at https://hub.oomol.com/package/@alice/blocked-skill.\n",
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain(
+                `Skill name conflict-skill is already used by a non-OOMOL skill at ${claudeSkillDirectoryPath}.`,
             );
-
-            const parsed = parseSkillMarkdownMatter(
-                await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8"),
-            );
-
-            expect(parsed.data.metadata).toMatchObject({
-                packageName: "@alice/blocked-skill",
-                version: "1.2.4",
-            });
+            expect(requests.map(request => request.method)).toEqual(["GET"]);
         }
         finally {
             await sandbox.cleanup();
         }
     });
 
-    test("rejects publishing over a remote package with blocks when confirmation is declined", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-blocks-config");
-        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
-        const stdin = createInteractiveInput();
-        const context = createPublishContext(settingsFilePath, {
-            fetcher: async () => new Response(JSON.stringify({
-                blocks: [
-                    {
-                        blockName: "main",
-                        inputHandleDefs: [],
-                        outputHandleDefs: [],
-                    },
-                ],
-                description: "Remote block package",
-                packageName: "@alice/blocked-skill",
-                packageVersion: "1.2.3",
-                title: "Blocked Skill",
-            })),
-            stdin,
-        });
-        const skillDirectoryPath = resolveCodexSkillDirectoryPath(context.env, "blocked-skill");
-
-        cleanup.track(configRootDirectoryPath);
-
-        await writeLocalSkillFile(skillDirectoryPath, [
-            "---",
-            "name: blocked-skill",
-            "description: Use a known package workflow.",
-            "---",
-            "",
-        ].join("\n"));
-
-        stdin.feed("no\n");
-
-        await expect(publishLocalSkillPackage(
-            "blocked-skill",
-            context,
-            "private",
-            {
-                convertSkillDirectoryToPackage: () => {
-                    throw new Error("Conversion should not run.");
-                },
-                publishConvertedSkillPackage: () => Promise.resolve(),
-            },
-        )).rejects.toMatchObject({
-            key: "errors.skills.publish.remotePackageHasBlocks",
-            params: {
-                name: "blocked-skill",
-                packageName: "@alice/blocked-skill",
-                version: "1.2.3",
-            },
-        });
-
-        const parsed = parseSkillMarkdownMatter(
-            await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8"),
-        );
-
-        expect(parsed.data.metadata).toBeUndefined();
-    });
-
-    test("requires an interactive confirmation when a remote package has blocks", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-blocks-non-interactive-config");
-        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
-        const context = createPublishContext(settingsFilePath, {
-            fetcher: async () => new Response(JSON.stringify({
-                blocks: [
-                    {
-                        blockName: "main",
-                        inputHandleDefs: [],
-                        outputHandleDefs: [],
-                    },
-                ],
-                description: "Remote block package",
-                packageName: "@alice/blocked-skill",
-                packageVersion: "1.2.3",
-                title: "Blocked Skill",
-            })),
-            stdin: createNonInteractiveInput(),
-        });
-        const skillDirectoryPath = resolveCodexSkillDirectoryPath(context.env, "blocked-skill");
-
-        cleanup.track(configRootDirectoryPath);
-
-        await writeLocalSkillFile(skillDirectoryPath, [
-            "---",
-            "name: blocked-skill",
-            "description: Use a known package workflow.",
-            "---",
-            "",
-        ].join("\n"));
-
-        await expect(publishLocalSkillPackage(
-            "blocked-skill",
-            context,
-            "private",
-            {
-                convertSkillDirectoryToPackage: () => {
-                    throw new Error("Conversion should not run.");
-                },
-                publishConvertedSkillPackage: () => Promise.resolve(),
-            },
-        )).rejects.toMatchObject({
-            key: "errors.skills.publish.remotePackageHasBlocksConfirmationRequired",
-            params: {
-                name: "blocked-skill",
-                packageName: "@alice/blocked-skill",
-                version: "1.2.3",
-            },
-        });
-    });
-
-    test("uses the injected final version and removes the temporary package root", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-config");
-        const temporaryPackageRoot = await createTemporaryDirectory("publish-package");
-        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
-        const context = createPublishContext(settingsFilePath);
-        const skillDirectoryPath = resolveCodexSkillDirectoryPath(context.env, "versioned-skill");
-
-        cleanup.track(configRootDirectoryPath);
-
-        await writeLocalSkillFile(skillDirectoryPath, [
-            "---",
-            "name: versioned-skill",
-            "description: Use a known package workflow.",
-            "metadata:",
-            "  version: '0.0.3'",
-            "---",
-            "",
-        ].join("\n"));
-
-        const result = await publishLocalSkillPackage(
-            "versioned-skill",
-            context,
-            "private",
-            {
-                createTemporaryPackageRoot: () => Promise.resolve(temporaryPackageRoot),
-                publishConvertedSkillPackage: () => Promise.resolve(),
-                resolveFinalPublishVersion: request => Promise.resolve(
-                    request.requestedVersion === "0.0.3" ? "0.0.4" : "0.0.1",
-                ),
-            },
-        );
-
-        expect(result).toMatchObject({
-            hubUrl: "https://hub.oomol.com/package/@alice/versioned-skill",
-            packageName: "@alice/versioned-skill",
-            skillDirectoryPath,
-            skillId: "versioned-skill",
-            version: "0.0.4",
-        });
-        await expect(stat(temporaryPackageRoot)).rejects.toMatchObject({
-            code: "ENOENT",
-        });
-
-        const parsed = parseSkillMarkdownMatter(
-            await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8"),
-        );
-
-        expect(parsed.data.metadata).toMatchObject({
-            packageName: "@alice/versioned-skill",
-            version: "0.0.4",
-        });
-    });
-
-    test("preserves local metadata when publishing fails", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-fail-config");
-        const temporaryPackageRoot = await createTemporaryDirectory("publish-fail-package");
-        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
-        const context = createPublishContext(settingsFilePath);
-        const skillDirectoryPath = resolveCodexSkillDirectoryPath(context.env, "failing-skill");
-
-        cleanup.track(configRootDirectoryPath);
-
-        await writeLocalSkillFile(skillDirectoryPath, [
-            "---",
-            "name: failing-skill",
-            "description: Use a known package workflow.",
-            "---",
-            "",
-        ].join("\n"));
-
-        await expect(publishLocalSkillPackage(
-            "failing-skill",
-            context,
-            "private",
-            {
-                createTemporaryPackageRoot: () => Promise.resolve(temporaryPackageRoot),
-                publishConvertedSkillPackage: () => Promise.reject(new Error("publish failed")),
-                resolveFinalPublishVersion: request => Promise.resolve(request.requestedVersion),
-            },
-        )).rejects.toThrow("publish failed");
-        await expect(stat(temporaryPackageRoot)).rejects.toMatchObject({
-            code: "ENOENT",
-        });
-
-        const parsed = parseSkillMarkdownMatter(
-            await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8"),
-        );
-
-        expect(parsed.data.metadata).toBeUndefined();
-        expect(await readFile(resolveManagedSkillMetadataFilePath(skillDirectoryPath), "utf8")).toBe(
-            renderSkillMetadataJson(createLocalSkillMetadata()),
-        );
-    });
-
-    test("rejects a missing local skill", async () => {
-        const configRootDirectoryPath = await createTemporaryDirectory("publish-missing-config");
+    test("rejects bare skill ids because publish is path-first", async () => {
+        const configRootDirectoryPath = await createTemporaryDirectory("publish-id-config");
         const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
         const context = createPublishContext(settingsFilePath);
 
         cleanup.track(configRootDirectoryPath);
 
-        await expect(publishLocalSkillPackage(
+        await expect(publishSkillPackage(
             "missing-skill",
             context,
             "private",
+            {},
             {
+                convertSkillDirectoryToPackage: () => {
+                    throw new Error("Conversion should not run.");
+                },
+                publishConvertedSkillPackage: () => Promise.resolve(),
             },
         )).rejects.toMatchObject({
             key: "errors.skills.publish.skillNotFound",
         });
     });
+
+    test("rejects invalid oo ownership metadata", async () => {
+        const configRootDirectoryPath = await createTemporaryDirectory("publish-invalid-metadata-config");
+        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
+        const context = createPublishContext(settingsFilePath);
+        const skillDirectoryPath = join(configRootDirectoryPath, "invalid-metadata-skill");
+
+        cleanup.track(configRootDirectoryPath);
+
+        await writeSkillFile(skillDirectoryPath, createSkillMarkdown(
+            "invalid-metadata-skill",
+            "Use an invalid metadata workflow.",
+        ));
+        await Bun.write(
+            resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+            "{",
+        );
+
+        await expect(publishSkillPackage(
+            skillDirectoryPath,
+            context,
+            "private",
+            {},
+            {
+                convertSkillDirectoryToPackage: () => {
+                    throw new Error("Conversion should not run.");
+                },
+                publishConvertedSkillPackage: () => Promise.resolve(),
+            },
+        )).rejects.toMatchObject({
+            key: "errors.skills.publish.invalidOwnershipMetadata",
+        });
+    });
 });
-
-function resolveCodexSkillDirectoryPath(
-    env: Record<string, string | undefined>,
-    skillId: string,
-): string {
-    return resolveManagedSkillDirectoryPath(
-        resolveCodexHomeDirectory(env),
-        skillId,
-    );
-}
-
-async function createCliPublishSkillSandbox(
-    skillId: string,
-    skillMarkdown: string,
-    options: {
-        auth?: Parameters<typeof writeAuthFile>[1];
-    } = {},
-) {
-    const sandbox = await createCliSandbox();
-    const codexHomeDirectory = resolveCodexHomeDirectory(sandbox.env);
-    const skillDirectoryPath = resolveCodexSkillDirectoryPath(sandbox.env, skillId);
-
-    await mkdir(codexHomeDirectory, { recursive: true });
-    await writeAuthFile(sandbox, options.auth);
-    await writeLocalSkillFile(skillDirectoryPath, skillMarkdown);
-
-    return {
-        sandbox,
-        skillDirectoryPath,
-    };
-}
 
 function createPublishContext(
     settingsFilePath: string,
-    options: {
-        fetcher?: Fetcher;
-        stdin?: CliExecutionContext["stdin"];
-        stdout?: CliExecutionContext["stdout"];
-    } = {},
 ): CliExecutionContext {
     const stdout = createTextBuffer();
     const stderr = createTextBuffer();
@@ -1338,8 +391,7 @@ function createPublishContext(
         cacheStore: createCacheStore(),
         currentLogFilePath: "",
         execPath: process.execPath,
-        fetcher: options.fetcher
-            ?? (() => Promise.reject(new Error("Unexpected fetch."))),
+        fetcher: () => Promise.reject(new Error("Unexpected fetch.")),
         cwd: process.cwd(),
         env: {
             CODEX_HOME: join(configRootDirectoryPath, ".codex"),
@@ -1348,13 +400,13 @@ function createPublishContext(
         },
         fileDownloadSessionStore: createNoopFileDownloadSessionStore(),
         fileUploadStore: createNoopFileUploadStore(),
-        stdin: options.stdin ?? createInteractiveInput(),
+        stdin: createInteractiveInput(),
         logger: pino({
             enabled: false,
         }),
         packageName: "@oomol-lab/oo-cli",
         settingsStore,
-        stdout: options.stdout ?? stdout.writer,
+        stdout: stdout.writer,
         stderr: stderr.writer,
         translator: createTranslator("en"),
         completionRenderer: {
@@ -1362,14 +414,6 @@ function createPublishContext(
         },
         catalog: emptyCatalog,
         version: "0.1.0",
-    };
-}
-
-function createNonInteractiveInput(): CliExecutionContext["stdin"] {
-    return {
-        isTTY: false,
-        off() {},
-        on() {},
     };
 }
 
@@ -1399,12 +443,7 @@ async function writeRegistrySkillMetadata(
 ): Promise<void> {
     await Bun.write(
         resolveManagedSkillMetadataFilePath(directoryPath),
-        renderSkillMetadataJson({
-            kind: "registry",
-            packageName,
-            schemaVersion: 1,
-            version,
-        }),
+        renderSkillMetadataJson(createRegistrySkillMetadata({ packageName, version })),
     );
 }
 

--- a/src/application/commands/skills/publish.ts
+++ b/src/application/commands/skills/publish.ts
@@ -1,13 +1,12 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
 import type { PackageInfoResponse } from "../package/shared.ts";
-import type { BundledSkillAgentName } from "./embedded-assets.ts";
+import type { ManagedSkillHostInstallation } from "./managed-skill-hosts.ts";
 
-import type { LocalSkillSource } from "./local-skill-source.ts";
 import type { SkillPublishVisibility } from "./package-conversion.ts";
-import { lstat, mkdtemp, rm } from "node:fs/promises";
+import { cp, lstat, mkdir, mkdtemp, realpath, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, isAbsolute, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { z } from "zod";
 import { resolveRequestLanguage } from "../../../i18n/locale.ts";
 import { CliUserError } from "../../contracts/cli.ts";
@@ -18,29 +17,20 @@ import { parseEnumOption } from "../shared/input-parsing.ts";
 import { writeLine } from "../shared/output.ts";
 import {
     isNodeNotFoundError,
+    removePath,
 } from "./bundled-skill-filesystem.ts";
-import { directoryExists } from "./bundled-skill-observation.ts";
-import {
-    resolveBundledSkillCanonicalRootDirectoryPath,
-    resolveBundledSkillHomeDirectory,
-} from "./bundled-skill-paths.ts";
-import {
-    availableBundledSkillAgentNames,
-    availableBundledSkillNames,
-} from "./embedded-assets.ts";
 import {
     confirmInteractiveValue,
     selectInteractiveValue,
 } from "./interactive-prompts.ts";
-import { writeLocalSkillMetadata } from "./local-skill-ownership.ts";
+import { readSkillMetadataFileState, writeLocalSkillMetadata } from "./local-skill-ownership.ts";
 import {
-    findLocalSkillSources,
-    isLocalSkillDirectory,
-} from "./local-skill-source.ts";
-import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
+    resolveAvailableManagedSkillHosts,
+    resolveManagedSkillHostInstallations,
+} from "./managed-skill-hosts.ts";
+import { writeManagedSkillMetadata } from "./managed-skill-metadata.ts";
 import {
     resolveManagedSkillCanonicalDirectoryPath,
-    resolveManagedSkillDirectoryPath,
     resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
 import {
@@ -50,11 +40,15 @@ import {
     skillPublishVisibilityValues,
     writePublishedSkillMetadata,
 } from "./package-conversion.ts";
+import {
+    publishPreparedRegistrySkillPublication,
+    validateRegistrySkillPublicationTargets,
+} from "./registry-skill-publication.ts";
+import { isSkillIdReference } from "./skill-id.ts";
 
 interface SkillsPublishInput {
-    agent?: string;
     force?: boolean;
-    skill: string;
+    path: string;
     visibility?: string;
     yes?: boolean;
 }
@@ -69,13 +63,11 @@ interface PublishLocalSkillPackageResult {
 }
 
 interface PublishSkillPackageOptions {
-    agentName?: BundledSkillAgentName;
     force?: boolean;
     yes?: boolean;
 }
 
 interface LocalSkillPublishSource {
-    agentName?: BundledSkillAgentName;
     kind: "local";
     skillDirectoryPath: string;
     skillId: string;
@@ -141,18 +133,12 @@ export const skillsPublishCommand: CliCommandDefinition<SkillsPublishInput> = {
     descriptionKey: "commands.skills.publish.description",
     arguments: [
         {
-            name: "skill",
-            descriptionKey: "arguments.skill",
+            name: "path",
+            descriptionKey: "arguments.filePath",
             required: true,
         },
     ],
     options: [
-        {
-            name: "agent",
-            longFlag: "--agent",
-            valueName: "agent",
-            descriptionKey: "options.agent",
-        },
         {
             name: "force",
             longFlag: "--force",
@@ -172,22 +158,19 @@ export const skillsPublishCommand: CliCommandDefinition<SkillsPublishInput> = {
         },
     ],
     inputSchema: z.object({
-        agent: z.string().optional(),
         force: z.boolean().optional(),
-        skill: z.string(),
+        path: z.string(),
         visibility: z.string().optional(),
         yes: z.boolean().optional(),
     }),
     handler: async (input, context) => {
-        const agentName = parseSkillPublishAgent(input.agent);
         const visibility = parseSkillPublishVisibility(input.visibility);
 
         const result = await publishSkillPackage(
-            input.skill,
+            input.path,
             context,
             visibility,
             {
-                agentName,
                 force: input.force === true,
                 yes: input.yes === true,
             },
@@ -209,15 +192,13 @@ export const skillsPublishCommand: CliCommandDefinition<SkillsPublishInput> = {
 };
 
 export async function publishSkillPackage(
-    skillReference: string,
+    skillPath: string,
     context: CliExecutionContext,
     visibility?: SkillPublishVisibility,
     options: PublishSkillPackageOptions = {},
     dependencies: PublishSkillPackageDependencies = {},
 ): Promise<PublishLocalSkillPackageResult> {
-    const source = await resolveSkillPublishSource(skillReference, context, {
-        agentName: options.agentName,
-    });
+    const source = await resolveSkillPublishSource(skillPath, context);
     const yes = options.yes === true;
     const force = options.force === true;
     const requireAccount = dependencies.requireCurrentAccount ?? requireCurrentAccount;
@@ -251,21 +232,6 @@ export async function publishSkillPackage(
         },
         context,
         visibility,
-        dependencies,
-    );
-}
-
-export async function publishLocalSkillPackage(
-    skillId: string,
-    context: CliExecutionContext,
-    visibility?: SkillPublishVisibility,
-    dependencies: PublishSkillPackageDependencies = {},
-): Promise<PublishLocalSkillPackageResult> {
-    return await publishSkillPackage(
-        skillId,
-        context,
-        visibility,
-        {},
         dependencies,
     );
 }
@@ -324,6 +290,20 @@ async function publishResolvedSkillPackage(
     context.telemetry?.recordProperties({
         visibility: publishPlan.visibility,
     });
+    const registryHostInstallations = request.sourceKind === "registry"
+        ? resolveManagedSkillHostInstallations(
+                await resolveAvailableManagedSkillHosts(context.env),
+                request.skillId,
+            )
+        : [];
+
+    if (request.sourceKind === "registry") {
+        await validateRegistrySkillPublicationTargets({
+            hostInstallations: registryHostInstallations,
+            skillName: request.skillId,
+        });
+    }
+
     let packageRootDirectoryPath: string | undefined;
 
     try {
@@ -347,6 +327,22 @@ async function publishResolvedSkillPackage(
             skillDirectoryPath: request.skillDirectoryPath,
             version: publishPlan.version,
         });
+        if (request.sourceKind === "registry") {
+            await writeManagedSkillMetadata(request.skillDirectoryPath, {
+                icon: skillMetadata.icon,
+                packageName: request.packageName,
+                version: publishPlan.version,
+            });
+            await synchronizePublishedRegistrySkill({
+                hostInstallations: registryHostInstallations,
+                icon: skillMetadata.icon,
+                packageName: request.packageName,
+                settingsFilePath: context.settingsStore.getFilePath(),
+                skillDirectoryPath: request.skillDirectoryPath,
+                skillId: request.skillId,
+                version: publishPlan.version,
+            });
+        }
     }
     finally {
         if (packageRootDirectoryPath !== undefined) {
@@ -362,6 +358,72 @@ async function publishResolvedSkillPackage(
         visibility: publishPlan.visibility,
         version: publishPlan.version,
     };
+}
+
+async function synchronizePublishedRegistrySkill(options: {
+    hostInstallations: readonly ManagedSkillHostInstallation[];
+    icon?: string;
+    packageName: string;
+    settingsFilePath: string;
+    skillDirectoryPath: string;
+    skillId: string;
+    version: string;
+}): Promise<void> {
+    const canonicalSkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+        options.settingsFilePath,
+        options.skillId,
+    );
+
+    if (!(await areSamePath(options.skillDirectoryPath, canonicalSkillDirectoryPath))) {
+        await copyRegistrySkillToCanonical(
+            options.skillDirectoryPath,
+            canonicalSkillDirectoryPath,
+        );
+    }
+
+    await writeManagedSkillMetadata(canonicalSkillDirectoryPath, {
+        icon: options.icon,
+        packageName: options.packageName,
+        version: options.version,
+    });
+
+    await publishPreparedRegistrySkillPublication({
+        canonicalSkillDirectoryPath,
+        hostInstallations: [...options.hostInstallations],
+        packageName: options.packageName,
+        packageVersion: options.version,
+        skillName: options.skillId,
+    });
+}
+
+async function copyRegistrySkillToCanonical(
+    sourceSkillDirectoryPath: string,
+    canonicalSkillDirectoryPath: string,
+): Promise<void> {
+    await removePath(canonicalSkillDirectoryPath);
+    await mkdir(dirname(canonicalSkillDirectoryPath), { recursive: true });
+    await cp(sourceSkillDirectoryPath, canonicalSkillDirectoryPath, {
+        dereference: true,
+        force: true,
+        recursive: true,
+    });
+}
+
+async function areSamePath(leftPath: string, rightPath: string): Promise<boolean> {
+    if (resolve(leftPath) === resolve(rightPath)) {
+        return true;
+    }
+
+    try {
+        return await realpath(leftPath) === await realpath(rightPath);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
 }
 
 async function resolveSkillPublishPackageName(
@@ -427,16 +489,6 @@ function readScopedPackageName(packageName: string | undefined): string | undefi
     return scopedPackageName;
 }
 
-function parseSkillPublishAgent(
-    value: string | undefined,
-): BundledSkillAgentName | undefined {
-    return parseEnumOption(
-        value,
-        availableBundledSkillAgentNames,
-        "errors.skills.publish.invalidAgent",
-    );
-}
-
 function parseSkillPublishVisibility(
     value: string | undefined,
 ): SkillPublishVisibility | undefined {
@@ -449,59 +501,16 @@ function parseSkillPublishVisibility(
 
 async function resolveSkillPublishSource(
     skillReference: string,
-    context: Pick<CliExecutionContext, "cwd" | "env" | "settingsStore">,
-    options: PublishSkillPackageOptions,
+    context: Pick<CliExecutionContext, "cwd">,
 ): Promise<SkillPublishSource> {
     const normalizedReference = skillReference.trim();
 
     if (normalizedReference === "") {
         throw createSkillPublishSourceMissingError(skillReference);
     }
-
-    const settingsFilePath = context.settingsStore.getFilePath();
-
-    if (isSkillIdReference(normalizedReference)) {
-        const localSkillSource = await resolveLocalSkillPublishSource(
-            normalizedReference,
-            context,
-            options.agentName,
-        );
-
-        if (localSkillSource !== undefined) {
-            return localSkillSource;
-        }
-
-        await rejectBundledSkillPublishIfMatched(
-            settingsFilePath,
-            normalizedReference,
-        );
-
-        const registrySkillSource = await resolveRegistrySkillPublishSource(
-            settingsFilePath,
-            normalizedReference,
-        );
-
-        if (registrySkillSource !== undefined) {
-            return registrySkillSource;
-        }
-
-        const agentSkillSource = options.agentName === undefined
-            ? undefined
-            : await resolveAgentPathSkillPublishSource(
-                    context.env,
-                    normalizedReference,
-                    options.agentName,
-                );
-
-        if (agentSkillSource !== undefined) {
-            return agentSkillSource;
-        }
-    }
-
     const pathSkillSource = await resolvePathSkillPublishSource(
         normalizedReference,
         context.cwd,
-        settingsFilePath,
     );
 
     if (pathSkillSource !== undefined) {
@@ -511,148 +520,16 @@ async function resolveSkillPublishSource(
     throw createSkillPublishSourceMissingError(skillReference);
 }
 
-async function resolveLocalSkillPublishSource(
-    skillId: string,
-    context: Pick<CliExecutionContext, "env">,
-    agentName?: BundledSkillAgentName,
-): Promise<LocalSkillPublishSource | undefined> {
-    const sources = await findLocalSkillSources({
-        agentName,
-        context: {
-            env: context.env,
-        },
-        skillName: skillId,
-    });
-
-    if (sources.length === 0) {
-        return undefined;
-    }
-
-    if (sources.length > 1) {
-        throw new CliUserError("errors.skills.publish.localSkillAmbiguous", 1, {
-            agents: renderLocalSkillSourceAgents(sources),
-            name: skillId,
-        });
-    }
-
-    return createLocalSkillPublishSource(skillId, sources[0]!);
-}
-
-function createLocalSkillPublishSource(
-    skillId: string,
-    source: LocalSkillSource,
-): LocalSkillPublishSource {
-    return {
-        agentName: source.agentName,
-        kind: "local",
-        skillDirectoryPath: source.path,
-        skillId,
-    };
-}
-
-async function rejectBundledSkillPublishIfMatched(
-    settingsFilePath: string,
-    skillId: string,
-): Promise<void> {
-    if (isBundledSkillName(skillId)) {
-        throw createBundledSkillPublishError(skillId);
-    }
-
-    const bundledSkillDirectoryPath = await findExistingBundledSkillDirectoryPath(
-        settingsFilePath,
-        skillId,
-    );
-
-    if (bundledSkillDirectoryPath !== undefined) {
-        throw createBundledSkillPublishError(skillId);
-    }
-}
-
-async function findExistingBundledSkillDirectoryPath(
-    settingsFilePath: string,
-    skillId: string,
-): Promise<string | undefined> {
-    const bundledSkillDirectoryPaths = availableBundledSkillAgentNames.map(
-        agentName => join(
-            resolveBundledSkillCanonicalRootDirectoryPath(
-                settingsFilePath,
-                agentName,
-            ),
-            skillId,
-        ),
-    );
-
-    for (const bundledSkillDirectoryPath of bundledSkillDirectoryPaths) {
-        if (await directoryExists(bundledSkillDirectoryPath)) {
-            return bundledSkillDirectoryPath;
-        }
-    }
-
-    return undefined;
-}
-
-async function resolveRegistrySkillPublishSource(
-    settingsFilePath: string,
-    skillId: string,
-): Promise<RegistrySkillPublishSource | undefined> {
-    const skillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
-        settingsFilePath,
-        skillId,
-    );
-
-    if (!(await directoryExists(skillDirectoryPath))) {
-        return undefined;
-    }
-
-    const metadata = await readManagedSkillMetadata(skillDirectoryPath);
-
-    if (metadata?.packageName === undefined) {
-        throw new CliUserError("errors.skills.publish.registryMetadataMissing", 1, {
-            name: skillId,
-            path: resolveManagedSkillMetadataFilePath(skillDirectoryPath),
-        });
-    }
-
-    return {
-        kind: "registry",
-        packageName: metadata.packageName,
-        skillDirectoryPath,
-        skillId,
-    };
-}
-
-async function resolveAgentPathSkillPublishSource(
-    env: Record<string, string | undefined>,
-    skillId: string,
-    agentName: BundledSkillAgentName,
-): Promise<PathSkillPublishSource | undefined> {
-    const homeDirectory = resolveBundledSkillHomeDirectory(env, agentName);
-    const skillDirectoryPath = resolveManagedSkillDirectoryPath(
-        homeDirectory,
-        skillId,
-    );
-
-    if (!(await isSkillDirectoryWithSkillFile(skillDirectoryPath))) {
-        return undefined;
-    }
-
-    return {
-        kind: "path",
-        skillDirectoryPath,
-        skillId,
-    };
-}
-
 async function resolvePathSkillPublishSource(
     skillReference: string,
     cwd: string,
-    settingsFilePath: string,
 ): Promise<SkillPublishSource | undefined> {
-    const skillDirectoryPath = isAbsolute(skillReference)
+    const resolvedPath = isAbsolute(skillReference)
         ? resolve(skillReference)
         : resolve(cwd, skillReference);
+    const skillDirectoryPath = await resolveSkillDirectoryPath(resolvedPath);
 
-    if (!(await isSkillDirectoryWithSkillFile(skillDirectoryPath))) {
+    if (skillDirectoryPath === undefined) {
         return undefined;
     }
 
@@ -662,44 +539,37 @@ async function resolvePathSkillPublishSource(
         return undefined;
     }
 
-    if (await isLocalSkillDirectory(skillDirectoryPath)) {
-        return {
-            kind: "local",
-            skillDirectoryPath,
-            skillId,
-        };
+    const metadataState = await readSkillMetadataFileState(skillDirectoryPath);
+
+    if (metadataState.exists && metadataState.metadata === undefined) {
+        throw new CliUserError("errors.skills.publish.invalidOwnershipMetadata", 1, {
+            path: resolveManagedSkillMetadataFilePath(skillDirectoryPath),
+        });
     }
 
-    if (isBundledSkillName(skillId)) {
-        throw createBundledSkillPublishError(skillId);
+    switch (metadataState.metadata?.kind) {
+        case "bundled":
+            throw createBundledSkillPublishError(skillId);
+        case "local":
+            return {
+                kind: "local",
+                skillDirectoryPath,
+                skillId,
+            };
+        case "registry":
+            return {
+                kind: "registry",
+                packageName: metadataState.metadata.packageName,
+                skillDirectoryPath,
+                skillId,
+            };
+        case undefined:
+            return {
+                kind: "path",
+                skillDirectoryPath,
+                skillId,
+            };
     }
-
-    const bundledSkillDirectoryPath = await findExistingBundledSkillDirectoryPath(
-        settingsFilePath,
-        skillId,
-    );
-
-    if (
-        bundledSkillDirectoryPath !== undefined
-        && resolve(bundledSkillDirectoryPath) === skillDirectoryPath
-    ) {
-        throw createBundledSkillPublishError(skillId);
-    }
-
-    const registrySkillDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
-        settingsFilePath,
-        skillId,
-    );
-
-    if (resolve(registrySkillDirectoryPath) === skillDirectoryPath) {
-        return await resolveRegistrySkillPublishSource(settingsFilePath, skillId);
-    }
-
-    return {
-        kind: "path",
-        skillDirectoryPath,
-        skillId,
-    };
 }
 
 async function confirmSkillPublishSource(
@@ -784,21 +654,36 @@ async function confirmRegistrySkillPackagePublish(
     }
 }
 
-function renderLocalSkillSourceAgents(
-    sources: readonly LocalSkillSource[],
-): string {
-    return sources
-        .map(source => source.agentName)
-        .join(", ");
-}
+async function resolveSkillDirectoryPath(
+    resolvedPath: string,
+): Promise<string | undefined> {
+    let pathStats: Awaited<ReturnType<typeof stat>>;
 
-async function isSkillDirectoryWithSkillFile(
-    directoryPath: string,
-): Promise<boolean> {
-    if (!(await directoryExists(directoryPath))) {
-        return false;
+    try {
+        pathStats = await stat(resolvedPath);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return undefined;
+        }
+
+        throw error;
     }
 
+    if (pathStats.isFile() && basename(resolvedPath) === "SKILL.md") {
+        return dirname(resolvedPath);
+    }
+
+    if (pathStats.isDirectory() && await hasSkillMarkdownFile(resolvedPath)) {
+        return resolvedPath;
+    }
+
+    return undefined;
+}
+
+async function hasSkillMarkdownFile(
+    directoryPath: string,
+): Promise<boolean> {
     try {
         const skillFileStats = await lstat(join(directoryPath, "SKILL.md"));
 
@@ -813,21 +698,8 @@ async function isSkillDirectoryWithSkillFile(
     }
 }
 
-function isSkillIdReference(value: string): boolean {
-    const trimmedValue = value.trim();
-
-    return trimmedValue !== ""
-        && trimmedValue !== "."
-        && trimmedValue !== ".."
-        && basename(trimmedValue) === trimmedValue;
-}
-
 function normalizePackageNameForComparison(packageName: string): string {
     return packageName.trim().toLowerCase();
-}
-
-function isBundledSkillName(value: string): boolean {
-    return (availableBundledSkillNames as readonly string[]).includes(value);
 }
 
 function createBundledSkillPublishError(skillId: string): CliUserError {

--- a/src/application/commands/skills/share.ts
+++ b/src/application/commands/skills/share.ts
@@ -33,6 +33,7 @@ import {
     parseSkillMarkdownMatter,
     toNonBlankString,
 } from "./skill-frontmatter.ts";
+import { isSkillIdReference } from "./skill-id.ts";
 
 interface SkillsShareInput {
     days?: string;
@@ -750,15 +751,6 @@ function createSkillShareInstallCommand(
     }
 
     return `oo skills install ${installPackageSpecifier} --skill ${skillId} -y`;
-}
-
-function isSkillIdReference(value: string): boolean {
-    const trimmedValue = value.trim();
-
-    return trimmedValue !== ""
-        && trimmedValue !== "."
-        && trimmedValue !== ".."
-        && basename(trimmedValue) === trimmedValue;
 }
 
 function resolveSkillIdFromPackageName(packageName: string): string {

--- a/src/application/commands/skills/skill-id.ts
+++ b/src/application/commands/skills/skill-id.ts
@@ -1,0 +1,10 @@
+import { basename } from "node:path";
+
+export function isSkillIdReference(value: string): boolean {
+    const trimmedValue = value.trim();
+
+    return trimmedValue !== ""
+        && trimmedValue !== "."
+        && trimmedValue !== ".."
+        && basename(trimmedValue) === trimmedValue;
+}

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -304,6 +304,11 @@ const commandTelemetryDecisions = {
         properties: ["has_agent_filter", "source_filter"],
         reason: "Records filter usage without installed skill inventory.",
     },
+    "skills.locate": {
+        kind: "properties",
+        properties: ["has_agent_filter"],
+        reason: "Records locate filter usage without skill ids or local paths.",
+    },
     "skills.preflight": {
         kind: "generic",
         reason: "Generic command telemetry is enough; local paths are not recorded.",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -155,6 +155,9 @@ export const enMessages = {
         "List bundled, registry, and local skills.",
     "commands.skills.list.summary":
         "List skills",
+    "commands.skills.locate.description":
+        "Print the local path for an installed skill.",
+    "commands.skills.locate.summary": "Locate a skill path",
     "commands.skills.sync.description":
         "Sync oo-managed registry skills through the skills sync API.",
     "commands.skills.sync.summary": "Sync registry skills",
@@ -421,8 +424,18 @@ export const enMessages = {
         "Invalid skill package metadata: {message}",
     "errors.skills.publish.invalidAgent":
         "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.",
+    "errors.skills.locate.invalidAgent":
+        "Unsupported skill agent: {value}. Use codex, claude, hermes, codebuddy, workbuddy, trae, trae-cn, openclaw, qoderwork, or deepseek-tui.",
+    "errors.skills.locate.ambiguous":
+        "Skill {name} matches multiple local paths. Pass --agent or publish one path directly:\n{paths}",
+    "errors.skills.locate.invalidSkillId":
+        "Invalid skill id {name}. Pass a skill id to locate, or pass a path directly to oo skills publish.",
+    "errors.skills.locate.notFound":
+        "Cannot find skill {name} in installed skill paths.",
     "errors.skills.publish.invalidSkillFile":
         "Cannot publish the skill at {path}: {message}",
+    "errors.skills.publish.invalidOwnershipMetadata":
+        "Cannot publish the skill because its oo metadata file at {path} is invalid.",
     "errors.skills.publish.invalidVisibility":
         "Invalid skill publish visibility: {value}. Use private or public.",
     "errors.skills.publish.bundledSkill":
@@ -448,7 +461,7 @@ export const enMessages = {
     "errors.skills.publish.requestFailed":
         "The skill package publish request returned HTTP {status}: {message}",
     "errors.skills.publish.skillNotFound":
-        "Cannot find skill {name} in local, bundled, registry, requested agent, or path sources.",
+        "Cannot find a skill directory or SKILL.md at {name}. Use oo skills locate <skill-id> to resolve an installed skill path.",
     "errors.skills.publish.visibilityRequired":
         "Package {packageName} does not have an existing visibility to preserve. Run in an interactive terminal or pass --visibility private or --visibility public.",
     "errors.skills.list.invalidAgent":
@@ -1111,6 +1124,9 @@ export const zhMessages = {
         "列出 bundled、registry 和 local skill。",
     "commands.skills.list.summary":
         "列出 skill",
+    "commands.skills.locate.description":
+        "输出已安装 skill 的本地路径。",
+    "commands.skills.locate.summary": "定位 skill 路径",
     "commands.skills.sync.description":
         "通过 skills sync API 同步由 oo 管理的 registry skill。",
     "commands.skills.sync.summary": "同步 registry skill",
@@ -1365,8 +1381,18 @@ export const zhMessages = {
         "skill 包元数据无效：{message}",
     "errors.skills.publish.invalidAgent":
         "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw、qoderwork 或 deepseek-tui。",
+    "errors.skills.locate.invalidAgent":
+        "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw、qoderwork 或 deepseek-tui。",
+    "errors.skills.locate.ambiguous":
+        "skill {name} 匹配到多个本地路径。请传入 --agent，或直接发布其中一个路径：\n{paths}",
+    "errors.skills.locate.invalidSkillId":
+        "无效的 skill id：{name}。请给 locate 传入 skill id；如需发布路径，请直接传给 oo skills publish。",
+    "errors.skills.locate.notFound":
+        "无法在已安装 skill 路径中找到 skill {name}。",
     "errors.skills.publish.invalidSkillFile":
         "无法发布 {path} 中的 skill：{message}",
+    "errors.skills.publish.invalidOwnershipMetadata":
+        "无法发布该 skill，因为位于 {path} 的 oo 元数据文件无效。",
     "errors.skills.publish.invalidVisibility":
         "无效的 skill 发布可见性：{value}。请使用 private 或 public。",
     "errors.skills.publish.bundledSkill":
@@ -1398,7 +1424,7 @@ export const zhMessages = {
     "errors.skills.uninstall.invalidAgent":
         "不支持的 skill Agent：{value}。请使用 codex、claude、hermes、codebuddy、workbuddy、trae、trae-cn、openclaw、qoderwork 或 deepseek-tui。",
     "errors.skills.publish.skillNotFound":
-        "无法在 local、bundled、registry、指定 Agent 或路径来源中找到 skill {name}。",
+        "无法在 {name} 找到 skill 目录或 SKILL.md。可使用 oo skills locate <skill-id> 解析已安装 skill 路径。",
     "errors.skills.share.cancelled":
         "已取消分享 skill {name}。",
     "errors.skills.share.confirmationRequired":


### PR DESCRIPTION
- Updated `skills/publish.ts` to streamline skill publishing process, removing unused code and enhancing functionality for registry skills.
- Introduced new functions for managing skill metadata and synchronizing published registry skills.
- Added error handling for invalid ownership metadata and ambiguous skill paths.
- Refactored skill ID reference checks into a new file `skill-id.ts` for better code organization.
- Enhanced localization messages for skill locating and publishing errors in both English and Chinese.
- Updated tests to cover new telemetry decisions related to skill locating.