### PR TITLE
feat: report download count on install skill

### DIFF
--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -225,6 +225,10 @@ describe("skills commands", () => {
                         }));
                     }
 
+                    if (isRegistryPackageDownloadCountRequest(request)) {
+                        return new Response(null, { status: 204 });
+                    }
+
                     throw new Error(`Unexpected request: ${request.url}`);
                 },
                 version: "9.9.9",
@@ -246,7 +250,7 @@ describe("skills commands", () => {
             await expect(stat(secondPresetSkillDirectoryPath)).resolves.toMatchObject({
                 isDirectory: expect.any(Function),
             });
-            expect(requests).toHaveLength(2);
+            expect(requests).toHaveLength(3);
         }
         finally {
             await sandbox.cleanup();
@@ -460,6 +464,10 @@ describe("skills commands", () => {
                             }));
                         }
 
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
+                        }
+
                         throw new Error(`Unexpected request: ${request.url}`);
                     },
                 },
@@ -472,6 +480,7 @@ describe("skills commands", () => {
             );
             expect(requests.map(request => request.url)).toEqual([
                 "https://registry.oomol.com/-/oomol/package-info/oo/0.0.2",
+                "https://registry.oomol.com/-/oomol/packages/oo/0.0.2/download-count",
                 "https://registry.oomol.com/oo/-/meta/oo-0.0.2.tgz",
             ]);
         }
@@ -2170,6 +2179,10 @@ describe("skills commands", () => {
                             }));
                         }
 
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
+                        }
+
                         throw new Error(`Unexpected request: ${request.url}`);
                     },
                 },
@@ -2215,9 +2228,10 @@ describe("skills commands", () => {
             expect(await readFile(metadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: "openai", version: "0.0.3" })),
             );
-            expect(requests).toHaveLength(2);
+            expect(requests).toHaveLength(3);
             expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
             expect(requests[1]!.headers.get("Authorization")).toBe("secret-1");
+            expect(requests[2]!.headers.get("Authorization")).toBe("secret-1");
             const telemetryPayload = parseTelemetryRowPayload(
                 readTelemetryRowsForTest(storePaths.telemetryDirectory)[0]!,
             );
@@ -2277,6 +2291,10 @@ describe("skills commands", () => {
                             }));
                         }
 
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
+                        }
+
                         throw new Error(`Unexpected request: ${request.url}`);
                     },
                 },
@@ -2289,6 +2307,7 @@ describe("skills commands", () => {
             );
             expect(requests.map(request => request.url)).toEqual([
                 "https://registry.oomol.com/-/oomol/package-info/%40alice%2Fopenai/0.0.2",
+                "https://registry.oomol.com/-/oomol/packages/@alice/openai/0.0.2/download-count",
                 "https://registry.oomol.com/@alice/openai/-/meta/openai-0.0.2.tgz",
             ]);
             expect(await readFile(metadataFilePath, "utf8")).toBe(
@@ -2339,6 +2358,10 @@ describe("skills commands", () => {
                             }));
                         }
 
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
+                        }
+
                         throw new Error(`Unexpected request: ${request.url}`);
                     },
                 },
@@ -2354,6 +2377,7 @@ describe("skills commands", () => {
             );
             expect(requests.map(request => request.url)).toEqual([
                 "https://registry.oomol.com/-/oomol/package-info/openai/latest",
+                "https://registry.oomol.com/-/oomol/packages/openai/0.0.3/download-count",
                 "https://registry.oomol.com/-/oomol/package-shares/download-meta/share-1",
             ]);
             expect(requests.every(request =>
@@ -2605,6 +2629,10 @@ describe("skills commands", () => {
                         }));
                     }
 
+                    if (isRegistryPackageDownloadCountRequest(request)) {
+                        return new Response(null, { status: 204 });
+                    }
+
                     throw new Error(`Unexpected request: ${request.url}`);
                 },
             });
@@ -2674,6 +2702,10 @@ describe("skills commands", () => {
                             return new Response(await createRegistrySkillArchiveBytes({
                                 [`package/package/skills/${skillName}/SKILL.md`]: `# ${skillName}\n`,
                             }));
+                        }
+
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
                         }
 
                         throw new Error(`Unexpected request: ${request.url}`);
@@ -2773,6 +2805,10 @@ describe("skills commands", () => {
                             return new Response(await createRegistrySkillArchiveBytes({
                                 "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
                             }));
+                        }
+
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
                         }
 
                         throw new Error(`Unexpected request: ${request.url}`);
@@ -2887,6 +2923,10 @@ describe("skills commands", () => {
                             }));
                         }
 
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
+                        }
+
                         throw new Error(`Unexpected request: ${request.url}`);
                     },
                 },
@@ -2940,6 +2980,10 @@ describe("skills commands", () => {
                                     },
                                 ],
                             }));
+                        }
+
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
                         }
 
                         throw new Error(`Unexpected request: ${request.url}`);
@@ -3003,6 +3047,10 @@ describe("skills commands", () => {
                             return new Response(await createRegistrySkillArchiveBytes({
                                 "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
                             }));
+                        }
+
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
                         }
 
                         throw new Error(`Unexpected request: ${request.url}`);
@@ -3070,6 +3118,10 @@ describe("skills commands", () => {
                             }));
                         }
 
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
+                        }
+
                         throw new Error(`Unexpected request: ${request.url}`);
                     },
                 },
@@ -3132,6 +3184,10 @@ describe("skills commands", () => {
                             "package/package/skills/chatgpt/SKILL.md": "# ChatGPT\n",
                             "package/package/skills/vision/SKILL.md": "# Vision\n",
                         }));
+                    }
+
+                    if (isRegistryPackageDownloadCountRequest(request)) {
+                        return new Response(null, { status: 204 });
                     }
 
                     throw new Error(`Unexpected request: ${request.url}`);
@@ -3246,6 +3302,10 @@ describe("skills commands", () => {
                         }));
                     }
 
+                    if (isRegistryPackageDownloadCountRequest(request)) {
+                        return new Response(null, { status: 204 });
+                    }
+
                     throw new Error(`Unexpected request: ${request.url}`);
                 },
                 stdin,
@@ -3335,6 +3395,10 @@ describe("skills commands", () => {
                             }));
                         }
 
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
+                        }
+
                         throw new Error(`Unexpected request: ${request.url}`);
                     },
                     stdin,
@@ -3401,6 +3465,10 @@ describe("skills commands", () => {
                             }));
                         }
 
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
+                        }
+
                         throw new Error(`Unexpected request: ${request.url}`);
                     },
                 },
@@ -3452,6 +3520,10 @@ describe("skills commands", () => {
                                     },
                                 ],
                             }));
+                        }
+
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
                         }
 
                         throw new Error(`Unexpected request: ${request.url}`);
@@ -3566,4 +3638,10 @@ async function writeLocalSkillDirectory(
         resolveManagedSkillMetadataFilePath(skillDirectoryPath),
         renderSkillMetadataJson(createLocalSkillMetadata()),
     );
+}
+
+function isRegistryPackageDownloadCountRequest(request: Request): boolean {
+    return request.method === "POST"
+        && request.url.includes("/-/oomol/packages/")
+        && request.url.endsWith("/download-count");
 }

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -42,6 +42,7 @@ import {
 import {
     downloadRegistryPackageTarball,
     loadRegistryPackageSkillInfo,
+    tryReportRegistryPackageDownload,
 } from "./registry-skill-source.ts";
 import { createSkillIdsTelemetryProperties } from "./telemetry.ts";
 
@@ -253,6 +254,12 @@ async function executeInstallActions(
         });
     }
 
+    await tryReportRegistryPackageDownload(
+        packageInfo.packageName,
+        packageInfo.packageVersion,
+        account,
+        context,
+    );
     const packageBytes = await downloadRegistryPackageTarball(
         packageInfo.packageName,
         packageInfo.packageVersion,

--- a/src/application/commands/skills/registry-skill-source.test.ts
+++ b/src/application/commands/skills/registry-skill-source.test.ts
@@ -14,6 +14,7 @@ import {
     createRegistryPackageTarballRequestUrl,
     downloadRegistryPackageTarball,
     loadRegistryPackageSkillInfo,
+    tryReportRegistryPackageDownload,
 } from "./registry-skill-source.ts";
 
 describe("registry skill source", () => {
@@ -120,7 +121,7 @@ describe("registry skill source", () => {
         expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
     });
 
-    test("reports download count before downloading the package tarball", async () => {
+    test("downloads a package tarball with authorization", async () => {
         const requests: Request[] = [];
         const context = createRegistrySkillSourceContext({
             fetcher: async (input, init) => {
@@ -141,14 +142,12 @@ describe("registry skill source", () => {
                 context,
             ),
         ).resolves.toEqual(new Uint8Array([1, 2, 3]));
-        expect(requests).toHaveLength(2);
-        expect(requests[0]!.method).toBe("POST");
-        expect(requests[0]!.url).toBe(
-            "https://registry.oomol.com/-/oomol/packages/openai/0.0.3/download-count",
-        );
+        expect(requests).toHaveLength(1);
         expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
-        expect(requests[0]!.headers.get("Content-Type")).toBe("application/json");
-        expect(requests[1]!.headers.get("Authorization")).toBe("secret-1");
+        expect(requests[0]!.method).toBe("GET");
+        expect(requests[0]!.url).toBe(
+            "https://registry.oomol.com/openai/-/meta/openai-0.0.3.tgz",
+        );
     });
 
     test("downloads a shared package tarball with authorization", async () => {
@@ -173,30 +172,54 @@ describe("registry skill source", () => {
                 "share-1",
             ),
         ).resolves.toEqual(new Uint8Array([4, 5, 6]));
-        expect(requests).toHaveLength(2);
-        expect(requests[1]!.url).toBe(
+        expect(requests).toHaveLength(1);
+        expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
+        expect(requests[0]!.method).toBe("GET");
+        expect(requests[0]!.url).toBe(
             "https://registry.oomol.com/-/oomol/package-shares/download-meta/share-1",
         );
-        expect(requests[1]!.headers.get("Authorization")).toBe("secret-1");
     });
 
-    test("download count reporting failure does not block package download", async () => {
+    test("reports package download count with authorization", async () => {
         const requests: Request[] = [];
         const context = createRegistrySkillSourceContext({
             fetcher: async (input, init) => {
-                const request = toRequest(input, init);
+                requests.push(toRequest(input, init));
 
-                requests.push(request);
-                if (request.url.endsWith("/download-count")) {
-                    return new Response("failed", { status: 500 });
-                }
+                return new Response(null, { status: 204 });
+            },
+        });
 
-                return new Response(new Uint8Array([7, 8, 9]));
+        await tryReportRegistryPackageDownload(
+            "openai",
+            "0.0.3",
+            {
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+            },
+            context,
+        );
+        expect(requests).toHaveLength(1);
+        expect(requests[0]!.method).toBe("POST");
+        expect(requests[0]!.url).toBe(
+            "https://registry.oomol.com/-/oomol/packages/openai/0.0.3/download-count",
+        );
+        expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
+        expect(requests[0]!.headers.get("Content-Type")).toBe("application/json");
+    });
+
+    test("download count reporting failure does not throw", async () => {
+        const requests: Request[] = [];
+        const context = createRegistrySkillSourceContext({
+            fetcher: async (input, init) => {
+                requests.push(toRequest(input, init));
+
+                return new Response("failed", { status: 500 });
             },
         });
 
         await expect(
-            downloadRegistryPackageTarball(
+            tryReportRegistryPackageDownload(
                 "openai",
                 "0.0.3",
                 {
@@ -205,13 +228,10 @@ describe("registry skill source", () => {
                 },
                 context,
             ),
-        ).resolves.toEqual(new Uint8Array([7, 8, 9]));
-        expect(requests).toHaveLength(2);
+        ).resolves.toBeUndefined();
+        expect(requests).toHaveLength(1);
         expect(requests[0]!.url).toBe(
             "https://registry.oomol.com/-/oomol/packages/openai/0.0.3/download-count",
-        );
-        expect(requests[1]!.url).toBe(
-            "https://registry.oomol.com/openai/-/meta/openai-0.0.3.tgz",
         );
     });
 });

--- a/src/application/commands/skills/registry-skill-source.test.ts
+++ b/src/application/commands/skills/registry-skill-source.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../../__tests__/helpers.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
 import {
+    createRegistryPackageDownloadCountRequestUrl,
     createRegistryPackageInfoRequestUrl,
     createRegistryPackageShareDownloadMetaRequestUrl,
     createRegistryPackageTarballRequestUrl,
@@ -62,6 +63,18 @@ describe("registry skill source", () => {
         );
     });
 
+    test("creates the package download count URL for scoped packages", () => {
+        expect(
+            createRegistryPackageDownloadCountRequestUrl(
+                "oomol.com",
+                "@foo/bar",
+                "1.2.3",
+            ).toString(),
+        ).toBe(
+            "https://registry.oomol.com/-/oomol/packages/@foo/bar/1.2.3/download-count",
+        );
+    });
+
     test("loads package skills info and ignores the when field", async () => {
         const requests: Request[] = [];
         const context = createRegistrySkillSourceContext({
@@ -107,7 +120,7 @@ describe("registry skill source", () => {
         expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
     });
 
-    test("downloads the package tarball with authorization", async () => {
+    test("reports download count before downloading the package tarball", async () => {
         const requests: Request[] = [];
         const context = createRegistrySkillSourceContext({
             fetcher: async (input, init) => {
@@ -128,8 +141,14 @@ describe("registry skill source", () => {
                 context,
             ),
         ).resolves.toEqual(new Uint8Array([1, 2, 3]));
-        expect(requests).toHaveLength(1);
+        expect(requests).toHaveLength(2);
+        expect(requests[0]!.method).toBe("POST");
+        expect(requests[0]!.url).toBe(
+            "https://registry.oomol.com/-/oomol/packages/openai/0.0.3/download-count",
+        );
         expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
+        expect(requests[0]!.headers.get("Content-Type")).toBe("application/json");
+        expect(requests[1]!.headers.get("Authorization")).toBe("secret-1");
     });
 
     test("downloads a shared package tarball with authorization", async () => {
@@ -154,11 +173,46 @@ describe("registry skill source", () => {
                 "share-1",
             ),
         ).resolves.toEqual(new Uint8Array([4, 5, 6]));
-        expect(requests).toHaveLength(1);
-        expect(requests[0]!.url).toBe(
+        expect(requests).toHaveLength(2);
+        expect(requests[1]!.url).toBe(
             "https://registry.oomol.com/-/oomol/package-shares/download-meta/share-1",
         );
-        expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
+        expect(requests[1]!.headers.get("Authorization")).toBe("secret-1");
+    });
+
+    test("download count reporting failure does not block package download", async () => {
+        const requests: Request[] = [];
+        const context = createRegistrySkillSourceContext({
+            fetcher: async (input, init) => {
+                const request = toRequest(input, init);
+
+                requests.push(request);
+                if (request.url.endsWith("/download-count")) {
+                    return new Response("failed", { status: 500 });
+                }
+
+                return new Response(new Uint8Array([7, 8, 9]));
+            },
+        });
+
+        await expect(
+            downloadRegistryPackageTarball(
+                "openai",
+                "0.0.3",
+                {
+                    apiKey: "secret-1",
+                    endpoint: "oomol.com",
+                },
+                context,
+            ),
+        ).resolves.toEqual(new Uint8Array([7, 8, 9]));
+        expect(requests).toHaveLength(2);
+        expect(requests[0]!.url).toBe(
+            "https://registry.oomol.com/-/oomol/packages/openai/0.0.3/download-count",
+        );
+        expect(requests[1]!.url).toBe(
+            "https://registry.oomol.com/openai/-/meta/openai-0.0.3.tgz",
+        );
     });
 });
 

--- a/src/application/commands/skills/registry-skill-source.ts
+++ b/src/application/commands/skills/registry-skill-source.ts
@@ -63,6 +63,18 @@ export function createRegistryPackageShareDownloadMetaRequestUrl(
     );
 }
 
+export function createRegistryPackageDownloadCountRequestUrl(
+    endpoint: string,
+    packageName: string,
+    packageVersion: string,
+): URL {
+    const packagePath = encodeURI(packageName);
+
+    return new URL(
+        `https://registry.${endpoint}/-/oomol/packages/${packagePath}/${encodeURIComponent(packageVersion)}/download-count`,
+    );
+}
+
 export async function loadRegistryPackageSkillInfo(
     packageName: string,
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
@@ -122,6 +134,12 @@ export async function downloadRegistryPackageTarball(
                 account.endpoint,
                 packageShareId,
             );
+    await reportRegistryPackageDownload(
+        packageName,
+        packageVersion,
+        account,
+        context,
+    );
     const response = await performLoggedRequest({
         context,
         createRequestFailedError: status => new CliUserError(
@@ -151,6 +169,60 @@ export async function downloadRegistryPackageTarball(
     });
 
     return new Uint8Array(await response.arrayBuffer());
+}
+
+async function reportRegistryPackageDownload(
+    packageName: string,
+    packageVersion: string,
+    account: Pick<AuthAccount, "apiKey" | "endpoint">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
+): Promise<void> {
+    const requestUrl = createRegistryPackageDownloadCountRequestUrl(
+        account.endpoint,
+        packageName,
+        packageVersion,
+    );
+
+    try {
+        await performLoggedRequest({
+            context,
+            createRequestFailedError: status => new CliUserError(
+                "errors.skills.install.packageDownloadFailed",
+                1,
+                {
+                    status,
+                },
+            ),
+            createUnexpectedError: error => new CliUserError(
+                "errors.skills.install.packageDownloadError",
+                1,
+                {
+                    message: error instanceof Error ? error.message : String(error),
+                },
+            ),
+            fields: {
+                common: withPackageIdentity(packageName, packageVersion),
+            },
+            init: {
+                headers: {
+                    "Authorization": account.apiKey,
+                    "Content-Type": "application/json",
+                },
+                method: "POST",
+            },
+            requestLabel: "Skills install package download count",
+            requestUrl,
+        });
+    }
+    catch (error) {
+        context.logger.warn(
+            {
+                err: error,
+                ...withPackageIdentity(packageName, packageVersion),
+            },
+            "Failed to report registry skill package download count.",
+        );
+    }
 }
 
 function parseRegistryPackageSkillInfo(

--- a/src/application/commands/skills/registry-skill-source.ts
+++ b/src/application/commands/skills/registry-skill-source.ts
@@ -134,12 +134,6 @@ export async function downloadRegistryPackageTarball(
                 account.endpoint,
                 packageShareId,
             );
-    await reportRegistryPackageDownload(
-        packageName,
-        packageVersion,
-        account,
-        context,
-    );
     const response = await performLoggedRequest({
         context,
         createRequestFailedError: status => new CliUserError(
@@ -171,7 +165,7 @@ export async function downloadRegistryPackageTarball(
     return new Uint8Array(await response.arrayBuffer());
 }
 
-async function reportRegistryPackageDownload(
+export async function tryReportRegistryPackageDownload(
     packageName: string,
     packageVersion: string,
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
@@ -214,14 +208,7 @@ async function reportRegistryPackageDownload(
             requestUrl,
         });
     }
-    catch (error) {
-        context.logger.warn(
-            {
-                err: error,
-                ...withPackageIdentity(packageName, packageVersion),
-            },
-            "Failed to report registry skill package download count.",
-        );
+    catch {
     }
 }
 

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -244,6 +244,10 @@ describe("skills update command", () => {
                             }));
                         }
 
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
+                        }
+
                         throw new Error(`Unexpected request: ${request.url}`);
                     },
                 },
@@ -344,6 +348,10 @@ describe("skills update command", () => {
                             }));
                         }
 
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
+                        }
+
                         throw new Error(`Unexpected request: ${request.url}`);
                     },
                 },
@@ -424,6 +432,10 @@ describe("skills update command", () => {
                             return new Response(await createRegistrySkillArchiveBytes({
                                 "package/package/skills/chatgpt/SKILL.md": "# ChatGPT fresh\n",
                             }));
+                        }
+
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
                         }
 
                         throw new Error(`Unexpected request: ${request.url}`);
@@ -553,6 +565,10 @@ describe("skills update command", () => {
                             }));
                         }
 
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
+                        }
+
                         throw new Error(`Unexpected request: ${request.url}`);
                     },
                 },
@@ -645,6 +661,10 @@ describe("skills update command", () => {
                             }));
                         }
 
+                        if (isRegistryPackageDownloadCountRequest(request)) {
+                            return new Response(null, { status: 204 });
+                        }
+
                         throw new Error(`Unexpected request: ${request.url}`);
                     },
                 },
@@ -730,6 +750,10 @@ describe("skills update command", () => {
                         return new Response(await createRegistrySkillArchiveBytes({
                             "package/package/skills/chatgpt/SKILL.md": "# ChatGPT fresh\n",
                         }));
+                    }
+
+                    if (isRegistryPackageDownloadCountRequest(request)) {
+                        return new Response(null, { status: 204 });
                     }
 
                     throw new Error(`Unexpected request: ${request.url}`);
@@ -868,4 +892,10 @@ async function writeUnparseableManagedSkillInstallation(
     await mkdir(skillDirectoryPath, { recursive: true });
     await Bun.write(join(skillDirectoryPath, "SKILL.md"), "# Broken\n");
     await Bun.write(resolveManagedSkillMetadataFilePath(skillDirectoryPath), "{\n");
+}
+
+function isRegistryPackageDownloadCountRequest(request: Request): boolean {
+    return request.method === "POST"
+        && request.url.includes("/-/oomol/packages/")
+        && request.url.endsWith("/download-count");
 }

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -55,6 +55,7 @@ import {
 import {
     downloadRegistryPackageTarball,
     loadRegistryPackageSkillInfo,
+    tryReportRegistryPackageDownload,
 } from "./registry-skill-source.ts";
 import { isBundledSkillName } from "./shared.ts";
 import {
@@ -608,6 +609,12 @@ async function prepareRegistrySkillGroupUpdate(
             ),
         );
 
+        await tryReportRegistryPackageDownload(
+            packageInfo.packageName,
+            packageInfo.packageVersion,
+            options.account,
+            context,
+        );
         const packageBytes = await downloadRegistryPackageTarball(
             packageInfo.packageName,
             packageInfo.packageVersion,
@@ -1099,6 +1106,12 @@ async function runGroupUpdateJson(
             ),
         );
 
+        await tryReportRegistryPackageDownload(
+            packageInfo.packageName,
+            packageInfo.packageVersion,
+            account,
+            context,
+        );
         packageBytes = await downloadRegistryPackageTarball(
             packageInfo.packageName,
             packageInfo.packageVersion,


### PR DESCRIPTION
## Summary
- Report registry package download counts once from install/update flows before tarball downloads.
- Keep tarball download helpers focused on fetching package bytes.
- Keep download-count reporting non-blocking and covered by source/install/update tests.

## Verification
- bun run lint:fix
- bun run ts-check
- bun run test
