### PR TITLE
feat(skills): add `oo skills repair` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1035,6 +1035,118 @@ Remove oo-managed skills from supported local skill directories.
   agent-native local skill exists for the requested skill, or an existing same-name
   target is not managed by `oo`, the command exits with an error.
 
+### `oo skills repair`
+
+Force re-deploy one or more oo-managed skills from their trusted source into one
+or more agent skill directories. Always overwrites the target directory.
+
+This is **not** `oo skills update`: the command never goes to the network, never
+fetches a new registry package version, and never changes the package or
+version that is recorded for an installed skill. It only rewrites the agent
+copy from the trusted local source.
+
+- Options: `--skill <skill>` is required and may be repeated to repair multiple
+  skills. Inputs are de-duplicated; input order is preserved.
+- Options: `--agent <agent>` may be repeated to choose target agents. When
+  omitted, the command targets every currently-available supported agent (the
+  same set used by `oo skills install` defaults). Inputs are de-duplicated.
+- Options: `--json` / `--format json` emits a structured payload (see JSON
+  output below). `--show-schema-version` (only meaningful with JSON output)
+  prepends `schemaVersion`.
+- Source priority:
+  - If `<skill>` is a bundled skill name (`oo`, `oo-find-skills`,
+    `oo-create-skill`, `oo-publish-skill`), the command re-materializes the
+    per-agent bundled canonical source from the CLI's embedded assets, then
+    publishes that canonical source to the target agent. A repair on a bundled
+    skill therefore **also** refreshes the canonical bundled storage at
+    `<config-dir>/skills/bundled/<agent>/<skill>`.
+  - Otherwise, the command checks
+    `<config-dir>/skills/registry/<skill>` for managed registry metadata. If
+    found, the command publishes the canonical registry source to the target
+    agent. Registry repair never refreshes the canonical registry directory.
+  - If the skill is only known as a local skill in an agent's `skills`
+    directory, the command exits with `errors.skills.repair.localUnsupported`.
+    `repair` does not copy local skills across agents.
+  - If neither bundled nor managed registry source can be found, the affected
+    `(skill, agent)` pair surfaces as a per-pair failure with
+    `error.code: source_not_found`. The command does not fall back to copying
+    from one host's installed directory into another.
+- Overwrite semantics: the target host directory is rewritten regardless of
+  whether it is currently managed, manually modified, has corrupt metadata, or
+  is an unmanaged same-name directory. `repair` carries `--force`-style
+  semantics for the exact `(source, target agent, skill)` pair that it
+  resolves.
+- Safety: `repair` does not bypass path containment checks, the supported-agent
+  name list, registry canonical metadata validation, startup auto-sync rules,
+  or the existing safety borders for `oo skills add`, `oo skills update`,
+  `oo skills sync`, `oo skills publish`, and `oo skills uninstall`.
+- Fail-soft execution: each `(skill, agent)` pair is attempted independently.
+  If any pair fails, the command continues with the remaining pairs, prints a
+  summary of successes and failures, and finally exits non-zero.
+- Failure inputs that abort up-front (no JSON payload, normal CLI error):
+  - Missing `--skill` -> `errors.skills.repair.skillRequired`.
+  - `--agent` value outside the supported list -> existing
+    `errors.skills.list.invalidAgent`.
+  - Explicit `--agent` whose home directory does not exist ->
+    `errors.skills.agentNotInstalled`.
+  - Skill resolves only as a local skill ->
+    `errors.skills.repair.localUnsupported`.
+- Text output: text output prints the success summary, a per-skill agent
+  list, and any failures. Text output never prints filesystem paths;
+  consumers that need machine-readable paths should use `--json`.
+
+#### JSON output
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "summary": {
+    "requestedSkills": 2,
+    "targetAgents": 3,
+    "repaired": 5,
+    "failed": 1
+  },
+  "results": [
+    {
+      "skill": "oo",
+      "kind": "bundled",
+      "agentId": "codex",
+      "status": "repaired",
+      "path": "/Users/name/.codex/skills/oo",
+      "sourcePath": "/Users/name/Library/Application Support/oo/skills/bundled/codex/oo",
+      "version": "1.2.3"
+    },
+    {
+      "skill": "chatgpt",
+      "kind": "registry",
+      "agentId": "claude",
+      "status": "failed",
+      "path": "/Users/name/.claude/skills/chatgpt",
+      "sourcePath": "/Users/name/Library/Application Support/oo/skills/registry/chatgpt",
+      "version": "0.4.0",
+      "error": {
+        "code": "write_failed",
+        "message": "Failed to write the skill source to the target agent directory."
+      }
+    }
+  ]
+}
+```
+
+`schemaVersion` is included only when `--show-schema-version` is set.
+
+`error.code` values are an enumerated, machine-readable set:
+
+- `source_not_found`
+- `source_invalid`
+- `invalid_path`
+- `write_failed`
+- `unknown`
+
+`error.message` is a templated, scrubbed string; it never contains stack
+traces, raw exception messages, or filesystem paths beyond what already
+appears in the surrounding `path` / `sourcePath` fields.
+
 ## Logs
 
 ### `oo log path`

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -876,6 +876,105 @@ registry skills。
 - 说明：如果请求的 skill 在任何受支持目标中都不存在受管理安装，且不存在同名
   agent-native local skill，或某个已存在的同名目标不是由 `oo` 管理，命令会直接报错。
 
+### `oo skills repair`
+
+从可信 source 强制将一个或多个由 oo 管理的 skill 重新部署到一个或多个 Agent
+的 skill 目录，无论目标目录当前内容如何都直接覆盖。
+
+这**不是** `oo skills update`：命令不会联网，不会拉取 registry 的新版本，也
+不会改变已安装 skill 记录的 package/version。它只是用本机已有的可信 source
+重写 Agent 副本。
+
+- 选项：`--skill <skill>` 必填，可重复传入以同时修复多个 skill。输入会去重并
+  保留原顺序。
+- 选项：`--agent <agent>` 可重复传入以指定目标 Agent。缺省时目标为**所有当前
+  可用的受支持 Agent**（与 `oo skills install` 默认范围一致）。输入会去重。
+- 选项：`--json` / `--format json` 输出结构化 payload（见下文）。
+  `--show-schema-version` 仅在 JSON 模式下生效，向 payload 顶层添加
+  `schemaVersion`。
+- Source 判定顺序：
+  - 如果 `<skill>` 是内置 skill 名（`oo`、`oo-find-skills`、
+    `oo-create-skill`、`oo-publish-skill`），命令会从 CLI 内嵌资源**重新
+    materialize** 该 Agent 的 bundled canonical source，然后发布到目标 Agent。
+    因此对 bundled skill 的 repair **会同时**刷新
+    `<config-dir>/skills/bundled/<agent>/<skill>` 下的 canonical。
+  - 否则检查 `<config-dir>/skills/registry/<skill>` 是否存在合法的 registry
+    metadata。如果存在，命令把 canonical registry source 发布到目标 Agent；
+    **不**刷新 canonical registry 目录。
+  - 如果 skill 仅在某个 Agent 的 `skills` 目录里以 local skill 形式存在，命令
+    报 `errors.skills.repair.localUnsupported`；`repair` 不跨 Agent 复制
+    local skill。
+  - 既不是 bundled 也没有合法 registry canonical 时，对应的
+    `(skill, agent)` 组合作为 per-pair failure 输出，`error.code` 为
+    `source_not_found`，命令不会从某个 host 的已安装目录反推 source。
+- 覆盖语义：无论目标 host 目录当前是 managed、被本地修改、metadata 损坏、还是
+  同名 unmanaged 目录，都会被重写。`repair` 自带 `--force` 语义，但作用域仅限
+  解析出的 `(source, target agent, skill)` 精确组合。
+- 安全边界：`repair` 不绕过路径包含检查、受支持 Agent 名校验、registry
+  canonical metadata 校验、启动自动同步规则，也不影响 `oo skills add`、
+  `oo skills update`、`oo skills sync`、`oo skills publish`、
+  `oo skills uninstall` 的现有边界。
+- Fail-soft 执行：每个 `(skill, agent)` 组合独立尝试。任一组合失败时其它组合
+  继续执行，命令最后输出成功/失败汇总并以非 0 退出。
+- 命令前置校验失败（不输出 JSON payload，按普通 CLI 错误退出）：
+  - 缺少 `--skill` → `errors.skills.repair.skillRequired`
+  - `--agent` 值不在受支持 Agent 列表 → 现有 `errors.skills.list.invalidAgent`
+  - 显式 `--agent` 的 home 目录不存在 → `errors.skills.agentNotInstalled`
+  - skill 仅以 local skill 形式存在 → `errors.skills.repair.localUnsupported`
+- 文本输出：仅打印成功汇总、每个 skill 的目标 Agent 列表和失败原因，**永远不
+  打印任何路径**。需要机器可读路径的消费者请使用 `--json`。
+
+#### JSON 输出
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "summary": {
+    "requestedSkills": 2,
+    "targetAgents": 3,
+    "repaired": 5,
+    "failed": 1
+  },
+  "results": [
+    {
+      "skill": "oo",
+      "kind": "bundled",
+      "agentId": "codex",
+      "status": "repaired",
+      "path": "/Users/name/.codex/skills/oo",
+      "sourcePath": "/Users/name/Library/Application Support/oo/skills/bundled/codex/oo",
+      "version": "1.2.3"
+    },
+    {
+      "skill": "chatgpt",
+      "kind": "registry",
+      "agentId": "claude",
+      "status": "failed",
+      "path": "/Users/name/.claude/skills/chatgpt",
+      "sourcePath": "/Users/name/Library/Application Support/oo/skills/registry/chatgpt",
+      "version": "0.4.0",
+      "error": {
+        "code": "write_failed",
+        "message": "Failed to write the skill source to the target agent directory."
+      }
+    }
+  ]
+}
+```
+
+`schemaVersion` 仅在传入 `--show-schema-version` 时出现。
+
+`error.code` 是固定的机器可读枚举：
+
+- `source_not_found`
+- `source_invalid`
+- `invalid_path`
+- `write_failed`
+- `unknown`
+
+`error.message` 是脱敏过的模板文本，不包含 stack trace、原始 exception
+message，也不会出现在 `path` / `sourcePath` 字段之外的额外文件系统路径。
+
 ## 日志
 
 ### `oo log path`

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -6,6 +6,7 @@ import { skillsInstallCommand } from "./install.ts";
 import { skillsListCommand } from "./list.ts";
 import { skillsLocateCommand } from "./locate.ts";
 import { skillsPublishCommand } from "./publish.ts";
+import { skillsRepairCommand } from "./repair.ts";
 import { skillsSearchCommand } from "./search.ts";
 import { skillsShareCommand } from "./share.ts";
 import { skillsSyncCommand } from "./sync.ts";
@@ -30,5 +31,6 @@ export const skillsCommand: CliCommandDefinition = {
         skillsInstallCommand,
         skillsUpdateCommand,
         skillsUninstallCommand,
+        skillsRepairCommand,
     ],
 };

--- a/src/application/commands/skills/repair.cli.test.ts
+++ b/src/application/commands/skills/repair.cli.test.ts
@@ -1,0 +1,597 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+import { createCliSandbox } from "../../../../__tests__/helpers.ts";
+import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import { resolveBundledSkillCanonicalDirectoryPath } from "./bundled-skill-paths.ts";
+import { resolveManagedSkillAgentHomeDirectory } from "./managed-skill-agents.ts";
+import {
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillDirectoryPath,
+    resolveManagedSkillMetadataFilePath,
+} from "./managed-skill-paths.ts";
+import {
+    createLocalSkillMetadata,
+    createRegistrySkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
+
+const TEST_CLI_VERSION = "9.9.9";
+
+describe("skills repair CLI", () => {
+    test("rejects when --skill is not provided", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            const result = await sandbox.run(["skills", "repair"]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("--skill");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("repair --skill oo --agent codex overwrites a modified bundled host directory", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const ooSkillDirectory = resolveManagedSkillDirectoryPath(codexHomeDirectory, "oo");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install", "oo"], { version: TEST_CLI_VERSION });
+            await writeFile(join(ooSkillDirectory, "SKILL.md"), "tampered content\n");
+
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--skill",
+                "oo",
+                "--agent",
+                "codex",
+            ], { version: TEST_CLI_VERSION });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            const repairedContent = await readFile(join(ooSkillDirectory, "SKILL.md"), "utf8");
+
+            expect(repairedContent).not.toBe("tampered content\n");
+            expect(repairedContent.length).toBeGreaterThan(50);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("repair overwrites an unmanaged same-name host directory", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const ooSkillDirectory = resolveManagedSkillDirectoryPath(codexHomeDirectory, "oo");
+
+        try {
+            await mkdir(ooSkillDirectory, { recursive: true });
+            await writeFile(join(ooSkillDirectory, "SKILL.md"), "user content\n");
+
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--skill",
+                "oo",
+                "--agent",
+                "codex",
+            ], { version: TEST_CLI_VERSION });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            const metadataPath = resolveManagedSkillMetadataFilePath(ooSkillDirectory);
+            const metadataContent = await readFile(metadataPath, "utf8");
+
+            expect(metadataContent).toContain("\"kind\": \"bundled\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("repair re-materializes a poisoned bundled canonical source", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalDirectory = resolveBundledSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "oo",
+            "codex",
+        );
+        const hostDirectory = resolveManagedSkillDirectoryPath(codexHomeDirectory, "oo");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install", "oo"], { version: TEST_CLI_VERSION });
+            await rm(canonicalDirectory, { recursive: true, force: true });
+            await mkdir(canonicalDirectory, { recursive: true });
+            await writeFile(join(canonicalDirectory, "polluted.txt"), "junk\n");
+
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--skill",
+                "oo",
+                "--agent",
+                "codex",
+            ], { version: TEST_CLI_VERSION });
+
+            expect(result.exitCode).toBe(0);
+            const canonicalMetadataPath = resolveManagedSkillMetadataFilePath(canonicalDirectory);
+            const canonicalMetadataContent = await readFile(canonicalMetadataPath, "utf8");
+
+            expect(canonicalMetadataContent).toContain("\"kind\": \"bundled\"");
+            expect((await readFile(join(hostDirectory, "SKILL.md"), "utf8")).length)
+                .toBeGreaterThan(50);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("repair defaults to all available supported agents when --agent is omitted", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const claudeHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "claude");
+        const codexSkillDirectory = resolveManagedSkillDirectoryPath(codexHomeDirectory, "oo");
+        const claudeSkillDirectory = resolveManagedSkillDirectoryPath(claudeHomeDirectory, "oo");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(claudeHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install"], { version: TEST_CLI_VERSION });
+            await writeFile(join(codexSkillDirectory, "SKILL.md"), "tampered codex\n");
+            await writeFile(join(claudeSkillDirectory, "SKILL.md"), "tampered claude\n");
+
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--skill",
+                "oo",
+            ], { version: TEST_CLI_VERSION });
+
+            expect(result.exitCode).toBe(0);
+            const codexContent = await readFile(join(codexSkillDirectory, "SKILL.md"), "utf8");
+            const claudeContent = await readFile(join(claudeSkillDirectory, "SKILL.md"), "utf8");
+
+            expect(codexContent).not.toBe("tampered codex\n");
+            expect(claudeContent).not.toBe("tampered claude\n");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("repair runs the cartesian product of multiple --agent and --skill, de-duplicated", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const claudeHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "claude");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(claudeHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install"], { version: TEST_CLI_VERSION });
+
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--json",
+                "--skill",
+                "oo",
+                "--skill",
+                "oo",
+                "--skill",
+                "oo-find-skills",
+                "--agent",
+                "codex",
+                "--agent",
+                "claude",
+                "--agent",
+                "codex",
+            ], { version: TEST_CLI_VERSION });
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.summary).toMatchObject({
+                requestedSkills: 2,
+                targetAgents: 2,
+                repaired: 4,
+                failed: 0,
+            });
+            const results = payload.results as Array<Record<string, unknown>>;
+
+            expect(results).toHaveLength(4);
+            const pairKeys = results.map(entry => `${entry.skill}|${entry.agentId}`).sort();
+
+            expect(pairKeys).toEqual([
+                "oo-find-skills|claude",
+                "oo-find-skills|codex",
+                "oo|claude",
+                "oo|codex",
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("repair surfaces missing source as per-pair failure (--json includes failed result)", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--json",
+                "--skill",
+                "nonexistent-skill",
+                "--agent",
+                "codex",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.summary).toMatchObject({
+                requestedSkills: 1,
+                targetAgents: 1,
+                repaired: 0,
+                failed: 1,
+            });
+            const results = payload.results as Array<Record<string, unknown>>;
+
+            expect(results).toHaveLength(1);
+            expect(results[0]).toMatchObject({
+                skill: "nonexistent-skill",
+                status: "failed",
+            });
+            expect((results[0]!.error as Record<string, unknown>).code).toBe("source_not_found");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("repair valid + missing skill: valid is repaired and missing surfaces as failed entry", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const ooSkillDirectory = resolveManagedSkillDirectoryPath(codexHomeDirectory, "oo");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install", "oo"], { version: TEST_CLI_VERSION });
+            await writeFile(join(ooSkillDirectory, "SKILL.md"), "tampered\n");
+
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--json",
+                "--skill",
+                "oo",
+                "--skill",
+                "nonexistent",
+                "--agent",
+                "codex",
+            ], { version: TEST_CLI_VERSION });
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.summary).toMatchObject({
+                requestedSkills: 2,
+                targetAgents: 1,
+                repaired: 1,
+                failed: 1,
+            });
+            expect(await readFile(join(ooSkillDirectory, "SKILL.md"), "utf8"))
+                .not
+                .toBe("tampered\n");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("repair surfaces invalid registry canonical metadata as source_invalid", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalDirectory = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "broken-skill",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(canonicalDirectory, { recursive: true });
+            await writeFile(join(canonicalDirectory, "SKILL.md"), "# Broken\n");
+            await writeFile(
+                resolveManagedSkillMetadataFilePath(canonicalDirectory),
+                "not-valid-json{{",
+            );
+
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--json",
+                "--skill",
+                "broken-skill",
+                "--agent",
+                "codex",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const results = payload.results as Array<Record<string, unknown>>;
+
+            expect(results).toHaveLength(1);
+            expect((results[0]!.error as Record<string, unknown>).code).toBe("source_invalid");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("repair fails with localUnsupported when skill only exists as a local skill", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const localSkillDirectory = resolveManagedSkillDirectoryPath(
+            codexHomeDirectory,
+            "campaign-writer",
+        );
+
+        try {
+            await mkdir(localSkillDirectory, { recursive: true });
+            await writeFile(
+                join(localSkillDirectory, "SKILL.md"),
+                "---\nname: campaign-writer\ndescription: A local skill.\n---\n",
+            );
+            await writeFile(
+                resolveManagedSkillMetadataFilePath(localSkillDirectory),
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
+
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--skill",
+                "campaign-writer",
+                "--agent",
+                "codex",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("campaign-writer");
+            expect(result.stderr).toContain("local skill");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("repair fails when explicit --agent home directory does not exist", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--skill",
+                "oo",
+                "--agent",
+                "codex",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr.toLowerCase()).toContain("codex");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("repair --skill registry-skill from canonical never invokes HTTP", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const canonicalDirectory = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "alpha-skill",
+        );
+        const hostDirectory = resolveManagedSkillDirectoryPath(
+            codexHomeDirectory,
+            "alpha-skill",
+        );
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await mkdir(canonicalDirectory, { recursive: true });
+            await writeFile(join(canonicalDirectory, "SKILL.md"), "# Alpha Canonical\n");
+            await writeFile(
+                resolveManagedSkillMetadataFilePath(canonicalDirectory),
+                renderSkillMetadataJson(createRegistrySkillMetadata({
+                    packageName: "@oomol/alpha",
+                    version: "1.2.3",
+                })),
+            );
+            await mkdir(hostDirectory, { recursive: true });
+            await writeFile(join(hostDirectory, "SKILL.md"), "tampered\n");
+            await writeFile(
+                resolveManagedSkillMetadataFilePath(hostDirectory),
+                renderSkillMetadataJson(createRegistrySkillMetadata({
+                    packageName: "@oomol/alpha",
+                    version: "1.2.3",
+                })),
+            );
+
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--skill",
+                "alpha-skill",
+                "--agent",
+                "codex",
+            ], {
+                fetcher: async () => {
+                    throw new Error("repair must not perform HTTP calls");
+                },
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            const hostSkillMd = await readFile(join(hostDirectory, "SKILL.md"), "utf8");
+
+            expect(hostSkillMd).toBe("# Alpha Canonical\n");
+            const hostMetadata = await readFile(
+                resolveManagedSkillMetadataFilePath(hostDirectory),
+                "utf8",
+            );
+
+            expect(hostMetadata).toContain("\"packageName\": \"@oomol/alpha\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json default omits schemaVersion, --show-schema-version prepends it", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install", "oo"], { version: TEST_CLI_VERSION });
+
+            const resultDefault = await sandbox.run([
+                "skills",
+                "repair",
+                "--json",
+                "--skill",
+                "oo",
+                "--agent",
+                "codex",
+            ], { version: TEST_CLI_VERSION });
+            const resultWithSchema = await sandbox.run([
+                "skills",
+                "repair",
+                "--json",
+                "--show-schema-version",
+                "--skill",
+                "oo",
+                "--agent",
+                "codex",
+            ], { version: TEST_CLI_VERSION });
+
+            expect(resultDefault.exitCode).toBe(0);
+            const defaultPayload = JSON.parse(resultDefault.stdout) as Record<string, unknown>;
+
+            expect(defaultPayload).not.toHaveProperty("schemaVersion");
+            expect(defaultPayload).toHaveProperty("summary");
+            expect(defaultPayload).toHaveProperty("results");
+
+            expect(resultWithSchema.exitCode).toBe(0);
+            const schemaPayload = JSON.parse(resultWithSchema.stdout) as Record<string, unknown>;
+
+            expect(schemaPayload.schemaVersion).toBe("1.0.0");
+            expect(schemaPayload).toHaveProperty("summary");
+            expect(schemaPayload).toHaveProperty("results");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("JSON success result includes skill, kind, agentId, status, path, sourcePath, version", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install", "oo"], { version: TEST_CLI_VERSION });
+
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--json",
+                "--skill",
+                "oo",
+                "--agent",
+                "codex",
+            ], { version: TEST_CLI_VERSION });
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const results = payload.results as Array<Record<string, unknown>>;
+
+            expect(results).toHaveLength(1);
+            const entry = results[0]!;
+
+            expect(entry).toMatchObject({
+                skill: "oo",
+                kind: "bundled",
+                agentId: "codex",
+                status: "repaired",
+                version: TEST_CLI_VERSION,
+            });
+            expect(entry.path).toBeTypeOf("string");
+            expect(entry.sourcePath).toBeTypeOf("string");
+            expect(entry.error).toBeUndefined();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("text output never includes filesystem paths or sourcePath", async () => {
+        const sandbox = await createCliSandbox();
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+        const ooSkillDirectory = resolveManagedSkillDirectoryPath(codexHomeDirectory, "oo");
+
+        try {
+            await mkdir(codexHomeDirectory, { recursive: true });
+            await sandbox.run(["skills", "install", "oo"], { version: TEST_CLI_VERSION });
+
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--skill",
+                "oo",
+                "--agent",
+                "codex",
+            ], { version: TEST_CLI_VERSION });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).not.toContain(codexHomeDirectory);
+            expect(result.stdout).not.toContain(ooSkillDirectory);
+            expect(result.stdout).not.toMatch(/sourcePath/i);
+            expect(result.stdout).not.toMatch(/^\s*Path:/m);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/repair.cli.test.ts
+++ b/src/application/commands/skills/repair.cli.test.ts
@@ -1,5 +1,6 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import process from "node:process";
 
 import { describe, expect, test } from "bun:test";
 import { createCliSandbox } from "../../../../__tests__/helpers.ts";
@@ -594,4 +595,81 @@ describe("skills repair CLI", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("repair omits success summary when every pair fails", async () => {
+        const sandbox = await createCliSandbox();
+        const claudeHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "claude");
+        const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+
+        try {
+            await mkdir(claudeHomeDirectory, { recursive: true });
+            await mkdir(codexHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "repair",
+                "--skill",
+                "nonexistent",
+                "--agent",
+                "claude",
+                "--agent",
+                "codex",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).not.toMatch(/^Repaired /m);
+            expect(result.stdout).toMatch(/^Failed to repair 2 /m);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    // The success summary must reflect only agents that actually had a skill
+    // repaired, not the total number of targeted agents. chmod is unreliable
+    // on Windows and a no-op for root on Unix, so the test is scoped to a
+    // non-root POSIX environment.
+    const isUnixNonRoot = process.platform !== "win32" && process.getuid?.() !== 0;
+    const partialFailureTest = isUnixNonRoot ? test : test.skip;
+
+    partialFailureTest(
+        "repair success summary counts only agents that had a repair succeed",
+        async () => {
+            const sandbox = await createCliSandbox();
+            const claudeHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "claude");
+            const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+            const claudeOoDirectory = resolveManagedSkillDirectoryPath(claudeHomeDirectory, "oo");
+            const codexSkillsDirectory = join(codexHomeDirectory, "skills");
+
+            try {
+                await mkdir(claudeHomeDirectory, { recursive: true });
+                await mkdir(codexHomeDirectory, { recursive: true });
+                await sandbox.run(["skills", "install", "oo"], { version: TEST_CLI_VERSION });
+                await writeFile(join(claudeOoDirectory, "SKILL.md"), "tampered\n");
+                // Block writes into codex's skills root so that (oo, codex)
+                // fails while (oo, claude) still succeeds.
+                await chmod(codexSkillsDirectory, 0o555);
+
+                const result = await sandbox.run([
+                    "skills",
+                    "repair",
+                    "--skill",
+                    "oo",
+                    "--agent",
+                    "claude",
+                    "--agent",
+                    "codex",
+                ], { version: TEST_CLI_VERSION });
+
+                expect(result.exitCode).toBe(1);
+                expect(result.stdout).toMatch(/^Repaired 1 skill\(s\) for 1 agent\(s\)\./m);
+                expect(result.stdout).not.toMatch(/for 2 agent\(s\)/);
+                expect(result.stdout).toMatch(/^Failed to repair 1 /m);
+            }
+            finally {
+                await chmod(codexSkillsDirectory, 0o755).catch(() => undefined);
+                await sandbox.cleanup();
+            }
+        },
+    );
 });

--- a/src/application/commands/skills/repair.ts
+++ b/src/application/commands/skills/repair.ts
@@ -1,0 +1,506 @@
+import type {
+    CliCommandDefinition,
+    CliExecutionContext,
+} from "../../contracts/cli.ts";
+import type { BundledSkillAgentName, BundledSkillName } from "./embedded-assets.ts";
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { writeLine } from "../shared/output.ts";
+import { publishBundledSkillInstallation } from "./bundled-skill-filesystem.ts";
+import { directoryExists } from "./bundled-skill-observation.ts";
+import { resolveBundledSkillCanonicalDirectoryPath } from "./bundled-skill-paths.ts";
+import { listLocalSkillSources } from "./local-skill-source.ts";
+import {
+    createManagedSkillAgentNotInstalledError,
+    parseManagedSkillAgentOption,
+    readManagedSkillAgentLabel,
+    readManagedSkillAgentLabels,
+    resolveManagedSkillAgentHomeDirectory,
+} from "./managed-skill-agents.ts";
+import {
+    createMissingManagedSkillHostError,
+    resolveAvailableManagedSkillHosts,
+} from "./managed-skill-hosts.ts";
+import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
+import {
+    isManagedSkillPathContained,
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillDirectoryPath,
+} from "./managed-skill-paths.ts";
+import {
+    isBundledSkillName,
+    publishManagedBundledSkill,
+} from "./shared.ts";
+
+interface SkillsRepairInput {
+    agent?: string[];
+    format?: "json";
+    showSchemaVersion?: boolean;
+    skill?: string[];
+}
+
+type RepairSourceKind = "bundled" | "registry";
+
+type RepairErrorCode
+    = | "source_not_found"
+        | "source_invalid"
+        | "invalid_path"
+        | "write_failed"
+        | "unknown";
+
+const repairErrorMessageKey: Record<RepairErrorCode, string> = {
+    source_not_found: "errors.skills.repair.sourceNotFound",
+    source_invalid: "errors.skills.repair.sourceInvalid",
+    invalid_path: "errors.skills.repair.invalidPath",
+    write_failed: "errors.skills.repair.writeFailed",
+    unknown: "errors.skills.repair.writeFailed",
+};
+
+interface RepairResultEntry {
+    skill: string;
+    kind: RepairSourceKind;
+    agentId: BundledSkillAgentName;
+    status: "repaired" | "failed";
+    path: string;
+    sourcePath: string | null;
+    version: string | null;
+    error?: {
+        code: RepairErrorCode;
+        message: string;
+    };
+}
+
+interface RepairOutcome {
+    summary: {
+        requestedSkills: number;
+        targetAgents: number;
+        repaired: number;
+        failed: number;
+    };
+    results: RepairResultEntry[];
+}
+
+interface BundledRepairSource {
+    kind: "bundled";
+    skillName: BundledSkillName;
+}
+
+interface RegistryRepairSource {
+    kind: "registry";
+    skillName: string;
+    canonicalDirectoryPath: string;
+    version: string | null;
+}
+
+interface UnresolvedRepairSource {
+    kind: "unresolved";
+    skillName: string;
+    sourcePath: string | null;
+    unavailable: "source_not_found" | "source_invalid";
+}
+
+type RepairSource = BundledRepairSource | RegistryRepairSource | UnresolvedRepairSource;
+
+export const skillsRepairCommand: CliCommandDefinition<SkillsRepairInput> = {
+    name: "repair",
+    summaryKey: "commands.skills.repair.summary",
+    descriptionKey: "commands.skills.repair.description",
+    options: [
+        {
+            name: "skill",
+            longFlag: "--skill",
+            valueName: "skills...",
+            descriptionKey: "options.skills.repair.skill",
+        },
+        {
+            name: "agent",
+            longFlag: "--agent",
+            valueName: "agents...",
+            descriptionKey: "options.skills.repair.agent",
+        },
+        ...jsonOutputOptions,
+    ],
+    inputSchema: z.object({
+        agent: z.array(z.string()).optional(),
+        format: z.enum(["json"]).optional(),
+        showSchemaVersion: z.boolean().optional(),
+        skill: z.array(z.string()).optional(),
+    }),
+    handler: async (input, context) => {
+        const skillNames = dedupePreserveOrder(input.skill ?? []);
+
+        if (skillNames.length === 0) {
+            throw new CliUserError("errors.skills.repair.skillRequired", 2);
+        }
+
+        const agentNames = await resolveRepairAgents(
+            dedupePreserveOrder(input.agent ?? []),
+            context,
+        );
+        const sources = await resolveRepairSources(skillNames, context);
+        const outcome = await runRepair({
+            agents: agentNames,
+            sources,
+            context,
+        });
+
+        recordTelemetry(context, outcome, {
+            hasAgentFilter: (input.agent?.length ?? 0) > 0,
+        });
+
+        if (input.format === "json") {
+            writeJsonOutput(context.stdout, outcome, {
+                showSchemaVersion: input.showSchemaVersion,
+            });
+        }
+        else {
+            writeText(context, outcome);
+        }
+
+        if (outcome.summary.failed > 0) {
+            throw new CliUserError("errors.skills.repair.partialFailure", 1, {
+                count: outcome.summary.failed,
+            });
+        }
+    },
+};
+
+async function resolveRepairAgents(
+    requested: readonly string[],
+    context: CliExecutionContext,
+): Promise<BundledSkillAgentName[]> {
+    if (requested.length === 0) {
+        const hosts = await resolveAvailableManagedSkillHosts(context.env);
+
+        if (hosts.length === 0) {
+            throw createMissingManagedSkillHostError(context.env);
+        }
+        return hosts.map(host => host.agentName);
+    }
+
+    const validated: BundledSkillAgentName[] = [];
+
+    for (const value of requested) {
+        const agentName = parseManagedSkillAgentOption(
+            value,
+            "errors.skills.list.invalidAgent",
+        );
+
+        if (agentName === undefined) {
+            throw new CliUserError("errors.skills.list.invalidAgent", 2, { value });
+        }
+        const homeDirectory = resolveManagedSkillAgentHomeDirectory(context.env, agentName);
+
+        if (!(await directoryExists(homeDirectory))) {
+            throw createManagedSkillAgentNotInstalledError(
+                agentName,
+                homeDirectory,
+                context.translator,
+            );
+        }
+        validated.push(agentName);
+    }
+
+    return validated;
+}
+
+async function resolveRepairSources(
+    skillNames: readonly string[],
+    context: CliExecutionContext,
+): Promise<RepairSource[]> {
+    // Cache the local-skill scan once per invocation: the legacy per-skill
+    // lookup re-walked every agent's skills directory for each unresolved
+    // skill name.
+    let localSkillNames: Set<string> | undefined;
+    const loadLocalSkillNames = async (): Promise<Set<string>> => {
+        if (localSkillNames === undefined) {
+            const sources = await listLocalSkillSources({ env: context.env });
+
+            localSkillNames = new Set(sources.map(source => source.name));
+        }
+        return localSkillNames;
+    };
+    const settingsFilePath = context.settingsStore.getFilePath();
+    const sources: RepairSource[] = [];
+
+    for (const skillName of skillNames) {
+        if (isBundledSkillName(skillName)) {
+            sources.push({ kind: "bundled", skillName });
+            continue;
+        }
+
+        const canonicalDirectoryPath = resolveManagedSkillCanonicalDirectoryPath(
+            settingsFilePath,
+            skillName,
+        );
+        const metadata = (await directoryExists(canonicalDirectoryPath))
+            ? await readManagedSkillMetadata(canonicalDirectoryPath)
+            : undefined;
+
+        if (metadata !== undefined) {
+            sources.push({
+                kind: "registry",
+                skillName,
+                canonicalDirectoryPath,
+                version: metadata.version,
+            });
+            continue;
+        }
+
+        if (await directoryExists(canonicalDirectoryPath)) {
+            // Canonical directory exists but metadata is missing/invalid for a
+            // registry source: surface as per-pair failure rather than aborting
+            // the whole run.
+            sources.push({
+                kind: "unresolved",
+                skillName,
+                sourcePath: canonicalDirectoryPath,
+                unavailable: "source_invalid",
+            });
+            continue;
+        }
+
+        // local-only skills are a participation-class mismatch, not a per-pair
+        // execution failure: keep fail-fast so other valid skills are not
+        // partially executed under a misunderstanding of what repair covers.
+        if ((await loadLocalSkillNames()).has(skillName)) {
+            throw new CliUserError("errors.skills.repair.localUnsupported", 1, {
+                name: skillName,
+            });
+        }
+
+        sources.push({
+            kind: "unresolved",
+            skillName,
+            sourcePath: null,
+            unavailable: "source_not_found",
+        });
+    }
+
+    return sources;
+}
+
+interface RunRepairOptions {
+    agents: readonly BundledSkillAgentName[];
+    sources: readonly RepairSource[];
+    context: CliExecutionContext;
+}
+
+async function runRepair(options: RunRepairOptions): Promise<RepairOutcome> {
+    const pairs: Array<Promise<RepairResultEntry>> = [];
+
+    for (const source of options.sources) {
+        for (const agentId of options.agents) {
+            pairs.push(repairPair(source, agentId, options.context));
+        }
+    }
+
+    const results = await Promise.all(pairs);
+    let repaired = 0;
+    let failed = 0;
+
+    for (const entry of results) {
+        if (entry.status === "repaired") {
+            repaired += 1;
+        }
+        else {
+            failed += 1;
+        }
+    }
+
+    return {
+        summary: {
+            requestedSkills: options.sources.length,
+            targetAgents: options.agents.length,
+            repaired,
+            failed,
+        },
+        results,
+    };
+}
+
+async function repairPair(
+    source: RepairSource,
+    agentId: BundledSkillAgentName,
+    context: CliExecutionContext,
+): Promise<RepairResultEntry> {
+    const homeDirectory = resolveManagedSkillAgentHomeDirectory(context.env, agentId);
+    const settingsFilePath = context.settingsStore.getFilePath();
+    const installedPath = resolveManagedSkillDirectoryPath(homeDirectory, source.skillName);
+    // Unresolved sources surface in JSON as `registry` kind because the
+    // unresolved cases (missing/invalid canonical) are all registry source
+    // resolution failures; bundled name resolution never fails.
+    const kind: RepairSourceKind = source.kind === "bundled" ? "bundled" : "registry";
+    const expectedSourcePath = source.kind === "bundled"
+        ? resolveBundledSkillCanonicalDirectoryPath(settingsFilePath, source.skillName, agentId)
+        : source.kind === "registry"
+            ? source.canonicalDirectoryPath
+            : source.sourcePath;
+    const expectedVersion = source.kind === "bundled"
+        ? context.version
+        : source.kind === "registry"
+            ? source.version
+            : null;
+    const buildFailure = (code: RepairErrorCode, includeSource: boolean): RepairResultEntry => ({
+        skill: source.skillName,
+        kind,
+        agentId,
+        status: "failed",
+        path: installedPath,
+        sourcePath: includeSource ? expectedSourcePath : null,
+        version: includeSource ? expectedVersion : null,
+        error: {
+            code,
+            message: context.translator.t(repairErrorMessageKey[code]),
+        },
+    });
+
+    if (source.kind === "unresolved") {
+        return buildFailure(source.unavailable, true);
+    }
+
+    if (!isManagedSkillPathContained(homeDirectory, settingsFilePath, source.skillName)) {
+        return buildFailure("invalid_path", false);
+    }
+
+    try {
+        if (source.kind === "bundled") {
+            await publishManagedBundledSkill({
+                agentName: agentId,
+                homeDirectory,
+                settingsFilePath,
+                skillName: source.skillName,
+                version: context.version,
+            });
+        }
+        else {
+            await publishBundledSkillInstallation({
+                canonicalSkillDirectoryPath: source.canonicalDirectoryPath,
+                installedSkillDirectoryPath: installedPath,
+            });
+        }
+
+        return {
+            skill: source.skillName,
+            kind,
+            agentId,
+            status: "repaired",
+            path: installedPath,
+            sourcePath: expectedSourcePath,
+            version: expectedVersion,
+        };
+    }
+    catch (error) {
+        context.logger.warn(
+            {
+                err: error,
+                agentId,
+                skillName: source.skillName,
+                kind,
+            },
+            "Skill repair failed.",
+        );
+
+        return buildFailure("write_failed", true);
+    }
+}
+
+function writeText(
+    context: Pick<CliExecutionContext, "stdout" | "translator">,
+    outcome: RepairOutcome,
+): void {
+    const successfulBySkill = groupAgentsBySkill(
+        outcome.results.filter(entry => entry.status === "repaired"),
+    );
+    const failedEntries = outcome.results.filter(entry => entry.status === "failed");
+
+    if (successfulBySkill.size > 0) {
+        writeLine(
+            context.stdout,
+            context.translator.t("skills.repair.success", {
+                skillCount: successfulBySkill.size,
+                agentCount: outcome.summary.targetAgents,
+            }),
+        );
+
+        for (const [skill, agents] of successfulBySkill) {
+            writeLine(
+                context.stdout,
+                context.translator.t("skills.repair.success.line", {
+                    name: skill,
+                    agents: readManagedSkillAgentLabels(agents, context.translator),
+                }),
+            );
+        }
+    }
+
+    if (failedEntries.length > 0) {
+        writeLine(
+            context.stdout,
+            context.translator.t("skills.repair.failure", {
+                count: failedEntries.length,
+            }),
+        );
+
+        for (const entry of failedEntries) {
+            writeLine(
+                context.stdout,
+                context.translator.t("skills.repair.failure.line", {
+                    name: entry.skill,
+                    agent: readManagedSkillAgentLabel(entry.agentId, context.translator),
+                    reason: entry.error?.message ?? "",
+                }),
+            );
+        }
+    }
+}
+
+function groupAgentsBySkill(
+    entries: readonly RepairResultEntry[],
+): Map<string, BundledSkillAgentName[]> {
+    const result = new Map<string, BundledSkillAgentName[]>();
+
+    for (const entry of entries) {
+        const existing = result.get(entry.skill) ?? [];
+
+        existing.push(entry.agentId);
+        result.set(entry.skill, existing);
+    }
+
+    return result;
+}
+
+function dedupePreserveOrder<T>(values: readonly T[]): T[] {
+    const seen = new Set<T>();
+    const result: T[] = [];
+
+    for (const value of values) {
+        if (!seen.has(value)) {
+            seen.add(value);
+            result.push(value);
+        }
+    }
+
+    return result;
+}
+
+function recordTelemetry(
+    context: CliExecutionContext,
+    outcome: RepairOutcome,
+    options: { hasAgentFilter: boolean },
+): void {
+    const hasBundled = outcome.results.some(entry => entry.kind === "bundled");
+    const hasRegistry = outcome.results.some(entry => entry.kind === "registry");
+
+    context.telemetry?.recordProperties({
+        has_agent_filter: options.hasAgentFilter,
+        agent_count_bucket: bucketTelemetryCount(outcome.summary.targetAgents),
+        skill_count_bucket: bucketTelemetryCount(outcome.summary.requestedSkills),
+        has_bundled_source: hasBundled,
+        has_registry_source: hasRegistry,
+        success_count_bucket: bucketTelemetryCount(outcome.summary.repaired),
+        failure_count_bucket: bucketTelemetryCount(outcome.summary.failed),
+    });
+}

--- a/src/application/commands/skills/repair.ts
+++ b/src/application/commands/skills/repair.ts
@@ -411,9 +411,12 @@ function writeText(
     context: Pick<CliExecutionContext, "stdout" | "translator">,
     outcome: RepairOutcome,
 ): void {
-    const successfulBySkill = groupAgentsBySkill(
-        outcome.results.filter(entry => entry.status === "repaired"),
-    );
+    const successfulEntries = outcome.results.filter(entry => entry.status === "repaired");
+    const successfulBySkill = groupAgentsBySkill(successfulEntries);
+    // Count only agents that actually had at least one skill repaired, to keep
+    // the same "at least one success" counting rule as `skillCount`. Using
+    // `targetAgents` here would overstate the result on partial failure.
+    const successfulAgentCount = new Set(successfulEntries.map(entry => entry.agentId)).size;
     const failedEntries = outcome.results.filter(entry => entry.status === "failed");
 
     if (successfulBySkill.size > 0) {
@@ -421,7 +424,7 @@ function writeText(
             context.stdout,
             context.translator.t("skills.repair.success", {
                 skillCount: successfulBySkill.size,
-                agentCount: outcome.summary.targetAgents,
+                agentCount: successfulAgentCount,
             }),
         );
 

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -354,6 +354,19 @@ const commandTelemetryDecisions = {
         kind: "generic",
         reason: "Generic command telemetry is enough; sync source paths are not recorded.",
     },
+    "skills.repair": {
+        kind: "properties",
+        properties: [
+            "has_agent_filter",
+            "agent_count_bucket",
+            "skill_count_bucket",
+            "has_bundled_source",
+            "has_registry_source",
+            "success_count_bucket",
+            "failure_count_bucket",
+        ],
+        reason: "Records bucketed counts and source-kind flags; never records skill names or paths.",
+    },
     "skills.uninstall": {
         kind: "generic",
         reason: "Generic command telemetry is enough; local uninstall paths are not recorded.",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -194,6 +194,33 @@ export const enMessages = {
     "commands.skills.uninstall.description":
         "Remove oo-managed skills from supported local skill directories.",
     "commands.skills.uninstall.summary": "Remove a managed skill",
+    "commands.skills.repair.description":
+        "Force re-deploy one or more oo-managed skills from their trusted source into one or more agent skill directories.",
+    "commands.skills.repair.summary": "Repair installed skills from trusted source",
+    "options.skills.repair.skill":
+        "Skill name to repair (required, may be repeated)",
+    "options.skills.repair.agent":
+        "Agent to repair into (may be repeated; defaults to all currently available supported agents)",
+    "skills.repair.success":
+        "Repaired {skillCount} skill(s) for {agentCount} agent(s).",
+    "skills.repair.success.line": "  {name}: {agents}",
+    "skills.repair.failure":
+        "Failed to repair {count} skill-agent pair(s).",
+    "skills.repair.failure.line": "  {name} ({agent}): {reason}",
+    "errors.skills.repair.skillRequired":
+        "At least one --skill <name> is required.",
+    "errors.skills.repair.localUnsupported":
+        "Skill {name} is a local skill and is not repairable; local skills are agent-native sources.",
+    "errors.skills.repair.partialFailure":
+        "{count} skill-agent pair(s) failed to repair.",
+    "errors.skills.repair.sourceNotFound":
+        "Managed registry canonical source was not found.",
+    "errors.skills.repair.sourceInvalid":
+        "Managed registry canonical metadata is missing or not a registry skill.",
+    "errors.skills.repair.invalidPath":
+        "Target path escapes the managed skills directory.",
+    "errors.skills.repair.writeFailed":
+        "Failed to write the skill source to the target agent directory.",
     "config.set.success": "Set {key} to {value}.",
     "config.unset.success": "Removed {key}.",
     "telemetry.disable.success": "Telemetry disabled.",
@@ -1191,6 +1218,33 @@ export const zhMessages = {
     "commands.skills.update.summary": "更新由 oo 管理的 skill",
     "commands.skills.uninstall.description": "从受支持的本地 skill 目录移除由 oo 管理的 skill。",
     "commands.skills.uninstall.summary": "移除一个受管理的 skill",
+    "commands.skills.repair.description":
+        "从可信 source 强制将一个或多个由 oo 管理的 skill 重新部署到一个或多个 Agent 的 skill 目录。",
+    "commands.skills.repair.summary": "从可信 source 修复已安装的 skill",
+    "options.skills.repair.skill":
+        "要修复的 skill 名称（必填，可重复传入）",
+    "options.skills.repair.agent":
+        "目标 Agent 名称（可重复；缺省时为当前所有可用的受支持 Agent）",
+    "skills.repair.success":
+        "已为 {agentCount} 个 Agent 修复 {skillCount} 个 skill。",
+    "skills.repair.success.line": "  {name}：{agents}",
+    "skills.repair.failure":
+        "有 {count} 个 skill-Agent 组合修复失败。",
+    "skills.repair.failure.line": "  {name}（{agent}）：{reason}",
+    "errors.skills.repair.skillRequired":
+        "至少需要传入一个 --skill <name>。",
+    "errors.skills.repair.localUnsupported":
+        "skill {name} 是 local skill，不支持 repair；local skill 是 Agent 原生 source。",
+    "errors.skills.repair.partialFailure":
+        "有 {count} 个 skill-Agent 组合修复失败。",
+    "errors.skills.repair.sourceNotFound":
+        "未找到由 oo 管理的 registry canonical source。",
+    "errors.skills.repair.sourceInvalid":
+        "registry canonical metadata 缺失或不是 registry skill。",
+    "errors.skills.repair.invalidPath":
+        "目标路径超出受管 skills 目录范围。",
+    "errors.skills.repair.writeFailed":
+        "写入 skill source 到目标 Agent 目录失败。",
     "config.set.success": "已将 {key} 设置为 {value}。",
     "config.unset.success": "已移除 {key}。",
     "telemetry.disable.success": "已关闭 telemetry。",


### PR DESCRIPTION
Force re-deploy oo-managed skills from their trusted local source into agent skill directories, always overwriting the target. Unlike `update`, repair never goes to the network and never changes the recorded package or version — it only rewrites the agent copy from the canonical bundled or registry source already on disk.

This fills a gap when a host directory has been tampered with, has corrupt metadata, or collides with an unmanaged same-name folder. For bundled skills, repair also re-materializes the canonical bundled source from embedded assets, so a poisoned canonical store is recovered alongside the host copy.

Execution is fail-soft: each (skill, agent) pair is attempted independently, and the command exits non-zero only after reporting the full success/failure summary. Text output deliberately omits filesystem paths; consumers needing machine-readable paths should use `--json`.