### PR TITLE
revert(self-update): remove auto skills update from install/update flow

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -259,12 +259,9 @@ Install one managed `oo` release into the local self-managed runtime.
   could not be updated — followed by the restart-shell note. The user can
   then decide whether to update the failed profiles manually.
 - Notes: after a successful install workflow, the CLI silently runs
-  `oo skills add` followed by `oo skills update` with the managed executable,
-  so bundled skills refresh to the installed CLI version and any installed
-  oo-managed published skills are checked and updated. The `oo skills add`
-  step also includes any successfully installed preset registry skills in the
-  same skill summary. Child command stdout/stderr is not forwarded, and
-  failures do not change the install result.
+  `oo skills add` with the managed executable so bundled skills refresh to the
+  installed CLI version. That command also includes any successfully installed
+  preset registry skills in the same skill summary.
 - Notes: when the current version is `0.0.0-development`, the CLI prints the
   managed install/update unsupported message and exits successfully.
 
@@ -292,8 +289,8 @@ Update the managed `oo` install to the latest published release.
 - Notes: `oo update` ensures the managed install is current and usable, and
   does not expose a separate `--force` flag.
 - Notes: when the latest published release matches the current version, update
-  still runs the managed skill refresh and update maintenance for the active
-  managed version before printing the up-to-date message.
+  still runs `oo skills add` for the active managed version before printing the
+  up-to-date message.
 - Notes: after a successful update, the CLI best-effort removes legacy global
   `@oomol-lab/oo-cli` package-manager installs that appear anywhere on `PATH`;
   when `PATH` yields no `oo` candidates, the CLI falls back to the current
@@ -315,12 +312,9 @@ Update the managed `oo` install to the latest published release.
   could not be updated — followed by the restart-shell note. The user can
   then decide whether to update the failed profiles manually.
 - Notes: after a successful update workflow, the CLI silently runs
-  `oo skills add` followed by `oo skills update` with the managed executable,
-  so bundled skills refresh to the installed CLI version and any installed
-  oo-managed published skills are checked and updated. The `oo skills add`
-  step also includes any successfully installed preset registry skills in the
-  same skill summary. Child command stdout/stderr is not forwarded, and
-  failures do not change the update result.
+  `oo skills add` with the managed executable so bundled skills refresh to the
+  installed CLI version. That command also includes any successfully installed
+  preset registry skills in the same skill summary.
 - Notes: when the current version is `0.0.0-development`, the CLI prints the
   managed install/update unsupported message and exits successfully.
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -225,11 +225,9 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 说明：当部分 shell profile 配置成功、另一部分失败时，install 会分别列出两组
   ——已配置的 profile 和未能配置的 profile，并附带重启 shell 的提示；用户可据此
   决定是否手动补全未配置的 profile。
-- 说明：install 成功后，CLI 会使用托管的可执行文件依次静默执行
-  `oo skills add` 与 `oo skills update`，让 bundled skills 刷新到已安装的 CLI
-  版本，同时检查并更新已安装的 oo-managed published skills。`oo skills add`
-  也会把安装成功的预设 registry skills 合并进同一份 skill 摘要。子命令的
-  stdout/stderr 不会透传；即使失败，也不会改变 install 的结果。
+- 说明：install 成功后，CLI 会使用托管的可执行文件静默执行一次
+  `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。该命令也会把
+  安装成功的预设 registry skills 合并进同一份 skill 摘要。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /
   update 的提示，并以成功状态退出。
 
@@ -253,7 +251,7 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 说明：`oo update` 会确保托管安装保持为当前可用状态，不额外暴露
   `--force`。
 - 说明：当最新发布版本与当前版本一致时，update 仍会先为当前激活的托管版本
-  执行托管 skill 刷新与更新维护流程，再输出“已是最新版本”的消息。
+  执行 `oo skills add`，再输出“已是最新版本”的消息。
 - 说明：update 成功后，CLI 会尽力移除在 `PATH` 中任意位置出现的旧全局
   package-manager `@oomol-lab/oo-cli` 安装；如果 `PATH` 中没有找到 `oo`
   候选项，CLI 会回退到当前命令路径进行判断。对于 npm 安装，清理命令会在可推断时
@@ -268,11 +266,9 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 说明：当部分 shell profile 配置成功、另一部分失败时，update 会分别列出两组
   ——已配置的 profile 和未能配置的 profile，并附带重启 shell 的提示；用户可据此
   决定是否手动补全未配置的 profile。
-- 说明：update 成功后，CLI 会使用托管的可执行文件依次静默执行
-  `oo skills add` 与 `oo skills update`，让 bundled skills 刷新到已安装的 CLI
-  版本，同时检查并更新已安装的 oo-managed published skills。`oo skills add`
-  也会把安装成功的预设 registry skills 合并进同一份 skill 摘要。子命令的
-  stdout/stderr 不会透传；即使失败，也不会改变 update 的结果。
+- 说明：update 成功后，CLI 会使用托管的可执行文件静默执行一次
+  `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。该命令也会把
+  安装成功的预设 registry skills 合并进同一份 skill 摘要。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /
   update 的提示，并以成功状态退出。
 

--- a/src/application/commands/self-update.cli.test.ts
+++ b/src/application/commands/self-update.cli.test.ts
@@ -299,8 +299,13 @@ describe("self-update commands", () => {
                 stdout: `Installed oo 2.0.0.\nExecutable: <EXECUTABLE_PATH>\nAdded <HOME>/.local/bin to PATH. Restart your shell to reload PATH and use oo.\n`,
             });
             expect(selfUpdateRuntime.commands).toEqual(
-                createExpectedManagedSkillMaintenanceCommands(targetVersionPath),
+                createExpectedManagedSkillInstallCommands(targetVersionPath),
             );
+            // Regression guard for the auto skills-update removal: the install
+            // flow must NOT auto-invoke `oo skills update` anymore.
+            expect(
+                selfUpdateRuntime.commands.map(command => command.commandArguments),
+            ).not.toContainEqual(["skills", "update"]);
         }
         finally {
             await sandbox.cleanup();
@@ -353,8 +358,10 @@ describe("self-update commands", () => {
             expect(snapshot.stderr).toContain("Activated executable.");
             expect(snapshot.stderr).toContain("Verified installation.");
             expect(snapshot.stderr).toContain("Cleaned up old artifacts.");
-            expect(snapshot.stderr).toContain("Updating installed skills...");
-            expect(snapshot.stderr).toContain("Finished installed skill update.");
+            // Regression guard for the auto skills-update removal: the self-update
+            // flow must NOT report a skills-update progress stage anymore.
+            expect(snapshot.stderr).not.toContain("Updating installed skills");
+            expect(snapshot.stderr).not.toContain("Finished installed skill update");
         }
         finally {
             await sandbox.cleanup();
@@ -457,8 +464,13 @@ describe("self-update commands", () => {
                 },
             });
             expect(selfUpdateRuntime.commands).toEqual(
-                createExpectedManagedSkillMaintenanceCommands(targetVersionPath),
+                createExpectedManagedSkillInstallCommands(targetVersionPath),
             );
+            // Regression guard for the auto skills-update removal: the update
+            // flow must NOT auto-invoke `oo skills update` anymore.
+            expect(
+                selfUpdateRuntime.commands.map(command => command.commandArguments),
+            ).not.toContainEqual(["skills", "update"]);
         }
         finally {
             await sandbox.cleanup();
@@ -696,8 +708,13 @@ describe("self-update commands", () => {
             expect(latestRequestCount).toBe(1);
             expect(binaryRequestCount).toBe(0);
             expect(selfUpdateRuntime.commands).toEqual(
-                createExpectedManagedSkillMaintenanceCommands(currentVersionPath),
+                createExpectedManagedSkillInstallCommands(currentVersionPath),
             );
+            // Regression guard for the auto skills-update removal: the
+            // already-up-to-date fast path must NOT auto-invoke `oo skills update`.
+            expect(
+                selfUpdateRuntime.commands.map(command => command.commandArguments),
+            ).not.toContainEqual(["skills", "update"]);
         }
         finally {
             await sandbox.cleanup();
@@ -760,7 +777,7 @@ describe("self-update commands", () => {
             expect(latestRequestCount).toBe(1);
             expect(binaryRequestCount).toBe(1);
             expect(selfUpdateRuntime.commands).toEqual(
-                createExpectedManagedSkillMaintenanceCommands(currentVersionPath),
+                createExpectedManagedSkillInstallCommands(currentVersionPath),
             );
             expect((await stat(legacyVersionPath)).isDirectory()).toBeTrue();
             await expect(Bun.file(currentVersionPath).exists()).resolves.toBeTrue();
@@ -874,7 +891,7 @@ describe("self-update commands", () => {
             expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             expect(binaryRequestCount).toBe(1);
             expect(legacyCleanup.commands).toEqual([
-                ...createExpectedManagedSkillMaintenanceCommands(currentVersionPath),
+                ...createExpectedManagedSkillInstallCommands(currentVersionPath),
                 {
                     commandArguments: [
                         "uninstall",
@@ -939,8 +956,10 @@ describe("self-update commands", () => {
             expect(snapshot.stderr).toContain("Activated executable.");
             expect(snapshot.stderr).toContain("Verified installation.");
             expect(snapshot.stderr).toContain("Cleaned up old artifacts.");
-            expect(snapshot.stderr).toContain("Updating installed skills...");
-            expect(snapshot.stderr).toContain("Finished installed skill update.");
+            // Regression guard for the auto skills-update removal: the self-update
+            // flow must NOT report a skills-update progress stage anymore.
+            expect(snapshot.stderr).not.toContain("Updating installed skills");
+            expect(snapshot.stderr).not.toContain("Finished installed skill update");
         }
         finally {
             await sandbox.cleanup();
@@ -1047,17 +1066,12 @@ interface CapturedSelfUpdateCommand {
     timeoutMs: number;
 }
 
-function createExpectedManagedSkillMaintenanceCommands(
+function createExpectedManagedSkillInstallCommands(
     commandPath: string,
 ): CapturedSelfUpdateCommand[] {
     return [
         {
             commandArguments: ["skills", "add"],
-            commandPath,
-            timeoutMs: 40_000,
-        },
-        {
-            commandArguments: ["skills", "update"],
             commandPath,
             timeoutMs: 40_000,
         },

--- a/src/application/commands/update.ts
+++ b/src/application/commands/update.ts
@@ -5,7 +5,6 @@ import process from "node:process";
 import { z } from "zod";
 import {
     attemptManagedSkillInstall,
-    attemptManagedSkillUpdate,
     isManagedVersionExecutableInstalled,
     resolveManagedSkillInstallCommandPath,
 } from "../self-update/bundled-skills.ts";
@@ -120,25 +119,12 @@ export const updateCommand: CliCommandDefinition<
                     version: context.version,
                 })
             ) {
-                const managedSkillCommandPath = await resolveManagedSkillInstallCommandPath({
-                    env: context.env,
-                    platform: process.platform,
-                    version: context.version,
-                });
-
-                progressReporter?.setStage("skillsUpdate", {
-                    version: context.version,
-                });
                 await attemptManagedSkillInstall({
-                    commandPath: managedSkillCommandPath,
-                    runtime: {
+                    commandPath: await resolveManagedSkillInstallCommandPath({
                         env: context.env,
-                        logger: context.logger,
-                        ...context.selfUpdateRuntime,
-                    },
-                });
-                await attemptManagedSkillUpdate({
-                    commandPath: managedSkillCommandPath,
+                        platform: process.platform,
+                        version: context.version,
+                    }),
                     runtime: {
                         env: context.env,
                         logger: context.logger,

--- a/src/application/self-update/bundled-skills.ts
+++ b/src/application/self-update/bundled-skills.ts
@@ -9,7 +9,7 @@ import {
     resolveSelfUpdateVersionExecutablePath,
 } from "./paths.ts";
 
-const managedSkillMaintenanceTimeoutMs = 40_000;
+const managedSkillInstallTimeoutMs = 40_000;
 
 export async function resolveManagedSkillInstallCommandPath(options: {
     env: Record<string, string | undefined>;
@@ -76,27 +76,10 @@ export async function attemptManagedSkillInstall(options: {
         commandPath: options.commandPath,
         failureMessage: "Managed skill install failed.",
         logContext: {
-            timeoutMs: managedSkillMaintenanceTimeoutMs,
+            timeoutMs: managedSkillInstallTimeoutMs,
         },
         runtime: options.runtime,
         successMessage: "Managed skill install completed.",
-        timeoutMs: managedSkillMaintenanceTimeoutMs,
-    });
-}
-
-export async function attemptManagedSkillUpdate(options: {
-    commandPath: string;
-    runtime: SelfUpdateCommandRuntime;
-}): Promise<void> {
-    await runSelfUpdateCommandWithLogging({
-        commandArguments: ["skills", "update"],
-        commandPath: options.commandPath,
-        failureMessage: "Managed skill update failed.",
-        logContext: {
-            timeoutMs: managedSkillMaintenanceTimeoutMs,
-        },
-        runtime: options.runtime,
-        successMessage: "Managed skill update completed.",
-        timeoutMs: managedSkillMaintenanceTimeoutMs,
+        timeoutMs: managedSkillInstallTimeoutMs,
     });
 }

--- a/src/application/self-update/core.test.ts
+++ b/src/application/self-update/core.test.ts
@@ -646,7 +646,7 @@ describe("performSelfUpdateOperation", () => {
 
             expect(result.status).toBe("installed");
             expect(invokedCommands).toEqual([
-                ...createExpectedManagedSkillMaintenanceCommands(targetVersionPath),
+                ...createExpectedManagedSkillInstallCommands(targetVersionPath),
                 {
                     commandArguments: ["remove", "-g", "@oomol-lab/oo-cli"],
                     commandPath: "/mock/bin/pnpm",
@@ -727,7 +727,7 @@ describe("performSelfUpdateOperation", () => {
 
             expect(result.status).toBe("installed");
             expect(invokedCommands).toEqual([
-                ...createExpectedManagedSkillMaintenanceCommands(targetVersionPath),
+                ...createExpectedManagedSkillInstallCommands(targetVersionPath),
                 {
                     commandArguments: ["remove", "-g", "@oomol-lab/oo-cli"],
                     commandPath: "/mock/bin/bun",
@@ -824,10 +824,6 @@ describe("performSelfUpdateOperation", () => {
                 },
                 {
                     stage: "cleanup",
-                    version: "2.0.0",
-                },
-                {
-                    stage: "skillsUpdate",
                     version: "2.0.0",
                 },
             ]);
@@ -1155,10 +1151,6 @@ describe("performSelfUpdateOperation", () => {
                     stage: "cleanup",
                     version: "2.0.0",
                 },
-                {
-                    stage: "skillsUpdate",
-                    version: "2.0.0",
-                },
             ]);
         }
         finally {
@@ -1240,17 +1232,13 @@ function createSuccessfulSelfUpdateCommandRunner(
     };
 }
 
-function createExpectedManagedSkillMaintenanceCommands(commandPath: string): Array<{
+function createExpectedManagedSkillInstallCommands(commandPath: string): Array<{
     commandArguments: readonly string[];
     commandPath: string;
 }> {
     return [
         {
             commandArguments: ["skills", "add"],
-            commandPath,
-        },
-        {
-            commandArguments: ["skills", "update"],
             commandPath,
         },
     ];

--- a/src/application/self-update/core.ts
+++ b/src/application/self-update/core.ts
@@ -19,10 +19,7 @@ import {
     fetchLatestCliReleaseVersion,
     parseLatestCliSemverReleaseVersion,
 } from "../update/release-metadata.ts";
-import {
-    attemptManagedSkillInstall,
-    attemptManagedSkillUpdate,
-} from "./bundled-skills.ts";
+import { attemptManagedSkillInstall } from "./bundled-skills.ts";
 import { resolveSelfUpdateCommandResolution } from "./command-resolution.ts";
 import { attemptLegacyPackageManagerUninstall } from "./legacy-installation.ts";
 import {
@@ -212,21 +209,11 @@ export async function performSelfUpdateOperation(options: {
             platform: options.runtime.platform,
             targetVersion: options.targetVersion,
         });
-        const targetVersionCommandPath = resolveSelfUpdateVersionExecutablePath(
-            paths,
-            options.targetVersion,
-        );
-
-        options.reportStage?.({
-            stage: "skillsUpdate",
-            version: options.targetVersion,
-        });
         await attemptManagedSkillInstall({
-            commandPath: targetVersionCommandPath,
-            runtime: options.runtime,
-        });
-        await attemptManagedSkillUpdate({
-            commandPath: targetVersionCommandPath,
+            commandPath: resolveSelfUpdateVersionExecutablePath(
+                paths,
+                options.targetVersion,
+            ),
             runtime: options.runtime,
         });
         await attemptLegacyPackageManagerUninstall(options.runtime);

--- a/src/application/self-update/progress.ts
+++ b/src/application/self-update/progress.ts
@@ -5,8 +5,7 @@ export type SelfUpdateOperationStage
         | "reuse"
         | "activate"
         | "verify"
-        | "cleanup"
-        | "skillsUpdate";
+        | "cleanup";
 
 // All stages including "resolve", which is managed at the command level.
 export type SelfUpdateProgressStage = SelfUpdateOperationStage | "resolve";

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -740,8 +740,6 @@ export const enMessages = {
     "selfUpdate.progress.verify.complete": "Verified installation.",
     "selfUpdate.progress.cleanup.start": "Cleaning up old artifacts...",
     "selfUpdate.progress.cleanup.complete": "Cleaned up old artifacts.",
-    "selfUpdate.progress.skillsUpdate.start": "Updating installed skills...",
-    "selfUpdate.progress.skillsUpdate.complete": "Finished installed skill update.",
     "selfUpdate.lockBusy":
         "Another update is already in progress. Please try again later.",
     "selfUpdate.lockBusyWithPid":
@@ -1671,8 +1669,6 @@ export const zhMessages = {
     "selfUpdate.progress.verify.complete": "已校验安装结果。",
     "selfUpdate.progress.cleanup.start": "正在清理旧产物...",
     "selfUpdate.progress.cleanup.complete": "已清理旧产物。",
-    "selfUpdate.progress.skillsUpdate.start": "正在更新已安装的 skill...",
-    "selfUpdate.progress.skillsUpdate.complete": "已完成已安装 skill 更新。",
     "selfUpdate.lockBusy":
         "另一个更新已在进行中，请稍后再试。",
     "selfUpdate.lockBusyWithPid":


### PR DESCRIPTION
Reverts the implicit `oo skills update` step that PR #183 added to the install and update flows. The user-invokable `oo skills update` command itself stays untouched.

## Why

`oo skills add` (bundled skills refresh) maintains CLI-bundled skills against the installed CLI version — that's intrinsic CLI maintenance and stays. `oo skills update`, in contrast, reaches into user-installed published skills and behaves more like a user content/dependency update — that should be explicit, not implicit on every CLI install/update.

## Behavior changes

| | Before this PR | After this PR |
| --- | --- | --- |
| `oo install` post-step | `oo skills add` + `oo skills update` (with `skillsUpdate` progress stage) | `oo skills add` only, silent (pre-PR-#183 behavior) |
| `oo update` post-step | same as install | same as install |
| `oo update` "already up to date" | `oo skills add` + `oo skills update` | `oo skills add` only |
| `oo skills update` top-level command | available | **unchanged**, still available |

## Changes

### Source

- `src/application/self-update/bundled-skills.ts` — delete `attemptManagedSkillUpdate`; rename `managedSkillMaintenanceTimeoutMs` back to `managedSkillInstallTimeoutMs` since only install/add semantics remain.
- `src/application/self-update/core.ts` — drop import, `reportStage({ stage: "skillsUpdate" })`, and the second `await attemptManagedSkillUpdate(...)` call. `attemptManagedSkillInstall` stays in the same lifecycle slot.
- `src/application/commands/update.ts` — same removals from the same-version native fast path.
- `src/application/self-update/progress.ts` — remove `"skillsUpdate"` from `SelfUpdateOperationStage`.
- `src/i18n/catalog.ts` — remove EN/ZH `selfUpdate.progress.skillsUpdate.{start,complete}` keys.

### Tests

- `core.test.ts` — drop the `{ stage: "skillsUpdate" }` reported-stage expectations; rename helper to `createExpectedManagedSkillInstallCommands` and drop the `["skills","update"]` entry from its returned list.
- `self-update.cli.test.ts` — replace the "Updating installed skills..." / "Finished installed skill update." stderr `toContain` assertions with `not.toContain` **regression guards**; rename the helper and drop the entry; add explicit `not.toContainEqual(["skills","update"])` regression guards on three distinct surfaces (install, update, already-up-to-date fast path). Any future re-introduction of the implicit auto-update will fail the test suite.

### Docs

- `docs/commands.md` and `docs/commands.zh-CN.md` — restore the pre-PR-#183 install/update Notes wording in both languages. The `oo skills update` command's own documentation section is untouched.

## Out of scope (intentionally not touched)

- ❌ The top-level `oo skills update` command — remains available for explicit user invocation.
- ❌ `oo skills add` — bundled-skills refresh stays.
- ❌ Other skill machinery (startup synchronization, preset registry skills, etc.).
- ❌ No new `--no-skills-update` flag — the goal is removing default behavior, not adding a switch.

## Test plan

- [x] `bun test` → **1036 pass / 4 skip / 0 fail**
- [x] `bun run lint` clean
- [x] `bunx tsc --noEmit` clean (the `agentic-markdown` resolution error in `embedded-assets.ts` is pre-existing on `main`, resolved by `bun install`)
- [x] Negative-assertion regression guards on three install/update surfaces

## Convergence

Plan independently proposed and cross-reviewed with @codex-coder; we converged 99% in parallel without seeing each other's drafts. codex's signoff message at #cli:a38acd24 msg=38233b6c. The explicit `not.toContainEqual(["skills","update"])` regression guards were added at codex's suggestion to lock the removal into the test suite as a spec.