### PR TITLE
fix(uninstall): spawn windows cleanup helper via cmd start trampoline

### DIFF
--- a/src/application/self-update/uninstall.test.ts
+++ b/src/application/self-update/uninstall.test.ts
@@ -435,7 +435,10 @@ describe("performSelfUninstall", () => {
         expect(result.status).toBe("completed");
         expect((result as { deferredToHelper: boolean }).deferredToHelper).toBe(true);
         expect(spawnedCommands).toHaveLength(1);
-        expect(spawnedCommands[0]![0]).toBe("powershell");
+        // The helper is launched through a `cmd /c start "" /b` trampoline so it
+        // breaks away from Bun's job object and survives this process exit.
+        expect(spawnedCommands[0]!.slice(0, 5)).toEqual(["cmd", "/c", "start", "", "/b"]);
+        expect(spawnedCommands[0]).toContain("powershell");
         // The running binary is NOT removed in-process; the helper handles it.
         expect(await Bun.file(binaryPath).exists()).toBe(true);
         // staging was removed in-process
@@ -517,6 +520,81 @@ describe("performSelfUninstall", () => {
     });
 });
 
+describe("performSelfUninstall windows helper integration", () => {
+    // Exercises the REAL spawn path (no spawnDetached mock): a child Bun process
+    // runs performSelfUninstall for a win32 plan and exits; the post-exit helper
+    // must then unlink the deferred executable. This is the regression guard for
+    // the job-object bug where a directly-spawned helper was killed on parent
+    // exit and never removed the running image. Windows-only by nature.
+    test.skipIf(process.platform !== "win32")(
+        "spawned helper deletes the deferred executable after the parent exits",
+        async () => {
+            const exePath = join(tempHome, "bin", "oo.exe");
+            const helperDir = join(tempHome, "uninstall-helper");
+            const locksDir = join(tempHome, "locks");
+
+            await mkdir(join(tempHome, "bin"), { recursive: true });
+            await writeFile(exePath, "fake binary");
+
+            // The driver imports the real module by absolute file URL, runs the
+            // win32 plan against the fake executable, then exits so the helper
+            // can take over removal.
+            const moduleUrl = new URL("./uninstall.ts", import.meta.url).href;
+            const driverPath = join(tempHome, "uninstall-driver.ts");
+
+            await writeFile(driverPath, [
+                `import { performSelfUninstall } from ${JSON.stringify(moduleUrl)};`,
+                `const [exe, helper, locks] = process.argv.slice(2);`,
+                `const noop = { warn() {}, info() {}, debug() {}, error() {} } as never;`,
+                `await performSelfUninstall({`,
+                `  logger: noop,`,
+                `  plan: {`,
+                `    activeVersionLocksDirectory: locks,`,
+                `    deferred: [{ category: "binary", label: "oo", path: exe }],`,
+                `    helperDirectory: helper,`,
+                `    immediate: [],`,
+                `    installationMethod: "native",`,
+                `    platform: "win32",`,
+                `    purge: false,`,
+                `    retainedSkills: [],`,
+                `  },`,
+                `  processId: process.pid,`,
+                `  timestamp: Date.now(),`,
+                `});`,
+                ``,
+            ].join("\n"));
+
+            const driver = Bun.spawn({
+                cmd: [process.execPath, driverPath, exePath, helperDir, locksDir],
+                stderr: "ignore",
+                stdin: "ignore",
+                stdout: "ignore",
+            });
+
+            await driver.exited;
+
+            // The breakaway helper waits for the driver pid to exit, then unlinks
+            // the executable. Poll until it disappears.
+            expect(await waitForMissing(exePath, 20_000)).toBe(true);
+        },
+        30_000,
+    );
+});
+
 async function writeJsonFile(path: string, value: object): Promise<void> {
     await writeFile(path, `${JSON.stringify(value)}\n`);
+}
+
+async function waitForMissing(path: string, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        if (!(await Bun.file(path).exists())) {
+            return true;
+        }
+
+        await Bun.sleep(100);
+    }
+
+    return !(await Bun.file(path).exists());
 }

--- a/src/application/self-update/uninstall.ts
+++ b/src/application/self-update/uninstall.ts
@@ -468,7 +468,19 @@ async function spawnWindowsCleanupHelper(options: {
     await mkdir(helperDirectory, { recursive: true });
     await Bun.write(helperPath, options.script);
 
+    // Launch the helper through a `cmd /c start "" /b` trampoline. A process
+    // spawned directly by Bun joins Bun's kill-on-close job object and dies the
+    // instant this process exits: on Windows `detached` (UV_PROCESS_DETACHED)
+    // does NOT break a child out of that job, so a directly-spawned helper never
+    // survives to unlink the running image. `start` launches the helper as a
+    // job-breakaway process that outlives us. The empty "" is start's mandatory
+    // window-title argument; `/b` keeps it in this console so no window flashes.
     const command = [
+        "cmd",
+        "/c",
+        "start",
+        "",
+        "/b",
         "powershell",
         "-NoProfile",
         "-NonInteractive",
@@ -483,16 +495,20 @@ async function spawnWindowsCleanupHelper(options: {
         return;
     }
 
+    // Await the bootstrap `cmd`: `start` launches the breakaway helper and `cmd`
+    // exits immediately after. Awaiting guarantees the helper has been spawned
+    // before we return (and the caller proceeds to exit); otherwise the job
+    // could close and kill `cmd` before `start` ran. No `detached`/`unref()` is
+    // needed because the surviving helper is `start`'s child, not ours.
     const subprocess = Bun.spawn({
         cmd: command,
-        detached: true,
         stderr: "ignore",
         stdin: "ignore",
         stdout: "ignore",
         windowsHide: true,
     });
 
-    subprocess.unref();
+    await subprocess.exited;
 }
 
 function quotePowerShellSingle(value: string): string {


### PR DESCRIPTION
On Windows, `oo uninstall` left the running executable behind. The post-exit cleanup helper was launched with `Bun.spawn({ detached: true })`
+ `unref()`, but on Windows Bun places spawned children in a kill-on-close job object and `detached` (UV_PROCESS_DETACHED) does not break the child out of it. The helper was killed the instant the main process exited — before it could unlink the running image — leaving `oo.exe` on disk.

Launch the helper through a `cmd /c start "" /b` trampoline instead, which creates it as a process that breaks away from the job object and outlives the parent. Await the bootstrap `cmd` (rather than detached + unref) so `start` has launched the helper before we exit, closing the race where the job could close and kill `cmd` before `start` ran. The generated self-delete script is unchanged.

Update the Windows unit assertion for the new command shape, and add a real (non-mock) win32 integration test: a child process runs `performSelfUninstall`, exits, and the deferred executable must then be removed by the helper — covering the real spawn path that was previously exercised only through a mock.

The job-object behavior reproduces on bun 1.3.14 and 1.4.0-canary.1 (the Rust rewrite), so this is a deliberate long-term workaround rather than a version-specific patch.

Repro: https://github.com/BlackHole1/bun-detached-windows-bug
Issue: https://github.com/oven-sh/bun/issues/31603