### PR TITLE
feat(cli): add `oo info` command for environment inspection

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -350,6 +350,36 @@ Check whether a newer CLI release is available.
 - Notes: when the update check is temporarily unavailable, the CLI prints a
   retry-later message instead of exiting with an error.
 
+## Environment
+
+### `oo info`
+
+Print CLI environment details, persisted store paths, and detected skill
+agents.
+
+- Options: `--format=json` and `--json` switch to structured JSON output.
+  Without those flags, the command prints a human-readable colored summary.
+- Output (JSON): a single object with three top-level fields:
+  - `cli`: an object with the following string fields. `version` is the
+    running CLI version. `platform` is the Node-style platform identifier
+    (`darwin`, `linux`, `win32`, etc.). `arch` is the Node-style architecture
+    identifier (`arm64`, `x64`, etc.). `storeDir` is the root directory of
+    the persisted store. `logDir` is the persisted debug log directory.
+    `authFile` is the persisted auth file path. `settingsFile` is the
+    persisted configuration file path.
+  - `agents`: an array of `{ id, skillDir, status }` entries, one per
+    supported skill agent. `id` is the stable agent identifier (for example
+    `codex`, `claude`, `hermes`). `skillDir` is the agent's resolved skill
+    directory. `status` is one of `available`, `no_skills`, or
+    `not_installed`. `available` means both the agent home directory and
+    its skill directory exist locally. `no_skills` means the agent home
+    directory exists but the skill directory has not been created yet (for
+    example when `oo` could not write skills into the agent). `not_installed`
+    means the agent home directory itself is missing, so `oo` has nowhere to
+    install skills.
+  - `features`: a reserved array for optional CLI capability flags. The CLI
+    currently always returns an empty array.
+
 ## Connector
 
 ### `oo connector search <text>`

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -299,6 +299,30 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   最新发布版本。
 - 说明：如果更新检查暂时不可用，CLI 会输出稍后重试的提示，而不是直接报错退出。
 
+## 环境
+
+### `oo info`
+
+打印 CLI 运行环境信息、本地持久化路径以及检测到的 skill 代理。
+
+- 选项：`--format=json` 与 `--json` 用于切换到结构化 JSON 输出。
+  不指定时，命令会输出带颜色的可读摘要。
+- 输出（JSON）：返回一个对象，包含三个顶层字段：
+  - `cli`：包含以下字符串字段：`version` 为当前 CLI 版本；
+    `platform` 为 Node 风格的操作系统标识（如 `darwin`、`linux`、`win32`）；
+    `arch` 为 Node 风格的架构标识（如 `arm64`、`x64`）；
+    `storeDir` 为持久化存储根目录；`logDir` 为持久化 debug 日志目录；
+    `authFile` 为认证文件路径；`settingsFile` 为配置文件路径。
+  - `agents`：每个受支持的 skill 代理对应一项，结构为
+    `{ id, skillDir, status }`。`id` 为稳定的代理标识（例如 `codex`、
+    `claude`、`hermes` 等）；`skillDir` 为该代理对应的 skill 目录；
+    `status` 取值为 `available`、`no_skills` 或 `not_installed` 三者之一。
+    `available` 表示代理 home 目录与 skill 目录均存在；`no_skills` 表示
+    代理 home 目录存在但 skill 目录尚未创建（例如 `oo` 还没有向该代理
+    写入 skill）；`not_installed` 表示代理 home 目录本身不存在，`oo`
+    暂时无法向其安装 skill。
+  - `features`：保留字段，用于后续可选能力开关。当前始终返回空数组。
+
 ## Connector
 
 ### `oo connector search <text>`

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -45,6 +45,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
+  info [options]            Show CLI environment info
   llm                       Manage LLM client config
   login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
@@ -81,6 +82,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
+  info [options]            Show CLI environment info
   llm                       Manage LLM client config
   login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
@@ -120,6 +122,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
+  info [options]            Show CLI environment info
   llm                       Manage LLM client config
   login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
@@ -157,6 +160,7 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
   cloud-task                管理云任务
   connector                 管理 connector action
   file                      管理临时文件传输
+  info [options]            显示 CLI 环境信息
   llm                       管理 LLM client 配置
   login [options]           登录 OOMOL 账号（auth login 的别名）
   logout                    登出当前账号（auth logout 的别名）
@@ -190,6 +194,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
+  info [options]            Show CLI environment info
   llm                       Manage LLM client config
   login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
@@ -227,6 +232,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
+  info [options]            Show CLI environment info
   llm                       Manage LLM client config
   login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)

--- a/src/application/commands/__snapshots__/info.cli.test.ts.snap
+++ b/src/application/commands/__snapshots__/info.cli.test.ts.snap
@@ -1,0 +1,46 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`info CLI prints a human-readable view when --json is not set 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"CLI
+  Version: 1.2.3
+  Platform: darwin
+  Architecture: arm64
+  Store directory: <XDG_CONFIG_HOME>/oo
+  Log directory: <HOME>/Library/Logs/oo
+  Auth file: <XDG_CONFIG_HOME>/oo/auth.toml
+  Settings file: <XDG_CONFIG_HOME>/oo/settings.toml
+
+Agents
+  universal (not installed)
+    Skill directory: <HOME>/.agents/skills
+  codex (not installed)
+    Skill directory: <HOME>/.codex/skills
+  claude (not installed)
+    Skill directory: <HOME>/.claude/skills
+  hermes (not installed)
+    Skill directory: <HOME>/.hermes/skills
+  codebuddy (not installed)
+    Skill directory: <HOME>/.codebuddy/skills
+  workbuddy (not installed)
+    Skill directory: <HOME>/.workbuddy/skills
+  trae (not installed)
+    Skill directory: <HOME>/.trae/skills
+  trae-cn (not installed)
+    Skill directory: <HOME>/.trae-cn/skills
+  openclaw (not installed)
+    Skill directory: <HOME>/.openclaw/skills
+  qoderwork (not installed)
+    Skill directory: <HOME>/.qoderwork/skills
+  deepseek-tui (not installed)
+    Skill directory: <HOME>/.deepseek/skills
+
+Features
+  No optional features enabled.
+"
+,
+}
+`;

--- a/src/application/commands/__snapshots__/info.cli.test.ts.snap
+++ b/src/application/commands/__snapshots__/info.cli.test.ts.snap
@@ -7,10 +7,10 @@ exports[`info CLI prints a human-readable view when --json is not set 1`] = `
   "stdout": 
 "CLI
   Version: 1.2.3
-  Platform: darwin
-  Architecture: arm64
+  Platform: <PLATFORM>
+  Architecture: <ARCH>
   Store directory: <XDG_CONFIG_HOME>/oo
-  Log directory: <HOME>/Library/Logs/oo
+  Log directory: <LOG_DIR>
   Auth file: <XDG_CONFIG_HOME>/oo/auth.toml
   Settings file: <XDG_CONFIG_HOME>/oo/settings.toml
 

--- a/src/application/commands/catalog.ts
+++ b/src/application/commands/catalog.ts
@@ -8,6 +8,7 @@ import { completionCommand } from "./completion.ts";
 import { configCommand } from "./config/index.ts";
 import { connectorCommand } from "./connector/index.ts";
 import { fileCommand } from "./file/index.ts";
+import { infoCommand } from "./info.ts";
 import { installCommand } from "./install.ts";
 import { llmCommand } from "./llm/index.ts";
 import { logCommand } from "./log/index.ts";
@@ -46,6 +47,7 @@ export function createCliCatalog(): CliCatalog {
             cloudTaskCommand,
             connectorCommand,
             fileCommand,
+            infoCommand,
             installCommand,
             llmCommand,
             loginCommand,

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -31,6 +31,7 @@ Commands:
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
+  info [options]            Show CLI environment info
   llm                       Manage LLM client config
   login [options]           Log in with an OOMOL account (alias for auth login)
   logout                    Log out the current account (alias for auth logout)
@@ -64,6 +65,7 @@ Commands:
   cloud-task                管理云任务
   connector                 管理 connector action
   file                      管理临时文件传输
+  info [options]            显示 CLI 环境信息
   llm                       管理 LLM client 配置
   login [options]           登录 OOMOL 账号（auth login 的别名）
   logout                    登出当前账号（auth logout 的别名）

--- a/src/application/commands/info.cli.test.ts
+++ b/src/application/commands/info.cli.test.ts
@@ -116,10 +116,20 @@ describe("info CLI", () => {
             const result = await sandbox.run(["info"], {
                 version: "1.2.3",
             });
+            const logDirectoryPath = resolveStorePaths({
+                appName: APP_NAME,
+                env: sandbox.env,
+                platform: process.platform,
+            }).logDirectoryPath;
 
             expect(createCliSnapshot(result, {
                 sandbox,
                 stripAnsi: true,
+                replacements: [
+                    { placeholder: "<LOG_DIR>", value: logDirectoryPath },
+                    { placeholder: "<PLATFORM>", value: process.platform },
+                    { placeholder: "<ARCH>", value: process.arch },
+                ],
             })).toMatchSnapshot();
         }
         finally {

--- a/src/application/commands/info.cli.test.ts
+++ b/src/application/commands/info.cli.test.ts
@@ -80,7 +80,9 @@ describe("info CLI", () => {
                 sandbox.env,
                 "codex",
             );
-            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(resolveManagedSkillsDirectoryPath(codexHomeDirectory), {
+                recursive: true,
+            });
 
             const result = await sandbox.run(["info", "--json"]);
 
@@ -164,7 +166,9 @@ describe("info CLI", () => {
                 sandbox.env,
                 "claude",
             );
-            await mkdir(claudeHomeDirectory, { recursive: true });
+            await mkdir(resolveManagedSkillsDirectoryPath(claudeHomeDirectory), {
+                recursive: true,
+            });
 
             const result = await sandbox.run(["info"], { version: "1.2.3" });
 

--- a/src/application/commands/info.cli.test.ts
+++ b/src/application/commands/info.cli.test.ts
@@ -1,0 +1,197 @@
+import { mkdir } from "node:fs/promises";
+import process from "node:process";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    createCliSandbox,
+    createCliSnapshot,
+} from "../../../__tests__/helpers.ts";
+import { resolveStorePaths } from "../../adapters/store/store-path.ts";
+import { APP_NAME } from "../config/app-config.ts";
+import { JSON_OUTPUT_SCHEMA_VERSION } from "./json-output.ts";
+import {
+    availableBundledSkillAgentNames,
+    resolveManagedSkillAgentHomeDirectory,
+} from "./skills/managed-skill-agents.ts";
+import { resolveManagedSkillsDirectoryPath } from "./skills/managed-skill-paths.ts";
+
+describe("info CLI", () => {
+    test("prints a JSON payload with cli, agents, and features", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const storePaths = resolveStorePaths({
+                appName: APP_NAME,
+                env: sandbox.env,
+                platform: process.platform,
+            });
+            const result = await sandbox.run(["info", "--json"], {
+                version: "1.2.3",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            const payload = JSON.parse(result.stdout);
+            expect(payload).toMatchObject({
+                cli: {
+                    version: "1.2.3",
+                    platform: process.platform,
+                    arch: process.arch,
+                    storeDir: storePaths.rootDirectory,
+                    logDir: storePaths.logDirectoryPath,
+                    authFile: storePaths.authFilePath,
+                    settingsFile: storePaths.settingsFilePath,
+                },
+                features: [],
+            });
+            expect(Array.isArray(payload.agents)).toBe(true);
+            expect(payload.schemaVersion).toBeUndefined();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("adds schemaVersion when --show-schema-version is set with --json", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run([
+                "info",
+                "--json",
+                "--show-schema-version",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout);
+            expect(payload.schemaVersion).toBe(JSON_OUTPUT_SCHEMA_VERSION);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports agent status based on detected home directories", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(
+                sandbox.env,
+                "codex",
+            );
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["info", "--json"]);
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout);
+            const agents = payload.agents as ReadonlyArray<{
+                id: string;
+                skillDir: string;
+                status: string;
+            }>;
+            const agentIds = agents.map(agent => agent.id);
+            expect(agentIds).toEqual([...availableBundledSkillAgentNames]);
+
+            const codexAgent = agents.find(agent => agent.id === "codex");
+            expect(codexAgent).toEqual({
+                id: "codex",
+                skillDir: resolveManagedSkillsDirectoryPath(codexHomeDirectory),
+                status: "available",
+            });
+
+            const claudeAgent = agents.find(agent => agent.id === "claude");
+            expect(claudeAgent?.status).toBe("not_installed");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("prints a human-readable view when --json is not set", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["info"], {
+                version: "1.2.3",
+            });
+
+            expect(createCliSnapshot(result, {
+                sandbox,
+                stripAnsi: true,
+            })).toMatchSnapshot();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("includes ANSI color codes when stdout supports colors", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["info"], {
+                stdout: {
+                    hasColors: true,
+                },
+                version: "1.2.3",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("[");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("lists available agents before non-available ones in text output", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const claudeHomeDirectory = resolveManagedSkillAgentHomeDirectory(
+                sandbox.env,
+                "claude",
+            );
+            await mkdir(claudeHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["info"], { version: "1.2.3" });
+
+            expect(result.exitCode).toBe(0);
+            const agentLines = result.stdout
+                .split("\n")
+                .filter(line =>
+                    line.includes("(available)") || line.includes("(not installed)"),
+                );
+            const firstNotInstalledIndex = agentLines.findIndex(line =>
+                line.includes("(not installed)"),
+            );
+            const lastAvailableIndex
+                = agentLines.map(line => line.includes("(available)"))
+                    .lastIndexOf(true);
+
+            expect(firstNotInstalledIndex).toBeGreaterThan(-1);
+            expect(lastAvailableIndex).toBeGreaterThan(-1);
+            expect(lastAvailableIndex).toBeLessThan(firstNotInstalledIndex);
+            expect(agentLines[lastAvailableIndex]).toContain("claude");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects unsupported --format values", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["info", "--format=yaml"]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("yaml");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/info.test.ts
+++ b/src/application/commands/info.test.ts
@@ -1,0 +1,91 @@
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { collectAgents } from "./info.ts";
+import {
+    availableBundledSkillAgentNames,
+    resolveManagedSkillAgentHomeDirectory,
+} from "./skills/managed-skill-agents.ts";
+import { resolveManagedSkillsDirectoryPath } from "./skills/managed-skill-paths.ts";
+
+describe("collectAgents", () => {
+    let homeDirectory: string;
+
+    beforeEach(async () => {
+        homeDirectory = join(tmpdir(), `oo-info-${Bun.randomUUIDv7()}`);
+        await mkdir(homeDirectory, { recursive: true });
+    });
+
+    afterEach(async () => {
+        await rm(homeDirectory, { force: true, recursive: true });
+    });
+
+    test("reports not_installed when the agent home directory is missing", async () => {
+        const env = createEnv(homeDirectory);
+        const agents = await collectAgents(env);
+        const claudeAgent = findAgent(agents, "claude");
+
+        expect(claudeAgent.status).toBe("not_installed");
+        expect(claudeAgent.skillDir).toBe(
+            resolveManagedSkillsDirectoryPath(
+                resolveManagedSkillAgentHomeDirectory(env, "claude"),
+            ),
+        );
+    });
+
+    test("reports no_skills when the agent home exists but the skill directory does not", async () => {
+        const env = createEnv(homeDirectory);
+        const claudeHome = resolveManagedSkillAgentHomeDirectory(env, "claude");
+        await mkdir(claudeHome, { recursive: true });
+
+        const agents = await collectAgents(env);
+        const claudeAgent = findAgent(agents, "claude");
+
+        expect(claudeAgent.status).toBe("no_skills");
+    });
+
+    test("reports available when both the agent home and the skill directory exist", async () => {
+        const env = createEnv(homeDirectory);
+        const claudeHome = resolveManagedSkillAgentHomeDirectory(env, "claude");
+        await mkdir(resolveManagedSkillsDirectoryPath(claudeHome), {
+            recursive: true,
+        });
+
+        const agents = await collectAgents(env);
+        const claudeAgent = findAgent(agents, "claude");
+
+        expect(claudeAgent.status).toBe("available");
+    });
+
+    test("returns one entry per supported skill agent in registered order", async () => {
+        const env = createEnv(homeDirectory);
+        const agents = await collectAgents(env);
+
+        expect(agents.map(agent => agent.id)).toEqual([
+            ...availableBundledSkillAgentNames,
+        ]);
+    });
+});
+
+function createEnv(home: string): Record<string, string | undefined> {
+    return {
+        HOME: home,
+        USERPROFILE: home,
+    };
+}
+
+function findAgent(
+    agents: Awaited<ReturnType<typeof collectAgents>>,
+    id: string,
+): Awaited<ReturnType<typeof collectAgents>>[number] {
+    const found = agents.find(agent => agent.id === id);
+
+    if (!found) {
+        throw new Error(`Expected info agent entry for ${id}.`);
+    }
+
+    return found;
+}

--- a/src/application/commands/info.ts
+++ b/src/application/commands/info.ts
@@ -1,0 +1,246 @@
+import type { CliCommandDefinition, CliExecutionContext, Writer } from "../contracts/cli.ts";
+import type { TerminalColors } from "../terminal-colors.ts";
+import type { BundledSkillAgentName } from "./skills/managed-skill-agents.ts";
+
+import process from "node:process";
+import { z } from "zod";
+import { resolveStorePaths } from "../../adapters/store/store-path.ts";
+import { APP_NAME } from "../config/app-config.ts";
+import { createWriterColors } from "../terminal-colors.ts";
+import { jsonOutputOptions, writeJsonOutput } from "./json-output.ts";
+import { createFormatInputError } from "./shared/input-parsing.ts";
+import { directoryExists } from "./skills/bundled-skill-observation.ts";
+import {
+    availableBundledSkillAgentNames,
+    resolveManagedSkillAgentHomeDirectory,
+} from "./skills/managed-skill-agents.ts";
+import { resolveManagedSkillsDirectoryPath } from "./skills/managed-skill-paths.ts";
+
+const infoFormatValues = ["json"] as const;
+
+type InfoFormat = (typeof infoFormatValues)[number];
+
+type InfoAgentStatus = "available" | "no_skills" | "not_installed";
+
+const infoAgentStatusOrder: Record<InfoAgentStatus, number> = {
+    available: 0,
+    no_skills: 1,
+    not_installed: 2,
+};
+
+interface InfoInput {
+    format?: InfoFormat;
+    showSchemaVersion?: boolean;
+}
+
+export interface InfoAgentEntry {
+    id: BundledSkillAgentName;
+    skillDir: string;
+    status: InfoAgentStatus;
+}
+
+export type { InfoAgentStatus };
+
+interface InfoOutput {
+    cli: {
+        version: string;
+        platform: string;
+        arch: string;
+        storeDir: string;
+        logDir: string;
+        authFile: string;
+        settingsFile: string;
+    };
+    agents: readonly InfoAgentEntry[];
+    features: readonly string[];
+}
+
+export const infoCommand: CliCommandDefinition<InfoInput> = {
+    name: "info",
+    summaryKey: "commands.info.summary",
+    descriptionKey: "commands.info.description",
+    options: [...jsonOutputOptions],
+    inputSchema: z.object({
+        format: z.enum(infoFormatValues).optional(),
+        showSchemaVersion: z.boolean().optional(),
+    }),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+    handler: async (input, context) => {
+        const info = await collectInfo(context);
+
+        if (input.format === "json") {
+            writeJsonOutput(context.stdout, info, {
+                showSchemaVersion: input.showSchemaVersion,
+            });
+            return;
+        }
+
+        writeInfoAsText(info, context);
+    },
+};
+
+async function collectInfo(
+    context: CliExecutionContext,
+): Promise<InfoOutput> {
+    const storePaths = resolveStorePaths({
+        appName: APP_NAME,
+        env: context.env,
+        platform: process.platform,
+    });
+    const agents = await collectAgents(context.env);
+
+    return {
+        cli: {
+            version: context.version,
+            platform: process.platform,
+            arch: process.arch,
+            storeDir: storePaths.rootDirectory,
+            logDir: storePaths.logDirectoryPath,
+            authFile: context.authStore.getFilePath(),
+            settingsFile: context.settingsStore.getFilePath(),
+        },
+        agents,
+        features: [],
+    };
+}
+
+export async function collectAgents(
+    env: Record<string, string | undefined>,
+): Promise<readonly InfoAgentEntry[]> {
+    return await Promise.all(
+        availableBundledSkillAgentNames.map(async (agentName) => {
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(env, agentName);
+            const skillDir = resolveManagedSkillsDirectoryPath(homeDirectory);
+            const status = await resolveAgentStatus(homeDirectory, skillDir);
+
+            return {
+                id: agentName,
+                skillDir,
+                status,
+            } satisfies InfoAgentEntry;
+        }),
+    );
+}
+
+async function resolveAgentStatus(
+    homeDirectory: string,
+    skillDir: string,
+): Promise<InfoAgentStatus> {
+    const [homeExists, skillDirExists] = await Promise.all([
+        directoryExists(homeDirectory),
+        directoryExists(skillDir),
+    ]);
+
+    if (!homeExists) {
+        return "not_installed";
+    }
+
+    return skillDirExists ? "available" : "no_skills";
+}
+
+function writeInfoAsText(
+    info: InfoOutput,
+    context: CliExecutionContext,
+): void {
+    const colors = createWriterColors(context.stdout);
+    const writer = context.stdout;
+    const translate = (key: string): string => context.translator.t(key);
+
+    writeSectionHeading(writer, colors, translate("info.section.cli"));
+    writeKeyValue(writer, colors, translate("info.cli.version"), info.cli.version);
+    writeKeyValue(writer, colors, translate("info.cli.platform"), info.cli.platform);
+    writeKeyValue(writer, colors, translate("info.cli.arch"), info.cli.arch);
+    writeKeyValue(writer, colors, translate("info.cli.storeDir"), info.cli.storeDir);
+    writeKeyValue(writer, colors, translate("info.cli.logDir"), info.cli.logDir);
+    writeKeyValue(writer, colors, translate("info.cli.authFile"), info.cli.authFile);
+    writeKeyValue(writer, colors, translate("info.cli.settingsFile"), info.cli.settingsFile);
+
+    writer.write("\n");
+    writeSectionHeading(writer, colors, translate("info.section.agents"));
+
+    if (info.agents.length === 0) {
+        writer.write(`  ${colors.dim(translate("info.agents.empty"))}\n`);
+    }
+    else {
+        for (const agent of sortAgentsForText(info.agents)) {
+            writeAgentEntry(writer, colors, agent, translate);
+        }
+    }
+
+    writer.write("\n");
+    writeSectionHeading(writer, colors, translate("info.section.features"));
+
+    if (info.features.length === 0) {
+        writer.write(`  ${colors.dim(translate("info.features.empty"))}\n`);
+    }
+    else {
+        for (const feature of info.features) {
+            writer.write(`  ${colors.dim("-")} ${feature}\n`);
+        }
+    }
+}
+
+function sortAgentsForText(
+    agents: readonly InfoAgentEntry[],
+): readonly InfoAgentEntry[] {
+    // Stable sort by readiness: available → no_skills → not_installed, keeping
+    // the catalog-registered order within each group.
+    return Array.from(agents, (agent, index) => ({ agent, index }))
+        .sort((left, right) => {
+            const delta
+                = infoAgentStatusOrder[left.agent.status]
+                    - infoAgentStatusOrder[right.agent.status];
+
+            return delta !== 0 ? delta : left.index - right.index;
+        })
+        .map(entry => entry.agent);
+}
+
+function writeSectionHeading(
+    writer: Writer,
+    colors: TerminalColors,
+    label: string,
+): void {
+    writer.write(`${colors.bold(label)}\n`);
+}
+
+function writeKeyValue(
+    writer: Writer,
+    colors: TerminalColors,
+    label: string,
+    value: string,
+): void {
+    writer.write(`  ${colors.dim(`${label}:`)} ${value}\n`);
+}
+
+function formatAgentStatus(
+    status: InfoAgentStatus,
+    label: string,
+    colors: TerminalColors,
+): string {
+    switch (status) {
+        case "available":
+            return colors.green(label);
+        case "no_skills":
+            return colors.yellow(label);
+        case "not_installed":
+            return colors.dim(label);
+    }
+}
+
+function writeAgentEntry(
+    writer: Writer,
+    colors: TerminalColors,
+    agent: InfoAgentEntry,
+    translate: (key: string) => string,
+): void {
+    const statusLabel = translate(`info.agents.status.${agent.status}`);
+    const statusFormatted = formatAgentStatus(agent.status, statusLabel, colors);
+
+    writer.write(
+        `  ${colors.bold(agent.id)} ${colors.dim("(")}${statusFormatted}${colors.dim(")")}\n`,
+    );
+    writer.write(
+        `    ${colors.dim(`${translate("info.agents.skillDir")}:`)} ${agent.skillDir}\n`,
+    );
+}

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -214,6 +214,10 @@ const commandTelemetryDecisions = {
         properties: ["bytes_total_bucket", "rejected_too_large"],
         reason: "Records upload size bucket and rejection state without path or filename.",
     },
+    "info": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; environment paths and agent presence are not recorded.",
+    },
     "install": {
         kind: "properties",
         properties: [

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -104,6 +104,9 @@ export const enMessages = {
     "commands.file.upload.description":
         "Upload a file and store the signed download URL locally.",
     "commands.file.upload.summary": "Upload a file",
+    "commands.info.description":
+        "Print CLI environment details, persisted store paths, and detected skill agents.",
+    "commands.info.summary": "Show CLI environment info",
     "commands.install.description":
         "Install one oo-managed CLI release into the local managed runtime.",
     "commands.install.summary": "Install the CLI",
@@ -628,6 +631,22 @@ export const enMessages = {
     "errors.log.invalidIndex":
         "Invalid log index: {value}. Use an integer greater than or equal to 1.",
     "log.print.missing": "No debug log was found for index {index}.",
+    "info.section.cli": "CLI",
+    "info.section.agents": "Agents",
+    "info.section.features": "Features",
+    "info.cli.version": "Version",
+    "info.cli.platform": "Platform",
+    "info.cli.arch": "Architecture",
+    "info.cli.storeDir": "Store directory",
+    "info.cli.logDir": "Log directory",
+    "info.cli.authFile": "Auth file",
+    "info.cli.settingsFile": "Settings file",
+    "info.agents.empty": "No supported skill agents detected.",
+    "info.agents.skillDir": "Skill directory",
+    "info.agents.status.available": "available",
+    "info.agents.status.no_skills": "no skills",
+    "info.agents.status.not_installed": "not installed",
+    "info.features.empty": "No optional features enabled.",
     "checkUpdate.unavailable":
         "Unable to check for updates right now. Please try again later.",
     "checkUpdate.upToDate": "Already up to date at {version}.",
@@ -1074,6 +1093,9 @@ export const zhMessages = {
     "commands.file.summary": "管理临时文件传输",
     "commands.file.upload.description": "上传文件，并在本地保存带签名的下载地址。",
     "commands.file.upload.summary": "上传文件",
+    "commands.info.description":
+        "打印 CLI 运行环境信息、本地存储路径以及检测到的 skill 代理。",
+    "commands.info.summary": "显示 CLI 环境信息",
     "commands.install.description":
         "把一个由 oo 管理的 CLI 版本安装到本地托管运行时中。",
     "commands.install.summary": "安装 CLI",
@@ -1574,6 +1596,22 @@ export const zhMessages = {
     "errors.log.invalidIndex":
         "无效的日志序号：{value}。请使用大于等于 1 的整数。",
     "log.print.missing": "未找到序号为 {index} 的 debug 日志。",
+    "info.section.cli": "CLI",
+    "info.section.agents": "代理",
+    "info.section.features": "特性",
+    "info.cli.version": "版本",
+    "info.cli.platform": "操作系统",
+    "info.cli.arch": "架构",
+    "info.cli.storeDir": "存储目录",
+    "info.cli.logDir": "日志目录",
+    "info.cli.authFile": "认证文件",
+    "info.cli.settingsFile": "配置文件",
+    "info.agents.empty": "未检测到任何支持的 skill 代理。",
+    "info.agents.skillDir": "Skill 目录",
+    "info.agents.status.available": "已安装",
+    "info.agents.status.no_skills": "尚未注入 skill",
+    "info.agents.status.not_installed": "未安装",
+    "info.features.empty": "暂未启用任何可选特性。",
     "checkUpdate.unavailable": "暂时无法检查更新，请稍后重试。",
     "checkUpdate.upToDate": "当前已是最新版本 {version}。",
     "checkUpdate.unsupportedVersion":


### PR DESCRIPTION
Add a top-level `oo info` command that prints the running CLI version, platform, architecture, persisted store paths, and the status of every supported skill agent. The command supports `--json` / `--format=json` with `--show-schema-version`, and falls back to a colored, human-readable summary otherwise.

Agent status is reported as one of three values: `available` when both the agent home and its skill directory exist, `no_skills` when the agent home exists but `oo` has not populated the skill directory yet, and `not_installed` when the agent home itself is missing. Surfacing the middle state helps users diagnose half-installed setups instead of treating any non-`available` agent as simply absent.

In text mode the agents are sorted available → no_skills → not_installed while keeping the catalog-registered order within each group, so the output leads with what the user can use today. The command is registered with a generic telemetry decision because no command-specific dimensions need to be recorded.