### PR TITLE
feat(auth): add `--user` option to `oo auth switch`

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -122,7 +122,21 @@ Show every saved auth account and validate the API key of the active one.
 
 ### `oo auth switch`
 
-Switch to the next saved account.
+Switch the active auth account.
+
+- With no arguments the command rotates to the next saved account in the
+  `auth.toml` order.
+- Options: `-u, --user <user>` switches to a specific account. The value is
+  matched against `account.id` first (exact match) and then against
+  `account.name` (exact match, must be unique). Matching is never fuzzy,
+  case-insensitive, or substring-based.
+- When `<user>` matches multiple accounts by name, the command exits non-zero
+  without rewriting `auth.toml` and asks the caller to pass an account id.
+  Account ids are stable strings — use `oo auth status --json` to discover
+  them.
+- When the requested account is already the active one, the switch is
+  idempotent (exit `0`, no rewrite mode change).
+- API key values are never written to stdout or stderr in any output path.
 
 ### `oo login`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -110,7 +110,17 @@
 
 ### `oo auth switch`
 
-切换到下一个已保存账号。
+切换当前激活的认证账号。
+
+- 不传参数时，按 `auth.toml` 中的顺序轮转到下一个已保存账号。
+- 选项：`-u, --user <user>` 切换到指定账号。匹配规则为：先按 `account.id`
+  精确匹配，再按 `account.name` 精确匹配（必须唯一）；不做模糊、忽略大小写
+  或子串匹配。
+- 当 `<user>` 按 name 命中多个账号时，命令以非零退出，不重写 `auth.toml`，
+  并提示需要传 account id 进行消歧。account id 是稳定字符串，可通过
+  `oo auth status --json` 获取。
+- 当指定的账号已是激活账号时，切换为幂等操作（exit `0`，不改变激活状态）。
+- 任何输出路径都不会将 API key 写入 stdout/stderr。
 
 ### `oo login`
 

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -1043,6 +1043,184 @@ describe("auth CLI", () => {
         }
     });
 
+    test("--user switches by account id", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const authFilePath = await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                    { id: "user-2", name: "Bob", apiKey: "secret-2", endpoint: defaultAuthEndpoint },
+                    { id: "user-3", name: "Charlie", apiKey: "secret-3", endpoint: defaultAuthEndpoint },
+                ],
+            });
+
+            const result = await sandbox.run(["auth", "switch", "--user", "user-3"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("Switched active account for oomol.com to Charlie");
+            expect(await readFile(authFilePath, "utf8")).toContain("id = \"user-3\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--user switches by unique account name (with -u short flag)", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const authFilePath = await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                    { id: "user-2", name: "Bob", apiKey: "secret-2", endpoint: defaultAuthEndpoint },
+                ],
+            });
+
+            const result = await sandbox.run(["auth", "switch", "-u", "Bob"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("Switched active account for oomol.com to Bob");
+            expect(await readFile(authFilePath, "utf8")).toContain("id = \"user-2\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--user fails with userAmbiguous when multiple accounts share the same name", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const authFilePath = await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                    { id: "user-2", name: "Bob", apiKey: "secret-2", endpoint: defaultAuthEndpoint },
+                    { id: "user-3", name: "Bob", apiKey: "secret-3", endpoint: defaultAuthEndpoint },
+                ],
+            });
+            const before = await readFile(authFilePath, "utf8");
+
+            const result = await sandbox.run(["auth", "switch", "--user", "Bob"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("Multiple saved accounts have the name Bob");
+            expect(result.stderr).toContain("--user <account-id>");
+            // Auth file must not be rewritten.
+            expect(await readFile(authFilePath, "utf8")).toBe(before);
+            // Secrets must never leak to stdout/stderr.
+            expect(result.stdout + result.stderr).not.toContain("secret-1");
+            expect(result.stdout + result.stderr).not.toContain("secret-2");
+            expect(result.stdout + result.stderr).not.toContain("secret-3");
+            expect(result.stdout + result.stderr).not.toContain("apiKey");
+            expect(result.stdout + result.stderr).not.toContain("api_key");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--user fails with userNotFound when no account matches", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const authFilePath = await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                ],
+            });
+            const before = await readFile(authFilePath, "utf8");
+
+            const result = await sandbox.run(["auth", "switch", "--user", "nope"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("No saved account matches nope");
+            expect(await readFile(authFilePath, "utf8")).toBe(before);
+            expect(result.stdout + result.stderr).not.toContain("secret-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--user is idempotent when target is already active", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const authFilePath = await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                    { id: "user-2", name: "Bob", apiKey: "secret-2", endpoint: defaultAuthEndpoint },
+                ],
+            });
+
+            const result = await sandbox.run(["auth", "switch", "--user", "user-1"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("Switched active account for oomol.com to Alice");
+            expect(await readFile(authFilePath, "utf8")).toContain("id = \"user-1\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--user blank string fails without writing", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const authFilePath = await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                    { id: "user-2", name: "Bob", apiKey: "secret-2", endpoint: defaultAuthEndpoint },
+                ],
+            });
+            const before = await readFile(authFilePath, "utf8");
+
+            const result = await sandbox.run(["auth", "switch", "--user", "   "]);
+
+            // A whitespace-only --user is invalid input; the project's default
+            // CLI input-error path exits 1. The invariant we care about is
+            // that no switch is performed.
+            expect(result.exitCode).not.toBe(0);
+            expect(await readFile(authFilePath, "utf8")).toBe(before);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--user has precedence: id beats name when value matches both", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            // user-2's name happens to equal user-1's id; --user "user-1" must
+            // resolve to the id match (Alice), not the name match (Bob).
+            const authFilePath = await writeAuthFile(sandbox, {
+                activeId: "user-2",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                    { id: "user-2", name: "user-1", apiKey: "secret-2", endpoint: defaultAuthEndpoint },
+                ],
+            });
+
+            const result = await sandbox.run(["auth", "switch", "--user", "user-1"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("Switched active account for oomol.com to Alice");
+            expect(await readFile(authFilePath, "utf8")).toContain("id = \"user-1\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("renders the auth switch success block with gh-style emphasis when stdout supports colors", async () => {
         const sandbox = await createCliSandbox();
         const colors = createTerminalColors(true);

--- a/src/application/commands/auth/switch.ts
+++ b/src/application/commands/auth/switch.ts
@@ -1,36 +1,58 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
+import type { AuthAccount, AuthFile } from "../../schemas/auth.ts";
 
+import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { getNextAuthAccount, setCurrentAuthId } from "../../schemas/auth.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import {
-    emptyAuthCommandInputSchema,
     formatAuthStrong,
     writeAuthBlock,
 } from "./shared.ts";
 
-export const authSwitchCommand: CliCommandDefinition = {
+interface AuthSwitchInput {
+    user?: string;
+}
+
+type SwitchMatchKind = "ambiguous" | "id" | "name" | "next" | "not_found";
+
+export const authSwitchCommand: CliCommandDefinition<AuthSwitchInput> = {
     name: "switch",
     summaryKey: "commands.auth.switch.summary",
     descriptionKey: "commands.auth.switch.description",
-    inputSchema: emptyAuthCommandInputSchema,
-    handler: async (_, context) => {
+    options: [
+        {
+            name: "user",
+            longFlag: "--user",
+            shortFlag: "-u",
+            valueName: "user",
+            descriptionKey: "options.auth.switch.user",
+        },
+    ],
+    inputSchema: z.object({
+        user: z.string().trim().min(1).optional(),
+    }),
+    handler: async (input, context) => {
         const authFile = await context.authStore.read();
 
         context.telemetry?.recordProperties({
             account_count_bucket: bucketTelemetryCount(authFile.auth.length),
+            has_user_filter: input.user !== undefined,
         });
 
-        const account = getNextAuthAccount(authFile);
-
-        if (account === undefined) {
+        if (authFile.auth.length === 0) {
             throw new CliUserError("errors.auth.noSavedAccounts", 1);
         }
+
+        const { account, matchKind } = input.user === undefined
+            ? { account: getNextAuthAccount(authFile)!, matchKind: "next" as SwitchMatchKind }
+            : resolveAccountByUser(authFile, input.user);
 
         await context.authStore.write(setCurrentAuthId(authFile, account.id));
         context.logger.info(
             {
                 endpoint: account.endpoint,
+                matchKind,
                 nextAccountId: account.id,
                 previousCurrentAuthId: authFile.id,
             },
@@ -45,3 +67,32 @@ export const authSwitchCommand: CliCommandDefinition = {
         });
     },
 };
+
+interface ResolvedUser {
+    account: AuthAccount;
+    matchKind: SwitchMatchKind;
+}
+
+function resolveAccountByUser(authFile: AuthFile, user: string): ResolvedUser {
+    const byId = authFile.auth.find(account => account.id === user);
+
+    if (byId !== undefined) {
+        return { account: byId, matchKind: "id" };
+    }
+
+    const byName = authFile.auth.filter(account => account.name === user);
+
+    if (byName.length === 1) {
+        return { account: byName[0]!, matchKind: "name" };
+    }
+
+    if (byName.length > 1) {
+        throw new CliUserError("errors.auth.switch.userAmbiguous", 1, {
+            value: user,
+        });
+    }
+
+    throw new CliUserError("errors.auth.switch.userNotFound", 1, {
+        value: user,
+    });
+}

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -87,8 +87,8 @@ const commandTelemetryDecisions = {
     },
     "auth.switch": {
         kind: "properties",
-        properties: ["account_count_bucket"],
-        reason: "Records bounded saved-account count without account identity.",
+        properties: ["account_count_bucket", "has_user_filter"],
+        reason: "Records bounded saved-account count and whether --user was used, without account identity.",
     },
     "check-update": {
         kind: "properties",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -29,8 +29,9 @@ export const enMessages = {
     "commands.auth.status.description": "Show saved auth accounts and validate the active API key.",
     "commands.auth.status.summary": "Show auth status",
     "commands.auth.summary": "Manage CLI authentication",
-    "commands.auth.switch.description": "Switch to the next saved auth account.",
+    "commands.auth.switch.description": "Switch to the next saved auth account, or to a specific account with --user.",
     "commands.auth.switch.summary": "Switch to the next auth account",
+    "options.auth.switch.user": "Switch to the account whose id or unique name matches the given value",
     "commands.checkUpdate.description":
         "Check whether a newer CLI release is available.",
     "commands.checkUpdate.summary": "Check for CLI updates",
@@ -266,6 +267,10 @@ export const enMessages = {
         "You must log in before using this command.",
     "errors.auth.sessionTokenRequired":
         "Session token must not be empty.",
+    "errors.auth.switch.userAmbiguous":
+        "Multiple saved accounts have the name {value}. Pass --user <account-id> to disambiguate.",
+    "errors.auth.switch.userNotFound":
+        "No saved account matches {value}.",
     "errors.authStore.invalidToml":
         "The auth file at {path} is not valid TOML.",
     "errors.authStore.invalidSchema":
@@ -1103,8 +1108,9 @@ export const zhMessages = {
     "commands.auth.status.description": "显示已保存的认证账号，并校验当前激活账号的 API key。",
     "commands.auth.status.summary": "显示认证状态",
     "commands.auth.summary": "管理 CLI 认证",
-    "commands.auth.switch.description": "切换到下一个已保存的认证账号。",
+    "commands.auth.switch.description": "切换到下一个已保存的认证账号，或通过 --user 切换到指定账号。",
     "commands.auth.switch.summary": "切换到下一个认证账号",
+    "options.auth.switch.user": "切换到 id 或唯一 name 与该值匹配的账号",
     "commands.checkUpdate.description": "检查是否有新的 CLI 版本可用。",
     "commands.checkUpdate.summary": "检查 CLI 更新",
     "commands.cloudTask.description": "管理云任务执行流程。",
@@ -1317,6 +1323,10 @@ export const zhMessages = {
     "errors.auth.required":
         "使用此命令前请先登录。",
     "errors.auth.sessionTokenRequired": "session token 不能为空。",
+    "errors.auth.switch.userAmbiguous":
+        "存在多个 name 为 {value} 的账号。请通过 --user <account-id> 进行消歧。",
+    "errors.auth.switch.userNotFound":
+        "没有匹配 {value} 的已保存账号。",
     "errors.billing.insufficientCredit":
         "你的 OOMOL 账户余额不足。请充值后再重试：{url}",
     "errors.authStore.invalidToml": "认证文件 {path} 不是有效的 TOML。",


### PR DESCRIPTION
Previously `oo auth switch` could only rotate to the next saved account, which made scripted workflows pick the right account by running the command multiple times. The new `-u, --user <user>` option resolves a target account by exact `account.id` first and then by exact unique `account.name`, exiting non-zero without rewriting `auth.toml` when the value is ambiguous or unmatched.

Telemetry records a low-cardinality `has_user_filter` boolean so adoption of the new flag can be measured without capturing any account identity. Docs and the i18n catalog are updated in lock step with the user-facing contract.