### PR TITLE
feat(skills): add `--force` flag to `install`

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -850,6 +850,15 @@ Install bundled or published skills into supported local skill directories.
 - Options: `-y, --yes` skips confirmation prompts. When a package publishes
   multiple skills and no explicit `--skill` is provided, `-y` installs all of
   them.
+- Options: `-f, --force` overrides install when the target directory exists
+  with the same skill name but is **not** managed by oo (no readable
+  `.oo-metadata.json`). The previous directory contents are removed before the
+  new skill is written; a `warn` log records the overwrite. `--force` does
+  **not** bypass path containment, package validation, auth, or download
+  validation; it does **not** affect startup auto-sync, `oo skills update`,
+  `oo skills sync`, `oo skills uninstall`, or `oo skills publish`; and it does
+  **not** implicitly select all skills inside a multi-skill package (use
+  `--skill` or `--all -y` together with `--force`).
 - Output: successful non-interactive installs print a compact summary grouped by
   installed skills and target AI agents. When exactly one target is written, the
   summary includes that target path.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -725,6 +725,13 @@ registry skills。
 - 选项：`--all` 是安装全部已发布 skill 的快捷方式，并跳过 skill 选择提示。
 - 选项：`-y, --yes` 用于跳过确认提示。当 package 下有多个 skill 且未显式
   提供 `--skill` 时，`-y` 会安装全部 skill。
+- 选项：`-f, --force` 在目标目录存在同名 skill 但**不受 oo 管理**（缺少可读
+  `.oo-metadata.json`）时，允许覆盖安装。覆盖会先移除原目录内容再写入新
+  skill，并以 `warn` 日志记录此事件。`--force` **不会**绕过路径校验、
+  package 校验、auth 或下载校验；**不影响**启动自动同步、`oo skills update`、
+  `oo skills sync`、`oo skills uninstall`、`oo skills publish`；多 skill
+  package 下也**不**会因此隐式选中全部 skill（如需可配合 `--skill` 或
+  `--all -y` 使用）。
 - 输出：非交互安装成功时，会按已安装 skill 和目标 AI Agent 聚合输出精简摘要；
   当实际只写入一个目标时，摘要会包含该目标路径。
 - 输出：未提供 `[packageName]` 且有预设 registry skills 安装成功时，这些

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -1283,6 +1283,106 @@ describe("skills commands", () => {
         }
     });
 
+    test("`--force` overwrites an unmanaged same-name bundled host directory", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+        const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+
+        try {
+            await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
+            await Bun.write(
+                ownershipFilePath,
+                [
+                    "interface:",
+                    "  display_name: oo",
+                    "  short_description: Custom skill",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["skills", "install", "oo", "--force"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            const metadataPath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
+            const metadataContent = await readFile(metadataPath, "utf8");
+            expect(metadataContent).toContain("\"kind\": \"bundled\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("`-f` short flag matches `--force` for unmanaged bundled host overwrites", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(join(skillDirectoryPath, "user-file.txt"), "user content");
+
+            const result = await sandbox.run(["skills", "install", "oo", "-f"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            const metadataPath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
+            const metadataContent = await readFile(metadataPath, "utf8");
+            expect(metadataContent).toContain("\"kind\": \"bundled\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("`--force` overwrites unmanaged content in the bundled canonical storage", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalSkillDirectoryPath = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+        );
+        const ownershipFilePath = join(
+            canonicalSkillDirectoryPath,
+            "agents",
+            "openai.yaml",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(join(canonicalSkillDirectoryPath, "agents"), {
+                recursive: true,
+            });
+            await Bun.write(
+                ownershipFilePath,
+                [
+                    "interface:",
+                    "  display_name: oo",
+                    "  short_description: Custom skill",
+                    "",
+                ].join("\n"),
+            );
+
+            const result = await sandbox.run(["skills", "install", "oo", "--force"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            // After overwrite, canonical metadata should exist and indicate bundled.
+            const metadataPath = resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath);
+            const metadataContent = await readFile(metadataPath, "utf8");
+            expect(metadataContent).toContain("\"kind\": \"bundled\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("uninstalls all bundled skills from the Codex skills directory when no skill name is provided", async () => {
         const sandbox = await createCliSandbox();
         const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
@@ -2839,6 +2939,81 @@ describe("skills commands", () => {
             await expect(stat(codexSkillDirectoryPath)).rejects.toMatchObject({
                 code: "ENOENT",
             });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("`--force` installs a published registry skill over an unmanaged host target", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const claudeHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "claude");
+        const codexSkillDirectoryPath = join(codexHomeDirectory, "skills", "chatgpt");
+        const claudeSkillDirectoryPath = join(claudeHomeDirectory, "skills", "chatgpt");
+
+        try {
+            await Promise.all([
+                mkdir(codexHomeDirectory, { recursive: true }),
+                mkdir(claudeSkillDirectoryPath, { recursive: true }),
+            ]);
+            await Bun.write(join(claudeSkillDirectoryPath, "SKILL.md"), "# Existing\n");
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "--skill", "chatgpt", "--force"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return new Response(JSON.stringify({
+                                packageName: "openai",
+                                version: "0.0.3",
+                                skills: [
+                                    {
+                                        description: "Chat with a model",
+                                        name: "chatgpt",
+                                        title: "ChatGPT",
+                                    },
+                                ],
+                            }));
+                        }
+
+                        if (request.url.endsWith("/openai/-/meta/openai-0.0.3.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            // Unmanaged Claude target has been overwritten by the registry install.
+            const claudeSkillMd = await readFile(
+                join(claudeSkillDirectoryPath, "SKILL.md"),
+                "utf8",
+            );
+            expect(claudeSkillMd).not.toBe("# Existing\n");
+            expect(claudeSkillMd).toContain("# ChatGPT");
+            expect(
+                await readFile(
+                    resolveManagedSkillMetadataFilePath(claudeSkillDirectoryPath),
+                    "utf8",
+                ),
+            ).toBe(
+                renderSkillMetadataJson(
+                    createRegistrySkillMetadata({ packageName: "openai", version: "0.0.3" }),
+                ),
+            );
+            // Codex target also receives the registry install through the same run.
+            expect(
+                await readFile(join(codexSkillDirectoryPath, "SKILL.md"), "utf8"),
+            ).toContain("# ChatGPT");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -1288,6 +1288,11 @@ describe("skills commands", () => {
         const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
         const skillDirectoryPath = join(codexHomeDirectory, "skills", "oo");
         const ownershipFilePath = join(skillDirectoryPath, "agents", "openai.yaml");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
 
         try {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
@@ -1308,6 +1313,20 @@ describe("skills commands", () => {
             const metadataPath = resolveManagedSkillMetadataFilePath(skillDirectoryPath);
             const metadataContent = await readFile(metadataPath, "utf8");
             expect(metadataContent).toContain("\"kind\": \"bundled\"");
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(storePaths.telemetryDirectory)[0]!,
+            )!;
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    bundled_skill: "oo",
+                    command_full: "skills.install",
+                    has_force: true,
+                    package_kind: "bundled",
+                },
+            });
+            expect(telemetryPayload.properties).not.toHaveProperty("cwd");
+            expect(telemetryPayload.properties).not.toHaveProperty("path");
+            expect(telemetryPayload.properties).not.toHaveProperty("file_name");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -17,6 +17,7 @@ import { createSkillIdsTelemetryProperties } from "./telemetry.ts";
 
 interface SkillsInstallInput {
     all?: boolean;
+    force?: boolean;
     packageName?: string;
     skill?: string[];
     yes?: boolean;
@@ -62,15 +63,28 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
             longFlag: "--all",
             descriptionKey: "options.all",
         },
+        {
+            name: "force",
+            longFlag: "--force",
+            shortFlag: "-f",
+            descriptionKey: "options.skills.install.force",
+        },
     ],
     inputSchema: z.object({
         all: z.boolean().optional(),
+        force: z.boolean().optional(),
         packageName: z.string().optional(),
         skill: z.array(z.string()).optional(),
         yes: z.boolean().optional(),
     }),
     handler: async (input, context) => {
         await migrateLegacyCanonicalSkillLayout(context);
+
+        const force = input.force === true;
+
+        context.telemetry?.recordProperties({
+            has_force: force,
+        });
 
         if (input.packageName === undefined) {
             context.telemetry?.recordProperties({
@@ -82,10 +96,10 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
             const summaries: ManagedSkillInstallSummary[] = [];
 
             for (const skillName of availableBundledSkillNames) {
-                summaries.push(await installBundledSkill(skillName, context));
+                summaries.push(await installBundledSkill(skillName, context, { force }));
             }
 
-            summaries.push(...await installPresetSkillPackages(context));
+            summaries.push(...await installPresetSkillPackages(context, force));
             writeManagedSkillInstallSummary(context, summaries);
             return;
         }
@@ -106,6 +120,7 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
             const summary = await installBundledSkill(
                 packageSpecifier.packageName as BundledSkillName,
                 context,
+                { force },
             );
 
             writeManagedSkillInstallSummary(context, [summary]);
@@ -115,6 +130,7 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         await installRegistrySkills(
             {
                 all: input.all === true,
+                force,
                 packageName: packageSpecifier.packageName,
                 packageShareId: packageSpecifier.packageShareId,
                 packageVersion: packageSpecifier.packageVersion,
@@ -128,6 +144,7 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
 
 async function installPresetSkillPackages(
     context: CliExecutionContext,
+    force: boolean,
 ): Promise<ManagedSkillInstallSummary[]> {
     const summaries: ManagedSkillInstallSummary[] = [];
 
@@ -136,6 +153,7 @@ async function installPresetSkillPackages(
             summaries.push(...await installRegistrySkills(
                 {
                     all: true,
+                    force,
                     packageName,
                     recordTelemetry: false,
                     skillNames: [],

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -52,6 +52,7 @@ interface ManagedSkillPathState {
 
 export interface RegistrySkillInstallRequest {
     all: boolean;
+    force?: boolean;
     packageName: string;
     packageShareId?: string;
     packageVersion?: string;
@@ -178,6 +179,7 @@ export async function installRegistrySkills(
                     availableHosts,
                     settingsFilePath,
                     context,
+                    request.force === true,
                 );
                 installedSummaries.push(...summaries);
 
@@ -237,9 +239,12 @@ async function executeInstallActions(
     availableHosts: readonly ManagedSkillHost[],
     settingsFilePath: string,
     context: CliExecutionContext,
+    force: boolean,
 ): Promise<ManagedSkillInstallSummary[]> {
     for (const { skillName } of installActions) {
         await validateRegistrySkillPublicationTargets({
+            context,
+            force,
             hostInstallations: resolveManagedSkillHostInstallations(
                 availableHosts,
                 skillName,
@@ -344,6 +349,7 @@ async function resolveSelectionActions(
                     availableHosts,
                     context,
                     shouldWriteOutput,
+                    request.force === true,
                 ),
             ),
             isInteractive: false,
@@ -433,10 +439,18 @@ async function filterConfirmedSkillNames(
         "settingsStore" | "stdin" | "stdout" | "translator"
     >,
     shouldWriteOutput: boolean,
+    force: boolean,
 ): Promise<string[]> {
     const confirmedSkillNames: string[] = [];
 
     for (const skillName of skillNames) {
+        if (force) {
+            // --force bypasses the conflict check; the unmanaged-directory
+            // warning is emitted later by validateRegistrySkillPublicationTargets.
+            confirmedSkillNames.push(skillName);
+            continue;
+        }
+
         const status = await readRegistrySkillInstallStatus(
             packageName,
             skillName,

--- a/src/application/commands/skills/registry-skill-publication.ts
+++ b/src/application/commands/skills/registry-skill-publication.ts
@@ -1,3 +1,4 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { BundledSkillAgentName } from "./embedded-assets.ts";
 import type { ManagedSkillHostInstallation } from "./managed-skill-hosts.ts";
 import type { ExtractedRegistryPackageArchive } from "./registry-skill-archive.ts";
@@ -86,8 +87,8 @@ export async function prepareRegistrySkillPublication(options: {
 export async function publishPreparedRegistrySkillPublication(
     preparedPublication: PreparedRegistrySkillPublication,
 ): Promise<RegistrySkillPublicationResult[]> {
-    await validateRegistrySkillPublicationTargets(preparedPublication);
-
+    // Callers are expected to call validateRegistrySkillPublicationTargets
+    // beforehand so the conflict warning fires exactly once per host.
     return Promise.all(
         preparedPublication.hostInstallations.map(async (installation) => {
             await publishBundledSkillInstallation({
@@ -104,6 +105,8 @@ export async function publishPreparedRegistrySkillPublication(
 }
 
 export async function validateRegistrySkillPublicationTargets(options: {
+    context?: Pick<CliExecutionContext, "logger">;
+    force?: boolean;
     hostInstallations: readonly ManagedSkillHostInstallation[];
     skillName: string;
 }): Promise<void> {
@@ -124,16 +127,30 @@ export async function validateRegistrySkillPublicationTargets(options: {
             };
         }),
     );
-    const unmanagedTarget = targetStates.find(
+    const unmanagedTargets = targetStates.filter(
         target => target.installedDirectoryExists && target.metadata === undefined,
     );
 
-    if (unmanagedTarget === undefined) {
+    if (unmanagedTargets.length === 0) {
+        return;
+    }
+
+    if (options.force === true) {
+        for (const target of unmanagedTargets) {
+            options.context?.logger.warn(
+                {
+                    agentName: target.installation.agentName,
+                    path: target.installation.installedSkillDirectoryPath,
+                    skillName: options.skillName,
+                },
+                "Forcefully overwriting unmanaged registry skill directory because --force was set.",
+            );
+        }
         return;
     }
 
     throw new CliUserError("errors.skills.nameConflict", 1, {
         name: options.skillName,
-        path: unmanagedTarget.installation.installedSkillDirectoryPath,
+        path: unmanagedTargets[0]!.installation.installedSkillDirectoryPath,
     });
 }

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -44,7 +44,9 @@ export interface BundledSkillHostInstallation extends ManagedSkillHostInstallati
 export async function installBundledSkill(
     skillName: BundledSkillName,
     context: CliExecutionContext,
+    options: { force?: boolean } = {},
 ): Promise<ManagedSkillInstallSummary> {
+    const force = options.force === true;
     const installations = await resolveAvailableBundledSkillHostInstallations(
         context,
         skillName,
@@ -59,6 +61,7 @@ export async function installBundledSkill(
             skillName,
             installation,
             context,
+            force,
         );
     }
 
@@ -180,6 +183,7 @@ async function validateBundledSkillInstallationTarget(
     skillName: BundledSkillName,
     installation: BundledSkillHostInstallation,
     context: Pick<CliExecutionContext, "logger">,
+    force: boolean,
 ): Promise<void> {
     const installedSkillDirectoryExists = await directoryExists(
         installation.installedSkillDirectoryPath,
@@ -197,17 +201,14 @@ async function validateBundledSkillInstallationTarget(
             installedDirectoryExists: true,
             installedDirectoryManaged: installedSkillDirectoryManaged,
         }) === "nameConflict") {
-            context.logger.warn(
-                {
-                    agentName: installation.agentName,
-                    path: installation.installedSkillDirectoryPath,
-                    skillName,
-                },
-                "Bundled skill install was blocked by an unmanaged directory.",
-            );
-            throw new CliUserError("errors.skills.nameConflict", 1, {
-                name: skillName,
+            reportUnmanagedBundledSkillConflict(context.logger, {
+                agentName: installation.agentName,
+                blockedMessage: "Bundled skill install was blocked by an unmanaged directory.",
+                errorKey: "errors.skills.nameConflict",
+                force,
+                forcedMessage: "Forcefully overwriting unmanaged skill directory because --force was set.",
                 path: installation.installedSkillDirectoryPath,
+                skillName,
             });
         }
     }
@@ -234,16 +235,43 @@ async function validateBundledSkillInstallationTarget(
         return;
     }
 
-    context.logger.warn(
-        {
-            agentName: installation.agentName,
-            path: installation.canonicalSkillDirectoryPath,
-            skillName,
-        },
-        "Bundled skill install was blocked by an unmanaged canonical directory.",
-    );
-    throw new CliUserError("errors.skills.storageConflict", 1, {
-        name: skillName,
+    reportUnmanagedBundledSkillConflict(context.logger, {
+        agentName: installation.agentName,
+        blockedMessage: "Bundled skill install was blocked by an unmanaged canonical directory.",
+        errorKey: "errors.skills.storageConflict",
+        force,
+        forcedMessage: "Forcefully overwriting unmanaged bundled skill canonical storage because --force was set.",
         path: installation.canonicalSkillDirectoryPath,
+        skillName,
+    });
+}
+
+function reportUnmanagedBundledSkillConflict(
+    logger: Pick<CliExecutionContext["logger"], "warn">,
+    options: {
+        agentName: BundledSkillAgentName;
+        blockedMessage: string;
+        errorKey: string;
+        force: boolean;
+        forcedMessage: string;
+        path: string;
+        skillName: BundledSkillName;
+    },
+): void {
+    const logFields = {
+        agentName: options.agentName,
+        path: options.path,
+        skillName: options.skillName,
+    };
+
+    if (options.force) {
+        logger.warn(logFields, options.forcedMessage);
+        return;
+    }
+
+    logger.warn(logFields, options.blockedMessage);
+    throw new CliUserError(options.errorKey, 1, {
+        name: options.skillName,
+        path: options.path,
     });
 }

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -297,13 +297,14 @@ const commandTelemetryDecisions = {
         kind: "properties",
         properties: [
             "bundled_skill",
+            "has_force",
             "package_kind",
             "package_name",
             "skill_ids_count_bucket",
             "skill_ids_sample",
             "skill_ids_truncated",
         ],
-        reason: "Records install source, product-domain package dimension, and bounded skill samples.",
+        reason: "Records install source, product-domain package dimension, bounded skill samples, and force-flag usage.",
     },
     "skills.info": {
         kind: "properties",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -739,6 +739,8 @@ export const enMessages = {
     "options.timeout":
         "Set how long to wait before timing out (default 6h, range 10s to 24h)",
     "options.yes": "Skip confirmation prompts",
+    "options.skills.install.force":
+        "Force install even when a same-name skill directory exists and is not managed by oo",
     "options.lang": "Specify the display language",
     "options.version": "Show the current version",
     "selfUpdate.install.success": "Installed oo {version}.",
@@ -1715,6 +1717,8 @@ export const zhMessages = {
     "options.system": "System prompt 文本，或使用 @路径 读取文本文件",
     "options.timeout": "设置等待超时时间（默认 6h，范围 10s 到 24h）",
     "options.yes": "跳过确认提示",
+    "options.skills.install.force":
+        "强制安装，即使同名 skill 目录已存在且不受 oo 管理",
     "options.lang": "指定显示语言",
     "options.version": "显示当前版本",
     "selfUpdate.install.success": "已安装 oo {version}。",


### PR DESCRIPTION
Allow `oo skills install` to overwrite an existing same-name skill directory that is not managed by oo (no readable `.oo-metadata.json`). Previously the install was blocked by a name conflict, forcing users to manually clean up the directory before retrying.

`--force` (or `-f`) replaces the previous contents and writes the new skill, emitting a `warn` log entry to record the overwrite. It still honors path containment, package validation, auth, and download validation, and does not affect startup auto-sync, `update`, `sync`, `uninstall`, or `publish`. In multi-skill packages it does not implicitly select all skills; combine with `--skill` or `--all -y`.

Telemetry records a low-cardinality `has_force` boolean so adoption of the new flag can be observed without leaking user input.