### PR TITLE
feat(uninstall): remove config root on `--purge`

### DIFF
--- a/src/application/commands/uninstall.cli.test.ts
+++ b/src/application/commands/uninstall.cli.test.ts
@@ -8,6 +8,7 @@ import { createCliSandbox } from "../../../__tests__/helpers.ts";
 import { resolveStorePaths } from "../../adapters/store/store-path.ts";
 import { APP_NAME } from "../config/app-config.ts";
 import { resolveSelfUpdatePaths } from "../self-update/paths.ts";
+import { pathExists } from "../shared/fs-utils.ts";
 import { resolveManagedSkillMetadataFilePath } from "./skills/managed-skill-paths.ts";
 import { presetSkillPackageNames } from "./skills/preset-packages.ts";
 import {
@@ -200,6 +201,9 @@ describe("oo uninstall", () => {
             await mkdir(store.rootDirectory, { recursive: true });
             await writeFile(store.authFilePath, "id = \"\"\n");
             await writeFile(store.settingsFilePath, "x = 1\n");
+            // A residual file that no explicit child item targets: it must still
+            // be gone because --purge removes the whole config root.
+            await writeFile(join(store.rootDirectory, "leftover.txt"), "x");
             const registrySkill = await seedHostSkill({
                 sandbox,
                 skillName: "demo",
@@ -222,6 +226,9 @@ describe("oo uninstall", () => {
             expect(result.exitCode).toBe(0);
             expect(await Bun.file(store.authFilePath).exists()).toBe(false);
             expect(await Bun.file(store.settingsFilePath).exists()).toBe(false);
+            // The entire config root is removed, including residual files.
+            expect(await Bun.file(join(store.rootDirectory, "leftover.txt")).exists()).toBe(false);
+            expect(await pathExists(store.rootDirectory)).toBe(false);
             // All registry skills removed under purge
             expect(await Bun.file(join(registrySkill, "SKILL.md")).exists()).toBe(false);
             // Local still retained even under purge

--- a/src/application/commands/uninstall.cli.test.ts
+++ b/src/application/commands/uninstall.cli.test.ts
@@ -224,15 +224,32 @@ describe("oo uninstall", () => {
             });
 
             expect(result.exitCode).toBe(0);
+            // Config files are not held open, so they are removed in-process on
+            // every platform.
             expect(await Bun.file(store.authFilePath).exists()).toBe(false);
             expect(await Bun.file(store.settingsFilePath).exists()).toBe(false);
-            // The entire config root is removed, including residual files.
-            expect(await Bun.file(join(store.rootDirectory, "leftover.txt")).exists()).toBe(false);
-            expect(await pathExists(store.rootDirectory)).toBe(false);
             // All registry skills removed under purge
             expect(await Bun.file(join(registrySkill, "SKILL.md")).exists()).toBe(false);
             // Local still retained even under purge
             expect(await Bun.file(join(localSkill, "SKILL.md")).exists()).toBe(true);
+
+            if (process.platform === "win32") {
+                // The running process may still hold open SQLite handles under the
+                // config root, so its wholesale removal — and any residual files
+                // like leftover.txt — is deferred to the post-exit helper. Right
+                // after this in-process run the root is still present and the
+                // message reports a scheduled cleanup rather than a completed one.
+                expect(result.stdout).toContain("scheduled");
+                expect(await Bun.file(join(store.rootDirectory, "leftover.txt")).exists()).toBe(true);
+                expect(await pathExists(store.rootDirectory)).toBe(true);
+            }
+            else {
+                expect(result.stdout).toContain("uninstalled");
+                // The entire config root is removed in-process, including residual
+                // files.
+                expect(await Bun.file(join(store.rootDirectory, "leftover.txt")).exists()).toBe(false);
+                expect(await pathExists(store.rootDirectory)).toBe(false);
+            }
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/uninstall.ts
+++ b/src/application/commands/uninstall.ts
@@ -79,6 +79,13 @@ export const uninstallCommand: CliCommandDefinition<UninstallInput> = {
             ),
         });
 
+        // `--purge` deletes the config root, which contains the telemetry
+        // directory. Suppress this invocation's telemetry so the teardown flush
+        // does not re-create the directory we just removed.
+        if (purge && input.dryRun !== true) {
+            context.telemetry?.suppressCurrentInvocation();
+        }
+
         if (input.dryRun === true) {
             writeUninstallPlan(context, plan);
             return;

--- a/src/application/self-update/uninstall.test.ts
+++ b/src/application/self-update/uninstall.test.ts
@@ -6,6 +6,7 @@ import { join, win32 } from "node:path";
 import process from "node:process";
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { resolveStorePaths } from "../../adapters/store/store-path.ts";
 import { resolveManagedSkillMetadataFilePath } from "../commands/skills/managed-skill-paths.ts";
 import { presetSkillPackageNames } from "../commands/skills/preset-packages.ts";
 import {
@@ -14,6 +15,7 @@ import {
     createRegistrySkillMetadata,
     renderSkillMetadataJson,
 } from "../commands/skills/skill-metadata.ts";
+import { APP_NAME } from "../config/app-config.ts";
 import { readPathModule } from "./paths.ts";
 import {
     buildSelfUninstallPlan,
@@ -188,15 +190,56 @@ describe("buildSelfUninstallPlan", () => {
 
         expect(paths(immediateUserData).some(path => path.endsWith("auth.toml"))).toBe(true);
         expect(paths(immediateUserData).some(path => path.endsWith("settings.toml"))).toBe(true);
+
+        // The whole config root is also deferred on Windows (open SQLite under it).
+        const rootDirectory = resolveStorePaths({
+            appName: APP_NAME,
+            env: { HOME: tempHome },
+            homeDirectory: tempHome,
+            platform: "win32",
+        }).rootDirectory;
+
+        expect(paths(deferredUserData)).toContain(rootDirectory);
     });
 
-    test("--purge adds user-data targets", async () => {
+    test("--purge adds user-data targets including the config root last", async () => {
         const plan = await buildSelfUninstallPlan(nativeOptions({ purge: true }));
         const userData = plan.immediate.filter(item => item.category === "user-data");
 
         expect(userData.length).toBeGreaterThanOrEqual(4);
         expect(paths(userData).some(path => path.endsWith("auth.toml"))).toBe(true);
         expect(paths(userData).some(path => path.endsWith("settings.toml"))).toBe(true);
+
+        // The config root itself is removed, and it must be the last user-data
+        // item so it sweeps anything the explicit child items did not cover.
+        const rootDirectory = resolveStorePaths({
+            appName: APP_NAME,
+            env: { HOME: tempHome },
+            homeDirectory: tempHome,
+            platform: "linux",
+        }).rootDirectory;
+
+        expect(paths(userData)).toContain(rootDirectory);
+        expect(userData.at(-1)?.path).toBe(rootDirectory);
+    });
+
+    test("--purge config root resolves to the app-support directory on darwin", async () => {
+        const plan = await buildSelfUninstallPlan(
+            nativeOptions({ platform: "darwin", purge: true }),
+        );
+        const userData = plan.immediate.filter(item => item.category === "user-data");
+        const rootItem = userData.at(-1);
+
+        expect(rootItem?.path.endsWith(
+            join("Library", "Application Support", "oo"),
+        )).toBe(true);
+    });
+
+    test("non-purge plan never includes the config root", async () => {
+        const plan = await buildSelfUninstallPlan(nativeOptions());
+
+        expect(plan.immediate.every(item => item.category !== "user-data")).toBe(true);
+        expect(plan.deferred.every(item => item.category !== "user-data")).toBe(true);
     });
 
     test("classifies skills by metadata: bundled+preset removed, registry kept, local/unmanaged retained", async () => {

--- a/src/application/self-update/uninstall.ts
+++ b/src/application/self-update/uninstall.ts
@@ -344,6 +344,17 @@ function addUserDataItems(args: {
             path: args.storePaths.logDirectoryPath,
         },
     );
+
+    // Finally, remove the app-support/config root itself so no empty `skills/`
+    // parent or other residual app data is left behind. It must come last so it
+    // sweeps anything the explicit child items above did not cover. On Windows
+    // it is deferred for the same reason as the data directory: the running
+    // process may still hold open SQLite handles under this root.
+    (args.isWindows ? args.deferred : args.immediate).push({
+        category: "user-data",
+        label: "Configuration directory",
+        path: args.storePaths.rootDirectory,
+    });
 }
 
 export interface PerformUninstallOptions {


### PR DESCRIPTION
`--purge` previously deleted only explicitly targeted child items (auth.toml, settings.toml, logs, registry skills), leaving the app-support/config root behind with residual files and an empty `skills/` parent. Append the config root as the last user-data target so it sweeps anything the explicit items did not cover. On Windows it is deferred for the same reason as the data directory, since the running process may still hold open SQLite handles.

Removing the config root also deletes the telemetry directory, so suppress this invocation's telemetry when purging; otherwise the teardown flush would re-create the directory we just removed.