### PR TITLE
feat(uninstall): add `oo uninstall` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -402,6 +402,44 @@ Update the managed `oo` install to the latest published release.
 
 Alias for `oo update`.
 
+### `oo uninstall`
+
+Uninstall the managed `oo` runtime and its built-in skills.
+
+- Arguments: none.
+- Options: `-y, --yes` skips the confirmation prompt and is required in
+  non-interactive terminals.
+- Options: `--dry-run` prints what would be removed (and retained) without
+  deleting anything.
+- Options: `--purge` additionally removes user data (auth, settings, cache,
+  logs, telemetry) and **all** oo-managed registry skills.
+- Default removal: the managed executable (`~/.local/bin/oo`), all installed
+  versions, self-update staging and locks, bundled skills, and the preset
+  registry skill package `@alwaysmavs/gpt-image-2` (host installs and canonical
+  source).
+- Default retention: PATH configuration is left untouched; non-preset registry
+  skills, local skills, and any same-name directory that is not oo-managed are
+  retained, as is user data (removed only with `--purge`).
+- Skill safety: a skill is removed only when its `.oo-metadata.json` proves
+  oo ownership (`kind: "bundled"`, or `kind: "registry"` matching the preset
+  list / `--purge`). Directories with missing, invalid, local, or non-matching
+  metadata are never deleted, so user-authored same-name skills are safe.
+- Installation method: when `oo` was installed via a package manager
+  (npm/bun/pnpm/yarn), the command removes oo-managed skills, prints the
+  matching `npm uninstall -g @oomol-lab/oo-cli` (or equivalent) command, and
+  exits non-zero so callers know the binary still needs manual removal. When the
+  executable is at an unknown location, it removes oo-managed skills only and
+  asks the user to remove the binary manually.
+- Windows: the running executable cannot delete itself in-process, so removal
+  of `~/.local/bin/oo.exe` is deferred to a one-shot PowerShell helper that
+  waits for this process to exit, then deletes the executable and removes
+  itself. Every other path (versions, staging, locks, skills) is removed
+  in-process. On Unix, the executable and version directory are removed
+  in-process.
+- Safety: the command refuses to run while another live `oo` process holds an
+  active version marker, and it never writes API keys or other secrets to
+  stdout/stderr.
+
 ### `oo check-update`
 
 Check whether a newer CLI release is available.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -430,12 +430,13 @@ Uninstall the managed `oo` runtime and its built-in skills.
   exits non-zero so callers know the binary still needs manual removal. When the
   executable is at an unknown location, it removes oo-managed skills only and
   asks the user to remove the binary manually.
-- Windows: the running executable cannot delete itself in-process, so removal
-  of `~/.local/bin/oo.exe` is deferred to a one-shot PowerShell helper that
-  waits for this process to exit, then deletes the executable and removes
-  itself. Every other path (versions, staging, locks, skills) is removed
-  in-process. On Unix, the executable and version directory are removed
-  in-process.
+- Windows: the running process keeps its own image and (under `--purge`) the
+  SQLite databases in the data directory open, and Windows cannot delete files
+  held open by a live process. Removal of those paths is deferred to a one-shot
+  PowerShell helper that waits for this process to exit, then deletes them and
+  removes itself. Every other path (versions, staging, locks, skills, and the
+  remaining user data such as auth, settings, logs, and telemetry) is removed
+  in-process. On Unix, all paths are removed in-process.
 - Safety: the command refuses to run while another live `oo` process holds an
   active version marker, and it never writes API keys or other secrets to
   stdout/stderr.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -430,16 +430,12 @@ Uninstall the managed `oo` runtime and its built-in skills.
   exits non-zero so callers know the binary still needs manual removal. When the
   executable is at an unknown location, it removes oo-managed skills only and
   asks the user to remove the binary manually.
-- Windows: the running process keeps its own image and (under `--purge`) the
-  SQLite databases in the data directory open, and Windows cannot delete files
-  held open by a live process. Removal of those paths is deferred to a one-shot
-  PowerShell helper that waits for this process to exit, then deletes them and
-  removes itself. Every other path (versions, staging, locks, skills, and the
-  remaining user data such as auth, settings, logs, and telemetry) is removed
-  in-process. On Unix, all paths are removed in-process.
-- Safety: the command refuses to run while another live `oo` process holds an
-  active version marker, and it never writes API keys or other secrets to
-  stdout/stderr.
+- Windows: files that cannot be removed while `oo uninstall` is running are
+  removed after the process exits. Other runtime paths, skills, and user data
+  selected by the uninstall plan are cleaned up during command execution. On
+  Unix, cleanup happens during the command.
+- Safety: the command refuses to run while another live `oo` process is
+  running, and it never writes API keys or other secrets to stdout/stderr.
 
 ### `oo check-update`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -347,6 +347,34 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 
 `oo update` 的别名。
 
+### `oo uninstall`
+
+卸载受管的 `oo` 运行时及其内置 skills。
+
+- 参数：无。
+- 选项：`-y, --yes` 跳过确认提示；非交互式终端下必须传入。
+- 选项：`--dry-run` 只打印将删除（与将保留）的内容，不实际删除。
+- 选项：`--purge` 额外删除用户数据（auth、settings、cache、logs、telemetry）
+  以及**全部**由 oo 管理的 registry skills。
+- 默认删除：受管可执行文件（`~/.local/bin/oo`）、所有已安装版本、self-update
+  staging 与 locks、bundled skills，以及 preset registry skill 包
+  `@alwaysmavs/gpt-image-2`（host 安装与 canonical source）。
+- 默认保留：不动 PATH 配置；非 preset 的 registry skills、local skills、以及
+  任何不受 oo 管理的同名目录都保留；用户数据仅在 `--purge` 时删除。
+- skill 安全规则：仅当 `.oo-metadata.json` 能证明 oo 所有权（`kind: "bundled"`，
+  或 `kind: "registry"` 且匹配 preset 列表 / `--purge`）时才删除。metadata 缺失、
+  损坏、local 或不匹配的目录一律不删，因此用户手写的同名 skill 是安全的。
+- 安装方式：当 `oo` 是通过包管理器（npm/bun/pnpm/yarn）安装时，命令会删除
+  oo 管理的 skills，打印对应的 `npm uninstall -g @oomol-lab/oo-cli`（或等价）命令，
+  并以非零状态退出，提示调用方二进制仍需手动删除。当可执行文件位于未知位置时，
+  仅删除 oo 管理的 skills，并提示用户手动删除二进制。
+- Windows：正在运行的可执行文件无法在当前进程内自删，因此
+  `~/.local/bin/oo.exe` 的删除会交给一次性 PowerShell helper——它等待当前进程
+  退出后删除该可执行文件并删除自身。其它路径（versions、staging、locks、skills）
+  都在当前进程内删除。Unix 上可执行文件与版本目录都在当前进程内删除。
+- 安全：当有另一个存活的 `oo` 进程持有 active version marker 时，命令会拒绝执行；
+  且任何输出路径都不会把 API key 等机密写入 stdout/stderr。
+
 ### `oo check-update`
 
 检查是否有新的 CLI 版本可用。

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -368,10 +368,11 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   oo 管理的 skills，打印对应的 `npm uninstall -g @oomol-lab/oo-cli`（或等价）命令，
   并以非零状态退出，提示调用方二进制仍需手动删除。当可执行文件位于未知位置时，
   仅删除 oo 管理的 skills，并提示用户手动删除二进制。
-- Windows：正在运行的可执行文件无法在当前进程内自删，因此
-  `~/.local/bin/oo.exe` 的删除会交给一次性 PowerShell helper——它等待当前进程
-  退出后删除该可执行文件并删除自身。其它路径（versions、staging、locks、skills）
-  都在当前进程内删除。Unix 上可执行文件与版本目录都在当前进程内删除。
+- Windows：正在运行的进程会持有自身可执行文件，以及（在 `--purge` 时）数据目录中
+  打开的 SQLite 数据库，而 Windows 无法删除被存活进程持有的文件。因此这些路径的删除
+  会交给一次性 PowerShell helper——它等待当前进程退出后删除这些路径并删除自身。其它
+  路径（versions、staging、locks、skills，以及 auth、settings、logs、telemetry 等
+  剩余用户数据）都在当前进程内删除。Unix 上所有路径都在当前进程内删除。
 - 安全：当有另一个存活的 `oo` 进程持有 active version marker 时，命令会拒绝执行；
   且任何输出路径都不会把 API key 等机密写入 stdout/stderr。
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -368,13 +368,11 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   oo 管理的 skills，打印对应的 `npm uninstall -g @oomol-lab/oo-cli`（或等价）命令，
   并以非零状态退出，提示调用方二进制仍需手动删除。当可执行文件位于未知位置时，
   仅删除 oo 管理的 skills，并提示用户手动删除二进制。
-- Windows：正在运行的进程会持有自身可执行文件，以及（在 `--purge` 时）数据目录中
-  打开的 SQLite 数据库，而 Windows 无法删除被存活进程持有的文件。因此这些路径的删除
-  会交给一次性 PowerShell helper——它等待当前进程退出后删除这些路径并删除自身。其它
-  路径（versions、staging、locks、skills，以及 auth、settings、logs、telemetry 等
-  剩余用户数据）都在当前进程内删除。Unix 上所有路径都在当前进程内删除。
-- 安全：当有另一个存活的 `oo` 进程持有 active version marker 时，命令会拒绝执行；
-  且任何输出路径都不会把 API key 等机密写入 stdout/stderr。
+- Windows：在 `oo uninstall` 运行期间无法删除的文件，会在进程退出后删除。其它被卸载
+  计划选中的运行时路径、skills 和用户数据会在命令执行期间清理。Unix 上的清理会在命令
+  执行期间完成。
+- 安全：当检测到另一个运行中的 `oo` 进程时，命令会拒绝执行；且任何输出路径都不会把
+  API key 等机密写入 stdout/stderr。
 
 ### `oo check-update`
 

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -56,6 +56,7 @@ Commands:
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
   telemetry                 Manage CLI telemetry
+  uninstall [options]       Uninstall the CLI
   update|upgrade [options]  Update the CLI
   version [options]         Print the CLI version
   help [command]            Show help for a command
@@ -94,6 +95,7 @@ Commands:
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
   telemetry                 Manage CLI telemetry
+  uninstall [options]       Uninstall the CLI
   update|upgrade [options]  Update the CLI
   version [options]         Print the CLI version
   help [command]            Show help for a command
@@ -135,6 +137,7 @@ Commands:
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
   telemetry                 Manage CLI telemetry
+  uninstall [options]       Uninstall the CLI
   update|upgrade [options]  Update the CLI
   version [options]         Print the CLI version
   help [command]            Show help for a command
@@ -174,6 +177,7 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
   search [options] <text>   搜索 package 与 connector action
   packages                  包相关工具
   telemetry                 管理 CLI telemetry
+  uninstall [options]       卸载 CLI
   update|upgrade [options]  更新 CLI
   version [options]         输出 CLI 版本
   help [command]            显示命令帮助
@@ -209,6 +213,7 @@ Commands:
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
   telemetry                 Manage CLI telemetry
+  uninstall [options]       Uninstall the CLI
   update|upgrade [options]  Update the CLI
   version [options]         Print the CLI version
   help [command]            Show help for a command
@@ -248,6 +253,7 @@ Commands:
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
   telemetry                 Manage CLI telemetry
+  uninstall [options]       Uninstall the CLI
   update|upgrade [options]  Update the CLI
   version [options]         Print the CLI version
   help [command]            Show help for a command

--- a/src/application/commands/catalog.ts
+++ b/src/application/commands/catalog.ts
@@ -18,6 +18,7 @@ import { packageCommand } from "./package/index.ts";
 import { mixedSearchCommand } from "./search.ts";
 import { skillsCommand } from "./skills/index.ts";
 import { telemetryCommand } from "./telemetry/index.ts";
+import { uninstallCommand } from "./uninstall.ts";
 import { updateCommand } from "./update.ts";
 import { versionCommand } from "./version.ts";
 
@@ -60,6 +61,7 @@ export function createCliCatalog(): CliCatalog {
             mixedSearchCommand,
             packageCommand,
             telemetryCommand,
+            uninstallCommand,
             updateCommand,
             versionCommand,
         ],

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -42,6 +42,7 @@ Commands:
   search [options] <text>   Search packages and connector actions
   packages                  Package utilities
   telemetry                 Manage CLI telemetry
+  uninstall [options]       Uninstall the CLI
   update|upgrade [options]  Update the CLI
   version [options]         Print the CLI version
   help [command]            Show help for a command
@@ -77,6 +78,7 @@ Commands:
   search [options] <text>   搜索 package 与 connector action
   packages                  包相关工具
   telemetry                 管理 CLI telemetry
+  uninstall [options]       卸载 CLI
   update|upgrade [options]  更新 CLI
   version [options]         输出 CLI 版本
   help [command]            显示命令帮助

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -33,13 +33,13 @@ import {
     getBundledSkillFiles,
     readBundledSkillFileContent,
 } from "./embedded-assets.ts";
-import { presetSkillPackageNames } from "./install.ts";
 import { resolveManagedSkillAgentHomeDirectory } from "./managed-skill-agents.ts";
 import {
     resolveManagedSkillCanonicalDirectoryPath,
     resolveManagedSkillDirectoryPath,
     resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
+import { presetSkillPackageNames } from "./preset-packages.ts";
 import {
     installedRegistrySkillCompatibility,
     renderOoPackageExecutionGuidance,

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -35,6 +35,7 @@ import {
     skillOperationOutputOptions,
     writeSkillOperationJson,
 } from "./operation-result.ts";
+import { presetSkillPackageNames } from "./preset-packages.ts";
 import { installRegistrySkills } from "./registry-skill-install.ts";
 import {
     installBundledSkill,
@@ -59,8 +60,6 @@ interface SkillsInstallPackageSpecifier {
     packageShareId?: string;
     packageVersion: string;
 }
-
-export const presetSkillPackageNames = ["@alwaysmavs/gpt-image-2"] as const;
 
 const installErrorMessages: Record<string, string> = {
     not_authenticated: "Authentication is required.",

--- a/src/application/commands/skills/preset-packages.ts
+++ b/src/application/commands/skills/preset-packages.ts
@@ -1,0 +1,8 @@
+// Preset registry skill packages that ship with the CLI: they are installed by
+// default during a no-argument `oo skills install` / `oo install`, and removed
+// by default during `oo uninstall`. Keeping this list in one module makes
+// "what install adds by default" and "what uninstall removes by default" a
+// single source of truth.
+export const presetSkillPackageNames = ["@alwaysmavs/gpt-image-2"] as const;
+
+export type PresetSkillPackageName = (typeof presetSkillPackageNames)[number];

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -450,6 +450,15 @@ const commandTelemetryDecisions = {
         kind: "excluded",
         reason: "Status must not change pending telemetry counts.",
     },
+    "uninstall": {
+        kind: "properties",
+        properties: [
+            "has_purge",
+            "installation_method",
+            "item_count_bucket",
+        ],
+        reason: "Records purge flag, installation method, and a bucketed count of removed items; never records skill names, package names, or paths.",
+    },
     "update": {
         kind: "properties",
         properties: [

--- a/src/application/commands/uninstall.cli.test.ts
+++ b/src/application/commands/uninstall.cli.test.ts
@@ -1,0 +1,309 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import process from "node:process";
+
+import { describe, expect, test } from "bun:test";
+
+import { createCliSandbox } from "../../../__tests__/helpers.ts";
+import { resolveStorePaths } from "../../adapters/store/store-path.ts";
+import { APP_NAME } from "../config/app-config.ts";
+import { resolveSelfUpdatePaths } from "../self-update/paths.ts";
+import { resolveManagedSkillMetadataFilePath } from "./skills/managed-skill-paths.ts";
+import {
+    createBundledSkillMetadata,
+    createLocalSkillMetadata,
+    createRegistrySkillMetadata,
+    renderSkillMetadataJson,
+} from "./skills/skill-metadata.ts";
+
+const PRESET_PACKAGE = "@alwaysmavs/gpt-image-2";
+
+function selfUpdatePaths(sandbox: Awaited<ReturnType<typeof createCliSandbox>>) {
+    return resolveSelfUpdatePaths({
+        env: sandbox.env,
+        platform: process.platform,
+    });
+}
+
+function storePaths(sandbox: Awaited<ReturnType<typeof createCliSandbox>>) {
+    return resolveStorePaths({
+        appName: APP_NAME,
+        env: sandbox.env,
+        platform: process.platform,
+    });
+}
+
+async function seedRuntime(
+    sandbox: Awaited<ReturnType<typeof createCliSandbox>>,
+): Promise<{ executablePath: string; versionsDirectory: string }> {
+    const paths = selfUpdatePaths(sandbox);
+
+    await mkdir(join(paths.executablePath, ".."), { recursive: true });
+    await writeFile(paths.executablePath, "binary");
+    await mkdir(join(paths.versionsDirectory, "1.2.3"), { recursive: true });
+    await writeFile(join(paths.versionsDirectory, "1.2.3", "oo"), "binary");
+
+    return {
+        executablePath: paths.executablePath,
+        versionsDirectory: paths.versionsDirectory,
+    };
+}
+
+async function seedHostSkill(options: {
+    sandbox: Awaited<ReturnType<typeof createCliSandbox>>;
+    skillName: string;
+    metadataJson?: string;
+}): Promise<string> {
+    const codexHome = join(options.sandbox.env.HOME!, ".codex");
+    const skillDirectory = join(codexHome, "skills", options.skillName);
+
+    await mkdir(skillDirectory, { recursive: true });
+    await writeFile(join(skillDirectory, "SKILL.md"), "# x\n");
+
+    if (options.metadataJson !== undefined) {
+        await writeFile(
+            resolveManagedSkillMetadataFilePath(skillDirectory),
+            options.metadataJson,
+        );
+    }
+
+    return skillDirectory;
+}
+
+function nativeExecPath(sandbox: Awaited<ReturnType<typeof createCliSandbox>>): string {
+    return selfUpdatePaths(sandbox).executablePath;
+}
+
+describe("oo uninstall", () => {
+    test("--dry-run prints the plan and deletes nothing", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const runtime = await seedRuntime(sandbox);
+
+            const result = await sandbox.run(["uninstall", "--dry-run"], {
+                execPath: nativeExecPath(sandbox),
+                version: "1.2.3",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("uninstall plan");
+            // Nothing removed.
+            expect(await Bun.file(runtime.executablePath).exists()).toBe(true);
+            expect(await Bun.file(join(runtime.versionsDirectory, "1.2.3", "oo")).exists()).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("non-interactive without --yes refuses and deletes nothing", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const runtime = await seedRuntime(sandbox);
+
+            const result = await sandbox.run(["uninstall"], {
+                execPath: nativeExecPath(sandbox),
+                stdout: { isTTY: false },
+                version: "1.2.3",
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("--yes");
+            expect(await Bun.file(runtime.executablePath).exists()).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--yes removes runtime + bundled + preset, keeps registry/local/unmanaged", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const runtime = await seedRuntime(sandbox);
+            const ooSkill = await seedHostSkill({
+                sandbox,
+                skillName: "oo",
+                metadataJson: renderSkillMetadataJson(createBundledSkillMetadata("1.2.3")),
+            });
+            const presetSkill = await seedHostSkill({
+                sandbox,
+                skillName: "gpt-image-2",
+                metadataJson: renderSkillMetadataJson(createRegistrySkillMetadata({
+                    packageName: PRESET_PACKAGE,
+                    version: "0.1.0",
+                })),
+            });
+            const registrySkill = await seedHostSkill({
+                sandbox,
+                skillName: "demo",
+                metadataJson: renderSkillMetadataJson(createRegistrySkillMetadata({
+                    packageName: "@alice/demo",
+                    version: "0.2.0",
+                })),
+            });
+            const localSkill = await seedHostSkill({
+                sandbox,
+                skillName: "mine",
+                metadataJson: renderSkillMetadataJson(createLocalSkillMetadata()),
+            });
+            const unmanagedSkill = await seedHostSkill({
+                sandbox,
+                skillName: "handwritten",
+            });
+
+            const result = await sandbox.run(["uninstall", "--yes"], {
+                execPath: nativeExecPath(sandbox),
+                version: "1.2.3",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("uninstalled");
+            // Removed
+            expect(await Bun.file(runtime.executablePath).exists()).toBe(false);
+            expect(await Bun.file(join(runtime.versionsDirectory, "1.2.3", "oo")).exists()).toBe(false);
+            expect(await Bun.file(join(ooSkill, "SKILL.md")).exists()).toBe(false);
+            expect(await Bun.file(join(presetSkill, "SKILL.md")).exists()).toBe(false);
+            // Retained
+            expect(await Bun.file(join(registrySkill, "SKILL.md")).exists()).toBe(true);
+            expect(await Bun.file(join(localSkill, "SKILL.md")).exists()).toBe(true);
+            expect(await Bun.file(join(unmanagedSkill, "SKILL.md")).exists()).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--yes --purge removes auth/settings and all registry skills", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await seedRuntime(sandbox);
+            const store = storePaths(sandbox);
+
+            await mkdir(store.rootDirectory, { recursive: true });
+            await writeFile(store.authFilePath, "id = \"\"\n");
+            await writeFile(store.settingsFilePath, "x = 1\n");
+            const registrySkill = await seedHostSkill({
+                sandbox,
+                skillName: "demo",
+                metadataJson: renderSkillMetadataJson(createRegistrySkillMetadata({
+                    packageName: "@alice/demo",
+                    version: "0.2.0",
+                })),
+            });
+            const localSkill = await seedHostSkill({
+                sandbox,
+                skillName: "mine",
+                metadataJson: renderSkillMetadataJson(createLocalSkillMetadata()),
+            });
+
+            const result = await sandbox.run(["uninstall", "--yes", "--purge"], {
+                execPath: nativeExecPath(sandbox),
+                version: "1.2.3",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(await Bun.file(store.authFilePath).exists()).toBe(false);
+            expect(await Bun.file(store.settingsFilePath).exists()).toBe(false);
+            // All registry skills removed under purge
+            expect(await Bun.file(join(registrySkill, "SKILL.md")).exists()).toBe(false);
+            // Local still retained even under purge
+            expect(await Bun.file(join(localSkill, "SKILL.md")).exists()).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("package-manager install removes skills, keeps binary, exits 1 with guidance", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const ooSkill = await seedHostSkill({
+                sandbox,
+                skillName: "oo",
+                metadataJson: renderSkillMetadataJson(createBundledSkillMetadata("1.2.3")),
+            });
+            const npmExecPath = join(
+                sandbox.env.HOME!,
+                "node_modules",
+                "@oomol-lab",
+                "oo-cli",
+                "bin",
+                "oo.js",
+            );
+
+            const result = await sandbox.run(["uninstall", "--yes"], {
+                execPath: npmExecPath,
+                version: "1.2.3",
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("npm uninstall -g @oomol-lab/oo-cli");
+            // Bundled skill still removed even on a package-manager install.
+            expect(await Bun.file(join(ooSkill, "SKILL.md")).exists()).toBe(false);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("package-manager install with empty plan still gives guidance and exits 1", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            // No bundled/preset skills present, so the plan is empty. A
+            // package-manager install must still surface binary guidance + exit 1.
+            const homeDirectory = sandbox.env.HOME!;
+
+            await mkdir(join(homeDirectory, ".codex"), { recursive: true });
+            const npmExecPath = join(
+                homeDirectory,
+                "node_modules",
+                "@oomol-lab",
+                "oo-cli",
+                "bin",
+                "oo.js",
+            );
+
+            const result = await sandbox.run(["uninstall", "--yes"], {
+                execPath: npmExecPath,
+                version: "1.2.3",
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("npm uninstall -g @oomol-lab/oo-cli");
+            // It did not falsely claim a successful uninstall.
+            expect(result.stdout).not.toContain("uninstalled");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not leak secrets in output", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await seedRuntime(sandbox);
+            const store = storePaths(sandbox);
+
+            await mkdir(store.rootDirectory, { recursive: true });
+            await writeFile(store.authFilePath, "id = \"u\"\napi_key = \"secret-xyz\"\n");
+
+            const result = await sandbox.run(["uninstall", "--yes", "--purge"], {
+                execPath: nativeExecPath(sandbox),
+                version: "1.2.3",
+            });
+
+            expect(result.stdout + result.stderr).not.toContain("secret-xyz");
+            expect(result.stdout + result.stderr).not.toContain("api_key");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/uninstall.cli.test.ts
+++ b/src/application/commands/uninstall.cli.test.ts
@@ -9,6 +9,7 @@ import { resolveStorePaths } from "../../adapters/store/store-path.ts";
 import { APP_NAME } from "../config/app-config.ts";
 import { resolveSelfUpdatePaths } from "../self-update/paths.ts";
 import { resolveManagedSkillMetadataFilePath } from "./skills/managed-skill-paths.ts";
+import { presetSkillPackageNames } from "./skills/preset-packages.ts";
 import {
     createBundledSkillMetadata,
     createLocalSkillMetadata,
@@ -16,7 +17,7 @@ import {
     renderSkillMetadataJson,
 } from "./skills/skill-metadata.ts";
 
-const PRESET_PACKAGE = "@alwaysmavs/gpt-image-2";
+const PRESET_PACKAGE = presetSkillPackageNames[0];
 
 function selfUpdatePaths(sandbox: Awaited<ReturnType<typeof createCliSandbox>>) {
     return resolveSelfUpdatePaths({

--- a/src/application/commands/uninstall.cli.test.ts
+++ b/src/application/commands/uninstall.cli.test.ts
@@ -160,9 +160,22 @@ describe("oo uninstall", () => {
             });
 
             expect(result.exitCode).toBe(0);
-            expect(result.stdout).toContain("uninstalled");
-            // Removed
-            expect(await Bun.file(runtime.executablePath).exists()).toBe(false);
+
+            if (process.platform === "win32") {
+                // The running image cannot unlink itself in place, so its removal
+                // is deferred to the post-exit helper: it is still present right
+                // after this in-process run, and the message reports a scheduled
+                // cleanup rather than a completed uninstall.
+                expect(result.stdout).toContain("scheduled");
+                expect(await Bun.file(runtime.executablePath).exists()).toBe(true);
+            }
+            else {
+                expect(result.stdout).toContain("uninstalled");
+                expect(await Bun.file(runtime.executablePath).exists()).toBe(false);
+            }
+
+            // Version directories are standalone copies, removed in-process on
+            // every platform.
             expect(await Bun.file(join(runtime.versionsDirectory, "1.2.3", "oo")).exists()).toBe(false);
             expect(await Bun.file(join(ooSkill, "SKILL.md")).exists()).toBe(false);
             expect(await Bun.file(join(presetSkill, "SKILL.md")).exists()).toBe(false);

--- a/src/application/commands/uninstall.ts
+++ b/src/application/commands/uninstall.ts
@@ -1,0 +1,270 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../contracts/cli.ts";
+import type {
+    InstallationMethod,
+    PackageManagerInstallationMethod,
+} from "../self-update/installation.ts";
+import type { UninstallPlan, UninstallPlanItem } from "../self-update/uninstall.ts";
+
+import process from "node:process";
+import { z } from "zod";
+import { CliUserError } from "../contracts/cli.ts";
+import {
+    buildSelfUninstallPlan,
+    performSelfUninstall,
+} from "../self-update/uninstall.ts";
+import { bucketTelemetryCount } from "../telemetry/buckets.ts";
+import { writeLine } from "./shared/output.ts";
+import { confirmInteractiveValue } from "./skills/interactive-prompts.ts";
+
+interface UninstallInput {
+    dryRun?: boolean;
+    purge?: boolean;
+    yes?: boolean;
+}
+
+const uninstallInputSchema = z.object({
+    dryRun: z.boolean().optional(),
+    purge: z.boolean().optional(),
+    yes: z.boolean().optional(),
+});
+
+const packageManagerUninstallCommands: Record<
+    PackageManagerInstallationMethod,
+    string
+> = {
+    bun: "bun remove -g @oomol-lab/oo-cli",
+    npm: "npm uninstall -g @oomol-lab/oo-cli",
+    pnpm: "pnpm remove -g @oomol-lab/oo-cli",
+    yarn: "yarn global remove @oomol-lab/oo-cli",
+};
+
+export const uninstallCommand: CliCommandDefinition<UninstallInput> = {
+    name: "uninstall",
+    summaryKey: "commands.uninstall.summary",
+    descriptionKey: "commands.uninstall.description",
+    options: [
+        {
+            name: "yes",
+            longFlag: "--yes",
+            shortFlag: "-y",
+            descriptionKey: "options.uninstall.yes",
+        },
+        {
+            name: "dryRun",
+            longFlag: "--dry-run",
+            descriptionKey: "options.uninstall.dryRun",
+        },
+        {
+            name: "purge",
+            longFlag: "--purge",
+            descriptionKey: "options.uninstall.purge",
+        },
+    ],
+    inputSchema: uninstallInputSchema,
+    handler: async (input, context) => {
+        const purge = input.purge === true;
+        const plan = await buildSelfUninstallPlan({
+            env: context.env,
+            execPath: context.execPath,
+            platform: process.platform,
+            purge,
+            version: context.version,
+        });
+
+        context.telemetry?.recordProperties({
+            has_purge: purge,
+            installation_method: plan.installationMethod,
+            item_count_bucket: bucketTelemetryCount(
+                plan.immediate.length + plan.deferred.length,
+            ),
+        });
+
+        if (input.dryRun === true) {
+            writeUninstallPlan(context, plan);
+            return;
+        }
+
+        const hasItems = plan.immediate.length + plan.deferred.length > 0;
+
+        // Only native installs short-circuit on an empty plan. For
+        // package-manager / unknown installs there is still binary-removal
+        // guidance to surface (and a non-zero exit), even with nothing to delete.
+        if (!hasItems && plan.installationMethod === "native") {
+            writeLine(context.stdout, context.translator.t("uninstall.plan.nothing"));
+            return;
+        }
+
+        let deferredToHelper = false;
+
+        if (hasItems) {
+            if (!(await confirmUninstall(input, plan, context))) {
+                return;
+            }
+
+            const result = await performSelfUninstall({
+                logger: context.logger,
+                plan,
+                processId: process.pid,
+                timestamp: Date.now(),
+            });
+
+            if (result.status === "busy") {
+                throw new CliUserError("uninstall.busy", 1, {
+                    pid: result.ownerPid ?? 0,
+                });
+            }
+
+            if (result.failedPaths.length > 0) {
+                throw new CliUserError("uninstall.partialFailure", 1, {
+                    count: result.failedPaths.length,
+                });
+            }
+
+            deferredToHelper = result.deferredToHelper;
+        }
+
+        writeUninstallResult(context, plan, deferredToHelper);
+    },
+};
+
+async function confirmUninstall(
+    input: UninstallInput,
+    plan: UninstallPlan,
+    context: CliExecutionContext,
+): Promise<boolean> {
+    if (input.yes === true) {
+        return true;
+    }
+
+    if (context.stdin.isTTY !== true || context.stdout.isTTY !== true) {
+        throw new CliUserError("uninstall.error.confirmationRequired", 1);
+    }
+
+    writeUninstallPlan(context, plan);
+
+    const confirmed = await confirmInteractiveValue(context, {
+        invalidMessage: context.translator.t("uninstall.confirm.invalid"),
+        prompt: context.translator.t(
+            plan.purge
+                ? "uninstall.confirm.purgePrompt"
+                : "uninstall.confirm.prompt",
+        ),
+    });
+
+    if (!confirmed) {
+        writeLine(context.stdout, context.translator.t("uninstall.confirm.cancelled"));
+        return false;
+    }
+
+    return true;
+}
+
+function writeUninstallPlan(
+    context: Pick<CliExecutionContext, "stdout" | "translator">,
+    plan: UninstallPlan,
+): void {
+    writeLine(context.stdout, context.translator.t("uninstall.plan.header"));
+
+    writePlanSection(context, "uninstall.plan.removeRuntime", plan.immediate, item =>
+        item.category === "binary"
+        || item.category === "versions"
+        || item.category === "staging"
+        || item.category === "locks");
+    writePlanSection(context, "uninstall.plan.removeSkills", plan.immediate, item =>
+        item.category === "bundled-skill" || item.category === "registry-skill");
+    writePlanSection(context, "uninstall.plan.removeData", plan.immediate, item =>
+        item.category === "user-data");
+
+    if (plan.deferred.length > 0) {
+        writeLine(context.stdout, context.translator.t("uninstall.plan.deferred"));
+        for (const item of plan.deferred) {
+            writePlanItem(context, item);
+        }
+    }
+
+    if (plan.retainedSkills.length > 0) {
+        writeLine(context.stdout, context.translator.t("uninstall.plan.retained"));
+        for (const retained of plan.retainedSkills) {
+            writeLine(
+                context.stdout,
+                context.translator.t(
+                    `uninstall.plan.retainedSkill.${retained.reason}`,
+                    { path: retained.path },
+                ),
+            );
+        }
+    }
+}
+
+function writePlanSection(
+    context: Pick<CliExecutionContext, "stdout" | "translator">,
+    headerKey: string,
+    items: readonly UninstallPlanItem[],
+    predicate: (item: UninstallPlanItem) => boolean,
+): void {
+    const matched = items.filter(predicate);
+
+    if (matched.length === 0) {
+        return;
+    }
+
+    writeLine(context.stdout, context.translator.t(headerKey));
+    for (const item of matched) {
+        writePlanItem(context, item);
+    }
+}
+
+function writePlanItem(
+    context: Pick<CliExecutionContext, "stdout" | "translator">,
+    item: UninstallPlanItem,
+): void {
+    writeLine(
+        context.stdout,
+        context.translator.t("uninstall.plan.item", {
+            label: item.label,
+            path: item.path,
+        }),
+    );
+}
+
+function writeUninstallResult(
+    context: CliExecutionContext,
+    plan: UninstallPlan,
+    deferredToHelper: boolean,
+): void {
+    if (plan.installationMethod !== "native") {
+        // Skills (and, under --purge, user data) were removed, but the binary
+        // itself is owned by a package manager or lives at an unknown path.
+        // Surface guidance and a non-zero exit so callers know the binary
+        // still needs to be removed manually.
+        throw createPackageManagerGuidanceError(plan.installationMethod);
+    }
+
+    if (deferredToHelper) {
+        writeLine(
+            context.stdout,
+            context.translator.t("uninstall.success.scheduled"),
+        );
+        return;
+    }
+
+    writeLine(context.stdout, context.translator.t("uninstall.success"));
+}
+
+function createPackageManagerGuidanceError(
+    method: InstallationMethod,
+): CliUserError {
+    if (method === "unknown") {
+        return new CliUserError("uninstall.unknown", 1);
+    }
+
+    return new CliUserError("uninstall.packageManager", 1, {
+        command: resolvePackageManagerCommand(method),
+        method,
+    });
+}
+
+function resolvePackageManagerCommand(method: InstallationMethod): string {
+    return packageManagerUninstallCommands[method as PackageManagerInstallationMethod]
+        ?? packageManagerUninstallCommands.npm;
+}

--- a/src/application/self-update/lock.ts
+++ b/src/application/self-update/lock.ts
@@ -218,6 +218,46 @@ export async function findActiveVersionOwner(options: {
     };
 }
 
+export async function findAnyActiveVersionOwner(options: {
+    excludeProcessId?: number;
+    locksDirectory: string;
+    platform: NodeJS.Platform;
+}): Promise<{ ownerPid: number } | undefined> {
+    const activeDirectory = join(options.locksDirectory, "active");
+    const versionEntries = await readDirectoryEntries(activeDirectory);
+
+    for (const versionEntry of versionEntries) {
+        const owner = await findActiveMarkerOwner(
+            join(activeDirectory, versionEntry),
+            options,
+        );
+
+        if (owner !== undefined) {
+            return owner;
+        }
+    }
+
+    const legacyEntries = await readDirectoryEntries(options.locksDirectory);
+
+    for (const legacyEntry of legacyEntries) {
+        if (!legacyEntry.endsWith(".lock")) {
+            continue;
+        }
+
+        const lock = await readVersionOwner(
+            join(options.locksDirectory, legacyEntry),
+        );
+
+        if (isLiveOwner(lock, options)) {
+            return {
+                ownerPid: lock.pid,
+            };
+        }
+    }
+
+    return undefined;
+}
+
 function createActiveVersionMarkerHandle(
     markerFilePath: string,
     marker: ActiveVersionMarker,

--- a/src/application/self-update/uninstall.test.ts
+++ b/src/application/self-update/uninstall.test.ts
@@ -13,6 +13,7 @@ import {
     createRegistrySkillMetadata,
     renderSkillMetadataJson,
 } from "../commands/skills/skill-metadata.ts";
+import { readPathModule } from "./paths.ts";
 import {
     buildSelfUninstallPlan,
     createWindowsSelfDeleteScript,
@@ -118,7 +119,16 @@ describe("buildSelfUninstallPlan", () => {
 
         return {
             env: { HOME: tempHome },
-            execPath: join(tempHome, ".local", "bin", executableName),
+            // Build the exec path with the simulated platform's separators so the
+            // managed-path comparison in detectInstallationMethodFromExecPath
+            // matches even when the host platform differs (e.g. simulating linux
+            // on a Windows CI runner, where node:path.join would emit backslashes).
+            execPath: readPathModule(platform).join(
+                tempHome,
+                ".local",
+                "bin",
+                executableName,
+            ),
             homeDirectory: tempHome,
             platform,
             purge: overrides.purge ?? false,
@@ -145,6 +155,30 @@ describe("buildSelfUninstallPlan", () => {
         // versions/staging/locks are standalone copies, still removed in-process
         expect(categoriesOf(plan.immediate)).toContain("versions");
         expect(categoriesOf(plan.immediate)).not.toContain("binary");
+    });
+
+    test("win32 --purge defers the data directory but removes config files in-process", async () => {
+        const plan = await buildSelfUninstallPlan(
+            nativeOptions({ platform: "win32", purge: true }),
+        );
+
+        // The data directory holds open SQLite handles, so it is deferred to the
+        // post-exit helper alongside the running executable.
+        expect(plan.helperDirectory).toBeDefined();
+        const deferredUserData = plan.deferred.filter(
+            item => item.category === "user-data",
+        );
+
+        expect(paths(deferredUserData).some(path => path.endsWith("data"))).toBe(true);
+        expect(plan.immediate.some(item => item.path.endsWith("data"))).toBe(false);
+
+        // Config files are not held open and are still removed in-process.
+        const immediateUserData = plan.immediate.filter(
+            item => item.category === "user-data",
+        );
+
+        expect(paths(immediateUserData).some(path => path.endsWith("auth.toml"))).toBe(true);
+        expect(paths(immediateUserData).some(path => path.endsWith("settings.toml"))).toBe(true);
     });
 
     test("--purge adds user-data targets", async () => {
@@ -348,14 +382,13 @@ describe("performSelfUninstall", () => {
     });
 
     test("reports failedPaths when a path cannot be removed (P1)", async () => {
-        // Platform-independent removal failure: the parent is a regular file,
-        // so removing `<file>/child` raises ENOTDIR (not the ENOENT that
-        // `force: true` tolerates). No chmod/ACL semantics, so it behaves the
-        // same on POSIX and Windows CI.
-        const parentFile = join(tempHome, "not-a-directory");
-        const unremovablePath = join(parentFile, "child");
-
-        await writeFile(parentFile, "x");
+        // A path with an embedded NUL makes fs.rm reject on every platform:
+        // `force: true` only swallows missing-path errors, not the argument
+        // validation an invalid path triggers. This deterministically exercises
+        // the failure-tracking branch without depending on platform fs semantics
+        // (POSIX raises ENOTDIR for `<file>/child`, Windows raises a tolerated
+        // ENOENT instead).
+        const unremovablePath = `${join(tempHome, "data")}${String.fromCharCode(0)}child`;
 
         const plan: UninstallPlan = {
             deferred: [],

--- a/src/application/self-update/uninstall.test.ts
+++ b/src/application/self-update/uninstall.test.ts
@@ -2,11 +2,12 @@ import type { UninstallPlan, UninstallPlanItem } from "./uninstall.ts";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 
-import { join } from "node:path";
+import { join, win32 } from "node:path";
 import process from "node:process";
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { resolveManagedSkillMetadataFilePath } from "../commands/skills/managed-skill-paths.ts";
+import { presetSkillPackageNames } from "../commands/skills/preset-packages.ts";
 import {
     createBundledSkillMetadata,
     createLocalSkillMetadata,
@@ -19,10 +20,9 @@ import {
     createWindowsSelfDeleteScript,
     performSelfUninstall,
     shouldRemoveManagedSkill,
-
 } from "./uninstall.ts";
 
-const PRESET_PACKAGE = "@alwaysmavs/gpt-image-2";
+const PRESET_PACKAGE = presetSkillPackageNames[0];
 
 const noopLogger = {
     warn: () => {},
@@ -90,25 +90,34 @@ describe("shouldRemoveManagedSkill", () => {
 
 describe("createWindowsSelfDeleteScript", () => {
     test("waits for the parent pid then removes literal paths and itself", () => {
+        const deferredPath = win32.join(
+            "C:\\",
+            "Users",
+            "a b",
+            ".local",
+            "bin",
+            "oo.exe",
+        );
         const script = createWindowsSelfDeleteScript({
-            deferredPaths: ["C:\\Users\\a b\\.local\\bin\\oo.exe"],
+            deferredPaths: [deferredPath],
             processId: 4321,
         });
 
         expect(script).toContain("Wait-Process -Id 4321");
         expect(script).toContain(
-            "Remove-Item -LiteralPath 'C:\\Users\\a b\\.local\\bin\\oo.exe' -Force -Recurse -ErrorAction SilentlyContinue",
+            `Remove-Item -LiteralPath '${deferredPath}' -Force -Recurse -ErrorAction SilentlyContinue`,
         );
         expect(script).toContain("Remove-Item -LiteralPath $PSCommandPath");
     });
 
     test("escapes single quotes in paths", () => {
+        const deferredPath = win32.join("C:\\", "o'o", "oo.exe");
         const script = createWindowsSelfDeleteScript({
-            deferredPaths: ["C:\\o'o\\oo.exe"],
+            deferredPaths: [deferredPath],
             processId: 1,
         });
 
-        expect(script).toContain("'C:\\o''o\\oo.exe'");
+        expect(script).toContain(`'${deferredPath.replaceAll("'", "''")}'`);
     });
 });
 
@@ -264,6 +273,54 @@ describe("buildSelfUninstallPlan", () => {
 });
 
 describe("performSelfUninstall", () => {
+    test("checks active owners even when the plan does not remove locks", async () => {
+        const locksDirectory = join(tempHome, "locks");
+        const skillDirectory = join(tempHome, "skills", "oo");
+        const markerPath = join(
+            locksDirectory,
+            "active",
+            "1.2.3",
+            `${process.pid}.marker.lock`,
+        );
+
+        await mkdir(skillDirectory, { recursive: true });
+        await writeFile(join(skillDirectory, "SKILL.md"), "# x\n");
+        await mkdir(join(locksDirectory, "active", "1.2.3"), { recursive: true });
+        await writeJsonFile(markerPath, {
+            acquiredAt: new Date().toISOString(),
+            execPath: process.execPath,
+            kind: "active",
+            markerId: "marker",
+            pid: process.pid,
+            version: "1.2.3",
+        });
+
+        const plan: UninstallPlan = {
+            activeVersionLocksDirectory: locksDirectory,
+            deferred: [],
+            immediate: [
+                { category: "bundled-skill", label: "x", path: skillDirectory },
+            ],
+            installationMethod: "npm",
+            platform: process.platform,
+            purge: false,
+            retainedSkills: [],
+        };
+
+        const result = await performSelfUninstall({
+            logger: noopLogger,
+            plan,
+            processId: 999_999,
+            timestamp: 1,
+        });
+
+        expect(result).toEqual({
+            ownerPid: process.pid,
+            status: "busy",
+        });
+        expect(await Bun.file(join(skillDirectory, "SKILL.md")).exists()).toBe(true);
+    });
+
     test("unix removes immediate and deferred in-process", async () => {
         const binaryPath = join(tempHome, "bin", "oo");
         const versionsPath = join(tempHome, "versions");
@@ -273,6 +330,7 @@ describe("performSelfUninstall", () => {
         await mkdir(versionsPath, { recursive: true });
 
         const plan: UninstallPlan = {
+            activeVersionLocksDirectory: join(tempHome, "locks"),
             deferred: [],
             immediate: [
                 { category: "binary", label: "x", path: binaryPath },
@@ -308,6 +366,7 @@ describe("performSelfUninstall", () => {
         await writeFile(binaryPath, "binary");
 
         const plan: UninstallPlan = {
+            activeVersionLocksDirectory: join(tempHome, "locks"),
             deferred: [
                 { category: "binary", label: "x", path: binaryPath },
             ],
@@ -353,6 +412,7 @@ describe("performSelfUninstall", () => {
         await writeFile(binaryPath, "binary");
 
         const plan: UninstallPlan = {
+            activeVersionLocksDirectory: join(tempHome, "locks"),
             deferred: [
                 { category: "binary", label: "x", path: binaryPath },
             ],
@@ -391,6 +451,7 @@ describe("performSelfUninstall", () => {
         const unremovablePath = `${join(tempHome, "data")}${String.fromCharCode(0)}child`;
 
         const plan: UninstallPlan = {
+            activeVersionLocksDirectory: join(tempHome, "locks"),
             deferred: [],
             immediate: [
                 { category: "user-data", label: "x", path: unremovablePath },
@@ -412,3 +473,7 @@ describe("performSelfUninstall", () => {
         expect((result as { failedPaths: string[] }).failedPaths).toContain(unremovablePath);
     });
 });
+
+async function writeJsonFile(path: string, value: object): Promise<void> {
+    await writeFile(path, `${JSON.stringify(value)}\n`);
+}

--- a/src/application/self-update/uninstall.test.ts
+++ b/src/application/self-update/uninstall.test.ts
@@ -1,0 +1,381 @@
+import type { UninstallPlan, UninstallPlanItem } from "./uninstall.ts";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
+import { join } from "node:path";
+import process from "node:process";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { resolveManagedSkillMetadataFilePath } from "../commands/skills/managed-skill-paths.ts";
+import {
+    createBundledSkillMetadata,
+    createLocalSkillMetadata,
+    createRegistrySkillMetadata,
+    renderSkillMetadataJson,
+} from "../commands/skills/skill-metadata.ts";
+import {
+    buildSelfUninstallPlan,
+    createWindowsSelfDeleteScript,
+    performSelfUninstall,
+    shouldRemoveManagedSkill,
+
+} from "./uninstall.ts";
+
+const PRESET_PACKAGE = "@alwaysmavs/gpt-image-2";
+
+const noopLogger = {
+    warn: () => {},
+    info: () => {},
+    debug: () => {},
+    error: () => {},
+} as never;
+
+let tempHome: string;
+
+beforeEach(async () => {
+    tempHome = await mkdtemp(join(tmpdir(), "oo-uninstall-test-"));
+});
+
+afterEach(async () => {
+    await Bun.$`rm -rf ${tempHome}`.quiet().nothrow();
+});
+
+function categoriesOf(items: readonly UninstallPlanItem[]): string[] {
+    return items.map(item => item.category);
+}
+
+function paths(items: readonly UninstallPlanItem[]): string[] {
+    return items.map(item => item.path);
+}
+
+async function writeSkill(
+    skillDirectory: string,
+    metadataJson: string,
+): Promise<void> {
+    await mkdir(skillDirectory, { recursive: true });
+    await writeFile(join(skillDirectory, "SKILL.md"), "# x\n");
+    await writeFile(resolveManagedSkillMetadataFilePath(skillDirectory), metadataJson);
+}
+
+describe("shouldRemoveManagedSkill", () => {
+    test("bundled is always removed", () => {
+        expect(shouldRemoveManagedSkill(createBundledSkillMetadata("1.0.0"), { purge: false })).toBe(true);
+        expect(shouldRemoveManagedSkill(createBundledSkillMetadata("1.0.0"), { purge: true })).toBe(true);
+    });
+
+    test("preset registry is removed by default", () => {
+        const metadata = createRegistrySkillMetadata({ packageName: PRESET_PACKAGE, version: "0.1.0" });
+
+        expect(shouldRemoveManagedSkill(metadata, { purge: false })).toBe(true);
+    });
+
+    test("non-preset registry is kept by default and removed under purge", () => {
+        const metadata = createRegistrySkillMetadata({ packageName: "@alice/demo", version: "0.1.0" });
+
+        expect(shouldRemoveManagedSkill(metadata, { purge: false })).toBe(false);
+        expect(shouldRemoveManagedSkill(metadata, { purge: true })).toBe(true);
+    });
+
+    test("local is never removed", () => {
+        expect(shouldRemoveManagedSkill(createLocalSkillMetadata(), { purge: false })).toBe(false);
+        expect(shouldRemoveManagedSkill(createLocalSkillMetadata(), { purge: true })).toBe(false);
+    });
+
+    test("missing metadata is never removed", () => {
+        expect(shouldRemoveManagedSkill(undefined, { purge: false })).toBe(false);
+        expect(shouldRemoveManagedSkill(undefined, { purge: true })).toBe(false);
+    });
+});
+
+describe("createWindowsSelfDeleteScript", () => {
+    test("waits for the parent pid then removes literal paths and itself", () => {
+        const script = createWindowsSelfDeleteScript({
+            deferredPaths: ["C:\\Users\\a b\\.local\\bin\\oo.exe"],
+            processId: 4321,
+        });
+
+        expect(script).toContain("Wait-Process -Id 4321");
+        expect(script).toContain(
+            "Remove-Item -LiteralPath 'C:\\Users\\a b\\.local\\bin\\oo.exe' -Force -Recurse -ErrorAction SilentlyContinue",
+        );
+        expect(script).toContain("Remove-Item -LiteralPath $PSCommandPath");
+    });
+
+    test("escapes single quotes in paths", () => {
+        const script = createWindowsSelfDeleteScript({
+            deferredPaths: ["C:\\o'o\\oo.exe"],
+            processId: 1,
+        });
+
+        expect(script).toContain("'C:\\o''o\\oo.exe'");
+    });
+});
+
+describe("buildSelfUninstallPlan", () => {
+    function nativeOptions(overrides: { platform?: NodeJS.Platform; purge?: boolean } = {}) {
+        const platform = overrides.platform ?? "linux";
+        const executableName = platform === "win32" ? "oo.exe" : "oo";
+
+        return {
+            env: { HOME: tempHome },
+            execPath: join(tempHome, ".local", "bin", executableName),
+            homeDirectory: tempHome,
+            platform,
+            purge: overrides.purge ?? false,
+            version: "1.2.3",
+        };
+    }
+
+    test("native linux default plan removes runtime synchronously, no user data", async () => {
+        const plan = await buildSelfUninstallPlan(nativeOptions());
+
+        expect(plan.installationMethod).toBe("native");
+        expect(plan.deferred).toEqual([]);
+        expect(categoriesOf(plan.immediate)).toContain("binary");
+        expect(categoriesOf(plan.immediate)).toContain("versions");
+        expect(categoriesOf(plan.immediate)).toContain("staging");
+        expect(categoriesOf(plan.immediate)).toContain("locks");
+        expect(categoriesOf(plan.immediate)).not.toContain("user-data");
+    });
+
+    test("native win32 defers the running executable only", async () => {
+        const plan = await buildSelfUninstallPlan(nativeOptions({ platform: "win32" }));
+
+        expect(categoriesOf(plan.deferred)).toEqual(["binary"]);
+        // versions/staging/locks are standalone copies, still removed in-process
+        expect(categoriesOf(plan.immediate)).toContain("versions");
+        expect(categoriesOf(plan.immediate)).not.toContain("binary");
+    });
+
+    test("--purge adds user-data targets", async () => {
+        const plan = await buildSelfUninstallPlan(nativeOptions({ purge: true }));
+        const userData = plan.immediate.filter(item => item.category === "user-data");
+
+        expect(userData.length).toBeGreaterThanOrEqual(4);
+        expect(paths(userData).some(path => path.endsWith("auth.toml"))).toBe(true);
+        expect(paths(userData).some(path => path.endsWith("settings.toml"))).toBe(true);
+    });
+
+    test("classifies skills by metadata: bundled+preset removed, registry kept, local/unmanaged retained", async () => {
+        const codexSkillsDir = join(tempHome, ".codex", "skills");
+
+        await mkdir(join(tempHome, ".codex"), { recursive: true });
+        await writeSkill(
+            join(codexSkillsDir, "oo"),
+            renderSkillMetadataJson(createBundledSkillMetadata("1.2.3")),
+        );
+        await writeSkill(
+            join(codexSkillsDir, "gpt-image-2"),
+            renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: PRESET_PACKAGE, version: "0.1.0" })),
+        );
+        await writeSkill(
+            join(codexSkillsDir, "demo"),
+            renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "@alice/demo", version: "0.2.0" })),
+        );
+        await writeSkill(
+            join(codexSkillsDir, "mine"),
+            renderSkillMetadataJson(createLocalSkillMetadata()),
+        );
+        // unmanaged same-name dir: no metadata file
+        await mkdir(join(codexSkillsDir, "handwritten"), { recursive: true });
+        await writeFile(join(codexSkillsDir, "handwritten", "SKILL.md"), "# user\n");
+
+        const plan = await buildSelfUninstallPlan(nativeOptions());
+        const removedPaths = paths(plan.immediate.filter(
+            item => item.category === "bundled-skill" || item.category === "registry-skill",
+        ));
+
+        expect(removedPaths.some(path => path.endsWith(join(".codex", "skills", "oo")))).toBe(true);
+        expect(removedPaths.some(path => path.endsWith(join(".codex", "skills", "gpt-image-2")))).toBe(true);
+        expect(removedPaths.some(path => path.endsWith(join(".codex", "skills", "demo")))).toBe(false);
+        expect(removedPaths.some(path => path.endsWith(join(".codex", "skills", "mine")))).toBe(false);
+        // unmanaged dir never appears in any removal set
+        expect(paths(plan.immediate).some(path => path.endsWith("handwritten"))).toBe(false);
+
+        const retainedReasons = plan.retainedSkills.map(skill => skill.reason);
+
+        expect(retainedReasons).toContain("registry");
+        expect(retainedReasons).toContain("local");
+    });
+
+    test("--purge removes all registry skills", async () => {
+        const codexSkillsDir = join(tempHome, ".codex", "skills");
+
+        await mkdir(join(tempHome, ".codex"), { recursive: true });
+        await writeSkill(
+            join(codexSkillsDir, "demo"),
+            renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "@alice/demo", version: "0.2.0" })),
+        );
+
+        const plan = await buildSelfUninstallPlan(nativeOptions({ purge: true }));
+        const removedPaths = paths(plan.immediate.filter(item => item.category === "registry-skill"));
+
+        expect(removedPaths.some(path => path.endsWith(join(".codex", "skills", "demo")))).toBe(true);
+    });
+
+    test("npm install: no runtime items, skills still classified", async () => {
+        const plan = await buildSelfUninstallPlan({
+            env: { HOME: tempHome },
+            execPath: join(tempHome, "node_modules", "@oomol-lab", "oo-cli", "bin", "oo.js"),
+            homeDirectory: tempHome,
+            platform: "linux",
+            purge: false,
+            version: "1.2.3",
+        });
+
+        expect(plan.installationMethod).toBe("npm");
+        expect(categoriesOf(plan.immediate)).not.toContain("binary");
+        expect(categoriesOf(plan.immediate)).not.toContain("versions");
+    });
+});
+
+describe("performSelfUninstall", () => {
+    test("unix removes immediate and deferred in-process", async () => {
+        const binaryPath = join(tempHome, "bin", "oo");
+        const versionsPath = join(tempHome, "versions");
+
+        await mkdir(join(tempHome, "bin"), { recursive: true });
+        await writeFile(binaryPath, "binary");
+        await mkdir(versionsPath, { recursive: true });
+
+        const plan: UninstallPlan = {
+            deferred: [],
+            immediate: [
+                { category: "binary", label: "x", path: binaryPath },
+                { category: "versions", label: "x", path: versionsPath },
+            ],
+            installationMethod: "native",
+            platform: "linux",
+            purge: false,
+            retainedSkills: [],
+        };
+
+        const result = await performSelfUninstall({
+            logger: noopLogger,
+            plan,
+            processId: 999_999,
+            timestamp: 1,
+        });
+
+        expect(result.status).toBe("completed");
+        expect((result as { deferredToHelper: boolean }).deferredToHelper).toBe(false);
+        expect(await Bun.file(binaryPath).exists()).toBe(false);
+    });
+
+    test("windows defers binary to spawned helper", async () => {
+        const stagingPath = join(tempHome, "staging");
+        const stagingMarker = join(stagingPath, "marker");
+        const helperDirectory = join(tempHome, "uninstall-helper");
+        const binaryPath = join(tempHome, "bin", "oo.exe");
+
+        await mkdir(stagingPath, { recursive: true });
+        await writeFile(stagingMarker, "x");
+        await mkdir(join(tempHome, "bin"), { recursive: true });
+        await writeFile(binaryPath, "binary");
+
+        const plan: UninstallPlan = {
+            deferred: [
+                { category: "binary", label: "x", path: binaryPath },
+            ],
+            helperDirectory,
+            immediate: [
+                { category: "staging", label: "x", path: stagingPath },
+            ],
+            installationMethod: "native",
+            platform: "win32",
+            purge: false,
+            retainedSkills: [],
+        };
+        const spawnedCommands: string[][] = [];
+
+        const result = await performSelfUninstall({
+            logger: noopLogger,
+            plan,
+            processId: 4242,
+            spawnDetached: command => spawnedCommands.push([...command]),
+            timestamp: 7,
+        });
+
+        expect(result.status).toBe("completed");
+        expect((result as { deferredToHelper: boolean }).deferredToHelper).toBe(true);
+        expect(spawnedCommands).toHaveLength(1);
+        expect(spawnedCommands[0]![0]).toBe("powershell");
+        // The running binary is NOT removed in-process; the helper handles it.
+        expect(await Bun.file(binaryPath).exists()).toBe(true);
+        // staging was removed in-process
+        expect(await Bun.file(stagingMarker).exists()).toBe(false);
+        // helper is written to its dedicated directory, not into a removed path
+        expect(spawnedCommands[0]!.at(-1)!.startsWith(helperDirectory)).toBe(true);
+    });
+
+    test("windows spawn failure aborts before destructive removal (P0)", async () => {
+        const stagingPath = join(tempHome, "staging");
+        const stagingMarker = join(stagingPath, "marker");
+        const binaryPath = join(tempHome, "bin", "oo.exe");
+
+        await mkdir(stagingPath, { recursive: true });
+        await writeFile(stagingMarker, "x");
+        await mkdir(join(tempHome, "bin"), { recursive: true });
+        await writeFile(binaryPath, "binary");
+
+        const plan: UninstallPlan = {
+            deferred: [
+                { category: "binary", label: "x", path: binaryPath },
+            ],
+            helperDirectory: join(tempHome, "uninstall-helper"),
+            immediate: [
+                { category: "staging", label: "x", path: stagingPath },
+            ],
+            installationMethod: "native",
+            platform: "win32",
+            purge: false,
+            retainedSkills: [],
+        };
+
+        await expect(performSelfUninstall({
+            logger: noopLogger,
+            plan,
+            processId: 1,
+            spawnDetached: () => {
+                throw new Error("spawn failed");
+            },
+            timestamp: 1,
+        })).rejects.toThrow();
+
+        // Nothing destructive happened: immediate items remain.
+        expect(await Bun.file(stagingMarker).exists()).toBe(true);
+        expect(await Bun.file(binaryPath).exists()).toBe(true);
+    });
+
+    test("reports failedPaths when a path cannot be removed (P1)", async () => {
+        // Platform-independent removal failure: the parent is a regular file,
+        // so removing `<file>/child` raises ENOTDIR (not the ENOENT that
+        // `force: true` tolerates). No chmod/ACL semantics, so it behaves the
+        // same on POSIX and Windows CI.
+        const parentFile = join(tempHome, "not-a-directory");
+        const unremovablePath = join(parentFile, "child");
+
+        await writeFile(parentFile, "x");
+
+        const plan: UninstallPlan = {
+            deferred: [],
+            immediate: [
+                { category: "user-data", label: "x", path: unremovablePath },
+            ],
+            installationMethod: "native",
+            platform: process.platform,
+            purge: true,
+            retainedSkills: [],
+        };
+
+        const result = await performSelfUninstall({
+            logger: noopLogger,
+            plan,
+            processId: 999_999,
+            timestamp: 1,
+        });
+
+        expect(result.status).toBe("completed");
+        expect((result as { failedPaths: string[] }).failedPaths).toContain(unremovablePath);
+    });
+});

--- a/src/application/self-update/uninstall.ts
+++ b/src/application/self-update/uninstall.ts
@@ -1,0 +1,491 @@
+import type { Logger } from "pino";
+import type { SkillMetadata } from "../commands/skills/skill-metadata.ts";
+
+import type { InstallationMethod } from "./installation.ts";
+import { mkdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { resolveStorePaths } from "../../adapters/store/store-path.ts";
+import {
+    canonicalBundledSkillsDirectoryName,
+    codexSkillsDirectoryName,
+} from "../commands/skills/bundled-skill-paths.ts";
+import { resolveAvailableManagedSkillHosts } from "../commands/skills/managed-skill-hosts.ts";
+import {
+    listManagedSkillInstallations,
+    listManagedSkillInstallationsForHosts,
+} from "../commands/skills/managed-skill-listings.ts";
+import {
+    resolveManagedSkillCanonicalRootDirectoryPath,
+} from "../commands/skills/managed-skill-paths.ts";
+import {
+    presetSkillPackageNames,
+} from "../commands/skills/preset-packages.ts";
+import { APP_NAME } from "../config/app-config.ts";
+import { pathExists } from "../shared/fs-utils.ts";
+import { detectInstallationMethodFromExecPath } from "./installation.ts";
+import { findAnyActiveVersionOwner } from "./lock.ts";
+import { resolveSelfUpdatePaths } from "./paths.ts";
+
+export type UninstallItemCategory
+    = | "binary"
+        | "versions"
+        | "staging"
+        | "locks"
+        | "bundled-skill"
+        | "registry-skill"
+        | "user-data";
+
+export interface UninstallPlanItem {
+    category: UninstallItemCategory;
+    label: string;
+    path: string;
+}
+
+export interface UninstallRetainedSkill {
+    path: string;
+    reason: "registry" | "local" | "unmanaged";
+}
+
+export interface UninstallPlan {
+    /**
+     * Items whose removal must be deferred to a post-exit helper (the Windows
+     * running image cannot unlink itself in-process). Membership in this array,
+     * not a per-item flag, is what marks an item as deferred.
+     */
+    deferred: UninstallPlanItem[];
+    /**
+     * Directory for the post-exit Windows cleanup helper. It is deliberately
+     * NOT one of the removed plan paths, so writing the helper there cannot
+     * recreate a directory we just deleted.
+     */
+    helperDirectory?: string;
+    immediate: UninstallPlanItem[];
+    installationMethod: InstallationMethod;
+    platform: NodeJS.Platform;
+    purge: boolean;
+    retainedSkills: UninstallRetainedSkill[];
+}
+
+export interface BuildUninstallPlanOptions {
+    env: Record<string, string | undefined>;
+    execPath: string;
+    homeDirectory?: string;
+    platform: NodeJS.Platform;
+    purge: boolean;
+    version: string;
+}
+
+/**
+ * Decide whether an oo-managed skill should be removed, based strictly on its
+ * `.oo-metadata.json`. Directory names are never trusted: a missing, invalid,
+ * or local metadata always means "retain", so a user-authored same-name skill
+ * is never deleted.
+ */
+export function shouldRemoveManagedSkill(
+    metadata: SkillMetadata | undefined,
+    options: { purge: boolean },
+): boolean {
+    if (metadata === undefined) {
+        return false;
+    }
+
+    if (metadata.kind === "bundled") {
+        return true;
+    }
+
+    if (metadata.kind === "registry") {
+        return options.purge
+            || (presetSkillPackageNames as readonly string[]).includes(
+                metadata.packageName,
+            );
+    }
+
+    return false;
+}
+
+export async function buildSelfUninstallPlan(
+    options: BuildUninstallPlanOptions,
+): Promise<UninstallPlan> {
+    const installationMethod = detectInstallationMethodFromExecPath({
+        env: options.env,
+        execPath: options.execPath,
+        platform: options.platform,
+    }).method;
+    const isWindows = options.platform === "win32";
+    const immediate: UninstallPlanItem[] = [];
+    const deferred: UninstallPlanItem[] = [];
+    const retainedSkills: UninstallRetainedSkill[] = [];
+    let helperDirectory: string | undefined;
+
+    if (installationMethod === "native") {
+        helperDirectory = addRuntimeItems({ deferred, immediate, isWindows, options });
+    }
+
+    const storePaths = resolveStorePaths({
+        appName: APP_NAME,
+        env: options.env,
+        homeDirectory: options.homeDirectory,
+        platform: options.platform,
+    });
+
+    await addSkillItems({
+        immediate,
+        options,
+        retainedSkills,
+        settingsFilePath: storePaths.settingsFilePath,
+    });
+
+    if (options.purge) {
+        addUserDataItems({ immediate, storePaths });
+    }
+
+    return {
+        deferred,
+        helperDirectory,
+        immediate,
+        installationMethod,
+        platform: options.platform,
+        purge: options.purge,
+        retainedSkills,
+    };
+}
+
+function addRuntimeItems(args: {
+    deferred: UninstallPlanItem[];
+    immediate: UninstallPlanItem[];
+    isWindows: boolean;
+    options: BuildUninstallPlanOptions;
+}): string {
+    const paths = resolveSelfUpdatePaths({
+        env: args.options.env,
+        homeDirectory: args.options.homeDirectory,
+        platform: args.options.platform,
+    });
+
+    // The currently running Windows image (`~/.local/bin/oo.exe`) cannot be
+    // unlinked while this process holds it open, so it is deferred to the
+    // post-exit helper. Every other runtime path — including the per-version
+    // directories — is a standalone copy and is safe to remove in-process on
+    // all platforms.
+    (args.isWindows ? args.deferred : args.immediate).push({
+        category: "binary",
+        label: "CLI executable",
+        path: paths.executablePath,
+    });
+
+    args.immediate.push(
+        {
+            category: "versions",
+            label: "Installed versions",
+            path: paths.versionsDirectory,
+        },
+        {
+            category: "staging",
+            label: "Self-update staging",
+            path: paths.stagingDirectory,
+        },
+        {
+            category: "locks",
+            label: "Self-update locks",
+            path: paths.locksDirectory,
+        },
+    );
+
+    // Sibling of staging/locks under `<temp|cache>/oo`, never itself a removed
+    // plan path, so the helper script can be written without recreating a
+    // directory we are about to delete.
+    return join(dirname(paths.stagingDirectory), "uninstall");
+}
+
+async function addSkillItems(args: {
+    immediate: UninstallPlanItem[];
+    options: BuildUninstallPlanOptions;
+    retainedSkills: UninstallRetainedSkill[];
+    settingsFilePath: string;
+}): Promise<void> {
+    const configDirectory = dirname(args.settingsFilePath);
+
+    // The bundled canonical root (`<config>/skills/bundled`) only ever contains
+    // oo-managed bundled canonical sources, so it is always removed wholesale.
+    const bundledCanonicalRoot = join(
+        configDirectory,
+        codexSkillsDirectoryName,
+        canonicalBundledSkillsDirectoryName,
+    );
+
+    if (await pathExists(bundledCanonicalRoot)) {
+        args.immediate.push({
+            category: "bundled-skill",
+            label: "Bundled skill canonical sources",
+            path: bundledCanonicalRoot,
+        });
+    }
+
+    const registryCanonicalRoot = resolveManagedSkillCanonicalRootDirectoryPath(
+        args.settingsFilePath,
+    );
+    const canonicalRegistrySkills = await listManagedSkillInstallations(
+        registryCanonicalRoot,
+    );
+
+    for (const skill of canonicalRegistrySkills) {
+        classifySkillForRemoval({
+            category: "registry-skill",
+            immediate: args.immediate,
+            metadata: skill.metadata,
+            path: skill.path,
+            purge: args.options.purge,
+            retainedSkills: args.retainedSkills,
+        });
+    }
+
+    const hosts = await resolveAvailableManagedSkillHosts(args.options.env);
+    const hostSkills = await listManagedSkillInstallationsForHosts(hosts);
+
+    for (const skill of hostSkills) {
+        classifySkillForRemoval({
+            category: skill.metadata?.kind === "registry"
+                ? "registry-skill"
+                : "bundled-skill",
+            immediate: args.immediate,
+            metadata: skill.metadata,
+            path: skill.path,
+            purge: args.options.purge,
+            retainedSkills: args.retainedSkills,
+        });
+    }
+}
+
+function classifySkillForRemoval(args: {
+    category: UninstallItemCategory;
+    immediate: UninstallPlanItem[];
+    metadata: SkillMetadata | undefined;
+    path: string;
+    purge: boolean;
+    retainedSkills: UninstallRetainedSkill[];
+}): void {
+    if (shouldRemoveManagedSkill(args.metadata, { purge: args.purge })) {
+        args.immediate.push({
+            category: args.category,
+            label: args.metadata?.kind === "registry"
+                ? "Registry skill"
+                : "Bundled skill",
+            path: args.path,
+        });
+        return;
+    }
+
+    args.retainedSkills.push({
+        path: args.path,
+        reason: resolveRetentionReason(args.metadata),
+    });
+}
+
+function resolveRetentionReason(
+    metadata: SkillMetadata | undefined,
+): UninstallRetainedSkill["reason"] {
+    if (metadata?.kind === "registry") {
+        return "registry";
+    }
+
+    if (metadata?.kind === "local") {
+        return "local";
+    }
+
+    return "unmanaged";
+}
+
+function addUserDataItems(args: {
+    immediate: UninstallPlanItem[];
+    storePaths: ReturnType<typeof resolveStorePaths>;
+}): void {
+    args.immediate.push(
+        {
+            category: "user-data",
+            label: "Auth credentials",
+            path: args.storePaths.authFilePath,
+        },
+        {
+            category: "user-data",
+            label: "Settings",
+            path: args.storePaths.settingsFilePath,
+        },
+        {
+            category: "user-data",
+            label: "Cache and data",
+            path: args.storePaths.dataDirectory,
+        },
+        {
+            category: "user-data",
+            label: "Telemetry",
+            path: args.storePaths.telemetryDirectory,
+        },
+        {
+            category: "user-data",
+            label: "Logs",
+            path: args.storePaths.logDirectoryPath,
+        },
+    );
+}
+
+export interface PerformUninstallOptions {
+    logger: Logger;
+    plan: UninstallPlan;
+    processId: number;
+    spawnDetached?: (command: readonly string[]) => void;
+    timestamp: number;
+}
+
+export type PerformUninstallResult
+    = | {
+        deferredToHelper: boolean;
+        failedPaths: string[];
+        status: "completed";
+    }
+    | {
+        ownerPid?: number;
+        status: "busy";
+    };
+
+export async function performSelfUninstall(
+    options: PerformUninstallOptions,
+): Promise<PerformUninstallResult> {
+    const locksItem = options.plan.immediate.find(item => item.category === "locks");
+
+    if (locksItem !== undefined) {
+        const owner = await findAnyActiveVersionOwner({
+            excludeProcessId: options.processId,
+            locksDirectory: locksItem.path,
+            platform: options.plan.platform,
+        });
+
+        if (owner !== undefined) {
+            return {
+                ownerPid: owner.ownerPid,
+                status: "busy",
+            };
+        }
+    }
+
+    // The Windows running image must be removed by a detached helper after this
+    // process exits. Write and spawn that helper FIRST: if spawning fails we
+    // throw before any destructive removal, so the install is never left
+    // half-removed. The helper only waits on this pid and deletes the deferred
+    // paths, so spawning it early is safe — it blocks until we exit.
+    const deferredToHelper = options.plan.deferred.length > 0;
+
+    if (deferredToHelper) {
+        await spawnWindowsCleanupHelper({
+            plan: options.plan,
+            processId: options.processId,
+            script: createWindowsSelfDeleteScript({
+                deferredPaths: options.plan.deferred.map(item => item.path),
+                processId: options.processId,
+            }),
+            spawnDetached: options.spawnDetached,
+            timestamp: options.timestamp,
+        });
+    }
+
+    const failedPaths: string[] = [];
+
+    for (const item of options.plan.immediate) {
+        await removePathTrackingFailures(item.path, failedPaths, options.logger);
+    }
+
+    if (!deferredToHelper) {
+        // Unix: the running binary's inode can be unlinked in-process.
+        for (const item of options.plan.deferred) {
+            await removePathTrackingFailures(item.path, failedPaths, options.logger);
+        }
+    }
+
+    return {
+        deferredToHelper,
+        failedPaths,
+        status: "completed",
+    };
+}
+
+export function createWindowsSelfDeleteScript(options: {
+    deferredPaths: readonly string[];
+    processId: number;
+}): string {
+    const removalLines = options.deferredPaths.map(
+        path => `Remove-Item -LiteralPath ${quotePowerShellSingle(path)} -Force -Recurse -ErrorAction SilentlyContinue`,
+    );
+
+    return [
+        "$ErrorActionPreference = 'SilentlyContinue'",
+        `Wait-Process -Id ${options.processId} -ErrorAction SilentlyContinue`,
+        ...removalLines,
+        // The helper removes itself last.
+        "Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue",
+        "",
+    ].join("\n");
+}
+
+async function spawnWindowsCleanupHelper(options: {
+    plan: UninstallPlan;
+    processId: number;
+    script: string;
+    spawnDetached?: (command: readonly string[]) => void;
+    timestamp: number;
+}): Promise<void> {
+    // The helper directory is deliberately not one of the removed plan paths.
+    const helperDirectory = options.plan.helperDirectory
+        ?? dirname(options.plan.deferred[0]!.path);
+    const helperPath = join(
+        helperDirectory,
+        `oo-uninstall.${options.processId}.${options.timestamp}.ps1`,
+    );
+
+    await mkdir(helperDirectory, { recursive: true });
+    await Bun.write(helperPath, options.script);
+
+    const command = [
+        "powershell",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        helperPath,
+    ];
+
+    if (options.spawnDetached !== undefined) {
+        options.spawnDetached(command);
+        return;
+    }
+
+    const subprocess = Bun.spawn({
+        cmd: command,
+        detached: true,
+        stderr: "ignore",
+        stdin: "ignore",
+        stdout: "ignore",
+        windowsHide: true,
+    });
+
+    subprocess.unref();
+}
+
+function quotePowerShellSingle(value: string): string {
+    return `'${value.replaceAll("'", "''")}'`;
+}
+
+async function removePathTrackingFailures(
+    path: string,
+    failedPaths: string[],
+    logger: Logger,
+): Promise<void> {
+    try {
+        // `force: true` already tolerates a missing path, so any throw here is
+        // a real failure (permission denied, busy, read-only fs, ...).
+        await rm(path, { force: true, recursive: true });
+    }
+    catch (error) {
+        failedPaths.push(path);
+        logger.warn({ err: error, path }, "Uninstall failed to remove a path.");
+    }
+}

--- a/src/application/self-update/uninstall.ts
+++ b/src/application/self-update/uninstall.ts
@@ -2,6 +2,7 @@ import type { Logger } from "pino";
 import type { SkillMetadata } from "../commands/skills/skill-metadata.ts";
 
 import type { InstallationMethod } from "./installation.ts";
+import type { SelfUpdatePaths } from "./paths.ts";
 import { mkdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { resolveStorePaths } from "../../adapters/store/store-path.ts";
@@ -115,10 +116,25 @@ export async function buildSelfUninstallPlan(
     const immediate: UninstallPlanItem[] = [];
     const deferred: UninstallPlanItem[] = [];
     const retainedSkills: UninstallRetainedSkill[] = [];
-    let helperDirectory: string | undefined;
+
+    const selfUpdatePaths = resolveSelfUpdatePaths({
+        env: options.env,
+        homeDirectory: options.homeDirectory,
+        platform: options.platform,
+    });
+
+    // The Windows post-exit helper owns removal of every path the running
+    // process holds open — the running image, and under `--purge` the SQLite
+    // data directory. Resolve its directory for every Windows plan so any
+    // deferred path has a post-exit home. It is a sibling of staging/locks under
+    // `<temp|cache>/oo` and is never itself a removed plan path, so writing the
+    // helper there cannot recreate a directory we just deleted.
+    const helperDirectory = isWindows
+        ? join(dirname(selfUpdatePaths.stagingDirectory), "uninstall")
+        : undefined;
 
     if (installationMethod === "native") {
-        helperDirectory = addRuntimeItems({ deferred, immediate, isWindows, options });
+        addRuntimeItems({ deferred, immediate, isWindows, paths: selfUpdatePaths });
     }
 
     const storePaths = resolveStorePaths({
@@ -136,7 +152,7 @@ export async function buildSelfUninstallPlan(
     });
 
     if (options.purge) {
-        addUserDataItems({ immediate, storePaths });
+        addUserDataItems({ deferred, immediate, isWindows, storePaths });
     }
 
     return {
@@ -154,13 +170,9 @@ function addRuntimeItems(args: {
     deferred: UninstallPlanItem[];
     immediate: UninstallPlanItem[];
     isWindows: boolean;
-    options: BuildUninstallPlanOptions;
-}): string {
-    const paths = resolveSelfUpdatePaths({
-        env: args.options.env,
-        homeDirectory: args.options.homeDirectory,
-        platform: args.options.platform,
-    });
+    paths: SelfUpdatePaths;
+}): void {
+    const paths = args.paths;
 
     // The currently running Windows image (`~/.local/bin/oo.exe`) cannot be
     // unlinked while this process holds it open, so it is deferred to the
@@ -190,11 +202,6 @@ function addRuntimeItems(args: {
             path: paths.locksDirectory,
         },
     );
-
-    // Sibling of staging/locks under `<temp|cache>/oo`, never itself a removed
-    // plan path, so the helper script can be written without recreating a
-    // directory we are about to delete.
-    return join(dirname(paths.stagingDirectory), "uninstall");
 }
 
 async function addSkillItems(args: {
@@ -296,7 +303,9 @@ function resolveRetentionReason(
 }
 
 function addUserDataItems(args: {
+    deferred: UninstallPlanItem[];
     immediate: UninstallPlanItem[];
+    isWindows: boolean;
     storePaths: ReturnType<typeof resolveStorePaths>;
 }): void {
     args.immediate.push(
@@ -310,11 +319,20 @@ function addUserDataItems(args: {
             label: "Settings",
             path: args.storePaths.settingsFilePath,
         },
-        {
-            category: "user-data",
-            label: "Cache and data",
-            path: args.storePaths.dataDirectory,
-        },
+    );
+
+    // The running process keeps the SQLite databases under the data directory
+    // (cache, uploads, download sessions) open. Windows refuses to delete files
+    // held open by a live process, so on Windows the data directory is handed to
+    // the post-exit helper instead of being removed in-process. On Unix an open
+    // file can still be unlinked, so it is removed immediately.
+    (args.isWindows ? args.deferred : args.immediate).push({
+        category: "user-data",
+        label: "Cache and data",
+        path: args.storePaths.dataDirectory,
+    });
+
+    args.immediate.push(
         {
             category: "user-data",
             label: "Telemetry",

--- a/src/application/self-update/uninstall.ts
+++ b/src/application/self-update/uninstall.ts
@@ -48,6 +48,7 @@ export interface UninstallRetainedSkill {
 }
 
 export interface UninstallPlan {
+    activeVersionLocksDirectory: string;
     /**
      * Items whose removal must be deferred to a post-exit helper (the Windows
      * running image cannot unlink itself in-process). Membership in this array,
@@ -156,6 +157,7 @@ export async function buildSelfUninstallPlan(
     }
 
     return {
+        activeVersionLocksDirectory: selfUpdatePaths.locksDirectory,
         deferred,
         helperDirectory,
         immediate,
@@ -172,8 +174,6 @@ function addRuntimeItems(args: {
     isWindows: boolean;
     paths: SelfUpdatePaths;
 }): void {
-    const paths = args.paths;
-
     // The currently running Windows image (`~/.local/bin/oo.exe`) cannot be
     // unlinked while this process holds it open, so it is deferred to the
     // post-exit helper. Every other runtime path — including the per-version
@@ -182,24 +182,24 @@ function addRuntimeItems(args: {
     (args.isWindows ? args.deferred : args.immediate).push({
         category: "binary",
         label: "CLI executable",
-        path: paths.executablePath,
+        path: args.paths.executablePath,
     });
 
     args.immediate.push(
         {
             category: "versions",
             label: "Installed versions",
-            path: paths.versionsDirectory,
+            path: args.paths.versionsDirectory,
         },
         {
             category: "staging",
             label: "Self-update staging",
-            path: paths.stagingDirectory,
+            path: args.paths.stagingDirectory,
         },
         {
             category: "locks",
             label: "Self-update locks",
-            path: paths.locksDirectory,
+            path: args.paths.locksDirectory,
         },
     );
 }
@@ -368,21 +368,17 @@ export type PerformUninstallResult
 export async function performSelfUninstall(
     options: PerformUninstallOptions,
 ): Promise<PerformUninstallResult> {
-    const locksItem = options.plan.immediate.find(item => item.category === "locks");
+    const owner = await findAnyActiveVersionOwner({
+        excludeProcessId: options.processId,
+        locksDirectory: options.plan.activeVersionLocksDirectory,
+        platform: options.plan.platform,
+    });
 
-    if (locksItem !== undefined) {
-        const owner = await findAnyActiveVersionOwner({
-            excludeProcessId: options.processId,
-            locksDirectory: locksItem.path,
-            platform: options.plan.platform,
-        });
-
-        if (owner !== undefined) {
-            return {
-                ownerPid: owner.ownerPid,
-                status: "busy",
-            };
-        }
+    if (owner !== undefined) {
+        return {
+            ownerPid: owner.ownerPid,
+            status: "busy",
+        };
     }
 
     // The Windows running image must be removed by a detached helper after this

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -703,6 +703,43 @@ export const enMessages = {
     "commands.update.description":
         "Update the managed CLI install to the latest published release.",
     "commands.update.summary": "Update the CLI",
+    "commands.uninstall.description":
+        "Uninstall the CLI runtime and its built-in skills. Use --purge to also remove user data and all oo-managed registry skills.",
+    "commands.uninstall.summary": "Uninstall the CLI",
+    "options.uninstall.yes": "Skip the confirmation prompt (required in non-interactive terminals)",
+    "options.uninstall.dryRun": "Print what would be removed without deleting anything",
+    "options.uninstall.purge":
+        "Also remove user data (auth, settings, cache, logs, telemetry) and all oo-managed registry skills",
+    "uninstall.plan.header": "oo uninstall plan",
+    "uninstall.plan.removeRuntime": "Runtime to remove:",
+    "uninstall.plan.removeSkills": "Skills to remove:",
+    "uninstall.plan.removeData": "User data to remove:",
+    "uninstall.plan.deferred": "Removed after this process exits:",
+    "uninstall.plan.retained": "Retained:",
+    "uninstall.plan.retainedSkill.registry": "  registry skill: {path}",
+    "uninstall.plan.retainedSkill.local": "  local skill: {path}",
+    "uninstall.plan.retainedSkill.unmanaged": "  unmanaged: {path}",
+    "uninstall.plan.item": "  {label}: {path}",
+    "uninstall.plan.nothing": "Nothing to remove.",
+    "uninstall.confirm.prompt":
+        "This will uninstall oo and remove the listed items. Continue? [y/N] ",
+    "uninstall.confirm.purgePrompt":
+        "This will uninstall oo and PERMANENTLY delete your auth, settings, and oo-managed registry skills. Continue? [y/N] ",
+    "uninstall.confirm.invalid": "Please answer y or n.",
+    "uninstall.confirm.cancelled": "Uninstall cancelled.",
+    "uninstall.error.confirmationRequired":
+        "Refusing to uninstall without confirmation. Re-run with --yes in a non-interactive terminal.",
+    "uninstall.busy":
+        "Another oo process (pid {pid}) is still running. Close it and retry.",
+    "uninstall.partialFailure":
+        "Uninstall could not remove {count} path(s). Check permissions and retry.",
+    "uninstall.success": "oo has been uninstalled.",
+    "uninstall.success.scheduled":
+        "oo runtime cleanup scheduled; the executable is removed once this process exits.",
+    "uninstall.packageManager":
+        "oo was installed with {method}. Removed oo-managed skills; remove the binary with: {command}",
+    "uninstall.unknown":
+        "Cannot locate a managed oo install for the current executable. Removed oo-managed skills only; remove the binary manually.",
     "commands.skills.checkUpdate.description":
         "Check for available updates for installed registry skills without downloading or modifying them.",
     "commands.skills.checkUpdate.summary":
@@ -1750,6 +1787,43 @@ export const zhMessages = {
     "commands.update.description":
         "把托管 CLI 安装更新到最新发布版本。",
     "commands.update.summary": "更新 CLI",
+    "commands.uninstall.description":
+        "卸载 CLI 运行时及其内置 skills。使用 --purge 可同时删除用户数据和全部由 oo 管理的 registry skills。",
+    "commands.uninstall.summary": "卸载 CLI",
+    "options.uninstall.yes": "跳过确认提示（非交互式终端下必须传入）",
+    "options.uninstall.dryRun": "只打印将删除的内容，不实际删除",
+    "options.uninstall.purge":
+        "同时删除用户数据（auth、settings、cache、logs、telemetry）和全部由 oo 管理的 registry skills",
+    "uninstall.plan.header": "oo 卸载计划",
+    "uninstall.plan.removeRuntime": "将删除的运行时：",
+    "uninstall.plan.removeSkills": "将删除的 skills：",
+    "uninstall.plan.removeData": "将删除的用户数据：",
+    "uninstall.plan.deferred": "在当前进程退出后删除：",
+    "uninstall.plan.retained": "将保留：",
+    "uninstall.plan.retainedSkill.registry": "  registry skill：{path}",
+    "uninstall.plan.retainedSkill.local": "  local skill：{path}",
+    "uninstall.plan.retainedSkill.unmanaged": "  未受管：{path}",
+    "uninstall.plan.item": "  {label}：{path}",
+    "uninstall.plan.nothing": "没有可删除的内容。",
+    "uninstall.confirm.prompt":
+        "这将卸载 oo 并删除上面列出的内容。是否继续？[y/N] ",
+    "uninstall.confirm.purgePrompt":
+        "这将卸载 oo，并**永久删除**你的 auth、settings 以及全部由 oo 管理的 registry skills。是否继续？[y/N] ",
+    "uninstall.confirm.invalid": "请输入 y 或 n。",
+    "uninstall.confirm.cancelled": "已取消卸载。",
+    "uninstall.error.confirmationRequired":
+        "未确认，拒绝卸载。在非交互式终端中请加 --yes 重试。",
+    "uninstall.busy":
+        "还有另一个 oo 进程（pid {pid}）在运行。请先关闭它再重试。",
+    "uninstall.partialFailure":
+        "卸载未能删除 {count} 个路径。请检查权限后重试。",
+    "uninstall.success": "oo 已卸载。",
+    "uninstall.success.scheduled":
+        "oo 运行时清理已计划；可执行文件会在当前进程退出后删除。",
+    "uninstall.packageManager":
+        "oo 是通过 {method} 安装的。已删除 oo 管理的 skills；请用以下命令删除二进制：{command}",
+    "uninstall.unknown":
+        "无法定位当前可执行文件对应的受管 oo 安装。仅删除了 oo 管理的 skills；请手动删除二进制。",
     "commands.skills.checkUpdate.description":
         "检查已安装的 registry skill 是否有可用更新，仅查询不下载也不写入。",
     "commands.skills.checkUpdate.summary":


### PR DESCRIPTION
Introduce `oo uninstall` to remove the managed oo runtime and its oo-owned skills, mirroring what `oo install` puts in place. By default it removes the managed executable, installed versions, self-update staging and locks, bundled skills, and the preset registry skill package, while leaving PATH config, user-authored skills, and unmanaged same-name directories untouched.

Skill removal is gated on `.oo-metadata.json` ownership so user-authored same-name skills are never deleted. `--purge` also clears user data and all oo-managed registry skills, `--dry-run` prints the plan without deleting, and `-y/--yes` is required in non-interactive terminals. On Windows the running executable is removed via a deferred one-shot PowerShell helper since a process cannot delete itself in place.

The preset skill package list moves into a shared preset-packages module so install and uninstall share a single source of truth, and the command refuses to run while another live oo process holds an active version marker.