### PR TITLE
feat(skills): add `oo skills info` with `list` as alias

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -501,10 +501,10 @@ for every supported host directory that already exists.
   require authentication, does not print additional command output, and does
   not overwrite same-name targets that are not managed by `oo`.
 
-### `oo skills list`
+### `oo skills info`
 
-List bundled and registry skills by default. Local skills are listed only when
-requested.
+Show bundled and registry skills by default. Local skills are listed only when
+requested. `oo skills list` is accepted as an alias for backwards compatibility.
 
 - Options: `--source <source>`, `-s <source>` filters the list to one source:
   `bundled`, `registry`, or `local`.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -434,9 +434,10 @@ registry skills。
 - 安全规则：启动同步不会请求 registry，不要求登录，不会产生额外命令输出，也
   不会覆盖不由 `oo` 管理的同名目标。
 
-### `oo skills list`
+### `oo skills info`
 
-默认列出 bundled 和 registry skill。只有显式请求时才列出 local skill。
+默认列出 bundled 和 registry skill。只有显式请求时才列出 local skill。为兼容
+旧版用法，`oo skills list` 作为别名仍然可用。
 
 - 选项：`--source <source>`、`-s <source>` 将列表过滤为一个来源：
   `bundled`、`registry` 或 `local`。

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -77,6 +77,66 @@ describe("skills list CLI", () => {
         }
     });
 
+    test("exposes the same listing under the info command name", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const skillsDirectoryPath = join(codexHomeDirectory, "skills");
+        const alphaSkillDirectoryPath = join(skillsDirectoryPath, "alpha-skill");
+
+        try {
+            await mkdir(alphaSkillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(alphaSkillDirectoryPath, ".oo-metadata.json"),
+                renderSkillMetadataJson({
+                    packageName: "@oomol/alpha",
+                    version: "1.2.3",
+                }),
+            );
+
+            const infoResult = await sandbox.run(["skills", "info"], {
+                version: "9.9.9",
+            });
+            const listResult = await sandbox.run(["skills", "list"], {
+                version: "9.9.9",
+            });
+
+            expect(infoResult.exitCode).toBe(0);
+            expect(infoResult.stderr).toBe("");
+            expect(infoResult.stdout).toBe(listResult.stdout);
+            expect(infoResult.stdout).toContain("alpha-skill");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("records info telemetry when invoked through the list alias", async () => {
+        const sandbox = await createCliSandbox();
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+
+        try {
+            const result = await sandbox.run(["skills", "list"]);
+
+            expect(result.exitCode).toBe(0);
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(storePaths.telemetryDirectory)[0]!,
+            );
+
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    command_full: "skills.info",
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("excludes local skills by default and lists them with --source local", async () => {
         const sandbox = await createCliSandbox();
         const codeBuddyHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codebuddy");
@@ -225,7 +285,7 @@ describe("skills list CLI", () => {
 
             expect(telemetryPayload).toMatchObject({
                 properties: {
-                    command_full: "skills.list",
+                    command_full: "skills.info",
                     has_agent_filter: true,
                     source_filter: "local",
                 },

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -104,9 +104,10 @@ interface SkillsListInput {
 }
 
 export const skillsListCommand: CliCommandDefinition<SkillsListInput> = {
-    name: "list",
-    summaryKey: "commands.skills.list.summary",
-    descriptionKey: "commands.skills.list.description",
+    name: "info",
+    aliases: ["list"],
+    summaryKey: "commands.skills.info.summary",
+    descriptionKey: "commands.skills.info.description",
     options: [
         {
             name: "agent",

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -305,7 +305,7 @@ const commandTelemetryDecisions = {
         ],
         reason: "Records install source, product-domain package dimension, and bounded skill samples.",
     },
-    "skills.list": {
+    "skills.info": {
         kind: "properties",
         properties: ["has_agent_filter", "source_filter"],
         reason: "Records filter usage without installed skill inventory.",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -154,10 +154,10 @@ export const enMessages = {
         "Search published skills against the skills search API.",
     "commands.skills.search.summary":
         "Search published skills",
-    "commands.skills.list.description":
-        "List bundled, registry, and local skills.",
-    "commands.skills.list.summary":
-        "List skills",
+    "commands.skills.info.description":
+        "Show bundled, registry, and local skills installed in this environment.",
+    "commands.skills.info.summary":
+        "Show installed skills",
     "commands.skills.locate.description":
         "Print the local path for an installed skill.",
     "commands.skills.locate.summary": "Locate a skill path",
@@ -1135,10 +1135,10 @@ export const zhMessages = {
         "使用自由文本通过 skills search API 搜索已发布的 skill。",
     "commands.skills.search.summary":
         "搜索已发布的 skill",
-    "commands.skills.list.description":
-        "列出 bundled、registry 和 local skill。",
-    "commands.skills.list.summary":
-        "列出 skill",
+    "commands.skills.info.description":
+        "查看当前环境中已安装的 bundled、registry 和 local skill。",
+    "commands.skills.info.summary":
+        "查看已安装的 skill",
     "commands.skills.locate.description":
         "输出已安装 skill 的本地路径。",
     "commands.skills.locate.summary": "定位 skill 路径",


### PR DESCRIPTION
Align the skills listing command with the recently introduced top-level `oo info` so users have a consistent verb for inspecting installed components. The existing `oo skills list` invocation continues to work as an alias for backwards compatibility, and the underlying behavior, options, and output remain unchanged.