### PR TITLE
feat(skills): add `oo skills check-update` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1080,6 +1080,84 @@ Update installed oo-managed published skills.
 - Non-interactive terminals: prints one status line for each current or failed
   skill, and one success line for each updated host target path.
 
+### `oo skills check-update`
+
+Check whether installed oo-managed registry skills have a newer published
+version, or have drifted from their canonical content. Read-only: the
+command **never** downloads a package archive or writes to any skill
+directory.
+
+- Options: `--skill <name>` limits the check to one or more skill ids;
+  the option may be repeated. Duplicate values are de-duplicated; the
+  original input order is preserved in the output.
+- Options: `--format=json` and `--json` switch to a structured payload.
+  `--show-schema-version` (only meaningful with JSON) prepends
+  `schemaVersion`.
+- Scope: only `registry` kind skills are checked. Bundled skills,
+  uninstalled skill names, and skill directories without registry metadata
+  are reported as `failed` entries (each carries a stable `error.code`).
+- Network: requires the current OOMOL account because the latest package
+  version is fetched from the registry's package-info endpoint. The
+  command does **not** download package tarballs.
+- JSON shape:
+
+  ```json
+  {
+    "summary": {
+      "registrySkills": 3,
+      "registrySkillUpdates": 1,
+      "registrySkillRepairs": 1,
+      "registrySkillsCurrent": 1,
+      "registrySkillFailures": 0
+    },
+    "skills": [
+      {
+        "skillId": "demo",
+        "packageName": "@alice/demo",
+        "currentVersion": "0.1.0",
+        "latestVersion": "0.2.0",
+        "status": "update-available"
+      },
+      {
+        "skillId": "foo",
+        "packageName": "@alice/foo",
+        "currentVersion": "0.2.0",
+        "latestVersion": "0.2.0",
+        "status": "up-to-date"
+      },
+      {
+        "skillId": "bar",
+        "packageName": "@alice/bar",
+        "currentVersion": "0.2.0",
+        "latestVersion": "0.2.0",
+        "status": "repair-required"
+      }
+    ]
+  }
+  ```
+
+- `status` values:
+  - `update-available` — registry latest is newer than the installed
+    version; `oo skills update` will upgrade.
+  - `up-to-date` — installed version matches the registry latest, **and**
+    all host directories match the canonical publication.
+  - `repair-required` — installed version equals the registry latest, but
+    the host publication has drifted from the canonical layout in a way
+    that `oo skills update` would rewrite. Concretely this fires when the
+    host directory is a legacy symlink (instead of a real copy) or when
+    its `.oo-metadata.json` records a different package/version than the
+    canonical metadata. **Content-level changes to host files are not
+    detected here**; run `oo skills info --json` to inspect host
+    `controlState` for content drift.
+  - `failed` — the skill could not be checked. The entry includes
+    `error.code` (machine-readable enum) and `error.message` (English
+    template).
+- Exit code: the command exits `0` even when individual entries are
+  `failed`, because failure is encoded in the payload. Argument errors
+  (for example `--format xml`) still exit `2`.
+- `error.code` enum: `not_installed` / `not_managed` / `invalid_path` /
+  `bundled_unsupported` / `package_lookup_failed` / `unknown`.
+
 ### `oo skills uninstall [skill]`
 
 Remove oo-managed skills from supported local skill directories.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -918,6 +918,76 @@ registry skills。
 - 非交互式终端：对每个已是最新或失败的 skill 输出一行状态信息；对每个已更新
   的 Agent 目标路径输出一行成功信息。
 
+### `oo skills check-update`
+
+检查由 oo 管理的 registry skill 是否有新版本，或本地内容是否已偏离 canonical。
+**只查询，不下载 package archive，不写入任何 skill 目录**。
+
+- 选项：`--skill <name>` 限定要检查的 skill id，可重复传入。重复值会去重，
+  输出按原始输入顺序。
+- 选项：`--format=json` 与 `--json` 切换到结构化 JSON 输出。
+  `--show-schema-version`（仅在 JSON 模式下生效）会向 payload 顶层添加
+  `schemaVersion`。
+- 范围：只检查 `kind=registry` 的 skill。bundled skill、未安装的 skill 名、
+  或非 registry metadata 的 skill 目录都会作为 `failed` entry 上报，并带
+  稳定的 `error.code`。
+- 网络：需要登录 OOMOL 账号，因为命令会请求 registry 的 package-info 接口
+  获取最新版本号；**不会**下载 package tarball。
+- JSON 形态：
+
+  ```json
+  {
+    "summary": {
+      "registrySkills": 3,
+      "registrySkillUpdates": 1,
+      "registrySkillRepairs": 1,
+      "registrySkillsCurrent": 1,
+      "registrySkillFailures": 0
+    },
+    "skills": [
+      {
+        "skillId": "demo",
+        "packageName": "@alice/demo",
+        "currentVersion": "0.1.0",
+        "latestVersion": "0.2.0",
+        "status": "update-available"
+      },
+      {
+        "skillId": "foo",
+        "packageName": "@alice/foo",
+        "currentVersion": "0.2.0",
+        "latestVersion": "0.2.0",
+        "status": "up-to-date"
+      },
+      {
+        "skillId": "bar",
+        "packageName": "@alice/bar",
+        "currentVersion": "0.2.0",
+        "latestVersion": "0.2.0",
+        "status": "repair-required"
+      }
+    ]
+  }
+  ```
+
+- `status` 取值：
+  - `update-available` —— registry 最新版本高于已安装版本；`oo skills update`
+    会升级。
+  - `up-to-date` —— 已安装版本与 registry 最新版本一致，且所有 host 目录
+    与 canonical 内容一致。
+  - `repair-required` —— 已安装版本与 registry 最新版本一致，但 host
+    publication 与 canonical 布局发生了 `oo skills update` 会重写的偏离：
+    具体而言是 host 目录变成了 legacy symlink（不是真实拷贝），或者其
+    `.oo-metadata.json` 记录的 package/version 与 canonical metadata 不
+    一致。**host 文件内容级的修改不会在此命令中检测到**；如需检查内容
+    drift，请用 `oo skills info --json` 查看 host 的 `controlState`。
+  - `failed` —— 该 skill 无法完成检查；entry 含 `error.code`（机器可读枚举）
+    与 `error.message`（英文模板）。
+- 退出码：即使 entry 含 `failed`，命令仍以 0 退出（失败由 payload 字段表达）。
+  参数错误（如 `--format xml`）仍以 2 退出。
+- `error.code` 枚举：`not_installed` / `not_managed` / `invalid_path` /
+  `bundled_unsupported` / `package_lookup_failed` / `unknown`。
+
 ### `oo skills uninstall [skill]`
 
 从受支持的本地 skill 目录移除由 oo 管理的 skill。

--- a/src/application/commands/skills/check-update.cli.test.ts
+++ b/src/application/commands/skills/check-update.cli.test.ts
@@ -1,0 +1,575 @@
+import { mkdir, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    createCliSandbox,
+    toRequest,
+    writeAuthFile,
+} from "../../../../__tests__/helpers.ts";
+import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import { resolveManagedSkillAgentHomeDirectory } from "./managed-skill-agents.ts";
+import {
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillDirectoryPath,
+    resolveManagedSkillMetadataFilePath,
+} from "./managed-skill-paths.ts";
+import {
+    createBundledSkillMetadata,
+    createLocalSkillMetadata,
+    createRegistrySkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
+
+function packageInfoResponse(packageName: string, version: string, skillName: string) {
+    return new Response(JSON.stringify({
+        packageName,
+        version,
+        skills: [
+            {
+                description: "demo",
+                name: skillName,
+                title: skillName,
+            },
+        ],
+    }));
+}
+
+async function seedRegistrySkill(options: {
+    sandbox: Awaited<ReturnType<typeof createCliSandbox>>;
+    skillName: string;
+    packageName: string;
+    version: string;
+    agent?: "codex" | "claude";
+    hostSkillMd?: string;
+}): Promise<{
+    hostDirectory: string;
+    canonicalDirectory: string;
+}> {
+    const agent = options.agent ?? "codex";
+    const homeDirectory = resolveManagedSkillAgentHomeDirectory(options.sandbox.env, agent);
+    const hostDirectory = resolveManagedSkillDirectoryPath(homeDirectory, options.skillName);
+    const storePaths = resolveStorePaths({
+        appName: APP_NAME,
+        env: options.sandbox.env,
+        platform: process.platform,
+    });
+    const canonicalDirectory = resolveManagedSkillCanonicalDirectoryPath(
+        storePaths.settingsFilePath,
+        options.skillName,
+    );
+
+    await mkdir(homeDirectory, { recursive: true });
+    await mkdir(canonicalDirectory, { recursive: true });
+    await mkdir(hostDirectory, { recursive: true });
+
+    const skillMd = options.hostSkillMd ?? "# Demo\n";
+
+    await writeFile(join(canonicalDirectory, "SKILL.md"), "# Demo\n");
+    await writeFile(join(hostDirectory, "SKILL.md"), skillMd);
+    await writeFile(
+        resolveManagedSkillMetadataFilePath(canonicalDirectory),
+        renderSkillMetadataJson(createRegistrySkillMetadata({
+            packageName: options.packageName,
+            version: options.version,
+        })),
+    );
+    await writeFile(
+        resolveManagedSkillMetadataFilePath(hostDirectory),
+        renderSkillMetadataJson(createRegistrySkillMetadata({
+            packageName: options.packageName,
+            version: options.version,
+        })),
+    );
+
+    return { hostDirectory, canonicalDirectory };
+}
+
+describe("skills check-update CLI", () => {
+    test("--json reports update-available when remote latest is newer", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "demo",
+                packageName: "@alice/demo",
+                version: "0.1.0",
+            });
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["skills", "check-update", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/demo", "0.2.0", "demo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload).toMatchObject({
+                summary: {
+                    registrySkills: 1,
+                    registrySkillUpdates: 1,
+                    registrySkillRepairs: 0,
+                    registrySkillsCurrent: 0,
+                    registrySkillFailures: 0,
+                },
+            });
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(1);
+            expect(skills[0]).toEqual({
+                skillId: "demo",
+                packageName: "@alice/demo",
+                currentVersion: "0.1.0",
+                latestVersion: "0.2.0",
+                status: "update-available",
+            });
+            // Read-only contract: no tarball download
+            expect(requests.every(r => !r.url.includes(".tgz"))).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json reports up-to-date when version matches and host content matches", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "demo",
+                packageName: "@alice/demo",
+                version: "0.2.0",
+            });
+
+            const result = await sandbox.run(
+                ["skills", "check-update", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/demo", "0.2.0", "demo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills[0]?.status).toBe("up-to-date");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json reports repair-required when host is a legacy symlink to canonical", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const { hostDirectory, canonicalDirectory } = await seedRegistrySkill({
+                sandbox,
+                skillName: "demo",
+                packageName: "@alice/demo",
+                version: "0.2.0",
+            });
+            // Replace the real host directory with a legacy symlink to the
+            // canonical copy. `isManagedSkillPublicationCurrent()` returns
+            // false for symlinks, so `oo skills update` would rewrite it
+            // even though version + content match. Auto-sync on startup sees
+            // matching metadata and skips, preserving the symlink for the
+            // test to observe.
+            await rm(hostDirectory, { recursive: true, force: true });
+            // Windows CI does not grant directory symlink privileges; use a
+            // junction there. Junctions still report as symbolic links via
+            // lstat(), which is the branch isManagedSkillPublicationCurrent()
+            // checks.
+            await symlink(
+                canonicalDirectory,
+                hostDirectory,
+                process.platform === "win32" ? "junction" : "dir",
+            );
+            await expect(stat(hostDirectory)).resolves.toMatchObject({});
+
+            const result = await sandbox.run(
+                ["skills", "check-update", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/demo", "0.2.0", "demo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills[0]?.status).toBe("repair-required");
+            expect(payload.summary).toMatchObject({
+                registrySkillUpdates: 0,
+                registrySkillRepairs: 1,
+                registrySkillsCurrent: 0,
+                registrySkillFailures: 0,
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json reports invalid_path when --skill escapes the managed root", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+            await mkdir(homeDirectory, { recursive: true });
+
+            const result = await sandbox.run(
+                ["skills", "check-update", "--skill", "../bad", "--json"],
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect((skills[0]?.error as Record<string, unknown>)?.code).toBe("invalid_path");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json reports not_managed when same-name host directory has no metadata", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+            const skillDirectory = resolveManagedSkillDirectoryPath(homeDirectory, "ghost");
+
+            // Same-name host directory exists but has no .oo-metadata.json.
+            await mkdir(skillDirectory, { recursive: true });
+            await writeFile(join(skillDirectory, "SKILL.md"), "# user content\n");
+
+            const result = await sandbox.run(
+                ["skills", "check-update", "--skill", "ghost", "--json"],
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect((skills[0]?.error as Record<string, unknown>)?.code).toBe("not_managed");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json multi --skill returns entries in input order with de-duplication", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.1.0",
+            });
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "bar",
+                packageName: "@alice/bar",
+                version: "1.0.0",
+            });
+
+            const result = await sandbox.run(
+                [
+                    "skills",
+                    "check-update",
+                    "--skill",
+                    "bar",
+                    "--skill",
+                    "foo",
+                    "--skill",
+                    "bar",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("package-info/%40alice%2Ffoo")
+                            || request.url.includes("package-info/@alice/foo")) {
+                            return packageInfoResponse("@alice/foo", "0.2.0", "foo");
+                        }
+                        if (request.url.includes("package-info/%40alice%2Fbar")
+                            || request.url.includes("package-info/@alice/bar")) {
+                            return packageInfoResponse("@alice/bar", "1.0.0", "bar");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills.map(entry => entry.skillId)).toEqual(["bar", "foo"]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json reports failed for unknown skill name", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+            await mkdir(homeDirectory, { recursive: true });
+
+            const result = await sandbox.run(
+                ["skills", "check-update", "--skill", "nonexistent", "--json"],
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills[0]).toMatchObject({
+                skillId: "nonexistent",
+                packageName: null,
+                currentVersion: null,
+                latestVersion: null,
+                status: "failed",
+            });
+            expect((skills[0]?.error as Record<string, unknown>)?.code).toBe("not_installed");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json reports failed bundled_unsupported for bundled skill", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+            await mkdir(homeDirectory, { recursive: true });
+
+            const result = await sandbox.run(
+                ["skills", "check-update", "--skill", "oo", "--json"],
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect((skills[0]?.error as Record<string, unknown>)?.code).toBe("bundled_unsupported");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json reports failed not_managed for local-only skill", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+            const skillDirectory = resolveManagedSkillDirectoryPath(homeDirectory, "local-skill");
+
+            await mkdir(skillDirectory, { recursive: true });
+            await writeFile(
+                join(skillDirectory, "SKILL.md"),
+                "---\nname: local-skill\ndescription: A local skill.\n---\n",
+            );
+            await writeFile(
+                resolveManagedSkillMetadataFilePath(skillDirectory),
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
+
+            const result = await sandbox.run(
+                ["skills", "check-update", "--skill", "local-skill", "--json"],
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect((skills[0]?.error as Record<string, unknown>)?.code).toBe("not_managed");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json reports package_lookup_failed when package-info request errors", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "demo",
+                packageName: "@alice/demo",
+                version: "0.1.0",
+            });
+
+            const result = await sandbox.run(
+                ["skills", "check-update", "--json"],
+                {
+                    fetcher: async () => {
+                        throw new Error("network blip");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect((skills[0]?.error as Record<string, unknown>)?.code).toBe("package_lookup_failed");
+            expect(payload.summary).toMatchObject({ registrySkillFailures: 1 });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json --show-schema-version prepends schemaVersion", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "demo",
+                packageName: "@alice/demo",
+                version: "0.2.0",
+            });
+
+            const result = await sandbox.run(
+                ["skills", "check-update", "--json", "--show-schema-version"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/demo", "0.2.0", "demo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.schemaVersion).toBe("1.0.0");
+            expect(payload).toHaveProperty("summary");
+            expect(payload).toHaveProperty("skills");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--format xml exits 2 with format error", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+            await mkdir(homeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "check-update", "--format", "xml"]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).not.toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("no --skill: checks all installed registry skills and excludes bundled", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "demo",
+                packageName: "@alice/demo",
+                version: "0.2.0",
+            });
+            // Seed a bundled skill — should be ignored by check-update default scan
+            const codexHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "codex");
+            const ooSkillDirectory = resolveManagedSkillDirectoryPath(codexHomeDirectory, "oo");
+            await mkdir(ooSkillDirectory, { recursive: true });
+            await writeFile(join(ooSkillDirectory, "SKILL.md"), "# oo\n");
+            await writeFile(
+                resolveManagedSkillMetadataFilePath(ooSkillDirectory),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
+            );
+
+            const result = await sandbox.run(
+                ["skills", "check-update", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/demo", "0.2.0", "demo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            // Only the registry skill is checked; bundled `oo` is skipped.
+            expect(skills.map(entry => entry.skillId)).toEqual(["demo"]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/check-update.ts
+++ b/src/application/commands/skills/check-update.ts
@@ -1,0 +1,594 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+import type { AuthAccount } from "../../schemas/auth.ts";
+import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
+import type { ManagedSkillListItem } from "./managed-skill-listings.ts";
+import type { RegistryPackageSkillInfo } from "./registry-skill-source.ts";
+
+import { z } from "zod";
+import { compareSemver } from "../../semver.ts";
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
+import { createFormatInputError } from "../shared/input-parsing.ts";
+import { writeLine } from "../shared/output.ts";
+import { directoryExists } from "./bundled-skill-observation.ts";
+import {
+    createMissingManagedSkillHostError,
+    resolveAvailableManagedSkillHosts,
+    resolveManagedSkillHostInstallations,
+} from "./managed-skill-hosts.ts";
+import {
+    listManagedSkillInstallations,
+    listManagedSkillInstallationsForHosts,
+} from "./managed-skill-listings.ts";
+import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
+import {
+    isManagedSkillPathContained,
+    resolveManagedSkillCanonicalRootDirectoryPath,
+} from "./managed-skill-paths.ts";
+import { isManagedSkillPublicationCurrent } from "./managed-skill-publication.ts";
+import { loadRegistryPackageSkillInfo } from "./registry-skill-source.ts";
+import { isBundledSkillName } from "./shared.ts";
+
+type CheckUpdateStatus
+    = | "update-available"
+        | "up-to-date"
+        | "repair-required"
+        | "failed";
+
+type CheckUpdateErrorCode
+    = | "not_installed"
+        | "not_managed"
+        | "invalid_path"
+        | "bundled_unsupported"
+        | "package_lookup_failed"
+        | "unknown";
+
+interface CheckUpdateResultEntry {
+    skillId: string;
+    packageName: string | null;
+    currentVersion: string | null;
+    latestVersion: string | null;
+    status: CheckUpdateStatus;
+    error?: {
+        code: CheckUpdateErrorCode;
+        message: string;
+    };
+}
+
+interface CheckUpdateOutcome {
+    summary: {
+        registrySkills: number;
+        registrySkillUpdates: number;
+        registrySkillRepairs: number;
+        registrySkillsCurrent: number;
+        registrySkillFailures: number;
+    };
+    skills: CheckUpdateResultEntry[];
+}
+
+const checkUpdateFormatValues = ["json"] as const;
+
+interface SkillsCheckUpdateInput {
+    format?: (typeof checkUpdateFormatValues)[number];
+    showSchemaVersion?: boolean;
+    skill?: string[];
+}
+
+interface RegistrySkillTarget {
+    skillId: string;
+    packageName: string;
+    currentVersion: string;
+}
+
+interface CheckUpdateError {
+    code: CheckUpdateErrorCode;
+    message: string;
+}
+
+const checkUpdateErrorMessages: Record<CheckUpdateErrorCode, string> = {
+    not_installed: "The skill is not installed.",
+    not_managed: "The skill directory exists but is not managed by oo.",
+    invalid_path: "Skill name resolves outside the managed skills directory.",
+    bundled_unsupported: "Bundled skills are not checked by oo skills check-update.",
+    package_lookup_failed: "Failed to fetch the latest package version.",
+    unknown: "Unknown error.",
+};
+
+export const skillsCheckUpdateCommand: CliCommandDefinition<SkillsCheckUpdateInput> = {
+    name: "check-update",
+    summaryKey: "commands.skills.checkUpdate.summary",
+    descriptionKey: "commands.skills.checkUpdate.description",
+    options: [
+        {
+            name: "skill",
+            longFlag: "--skill",
+            valueName: "skills...",
+            descriptionKey: "options.skills.checkUpdate.skill",
+        },
+        ...jsonOutputOptions,
+    ],
+    inputSchema: z.object({
+        format: z.enum(checkUpdateFormatValues).optional(),
+        showSchemaVersion: z.boolean().optional(),
+        skill: z.array(z.string()).optional(),
+    }),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+    handler: async (input, context) => {
+        const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
+
+        if (availableHosts.length === 0) {
+            throw createMissingManagedSkillHostError(context.env);
+        }
+
+        const settingsFilePath = context.settingsStore.getFilePath();
+        const installedSkills = await readKnownManagedSkillInstallations(
+            availableHosts,
+            settingsFilePath,
+        );
+        const skillNames = dedupePreserveOrder(input.skill ?? []);
+        const plan = await resolveCheckUpdatePlan(
+            skillNames,
+            installedSkills,
+            availableHosts,
+            settingsFilePath,
+        );
+
+        const hasRegistryEntry = plan.some(entry => entry.kind === "registry");
+        const account = hasRegistryEntry
+            ? await requireCurrentAccount(context)
+            : undefined;
+        const packageInfoCache = new Map<string, Promise<RegistryPackageSkillInfo | "failed">>();
+
+        const results = await Promise.all(
+            plan.map(async (planEntry): Promise<CheckUpdateResultEntry> => {
+                if (planEntry.kind === "failed") {
+                    return toFailedEntry(planEntry);
+                }
+                // Invariant: plan has at least one registry entry, so account is defined.
+                return checkRegistrySkill(
+                    planEntry.target,
+                    availableHosts,
+                    packageInfoCache,
+                    account as AuthAccount,
+                    context,
+                );
+            }),
+        );
+
+        const outcome: CheckUpdateOutcome = {
+            summary: computeSummary(results),
+            skills: results,
+        };
+
+        recordTelemetry(context, outcome, {
+            hasSkillFilter: skillNames.length > 0,
+            requestedCount: skillNames.length === 0 ? results.length : skillNames.length,
+        });
+
+        if (input.format === "json") {
+            writeJsonOutput(context.stdout, outcome, {
+                showSchemaVersion: input.showSchemaVersion,
+            });
+            return;
+        }
+
+        writeText(context, outcome);
+    },
+};
+
+interface CheckUpdatePlanEntryFailed {
+    kind: "failed";
+    skillId: string;
+    packageName: string | null;
+    currentVersion: string | null;
+    error: CheckUpdateError;
+}
+
+interface CheckUpdatePlanEntryRegistry {
+    kind: "registry";
+    target: RegistrySkillTarget;
+}
+
+type CheckUpdatePlanEntry = CheckUpdatePlanEntryFailed | CheckUpdatePlanEntryRegistry;
+
+async function resolveCheckUpdatePlan(
+    requestedSkillNames: readonly string[],
+    installedSkills: readonly ManagedSkillListItem[],
+    availableHosts: readonly ManagedSkillHost[],
+    settingsFilePath: string,
+): Promise<CheckUpdatePlanEntry[]> {
+    if (requestedSkillNames.length === 0) {
+        return installedSkills
+            .filter(skill => skill.metadata?.kind === "registry")
+            .map(skill => makeRegistryPlanEntryOrFail(skill));
+    }
+
+    const installedIndex = new Map(
+        installedSkills.map(skill => [skill.name, skill] as const),
+    );
+
+    return Promise.all(
+        requestedSkillNames.map(skillId => resolveRequestedSkillEntry({
+            skillId,
+            installedIndex,
+            availableHosts,
+            settingsFilePath,
+        })),
+    );
+}
+
+async function resolveRequestedSkillEntry(options: {
+    skillId: string;
+    installedIndex: ReadonlyMap<string, ManagedSkillListItem>;
+    availableHosts: readonly ManagedSkillHost[];
+    settingsFilePath: string;
+}): Promise<CheckUpdatePlanEntry> {
+    const { skillId, installedIndex, availableHosts, settingsFilePath } = options;
+
+    if (isBundledSkillName(skillId)) {
+        return {
+            kind: "failed",
+            skillId,
+            packageName: null,
+            currentVersion: null,
+            error: makeError("bundled_unsupported"),
+        };
+    }
+
+    const hostInstallations = resolveManagedSkillHostInstallations(availableHosts, skillId);
+
+    // Path containment is the highest-priority gate: a name that escapes the
+    // managed skills directory must never resolve to a real host scan.
+    if (hostInstallations.some(installation =>
+        !isManagedSkillPathContained(
+            installation.homeDirectory,
+            settingsFilePath,
+            skillId,
+        ),
+    )) {
+        return {
+            kind: "failed",
+            skillId,
+            packageName: null,
+            currentVersion: null,
+            error: makeError("invalid_path"),
+        };
+    }
+
+    const installed = installedIndex.get(skillId);
+
+    if (installed !== undefined) {
+        if (installed.metadata?.kind !== "registry") {
+            return {
+                kind: "failed",
+                skillId,
+                packageName: null,
+                currentVersion: null,
+                error: makeError("not_managed"),
+            };
+        }
+        return makeRegistryPlanEntryOrFail(installed);
+    }
+
+    // Not in installedSkills (no host or canonical entry recorded a managed
+    // metadata file). Distinguish "directory exists but oo doesn't manage it"
+    // from "skill name simply isn't installed anywhere".
+    const targetHasUnmanagedDirectory = await someHostHasUnmanagedDirectory(
+        hostInstallations,
+    );
+
+    if (targetHasUnmanagedDirectory) {
+        return {
+            kind: "failed",
+            skillId,
+            packageName: null,
+            currentVersion: null,
+            error: makeError("not_managed"),
+        };
+    }
+
+    return {
+        kind: "failed",
+        skillId,
+        packageName: null,
+        currentVersion: null,
+        error: makeError("not_installed"),
+    };
+}
+
+async function someHostHasUnmanagedDirectory(
+    hostInstallations: readonly { installedSkillDirectoryPath: string }[],
+): Promise<boolean> {
+    const checks = await Promise.all(
+        hostInstallations.map(async (installation) => {
+            if (!(await directoryExists(installation.installedSkillDirectoryPath))) {
+                return false;
+            }
+            const metadata = await readManagedSkillMetadata(
+                installation.installedSkillDirectoryPath,
+            );
+            return metadata === undefined;
+        }),
+    );
+    return checks.some(Boolean);
+}
+
+function makeRegistryPlanEntryOrFail(
+    skill: ManagedSkillListItem,
+): CheckUpdatePlanEntry {
+    if (skill.metadata?.kind !== "registry") {
+        return {
+            kind: "failed",
+            skillId: skill.name,
+            packageName: null,
+            currentVersion: null,
+            error: makeError("not_managed"),
+        };
+    }
+
+    return {
+        kind: "registry",
+        target: {
+            skillId: skill.name,
+            packageName: skill.metadata.packageName,
+            currentVersion: skill.metadata.version,
+        },
+    };
+}
+
+async function checkRegistrySkill(
+    target: RegistrySkillTarget,
+    availableHosts: readonly ManagedSkillHost[],
+    packageInfoCache: Map<string, Promise<RegistryPackageSkillInfo | "failed">>,
+    account: AuthAccount,
+    context: CliExecutionContext,
+): Promise<CheckUpdateResultEntry> {
+    const hostInstallations = resolveManagedSkillHostInstallations(
+        availableHosts,
+        target.skillId,
+    );
+    const packageInfo = await loadPackageInfoCached(
+        target.packageName,
+        account,
+        packageInfoCache,
+        context,
+    );
+
+    if (packageInfo === "failed") {
+        return {
+            skillId: target.skillId,
+            packageName: target.packageName,
+            currentVersion: target.currentVersion,
+            latestVersion: null,
+            status: "failed",
+            error: makeError("package_lookup_failed"),
+        };
+    }
+
+    const latestVersion = packageInfo.packageVersion;
+    const versionDelta = compareSemver(latestVersion, target.currentVersion);
+
+    if (versionDelta > 0) {
+        return {
+            skillId: target.skillId,
+            packageName: target.packageName,
+            currentVersion: target.currentVersion,
+            latestVersion,
+            status: "update-available",
+        };
+    }
+
+    const allHostsCurrent = await isEverythingCurrent(
+        hostInstallations,
+        target.packageName,
+        latestVersion,
+    );
+
+    return {
+        skillId: target.skillId,
+        packageName: target.packageName,
+        currentVersion: target.currentVersion,
+        latestVersion,
+        status: allHostsCurrent ? "up-to-date" : "repair-required",
+    };
+}
+
+async function isEverythingCurrent(
+    hostInstallations: readonly { installedSkillDirectoryPath: string }[],
+    packageName: string,
+    latestVersion: string,
+): Promise<boolean> {
+    const targetStates = await Promise.all(
+        hostInstallations.map(async (installation) => {
+            if (!(await directoryExists(installation.installedSkillDirectoryPath))) {
+                return { kind: "missing" as const };
+            }
+            const [metadata, publicationCurrent] = await Promise.all([
+                readManagedSkillMetadata(installation.installedSkillDirectoryPath),
+                isManagedSkillPublicationCurrent(installation.installedSkillDirectoryPath),
+            ]);
+            return { kind: "present" as const, metadata, publicationCurrent };
+        }),
+    );
+
+    return targetStates.every(state =>
+        state.kind === "present"
+        && state.metadata?.packageName === packageName
+        && state.metadata.version === latestVersion
+        && state.publicationCurrent,
+    );
+}
+
+function loadPackageInfoCached(
+    packageName: string,
+    account: AuthAccount,
+    cache: Map<string, Promise<RegistryPackageSkillInfo | "failed">>,
+    context: CliExecutionContext,
+): Promise<RegistryPackageSkillInfo | "failed"> {
+    // Cache stores the in-flight promise so concurrent lookups for the same
+    // package share a single network request.
+    const existing = cache.get(packageName);
+
+    if (existing !== undefined) {
+        return existing;
+    }
+    const pending = loadRegistryPackageSkillInfo(packageName, account, context)
+        .catch((error: unknown) => {
+            context.logger.warn(
+                { err: error, packageName },
+                "skills check-update package lookup failed.",
+            );
+            return "failed" as const;
+        });
+
+    cache.set(packageName, pending);
+    return pending;
+}
+
+function toFailedEntry(entry: CheckUpdatePlanEntryFailed): CheckUpdateResultEntry {
+    return {
+        skillId: entry.skillId,
+        packageName: entry.packageName,
+        currentVersion: entry.currentVersion,
+        latestVersion: null,
+        status: "failed",
+        error: entry.error,
+    };
+}
+
+function makeError(code: CheckUpdateErrorCode): CheckUpdateError {
+    return {
+        code,
+        message: checkUpdateErrorMessages[code],
+    };
+}
+
+function computeSummary(results: readonly CheckUpdateResultEntry[]): CheckUpdateOutcome["summary"] {
+    return {
+        registrySkills: results.length,
+        registrySkillUpdates: results.filter(entry => entry.status === "update-available").length,
+        registrySkillRepairs: results.filter(entry => entry.status === "repair-required").length,
+        registrySkillsCurrent: results.filter(entry => entry.status === "up-to-date").length,
+        registrySkillFailures: results.filter(entry => entry.status === "failed").length,
+    };
+}
+
+async function readKnownManagedSkillInstallations(
+    availableHosts: readonly ManagedSkillHost[],
+    settingsFilePath: string,
+): Promise<ManagedSkillListItem[]> {
+    const [canonicalSkills, hostSkills] = await Promise.all([
+        listManagedSkillInstallations(
+            resolveManagedSkillCanonicalRootDirectoryPath(settingsFilePath),
+        ),
+        listManagedSkillInstallationsForHosts(availableHosts),
+    ]);
+    // Host listings take precedence over canonical when a name collides.
+    const byName = new Map<string, ManagedSkillListItem>();
+
+    for (const skill of [...hostSkills, ...canonicalSkills]) {
+        if (skill.metadata !== undefined && !byName.has(skill.name)) {
+            byName.set(skill.name, {
+                metadata: skill.metadata,
+                name: skill.name,
+                path: skill.path,
+            });
+        }
+    }
+
+    return Array.from(byName.values());
+}
+
+function dedupePreserveOrder<T>(values: readonly T[]): T[] {
+    const seen = new Set<T>();
+    const result: T[] = [];
+
+    for (const value of values) {
+        if (!seen.has(value)) {
+            seen.add(value);
+            result.push(value);
+        }
+    }
+
+    return result;
+}
+
+function writeText(
+    context: CliExecutionContext,
+    outcome: CheckUpdateOutcome,
+): void {
+    const updates = outcome.skills.filter(entry => entry.status === "update-available");
+    const repairs = outcome.skills.filter(entry => entry.status === "repair-required");
+    const failures = outcome.skills.filter(entry => entry.status === "failed");
+
+    if (
+        outcome.summary.registrySkillUpdates === 0
+        && outcome.summary.registrySkillRepairs === 0
+        && outcome.summary.registrySkillFailures === 0
+    ) {
+        writeLine(
+            context.stdout,
+            context.translator.t("skills.checkUpdate.allCurrent"),
+        );
+        return;
+    }
+
+    writeLine(
+        context.stdout,
+        context.translator.t("skills.checkUpdate.summary", {
+            updates: outcome.summary.registrySkillUpdates,
+            repairs: outcome.summary.registrySkillRepairs,
+            current: outcome.summary.registrySkillsCurrent,
+            failed: outcome.summary.registrySkillFailures,
+        }),
+    );
+
+    writeReportSection(context, updates, "skills.checkUpdate.updatesHeader", "skills.checkUpdate.updatesLine", entry => ({
+        skillId: entry.skillId,
+        packageName: entry.packageName ?? "",
+        currentVersion: entry.currentVersion ?? "",
+        latestVersion: entry.latestVersion ?? "",
+    }));
+    writeReportSection(context, repairs, "skills.checkUpdate.repairsHeader", "skills.checkUpdate.repairsLine", entry => ({
+        skillId: entry.skillId,
+        packageName: entry.packageName ?? "",
+        currentVersion: entry.currentVersion ?? "",
+    }));
+    writeReportSection(context, failures, "skills.checkUpdate.failuresHeader", "skills.checkUpdate.failuresLine", entry => ({
+        skillId: entry.skillId,
+        message: entry.error?.message ?? "",
+    }));
+}
+
+function writeReportSection(
+    context: CliExecutionContext,
+    entries: readonly CheckUpdateResultEntry[],
+    headerKey: string,
+    lineKey: string,
+    formatEntry: (entry: CheckUpdateResultEntry) => Record<string, string>,
+): void {
+    if (entries.length === 0) {
+        return;
+    }
+    writeLine(context.stdout, "");
+    writeLine(context.stdout, context.translator.t(headerKey));
+    for (const entry of entries) {
+        writeLine(context.stdout, context.translator.t(lineKey, formatEntry(entry)));
+    }
+}
+
+function recordTelemetry(
+    context: CliExecutionContext,
+    outcome: CheckUpdateOutcome,
+    options: { hasSkillFilter: boolean; requestedCount: number },
+): void {
+    context.telemetry?.recordProperties({
+        has_skill_filter: options.hasSkillFilter,
+        skill_count_bucket: bucketTelemetryCount(options.requestedCount),
+        checked_count_bucket: bucketTelemetryCount(outcome.skills.length),
+        update_available_count_bucket: bucketTelemetryCount(outcome.summary.registrySkillUpdates),
+        repair_required_count_bucket: bucketTelemetryCount(outcome.summary.registrySkillRepairs),
+        failed_count_bucket: bucketTelemetryCount(outcome.summary.registrySkillFailures),
+    });
+}

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -1,5 +1,6 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
+import { skillsCheckUpdateCommand } from "./check-update.ts";
 import { skillsCheckCommand } from "./check.ts";
 import { skillsInitCommand } from "./init.ts";
 import { skillsInstallCommand } from "./install.ts";
@@ -32,5 +33,6 @@ export const skillsCommand: CliCommandDefinition = {
         skillsUpdateCommand,
         skillsUninstallCommand,
         skillsRepairCommand,
+        skillsCheckUpdateCommand,
     ],
 };

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -367,6 +367,18 @@ const commandTelemetryDecisions = {
         ],
         reason: "Records bucketed counts and source-kind flags; never records skill names or paths.",
     },
+    "skills.check-update": {
+        kind: "properties",
+        properties: [
+            "has_skill_filter",
+            "skill_count_bucket",
+            "checked_count_bucket",
+            "update_available_count_bucket",
+            "repair_required_count_bucket",
+            "failed_count_bucket",
+        ],
+        reason: "Records bucketed counts only; never records skill names, package names, versions, or paths.",
+    },
     "skills.uninstall": {
         kind: "generic",
         reason: "Generic command telemetry is enough; local uninstall paths are not recorded.",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -686,6 +686,25 @@ export const enMessages = {
     "commands.update.description":
         "Update the managed CLI install to the latest published release.",
     "commands.update.summary": "Update the CLI",
+    "commands.skills.checkUpdate.description":
+        "Check for available updates for installed registry skills without downloading or modifying them.",
+    "commands.skills.checkUpdate.summary":
+        "Check registry skills for updates",
+    "options.skills.checkUpdate.skill":
+        "Limit the check to one or more skill ids (may be repeated)",
+    "skills.checkUpdate.allCurrent":
+        "All checked registry skills are up to date.",
+    "skills.checkUpdate.summary":
+        "{updates} update(s) available, {repairs} repair(s) required, {current} up-to-date, {failed} failed.",
+    "skills.checkUpdate.updatesHeader": "Updates:",
+    "skills.checkUpdate.updatesLine":
+        "  {skillId}  {packageName}  {currentVersion} -> {latestVersion}",
+    "skills.checkUpdate.repairsHeader": "Repairs:",
+    "skills.checkUpdate.repairsLine":
+        "  {skillId}  {packageName}  {currentVersion}",
+    "skills.checkUpdate.failuresHeader": "Failures:",
+    "skills.checkUpdate.failuresLine":
+        "  {skillId}: {message}",
     "commands.version.description":
         "Print the CLI version. Use --json for a stable machine-readable payload.",
     "commands.version.summary": "Print the CLI version",
@@ -1697,6 +1716,25 @@ export const zhMessages = {
     "commands.update.description":
         "把托管 CLI 安装更新到最新发布版本。",
     "commands.update.summary": "更新 CLI",
+    "commands.skills.checkUpdate.description":
+        "检查已安装的 registry skill 是否有可用更新，仅查询不下载也不写入。",
+    "commands.skills.checkUpdate.summary":
+        "检查 registry skill 是否有更新",
+    "options.skills.checkUpdate.skill":
+        "仅检查指定的 skill id（可重复传入）",
+    "skills.checkUpdate.allCurrent":
+        "已检查的 registry skill 均为最新。",
+    "skills.checkUpdate.summary":
+        "{updates} 个可升级，{repairs} 个需修复，{current} 个已最新，{failed} 个失败。",
+    "skills.checkUpdate.updatesHeader": "可升级：",
+    "skills.checkUpdate.updatesLine":
+        "  {skillId}  {packageName}  {currentVersion} -> {latestVersion}",
+    "skills.checkUpdate.repairsHeader": "需修复：",
+    "skills.checkUpdate.repairsLine":
+        "  {skillId}  {packageName}  {currentVersion}",
+    "skills.checkUpdate.failuresHeader": "失败：",
+    "skills.checkUpdate.failuresLine":
+        "  {skillId}：{message}",
     "commands.version.description":
         "输出 CLI 版本。使用 --json 输出稳定的机器可读 payload。",
     "commands.version.summary": "输出 CLI 版本",


### PR DESCRIPTION
Provide a read-only way for users to see which installed registry skills have a newer published version, and which have drifted from the canonical publication in ways `oo skills update` would rewrite (legacy symlink hosts, mismatched host metadata). The command never downloads tarballs and never writes to skill directories, so it is safe to run interactively before deciding to upgrade.

JSON output exposes a stable per-skill status enum (`update-available` / `up-to-date` / `repair-required` / `failed`) plus a summary block for scripting. Failures are encoded in the payload with a stable `error.code`, so the command exits 0 on per-skill errors and only exits 2 on argument errors.