### PR TITLE
feat(cli): add `oo version` command with JSON output

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -349,6 +349,46 @@ Check whether a newer CLI release is available.
   checks the latest published release.
 - Notes: when the update check is temporarily unavailable, the CLI prints a
   retry-later message instead of exiting with an error.
+- Options: `--format=json` and `--json` switch to structured JSON output. The
+  shape is one of:
+
+  ```json
+  { "status": "update-available", "currentVersion": "1.2.3", "latestVersion": "1.3.0" }
+  ```
+
+  ```json
+  { "status": "up-to-date", "currentVersion": "1.2.3", "latestVersion": "1.2.3" }
+  ```
+
+  ```json
+  { "status": "failed", "currentVersion": "1.2.3", "message": "Cannot reach update service." }
+  ```
+
+- Notes (JSON): `status` is the stable machine-readable enum. `message` is a
+  human-readable English string and should not be parsed by scripts. The
+  command exits `0` even when `status` is `"failed"` because the failure is a
+  query result; scripts should branch on `status`. Argument errors (for example
+  `--format xml`) still exit `2`.
+
+### `oo version`
+
+Print the CLI version.
+
+- Notes: text output is identical to `oo --version` / `oo -V`. Use `oo version`
+  when you want a command-style invocation, particularly in combination with
+  `--json` for script consumption.
+- Options: `--format=json` and `--json` switch to structured JSON output. The
+  payload mirrors the same data the text output prints (version, build time,
+  and commit hash) so callers can switch formats without losing fields:
+
+  ```json
+  { "version": "1.2.3", "buildTime": "2026-05-26T00:00:00.000Z", "commit": "abc12345" }
+  ```
+
+  `buildTime` is the build timestamp formatted as ISO 8601, or `null` when the
+  binary was built without an embedded build timestamp. `commit` is the first
+  eight characters of the git commit hash recorded at build time, or `null`
+  when unknown.
 
 ## Environment
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -298,6 +298,42 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 说明：无论成功还是失败，检查结果都不会被缓存，因此每次执行都会重新检查
   最新发布版本。
 - 说明：如果更新检查暂时不可用，CLI 会输出稍后重试的提示，而不是直接报错退出。
+- 选项：`--format=json` 与 `--json` 切换到结构化 JSON 输出，形如：
+
+  ```json
+  { "status": "update-available", "currentVersion": "1.2.3", "latestVersion": "1.3.0" }
+  ```
+
+  ```json
+  { "status": "up-to-date", "currentVersion": "1.2.3", "latestVersion": "1.2.3" }
+  ```
+
+  ```json
+  { "status": "failed", "currentVersion": "1.2.3", "message": "Cannot reach update service." }
+  ```
+
+- 说明（JSON）：`status` 是稳定的机器可读枚举；`message` 是英文人类可读文本，
+  脚本不应解析。`status` 为 `"failed"` 时仍以 0 退出，因为这是查询结果而非
+  CLI 执行错误；脚本应通过 `status` 字段判断分支。参数错误（如 `--format xml`）
+  仍以 2 退出。
+
+### `oo version`
+
+打印 CLI 版本。
+
+- 说明：文本输出与 `oo --version` / `oo -V` 完全一致。当需要命令式调用（特别是
+  配合 `--json` 给脚本消费）时使用 `oo version`。
+- 选项：`--format=json` 与 `--json` 切换到结构化 JSON 输出。Payload 与文本输出
+  使用同一份数据（version、build 时间、commit hash），方便调用方在两种格式
+  间切换：
+
+  ```json
+  { "version": "1.2.3", "buildTime": "2026-05-26T00:00:00.000Z", "commit": "abc12345" }
+  ```
+
+  `buildTime` 为 ISO 8601 格式的构建时间戳；二进制构建时未嵌入构建时间戳
+  时为 `null`。`commit` 为构建时记录的 git commit hash 前 8 个字符；未知时
+  为 `null`。
 
 ## 环境
 

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -41,7 +41,7 @@ Options:
 
 Commands:
   auth                      Manage CLI authentication
-  check-update              Check for CLI updates
+  check-update [options]    Check for CLI updates
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
@@ -57,6 +57,7 @@ Commands:
   packages                  Package utilities
   telemetry                 Manage CLI telemetry
   update|upgrade [options]  Update the CLI
+  version [options]         Print the CLI version
   help [command]            Show help for a command
 "
 ,
@@ -78,7 +79,7 @@ Options:
 
 Commands:
   auth                      Manage CLI authentication
-  check-update              Check for CLI updates
+  check-update [options]    Check for CLI updates
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
@@ -94,6 +95,7 @@ Commands:
   packages                  Package utilities
   telemetry                 Manage CLI telemetry
   update|upgrade [options]  Update the CLI
+  version [options]         Print the CLI version
   help [command]            Show help for a command
 "
 ,
@@ -118,7 +120,7 @@ Options:
 
 Commands:
   auth                      Manage CLI authentication
-  check-update              Check for CLI updates
+  check-update [options]    Check for CLI updates
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
@@ -134,6 +136,7 @@ Commands:
   packages                  Package utilities
   telemetry                 Manage CLI telemetry
   update|upgrade [options]  Update the CLI
+  version [options]         Print the CLI version
   help [command]            Show help for a command
 "
 ,
@@ -156,7 +159,7 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
 
 命令：
   auth                      管理 CLI 认证
-  check-update              检查 CLI 更新
+  check-update [options]    检查 CLI 更新
   cloud-task                管理云任务
   connector                 管理 connector action
   file                      管理临时文件传输
@@ -172,6 +175,7 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
   packages                  包相关工具
   telemetry                 管理 CLI telemetry
   update|upgrade [options]  更新 CLI
+  version [options]         输出 CLI 版本
   help [command]            显示命令帮助
 "
 ,
@@ -190,7 +194,7 @@ Options:
 
 Commands:
   auth                      Manage CLI authentication
-  check-update              Check for CLI updates
+  check-update [options]    Check for CLI updates
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
@@ -206,6 +210,7 @@ Commands:
   packages                  Package utilities
   telemetry                 Manage CLI telemetry
   update|upgrade [options]  Update the CLI
+  version [options]         Print the CLI version
   help [command]            Show help for a command
 "
 ,
@@ -228,7 +233,7 @@ Options:
 
 Commands:
   auth                      Manage CLI authentication
-  check-update              Check for CLI updates
+  check-update [options]    Check for CLI updates
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
@@ -244,6 +249,7 @@ Commands:
   packages                  Package utilities
   telemetry                 Manage CLI telemetry
   update|upgrade [options]  Update the CLI
+  version [options]         Print the CLI version
   help [command]            Show help for a command
 "
 ,

--- a/src/application/commands/catalog.ts
+++ b/src/application/commands/catalog.ts
@@ -19,6 +19,7 @@ import { mixedSearchCommand } from "./search.ts";
 import { skillsCommand } from "./skills/index.ts";
 import { telemetryCommand } from "./telemetry/index.ts";
 import { updateCommand } from "./update.ts";
+import { versionCommand } from "./version.ts";
 
 const globalOptions = [
     {
@@ -60,6 +61,7 @@ export function createCliCatalog(): CliCatalog {
             packageCommand,
             telemetryCommand,
             updateCommand,
+            versionCommand,
         ],
     };
 }

--- a/src/application/commands/check-update.cli.test.ts
+++ b/src/application/commands/check-update.cli.test.ts
@@ -227,4 +227,184 @@ describe("checkUpdateCommand CLI", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("--json emits update-available payload with currentVersion and latestVersion", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["check-update", "--json"],
+                {
+                    fetcher: async () => new Response(JSON.stringify({ version: "1.3.0" })),
+                    version: "1.2.3",
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload).toEqual({
+                status: "update-available",
+                currentVersion: "1.2.3",
+                latestVersion: "1.3.0",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json emits up-to-date payload with matching latestVersion", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["check-update", "--json"],
+                {
+                    fetcher: async () => new Response(JSON.stringify({ version: "1.2.3" })),
+                    version: "1.2.3",
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload).toEqual({
+                status: "up-to-date",
+                currentVersion: "1.2.3",
+                latestVersion: "1.2.3",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json up-to-date reports remote latestVersion when current is ahead of remote", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["check-update", "--json"],
+                {
+                    fetcher: async () => new Response(JSON.stringify({ version: "1.2.3" })),
+                    version: "1.3.0",
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            // status is up-to-date because current >= remote, but latestVersion
+            // must reflect what the server actually said, not echo currentVersion.
+            expect(payload).toEqual({
+                status: "up-to-date",
+                currentVersion: "1.3.0",
+                latestVersion: "1.2.3",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json emits failed payload (exit 0) when latest-version is unavailable", async () => {
+        const sandbox = await createCliSandbox();
+        const originalSleep = Bun.sleep;
+
+        try {
+            // Skip retry backoff so the test stays fast.
+            Bun.sleep = (() => Promise.resolve()) as typeof Bun.sleep;
+
+            const result = await sandbox.run(
+                ["check-update", "--json"],
+                {
+                    fetcher: async () => {
+                        throw new Error("temporary network failure");
+                    },
+                    version: "1.2.3",
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.status).toBe("failed");
+            expect(payload.currentVersion).toBe("1.2.3");
+            expect(payload.message).toBeTypeOf("string");
+            expect(payload).not.toHaveProperty("latestVersion");
+        }
+        finally {
+            Bun.sleep = originalSleep;
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json emits failed payload for unsupported version", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["check-update", "--json"],
+                {
+                    version: "development",
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.status).toBe("failed");
+            expect(payload.currentVersion).toBe("development");
+            expect(payload.message).toBeTypeOf("string");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json --show-schema-version prepends schemaVersion", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["check-update", "--json", "--show-schema-version"],
+                {
+                    fetcher: async () => new Response(JSON.stringify({ version: "1.2.3" })),
+                    version: "1.2.3",
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.schemaVersion).toBe("1.0.0");
+            expect(payload.status).toBe("up-to-date");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--format xml exits 2 with a format error", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["check-update", "--format", "xml"],
+                {
+                    version: "1.2.3",
+                },
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).not.toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });

--- a/src/application/commands/check-update.ts
+++ b/src/application/commands/check-update.ts
@@ -1,4 +1,5 @@
-import type { CliCommandDefinition } from "../contracts/cli.ts";
+import type { CliCommandDefinition, CliExecutionContext } from "../contracts/cli.ts";
+import type { CliUpdateCheckResult } from "../update/update-notifier.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../contracts/cli.ts";
@@ -7,65 +8,159 @@ import {
     cliUpdateCommand,
     renderCliUpdateNotice,
 } from "../update/update-notifier.ts";
+import { jsonOutputOptions, writeJsonOutput } from "./json-output.ts";
 import { classifyTelemetryVersionKind } from "./self-update-telemetry.ts";
+import { createFormatInputError } from "./shared/input-parsing.ts";
 
-export const checkUpdateCommand: CliCommandDefinition = {
+const checkUpdateFormatValues = ["json"] as const;
+
+interface CheckUpdateInput {
+    format?: (typeof checkUpdateFormatValues)[number];
+    showSchemaVersion?: boolean;
+}
+
+interface CheckUpdateJsonPayload {
+    status: "update-available" | "up-to-date" | "failed";
+    currentVersion: string;
+    latestVersion?: string;
+    message?: string;
+}
+
+const checkUpdateFailureMessages = {
+    "invalid-current-version": "Current CLI version is not a recognized semantic version.",
+    "latest-version-unavailable": "Unable to determine the latest CLI version.",
+    "unexpected-error": "Update check encountered an unexpected error.",
+} as const satisfies Record<
+    Extract<CliUpdateCheckResult, { status: "failed" }>["reason"],
+    string
+>;
+
+export const checkUpdateCommand: CliCommandDefinition<CheckUpdateInput> = {
     name: "check-update",
     summaryKey: "commands.checkUpdate.summary",
     descriptionKey: "commands.checkUpdate.description",
-    inputSchema: z.object({}),
-    handler: async (_, context) => {
+    options: [...jsonOutputOptions],
+    inputSchema: z.object({
+        format: z.enum(checkUpdateFormatValues).optional(),
+        showSchemaVersion: z.boolean().optional(),
+    }),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+    handler: async (input, context) => {
         context.telemetry?.recordProperties({
             version_kind: classifyTelemetryVersionKind(context.version),
         });
 
         const result = await checkForCliUpdate(context);
 
-        switch (result.status) {
-            case "failed":
-                context.telemetry?.recordProperties({ update_available: false });
-                switch (result.reason) {
-                    case "invalid-current-version":
-                        context.stdout.write(
-                            `${context.translator.t("checkUpdate.unsupportedVersion", {
-                                version: context.version,
-                            })}\n`,
-                        );
-                        return;
-                    case "latest-version-unavailable":
-                        context.stdout.write(
-                            `${context.translator.t("checkUpdate.unavailable")}\n`,
-                        );
-                        return;
-                    case "unexpected-error":
-                        throw new CliUserError("errors.checkUpdate.failed", 1);
-                }
-                return;
-            case "up-to-date":
-                context.telemetry?.recordProperties({ update_available: false });
-                context.stdout.write(
-                    `${context.translator.t("checkUpdate.upToDate", {
-                        version: context.version,
-                    })}\n`,
-                );
-                return;
-            case "update-available":
-                context.telemetry?.recordProperties({ update_available: true });
-                context.stdout.write(
-                    renderCliUpdateNotice({
-                        context,
-                        latestVersion: result.latestVersion,
-                        updateCommand: cliUpdateCommand,
-                        writer: context.stdout,
-                    }),
-                );
-                context.logger.info(
-                    {
-                        currentVersion: context.version,
-                        latestVersion: result.latestVersion,
-                    },
-                    "CLI update notice emitted.",
-                );
+        if (input.format === "json") {
+            handleCheckUpdateJson(result, context, input);
+            return;
         }
+
+        handleCheckUpdateText(result, context);
     },
 };
+
+function handleCheckUpdateJson(
+    result: CliUpdateCheckResult,
+    context: CliExecutionContext,
+    input: CheckUpdateInput,
+): void {
+    const payload = buildCheckUpdateJsonPayload(result, context.version);
+
+    context.telemetry?.recordProperties({
+        update_available: payload.status === "update-available",
+    });
+
+    if (payload.status === "update-available") {
+        context.logger.info(
+            {
+                currentVersion: context.version,
+                latestVersion: payload.latestVersion,
+            },
+            "CLI update notice emitted.",
+        );
+    }
+
+    writeJsonOutput(context.stdout, payload, {
+        showSchemaVersion: input.showSchemaVersion,
+    });
+}
+
+function buildCheckUpdateJsonPayload(
+    result: CliUpdateCheckResult,
+    currentVersion: string,
+): CheckUpdateJsonPayload {
+    switch (result.status) {
+        case "update-available":
+            return {
+                status: "update-available",
+                currentVersion,
+                latestVersion: result.latestVersion,
+            };
+        case "up-to-date":
+            return {
+                status: "up-to-date",
+                currentVersion,
+                latestVersion: result.latestVersion,
+            };
+        case "failed":
+            return {
+                status: "failed",
+                currentVersion,
+                message: checkUpdateFailureMessages[result.reason],
+            };
+    }
+}
+
+function handleCheckUpdateText(
+    result: CliUpdateCheckResult,
+    context: CliExecutionContext,
+): void {
+    switch (result.status) {
+        case "failed":
+            context.telemetry?.recordProperties({ update_available: false });
+            switch (result.reason) {
+                case "invalid-current-version":
+                    context.stdout.write(
+                        `${context.translator.t("checkUpdate.unsupportedVersion", {
+                            version: context.version,
+                        })}\n`,
+                    );
+                    return;
+                case "latest-version-unavailable":
+                    context.stdout.write(
+                        `${context.translator.t("checkUpdate.unavailable")}\n`,
+                    );
+                    return;
+                case "unexpected-error":
+                    throw new CliUserError("errors.checkUpdate.failed", 1);
+            }
+            return;
+        case "up-to-date":
+            context.telemetry?.recordProperties({ update_available: false });
+            context.stdout.write(
+                `${context.translator.t("checkUpdate.upToDate", {
+                    version: context.version,
+                })}\n`,
+            );
+            return;
+        case "update-available":
+            context.telemetry?.recordProperties({ update_available: true });
+            context.stdout.write(
+                renderCliUpdateNotice({
+                    context,
+                    latestVersion: result.latestVersion,
+                    updateCommand: cliUpdateCommand,
+                    writer: context.stdout,
+                }),
+            );
+            context.logger.info(
+                {
+                    currentVersion: context.version,
+                    latestVersion: result.latestVersion,
+                },
+                "CLI update notice emitted.",
+            );
+    }
+}

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -27,7 +27,7 @@ Options:
 
 Commands:
   auth                      Manage CLI authentication
-  check-update              Check for CLI updates
+  check-update [options]    Check for CLI updates
   cloud-task                Manage cloud tasks
   connector                 Manage connector actions
   file                      Manage temporary file transfers
@@ -43,6 +43,7 @@ Commands:
   packages                  Package utilities
   telemetry                 Manage CLI telemetry
   update|upgrade [options]  Update the CLI
+  version [options]         Print the CLI version
   help [command]            Show help for a command
 "
 ,
@@ -61,7 +62,7 @@ Commands:
 
 命令：
   auth                      管理 CLI 认证
-  check-update              检查 CLI 更新
+  check-update [options]    检查 CLI 更新
   cloud-task                管理云任务
   connector                 管理 connector action
   file                      管理临时文件传输
@@ -77,6 +78,7 @@ Commands:
   packages                  包相关工具
   telemetry                 管理 CLI telemetry
   update|upgrade [options]  更新 CLI
+  version [options]         输出 CLI 版本
   help [command]            显示命令帮助
 "
 ,

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -415,6 +415,10 @@ const commandTelemetryDecisions = {
         ],
         reason: "Records self-update state without raw version strings.",
     },
+    "version": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; the CLI version and commit are already attached to every event via the global cli_version and cli_commit dimensions, and build time is not telemetry-relevant.",
+    },
 } as const satisfies Record<string, TelemetryDecision>;
 
 describe("command telemetry decisions", () => {

--- a/src/application/commands/version.cli.test.ts
+++ b/src/application/commands/version.cli.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+
+import { createCliSandbox } from "../../../__tests__/helpers.ts";
+
+describe("versionCommand CLI", () => {
+    test("text output mirrors `oo --version`", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const subcommandResult = await sandbox.run(["version"], { version: "1.2.3" });
+            const flagResult = await sandbox.run(["--version"], { version: "1.2.3" });
+
+            expect(subcommandResult.exitCode).toBe(0);
+            expect(subcommandResult.stderr).toBe("");
+            expect(flagResult.exitCode).toBe(0);
+            expect(flagResult.stderr).toBe("");
+            expect(subcommandResult.stdout).toBe(flagResult.stdout);
+            expect(subcommandResult.stdout).toContain("1.2.3");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json emits version with mirrored buildTime and commit fields", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["version", "--json"], { version: "1.2.3" });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload).toMatchObject({ version: "1.2.3" });
+            expect(payload).toHaveProperty("buildTime");
+            expect(payload).toHaveProperty("commit");
+            expect(["string", "null"]).toContain(payload.buildTime === null ? "null" : typeof payload.buildTime);
+            expect(["string", "null"]).toContain(payload.commit === null ? "null" : typeof payload.commit);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json --show-schema-version prepends schemaVersion", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["version", "--json", "--show-schema-version"],
+                { version: "1.2.3" },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.schemaVersion).toBe("1.0.0");
+            expect(payload.version).toBe("1.2.3");
+            expect(payload).toHaveProperty("buildTime");
+            expect(payload).toHaveProperty("commit");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--format json is equivalent to --json", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const formatResult = await sandbox.run(
+                ["version", "--format", "json"],
+                { version: "1.2.3" },
+            );
+            const jsonResult = await sandbox.run(["version", "--json"], { version: "1.2.3" });
+
+            expect(formatResult.exitCode).toBe(0);
+            expect(jsonResult.exitCode).toBe(0);
+            expect(formatResult.stdout).toBe(jsonResult.stdout);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--format xml exits 2 with a format error", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["version", "--format", "xml"],
+                { version: "1.2.3" },
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).not.toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/version.ts
+++ b/src/application/commands/version.ts
@@ -1,0 +1,47 @@
+import type { CliCommandDefinition } from "../contracts/cli.ts";
+
+import { z } from "zod";
+import {
+    formatBuildTimestampIso,
+    resolveCliBuildInfo,
+    shortenCommitHash,
+} from "../config/build-info.ts";
+import { jsonOutputOptions, writeJsonOutput } from "./json-output.ts";
+import { createFormatInputError } from "./shared/input-parsing.ts";
+
+const versionFormatValues = ["json"] as const;
+
+interface VersionInput {
+    format?: (typeof versionFormatValues)[number];
+    showSchemaVersion?: boolean;
+}
+
+export const versionCommand: CliCommandDefinition<VersionInput> = {
+    name: "version",
+    summaryKey: "commands.version.summary",
+    descriptionKey: "commands.version.description",
+    options: [...jsonOutputOptions],
+    inputSchema: z.object({
+        format: z.enum(versionFormatValues).optional(),
+        showSchemaVersion: z.boolean().optional(),
+    }),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+    handler: (input, context) => {
+        if (input.format === "json") {
+            const buildInfo = resolveCliBuildInfo(context.version);
+
+            writeJsonOutput(
+                context.stdout,
+                {
+                    version: buildInfo.version,
+                    buildTime: formatBuildTimestampIso(buildInfo.buildTimestamp) ?? null,
+                    commit: shortenCommitHash(buildInfo.commitHash) ?? null,
+                },
+                { showSchemaVersion: input.showSchemaVersion },
+            );
+            return;
+        }
+
+        context.stdout.write(`${context.versionText ?? context.version}\n`);
+    },
+};

--- a/src/application/config/build-info.ts
+++ b/src/application/config/build-info.ts
@@ -1,5 +1,7 @@
 import type { Translator } from "../contracts/translator.ts";
 
+const COMMIT_HASH_DISPLAY_LENGTH = 8;
+
 export interface CliBuildInfo {
     buildTimestamp?: number;
     commitHash?: string;
@@ -14,6 +16,22 @@ export function resolveCliBuildInfo(fallbackVersion: string): CliBuildInfo {
     };
 }
 
+export function formatBuildTimestampIso(
+    buildTimestamp: number | undefined,
+): string | undefined {
+    if (buildTimestamp === undefined) {
+        return undefined;
+    }
+
+    return new Date(buildTimestamp).toISOString();
+}
+
+export function shortenCommitHash(
+    commitHash: string | undefined,
+): string | undefined {
+    return commitHash?.slice(0, COMMIT_HASH_DISPLAY_LENGTH);
+}
+
 export function formatCliVersionText(
     buildInfo: CliBuildInfo,
     translator: Translator,
@@ -22,14 +40,12 @@ export function formatCliVersionText(
 
     return [
         `${translator.t("labels.version")}: ${buildInfo.version}`,
-        `${translator.t("versionInfo.buildTime")}: ${formatBuildTime(
-            buildInfo.buildTimestamp,
-            unknownValue,
-        )}`,
-        `${translator.t("versionInfo.commit")}: ${formatCommitHash(
-            buildInfo.commitHash,
-            unknownValue,
-        )}`,
+        `${translator.t("versionInfo.buildTime")}: ${
+            formatBuildTimestampIso(buildInfo.buildTimestamp) ?? unknownValue
+        }`,
+        `${translator.t("versionInfo.commit")}: ${
+            shortenCommitHash(buildInfo.commitHash) ?? unknownValue
+        }`,
     ].join("\n");
 }
 
@@ -58,22 +74,4 @@ function readCommitHash(): string | undefined {
     }
 
     return GIT_COMMIT.trim() || undefined;
-}
-
-function formatBuildTime(
-    buildTimestamp: number | undefined,
-    unknownValue: string,
-): string {
-    if (buildTimestamp === undefined) {
-        return unknownValue;
-    }
-
-    return new Date(buildTimestamp).toISOString();
-}
-
-function formatCommitHash(
-    commitHash: string | undefined,
-    unknownValue: string,
-): string {
-    return commitHash?.slice(0, 8) ?? unknownValue;
 }

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -686,6 +686,9 @@ export const enMessages = {
     "commands.update.description":
         "Update the managed CLI install to the latest published release.",
     "commands.update.summary": "Update the CLI",
+    "commands.version.description":
+        "Print the CLI version. Use --json for a stable machine-readable payload.",
+    "commands.version.summary": "Print the CLI version",
     "help.arguments": "Arguments:",
     "help.commands": "Commands:",
     "help.extra.choices": "choices",
@@ -1694,6 +1697,9 @@ export const zhMessages = {
     "commands.update.description":
         "把托管 CLI 安装更新到最新发布版本。",
     "commands.update.summary": "更新 CLI",
+    "commands.version.description":
+        "输出 CLI 版本。使用 --json 输出稳定的机器可读 payload。",
+    "commands.version.summary": "输出 CLI 版本",
     "help.arguments": "参数：",
     "help.commands": "命令：",
     "help.extra.choices": "可选值",


### PR DESCRIPTION
Introduce `oo version` as a command-style alternative to `oo --version`, with `--json` output exposing version, build time, and commit hash for script consumption. Also extend `oo check-update` with `--json` / `--format=json` so callers can branch on a stable `status` enum (`update-available`, `up-to-date`, `failed`) instead of parsing human-readable text. Failed update checks still exit 0 in JSON mode because the failure is a query result, not a CLI execution error.