### PR TITLE
docs(readme): use bounded Gmail example in quick start

### DIFF
--- a/README-ZH_CN.md
+++ b/README-ZH_CN.md
@@ -68,7 +68,7 @@ oo login
 
 然后用自然语言告诉 AI Agent 你想做什么，不需要记命令：
 
-> /oo 总结今天未读的 Gmail 邮件。
+> /oo 总结我最近 5 封 Gmail 邮件。
 
 > /oo 为 https://oomol.com 生成一个二维码。
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ oo login
 
 Then talk to your AI agent in natural language — describe intent, not commands:
 
-> /oo summarize unread Gmail messages from today.
+> /oo summarize my latest 5 Gmail messages.
 
 > /oo generate a QR code for https://oomol.com.
 


### PR DESCRIPTION
The previous "unread Gmail from today" example often returned an empty result for new users with no mail or no unread messages, making the first-run demo feel broken. Bounding the example to the latest 5 messages keeps it almost always non-empty while still showcasing the summarize capability.