### PR TITLE
fix(skills): drop misleading path from update not-installed error

### DIFF
--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -131,6 +131,32 @@ describe("skills update command", () => {
         }
     });
 
+    test("reports a generic not-installed error when the target is absent from every host", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const claudeHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "claude");
+
+        try {
+            await Promise.all([
+                mkdir(codexHomeDirectory, { recursive: true }),
+                mkdir(claudeHomeDirectory, { recursive: true }),
+            ]);
+
+            const result = await sandbox.run(["skills", "update", "aaa"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Skill aaa is not installed as an oo-managed skill in any supported agent.\n",
+            );
+            expect(result.stderr).not.toContain(codexHomeDirectory);
+            expect(result.stderr).not.toContain(claudeHomeDirectory);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("rejects an explicit update target with unparseable metadata as unmanaged", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -451,21 +451,18 @@ async function resolveSelectedManagedSkills(
         const unmanagedTarget = targetStates.find(
             target => target.hasDirectoryWithoutMetadata,
         );
-        const firstTarget = targetStates[0]!;
 
-        throw new CliUserError(
-            unmanagedTarget !== undefined
-                ? "errors.skills.update.notManaged"
-                : "errors.skills.notInstalled",
-            1,
-            {
-                hostName: unmanagedTarget?.agentName
-                    ?? firstTarget.agentName,
+        if (unmanagedTarget !== undefined) {
+            throw new CliUserError("errors.skills.update.notManaged", 1, {
+                hostName: unmanagedTarget.agentName,
                 name: requestedSkillName,
-                path: unmanagedTarget?.installedSkillDirectoryPath
-                    ?? firstTarget.installedSkillDirectoryPath,
-            },
-        );
+                path: unmanagedTarget.installedSkillDirectoryPath,
+            });
+        }
+
+        throw new CliUserError("errors.skills.update.notInstalled", 1, {
+            name: requestedSkillName,
+        });
     }
 
     return selectedSkills;

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -582,6 +582,8 @@ export const enMessages = {
         "Managed skill {name} cannot be updated in {hostNames} because its package metadata is missing.",
     "errors.skills.update.notManaged":
         "Skill {name} in host {hostName} is not managed by oo and cannot be updated.",
+    "errors.skills.update.notInstalled":
+        "Skill {name} is not installed as an oo-managed skill in any supported agent.",
     "errors.skills.nameConflict":
         "Skill name {name} is already used by a non-OOMOL skill at {path}.",
     "errors.skills.storageConflict":
@@ -1528,6 +1530,8 @@ export const zhMessages = {
         "无法在 {hostNames} 中更新由 oo 管理的 skill {name}，因为缺少 package 元数据。",
     "errors.skills.update.notManaged":
         "Agent {hostName} 中的 skill {name} 不是由 oo 管理的 skill，无法更新。",
+    "errors.skills.update.notInstalled":
+        "Skill {name} 未作为 oo 管理的 skill 安装到任何受支持的 agent 中。",
     "errors.skills.nameConflict":
         "Skill 名称 {name} 已被 {path} 中的非 OOMOL skill 占用。",
     "errors.skills.storageConflict":


### PR DESCRIPTION
The previous not-installed branch shared a throw with the unmanaged- target branch and filled in targetStates[0].installedSkillDirectoryPath as the displayed path. When the skill was absent from every host, that path was just an arbitrary host pick, making the error look as if update only checked one specific agent.

Split the branch so the unmanaged case keeps its meaningful path, and introduce errors.skills.update.notInstalled without a host path for the truly not-installed case.