### PR TITLE
fix(file): copy part bytes to avoid Bun FetchTasklet segfault

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: canary
+          bun-version-file: .bun-version
 
       - name: Install
         run: bun install --frozen-lockfile
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: canary
+          bun-version-file: .bun-version
 
       - name: Install
         run: bun install --frozen-lockfile

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: canary
+          bun-version-file: .bun-version
 
       - name: Compute Version
         id: compute
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: canary
+          bun-version-file: .bun-version
 
       - name: Configure Bun install cache directory
         shell: bash
@@ -100,7 +100,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .bun-install-cache
-          key: bun-install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock') }}
+          key: bun-install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock', '.bun-version') }}
           restore-keys: |
             bun-install-${{ runner.os }}-${{ runner.arch }}-
 
@@ -138,7 +138,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: canary
+          bun-version-file: .bun-version
 
       - name: Setup Node.js
         uses: actions/setup-node@v6.4.0
@@ -232,7 +232,7 @@ jobs:
         if: env.FEISHU_RELEASE_WEBHOOK != ''
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: canary
+          bun-version-file: .bun-version
 
       - name: Notify Feishu release group
         if: env.FEISHU_RELEASE_WEBHOOK != ''

--- a/.github/workflows/reject-large-external-pr.yaml
+++ b/.github/workflows/reject-large-external-pr.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: canary
+          bun-version-file: .bun-version
 
       - name: Reject Large External Pull Request
         env:

--- a/.github/workflows/upload-release-binaries-to-oss.yaml
+++ b/.github/workflows/upload-release-binaries-to-oss.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: canary
+          bun-version-file: .bun-version
 
       - name: Configure Alibaba Cloud CLI
         id: aliyun_credentials

--- a/src/application/commands/file/shared.ts
+++ b/src/application/commands/file/shared.ts
@@ -397,6 +397,13 @@ async function uploadFilePart(
         maxRetries: fileUploadPartExtraRetries,
     });
 
+    // Materialize the part into a fresh Uint8Array before handing it to fetch.
+    // A BunFile-backed Blob slice can trigger a segfault in Bun's FetchTasklet
+    // teardown (Blob.Any.detach) — see crash report referenced in
+    // https://github.com/oomol-lab/oo-cli/issues/242. Using an in-memory typed
+    // array sidesteps the lazy file-backed code path entirely.
+    const partBytes = new Uint8Array(await partData.arrayBuffer());
+
     const response = await performLoggedRequest({
         context: {
             fetcher: uploadPartFetcher,
@@ -428,12 +435,12 @@ async function uploadFilePart(
                 method: "PUT",
             },
             start: {
-                bodyBytes: partData.size,
+                bodyBytes: partBytes.byteLength,
                 method: "PUT",
             },
         },
         init: {
-            body: partData,
+            body: partBytes,
             headers: {
                 "Content-Type": "application/octet-stream",
             },


### PR DESCRIPTION
Bun's FetchTasklet teardown (Blob.Any.detach) can segfault when fetch
is given a BunFile-backed Blob slice during multipart upload, which
was the root cause behind the `oo file upload` crash tracked in
https://github.com/oomol-lab/oo-cli/issues/242. Materializing the part into a fresh Uint8Array
before handing it to fetch sidesteps the lazy file-backed code path
entirely.

With the underlying issue fixed in code, the CI workflows no longer
need the `bun-version: canary` workaround, so they are switched back
to the pinned `.bun-version` file. The publish cache key also picks
up `.bun-version` so cache entries invalidate when the runtime
version changes.