### PR TITLE
feat(auth): add JSON output to `oo auth status`

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -68,6 +68,51 @@ Remove the current account from persisted auth data.
 
 Show the current account and validate its API key.
 
+- Options: `--format=json` and `--json` switch to structured JSON output.
+  `--show-schema-version` prepends `schemaVersion` to the payload.
+- JSON shape (one of three):
+
+  ```json
+  {
+    "status": "logged-in",
+    "activeAccountId": "user-1",
+    "accounts": [
+      { "id": "user-1", "name": "Alice", "endpoint": "oomol.com", "active": true, "apiKeyStatus": "valid" },
+      { "id": "user-2", "name": "Bob",   "endpoint": "oomol.com", "active": false }
+    ]
+  }
+  ```
+
+  ```json
+  { "status": "logged-out", "activeAccountId": null, "accounts": [] }
+  ```
+
+  ```json
+  {
+    "status": "active-account-missing",
+    "activeAccountId": null,
+    "missingAccountId": "user-1",
+    "accounts": [
+      { "id": "user-2", "name": "Bob", "endpoint": "oomol.com", "active": false }
+    ]
+  }
+  ```
+
+- Notes (JSON):
+  - The `apiKey` field is **never** emitted, and the JSON payload never
+    contains the actual API key string under any field name.
+  - `accounts[]` lists every account saved in the local auth file in its
+    original order; each entry is `{ id, name, endpoint, active, apiKeyStatus? }`.
+  - `activeAccountId` is the active account id, or `null` when no active
+    account can be resolved (including the `active-account-missing` state).
+  - `accounts[].active` is `true` only for the active account.
+  - `accounts[].apiKeyStatus` is present only on the active entry and uses
+    the enum `valid` / `invalid` / `request_failed` / `request_failed_sandbox`.
+  - `missingAccountId` appears only when the auth file records an active id
+    that is no longer present in `accounts[]`.
+  - All three statuses exit `0` (this is a query command). Argument errors
+    (for example `--format xml`) still exit `2`.
+
 ### `oo auth switch`
 
 Switch to the next saved account.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -59,6 +59,49 @@
 
 显示当前账号，并校验其 API key 状态。
 
+- 选项：`--format=json` 与 `--json` 切换到结构化 JSON 输出。
+  `--show-schema-version` 会向 payload 顶层添加 `schemaVersion`。
+- JSON 三种形态：
+
+  ```json
+  {
+    "status": "logged-in",
+    "activeAccountId": "user-1",
+    "accounts": [
+      { "id": "user-1", "name": "Alice", "endpoint": "oomol.com", "active": true, "apiKeyStatus": "valid" },
+      { "id": "user-2", "name": "Bob",   "endpoint": "oomol.com", "active": false }
+    ]
+  }
+  ```
+
+  ```json
+  { "status": "logged-out", "activeAccountId": null, "accounts": [] }
+  ```
+
+  ```json
+  {
+    "status": "active-account-missing",
+    "activeAccountId": null,
+    "missingAccountId": "user-1",
+    "accounts": [
+      { "id": "user-2", "name": "Bob", "endpoint": "oomol.com", "active": false }
+    ]
+  }
+  ```
+
+- 说明（JSON）：
+  - **绝不**输出 `apiKey` 字段；JSON payload 在任何字段下都不包含实际 API key 字符串。
+  - `accounts[]` 按原顺序列出本地 auth file 中保存的全部账号，每条 entry 为
+    `{ id, name, endpoint, active, apiKeyStatus? }`。
+  - `activeAccountId` 是当前激活账号 ID；无可用激活账号时（包括
+    `active-account-missing` 状态）为 `null`。
+  - `accounts[].active` 仅在激活账号上为 `true`。
+  - `accounts[].apiKeyStatus` 只在激活账号 entry 出现，枚举为
+    `valid` / `invalid` / `request_failed` / `request_failed_sandbox`。
+  - `missingAccountId` 仅在 auth file 记录的 active id 已不存在于
+    `accounts[]` 时出现。
+  - 三种状态都以 0 退出（查询命令）；参数错误（如 `--format xml`）仍以 2 退出。
+
 ### `oo auth switch`
 
 切换到下一个已保存账号。

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -14,9 +14,11 @@ import {
     readLatestLogContent,
     runPrintedAuthLogin,
     toRequest,
+    writeAuthFile,
 } from "../../../../__tests__/helpers.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import { createTerminalColors } from "../../terminal-colors.ts";
+import { JSON_OUTPUT_SCHEMA_VERSION } from "../json-output.ts";
 
 const loginUrlColor = "#c09ff5";
 
@@ -574,6 +576,229 @@ describe("auth CLI", () => {
             expect(result.stdout).toContain(
                 "Request failed (network-restricted sandbox, try requesting elevated permissions)",
             );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json logged-in returns active account with valid apiKeyStatus", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                    { id: "user-2", name: "Bob", apiKey: "secret-2", endpoint: defaultAuthEndpoint },
+                ],
+            });
+
+            const result = await sandbox.run(
+                ["auth", "status", "--json"],
+                {
+                    fetcher: async () => new Response(null, { status: 200 }),
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload).toEqual({
+                status: "logged-in",
+                activeAccountId: "user-1",
+                accounts: [
+                    {
+                        id: "user-1",
+                        name: "Alice",
+                        endpoint: defaultAuthEndpoint,
+                        active: true,
+                        apiKeyStatus: "valid",
+                    },
+                    {
+                        id: "user-2",
+                        name: "Bob",
+                        endpoint: defaultAuthEndpoint,
+                        active: false,
+                    },
+                ],
+            });
+            expect(result.stdout).not.toContain("apiKey\"");
+            expect(result.stdout).not.toContain("secret-1");
+            expect(result.stdout).not.toContain("secret-2");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json maps HTTP 401 to apiKeyStatus invalid", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["auth", "status", "--json"],
+                {
+                    fetcher: async () => new Response(null, { status: 401 }),
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const accounts = payload.accounts as Array<Record<string, unknown>>;
+
+            expect(accounts[0]?.apiKeyStatus).toBe("invalid");
+            expect(result.stdout).not.toContain("secret-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json maps generic fetch error to apiKeyStatus request_failed", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["auth", "status", "--json"],
+                {
+                    fetcher: async () => {
+                        throw new Error("network blip");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const accounts = payload.accounts as Array<Record<string, unknown>>;
+
+            expect(accounts[0]?.apiKeyStatus).toBe("request_failed");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json maps sandbox socket error to apiKeyStatus request_failed_sandbox", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["auth", "status", "--json"],
+                {
+                    fetcher: async () => {
+                        throw createFailedToOpenSocketError("network down");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const accounts = payload.accounts as Array<Record<string, unknown>>;
+
+            expect(accounts[0]?.apiKeyStatus).toBe("request_failed_sandbox");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json logged-out returns empty accounts when no auth file exists", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["auth", "status", "--json"]);
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload).toEqual({
+                status: "logged-out",
+                activeAccountId: null,
+                accounts: [],
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json active-account-missing exposes stale id and excludes it from accounts", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-2", name: "Bob", apiKey: "secret-2", endpoint: defaultAuthEndpoint },
+                ],
+            });
+
+            const result = await sandbox.run(["auth", "status", "--json"]);
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload).toEqual({
+                status: "active-account-missing",
+                activeAccountId: null,
+                missingAccountId: "user-1",
+                accounts: [
+                    {
+                        id: "user-2",
+                        name: "Bob",
+                        endpoint: defaultAuthEndpoint,
+                        active: false,
+                    },
+                ],
+            });
+            expect(result.stdout).not.toContain("secret-2");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json --show-schema-version prepends schemaVersion", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["auth", "status", "--json", "--show-schema-version"],
+                {
+                    fetcher: async () => new Response(null, { status: 200 }),
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.schemaVersion).toBe(JSON_OUTPUT_SCHEMA_VERSION);
+            expect(payload.status).toBe("logged-in");
+            expect(result.stdout).not.toContain("secret-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--format xml exits 2 with format error", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["auth", "status", "--format", "xml"]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).not.toBe("");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/auth/status.ts
+++ b/src/application/commands/auth/status.ts
@@ -1,10 +1,13 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 
-import type { AuthAccount } from "../../schemas/auth.ts";
+import type { AuthAccount, AuthFile } from "../../schemas/auth.ts";
+
+import { z } from "zod";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { createFormatInputError } from "../shared/input-parsing.ts";
 import { isNetworkRestrictedSandboxError } from "../shared/request.ts";
 import {
-    emptyAuthCommandInputSchema,
     formatAuthStrong,
     readCurrentAuth,
     writeAuthBlock,
@@ -22,63 +25,172 @@ const apiKeyStatusConfig = {
 
 type ApiKeyStatus = keyof typeof apiKeyStatusConfig;
 
-export const authStatusCommand: CliCommandDefinition = {
+interface ActiveAccountStatus {
+    account: AuthAccount;
+    apiKeyStatus: ApiKeyStatus;
+}
+
+const authStatusFormatValues = ["json"] as const;
+
+interface AuthStatusInput {
+    format?: (typeof authStatusFormatValues)[number];
+    showSchemaVersion?: boolean;
+}
+
+interface AuthStatusJsonAccount {
+    id: string;
+    name: string;
+    endpoint: string;
+    active: boolean;
+    apiKeyStatus?: ApiKeyStatus;
+}
+
+type AuthStatusJsonPayload
+    = | {
+        status: "logged-in";
+        activeAccountId: string;
+        accounts: AuthStatusJsonAccount[];
+    }
+    | {
+        status: "logged-out";
+        activeAccountId: null;
+        accounts: AuthStatusJsonAccount[];
+    }
+    | {
+        status: "active-account-missing";
+        activeAccountId: null;
+        missingAccountId: string;
+        accounts: AuthStatusJsonAccount[];
+    };
+
+export const authStatusCommand: CliCommandDefinition<AuthStatusInput> = {
     name: "status",
     summaryKey: "commands.auth.status.summary",
     descriptionKey: "commands.auth.status.description",
-    inputSchema: emptyAuthCommandInputSchema,
-    handler: async (_, context) => {
+    options: [...jsonOutputOptions],
+    inputSchema: z.object({
+        format: z.enum(authStatusFormatValues).optional(),
+        showSchemaVersion: z.boolean().optional(),
+    }),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+    handler: async (input, context) => {
         const { authFile, currentAccount } = await readCurrentAuth(context);
 
         context.telemetry?.recordProperties({
             account_count_bucket: bucketTelemetryCount(authFile.auth.length),
         });
 
-        if (!currentAccount) {
-            const hasStaleId = authFile.id !== "";
+        const activeStatus: ActiveAccountStatus | undefined
+            = currentAccount === undefined
+                ? undefined
+                : {
+                        account: currentAccount,
+                        apiKeyStatus: await readApiKeyStatus(currentAccount, context),
+                    };
 
-            if (hasStaleId) {
-                writeAuthBlock(context, {
-                    tone: "danger",
-                    summary: context.translator.t("auth.account.activeAccountMissing"),
-                    details: [
-                        {
-                            label: context.translator.t("auth.status.accountId"),
-                            value: authFile.id,
-                        },
-                    ],
-                });
-            }
-            else {
-                writeAuthBlock(context, {
-                    tone: "warning",
-                    summary: context.translator.t("auth.status.loggedOut"),
-                });
-            }
+        if (input.format === "json") {
+            writeJsonOutput(
+                context.stdout,
+                buildAuthStatusJsonPayload(authFile, activeStatus),
+                { showSchemaVersion: input.showSchemaVersion },
+            );
             return;
         }
 
-        const apiKeyStatus = await readApiKeyStatus(currentAccount, context);
-        const statusConfig = apiKeyStatusConfig[apiKeyStatus];
-        writeAuthBlock(context, {
-            tone: statusConfig.tone,
-            summary: context.translator.t("auth.account.loggedIn", {
-                endpoint: formatAuthStrong(context, currentAccount.endpoint),
-                name: formatAuthStrong(context, currentAccount.name),
-            }),
-            details: [
-                {
-                    label: context.translator.t("auth.status.activeAccount"),
-                    value: "true",
-                },
-                {
-                    label: context.translator.t("auth.status.apiKeyStatus"),
-                    value: context.translator.t(statusConfig.translationKey),
-                },
-            ],
-        });
+        writeAuthStatusText(context, authFile, activeStatus);
     },
 };
+
+function buildAuthStatusJsonPayload(
+    authFile: AuthFile,
+    activeStatus: ActiveAccountStatus | undefined,
+): AuthStatusJsonPayload {
+    const activeId = activeStatus?.account.id;
+    const accounts: AuthStatusJsonAccount[] = authFile.auth.map((account) => {
+        const isActive = account.id === activeId;
+        return {
+            id: account.id,
+            name: account.name,
+            endpoint: account.endpoint,
+            active: isActive,
+            ...(isActive && activeStatus !== undefined
+                ? { apiKeyStatus: activeStatus.apiKeyStatus }
+                : {}),
+        };
+    });
+
+    if (activeStatus !== undefined) {
+        return {
+            status: "logged-in",
+            activeAccountId: activeStatus.account.id,
+            accounts,
+        };
+    }
+
+    if (authFile.id !== "") {
+        return {
+            status: "active-account-missing",
+            activeAccountId: null,
+            missingAccountId: authFile.id,
+            accounts,
+        };
+    }
+
+    return {
+        status: "logged-out",
+        activeAccountId: null,
+        accounts,
+    };
+}
+
+function writeAuthStatusText(
+    context: CliExecutionContext,
+    authFile: AuthFile,
+    activeStatus: ActiveAccountStatus | undefined,
+): void {
+    if (activeStatus === undefined) {
+        if (authFile.id !== "") {
+            writeAuthBlock(context, {
+                tone: "danger",
+                summary: context.translator.t("auth.account.activeAccountMissing"),
+                details: [
+                    {
+                        label: context.translator.t("auth.status.accountId"),
+                        value: authFile.id,
+                    },
+                ],
+            });
+            return;
+        }
+
+        writeAuthBlock(context, {
+            tone: "warning",
+            summary: context.translator.t("auth.status.loggedOut"),
+        });
+        return;
+    }
+
+    const { account, apiKeyStatus } = activeStatus;
+    const statusConfig = apiKeyStatusConfig[apiKeyStatus];
+
+    writeAuthBlock(context, {
+        tone: statusConfig.tone,
+        summary: context.translator.t("auth.account.loggedIn", {
+            endpoint: formatAuthStrong(context, account.endpoint),
+            name: formatAuthStrong(context, account.name),
+        }),
+        details: [
+            {
+                label: context.translator.t("auth.status.activeAccount"),
+                value: "true",
+            },
+            {
+                label: context.translator.t("auth.status.apiKeyStatus"),
+                value: context.translator.t(statusConfig.translationKey),
+            },
+        ],
+    });
+}
 
 async function readApiKeyStatus(
     account: AuthAccount,


### PR DESCRIPTION
Add `--format=json` and `--json` flags to expose `oo auth status` as a structured payload for scripting and automation, mirroring the JSON support recently added to `oo version` and `oo skills info`.

The payload distinguishes three states (`logged-in`, `logged-out`, `active-account-missing`) and lists every saved account in its original order. The active entry carries an `apiKeyStatus` enum (`valid`, `invalid`, `request_failed`, `request_failed_sandbox`) so callers can react to credential health without parsing human-readable text. The actual API key string is never emitted under any field name to keep secrets out of pipelines and logs. `--show-schema-version` prepends `schemaVersion` for consumers that want to pin against the contract.

All three statuses exit 0 because this is a query command; only argument errors (such as `--format xml`) exit 2.