### PR TITLE
fix: use bun canary to resolve `oo file upload` crash

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version-file: .bun-version
+          bun-version: canary
 
       - name: Install
         run: bun install --frozen-lockfile
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version-file: .bun-version
+          bun-version: canary
 
       - name: Install
         run: bun install --frozen-lockfile

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version-file: .bun-version
+          bun-version: canary
 
       - name: Compute Version
         id: compute
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version-file: .bun-version
+          bun-version: canary
 
       - name: Configure Bun install cache directory
         shell: bash
@@ -100,7 +100,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .bun-install-cache
-          key: bun-install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock', '.bun-version') }}
+          key: bun-install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}
           restore-keys: |
             bun-install-${{ runner.os }}-${{ runner.arch }}-
 
@@ -138,7 +138,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version-file: .bun-version
+          bun-version: canary
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0
@@ -232,7 +232,7 @@ jobs:
         if: env.FEISHU_RELEASE_WEBHOOK != ''
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version-file: .bun-version
+          bun-version: canary
 
       - name: Notify Feishu release group
         if: env.FEISHU_RELEASE_WEBHOOK != ''

--- a/.github/workflows/reject-large-external-pr.yaml
+++ b/.github/workflows/reject-large-external-pr.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version-file: .bun-version
+          bun-version: canary
 
       - name: Reject Large External Pull Request
         env:

--- a/.github/workflows/upload-release-binaries-to-oss.yaml
+++ b/.github/workflows/upload-release-binaries-to-oss.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version-file: .bun-version
+          bun-version: canary
 
       - name: Configure Alibaba Cloud CLI
         id: aliyun_credentials

--- a/contrib/ci/npm-packages.test.ts
+++ b/contrib/ci/npm-packages.test.ts
@@ -331,6 +331,21 @@ describe("npm-packages", () => {
         ]);
     });
 
+    test("omits --target when includeTarget is false", () => {
+        const args = buildCompileCommandArgs(
+            getRequiredTarget("darwin-arm64"),
+            {
+                buildTimestamp: 1_742_867_323_456,
+                gitCommit: "1234567890abcdef",
+                version: "1.2.3",
+            },
+            "dist/bin/oo",
+            { includeTarget: false },
+        );
+        expect(args).not.toContain("--target=bun-darwin-arm64");
+        expect(args.filter(arg => arg.startsWith("--target"))).toHaveLength(0);
+    });
+
     test("assembles staged platform packages into release artifacts", async () => {
         const rootDirectoryPath = process.cwd();
         const temporaryDirectoryPath = await createTemporaryDirectory(
@@ -477,6 +492,10 @@ describe("npm-packages", () => {
                                     version: "1.2.3",
                                 },
                                 executablePath,
+                                // Skip `--target` so Bun reuses the running runtime
+                                // instead of downloading a baseline variant that may
+                                // not be published yet (e.g. on canary).
+                                { includeTarget: false },
                             ),
                             {
                                 cwd: rootDirectoryPath,

--- a/contrib/ci/npm-packages.ts
+++ b/contrib/ci/npm-packages.ts
@@ -556,7 +556,9 @@ export function buildCompileCommandArgs(
     target: PlatformTarget,
     buildMetadata: CompileBuildMetadata,
     outputPath: string,
+    options?: { includeTarget?: boolean },
 ): string[] {
+    const includeTarget = options?.includeTarget ?? true;
     // Keep embedded asset filenames unique across bundled skills.
     return [
         "bun",
@@ -569,7 +571,7 @@ export function buildCompileCommandArgs(
         "--no-compile-autoload-dotenv",
         "--no-compile-autoload-bunfig",
         `--asset-naming=${compileAssetNamingPattern}`,
-        `--target=${target.bunTarget}`,
+        ...(includeTarget ? [`--target=${target.bunTarget}`] : []),
         ...buildCompileDefineArgs(buildMetadata),
         "./index.ts",
         "--outfile",


### PR DESCRIPTION
Stable Bun (v1.3.14, built with Zig) segfaults inside Blob.detach during FetchTasklet teardown when `oo file upload` runs, which leaves the published `oo` binaries unable to complete an upload at all. The crash is already addressed upstream in the canary channel, so build with canary in CI to ship a working `oo file upload` until the fix lands in a stable Bun release.

Fixed: https://github.com/oomol-lab/oo-cli/issues/242