### PR TITLE
[codex] focus create-skill on connector actions

### DIFF
--- a/contrib/skills/shared/oo-create-skill/SKILL.md
+++ b/contrib/skills/shared/oo-create-skill/SKILL.md
@@ -52,7 +52,10 @@ separate checklist.
    the capability, inspect metadata, run the smallest safe test when command,
    result, status, file, or envelope shape matters, and write from observed
    facts. Do not spend meaningful user money, mutate external state, disclose
-   sensitive data, or trigger large jobs only to learn a response shape.
+   sensitive data, or trigger large jobs only to learn a response shape. For
+   cheap, non-sensitive artifact transforms with tiny synthetic inputs, run one
+   representative invocation before finalizing unless the user or connector
+   context makes that unsafe.
 5. Choose the most direct executable connector action for the user's outcome.
    Use only connector entries as authoring candidates; treat non-connector
    entries as non-authoring catalog noise. During selection, classify service
@@ -81,7 +84,17 @@ separate checklist.
    not hand-roll transfer logic, and do not pass local filesystem paths or
    `file://` URLs to remote connector actions unless the schema explicitly
    supports local paths.
-7. Generated skills are execution runbooks. Write a compact execution runbook,
+7. Resolve user-provided files into readable runtime sources. For file, image,
+   audio, video, or document workflows, generated skills must distinguish
+   explicit local paths, remote URLs, environment-exposed attachment paths, and
+   chat-visible media that the CLI cannot read directly. If a pasted or
+   displayed attachment has no readable path or URL, say so and ask for a path
+   or use a clearly labeled recent-file fallback only when practical. If
+   multiple candidate files are present, compare concrete evidence such as
+   path, timestamp, size, type, hash, or preview. If candidates differ and the
+   intended source remains ambiguous, ask the user. If candidate hashes match,
+   treat them as the same source and explain the chosen file briefly.
+8. Generated skills are execution runbooks. Write a compact execution runbook,
    not API documentation. Keep generated skills concise and domain-focused.
    Include concrete connector service/action identifiers plus the minimum
    payload, result, file-transfer, artifact handoff, and failure guidance needed
@@ -92,12 +105,16 @@ separate checklist.
    future agents to preview the artifact when practical, or otherwise deliver
    it with a clear path, attachment, link, or user-appropriate handoff. A
    successful file path alone is not enough if the user cannot see or access the
-   result.
-8. Native skill commands are mandatory. Run the dedicated preflight, initialize
+   result. For local artifact downloads, default to the input file's directory
+   when the input was a local file; otherwise choose a user-accessible output
+   directory such as Downloads or an explicit requested directory. Do not
+   default generated artifacts into the current repository workspace unless the
+   user asked for that destination.
+9. Native skill commands are mandatory. Run the dedicated preflight, initialize
    with `oo skills init --agent <!-- agentic:var agent -->`, and validate with
    `oo skills validate`. Do not substitute manual file creation for native skill
    initialization.
-9. Write generated skills in English regardless of the user's language,
+10. Write generated skills in English regardless of the user's language,
    including `--description`, `--title`, frontmatter, headings, examples, and
    reference files. Preserve non-English only for literal runtime values,
    product names, language-pair requirements, or necessary sample I/O.
@@ -213,6 +230,13 @@ only to learn a response shape; ask the user or use documented dry-run or
 read-only paths when those risks are material. If a field path is inferred from
 schema rather than observed, label it as untested.
 
+Record the full `oo connector run --json` response paths that future agents must
+read, not only the connector payload's inner field names. If the CLI wraps the
+connector payload under `data` and adds `meta`, make that envelope explicit, for
+example `response.data.sessionId`, `response.data.state`, or
+`response.data.data.image.url`. When useful, also state the inner connector
+payload path separately.
+
 ### 5. Initialize the local skill
 
 Run `oo skills init <name> --agent <!-- agentic:var agent -->` with a required `--description`.
@@ -261,6 +285,9 @@ include these execution facts when metadata provides them:
 - Runtime input policy: when to use the skill, required inputs, inputs that can
   be inferred or defaulted, optional inputs to omit when absent, and the exact
   missing runtime values that justify asking the user.
+- Source resolution for file-like inputs: how to handle explicit local paths,
+  remote URLs, environment-exposed attachment paths, chat-visible media with no
+  readable CLI path, recent-file fallback, and multiple candidate files.
 - Invocation: the exact `service.action` and minimal
   `oo connector run "<service>" --action "<action>" --data ... --json` command
   shape. Include a small payload skeleton with schema-derived field names. For
@@ -269,13 +296,23 @@ include these execution facts when metadata provides them:
 - Payload rules: required fields, defaultable fields, accepted file or URL
   forms, and schema constraints that affect user-visible behavior.
 - Result handling: JSON field paths that contain the useful result,
-  downloadable artifact URL, status, id, or human-readable output. State what
-  to report on success and what not to treat as the final result. For generated
+  downloadable artifact URL, status, id, or human-readable output. Include full
+  CLI response paths when `--json` adds an envelope, and label schema-only paths
+  as untested. State what to report on success and what not to treat as the
+  final result. For generated
   files, images, documents, archives, media, or other artifacts, state how
   future agents should preview them or deliver them to the user instead of only
   reporting a local path. For inline base64 or `data:` URI artifacts, tell
   future agents to save and preview the artifact rather than printing the full
   encoded payload.
+- Async handling: for submit/poll/result workflows, include the status values,
+  bounded retry policy, not-found or timeout stop conditions, and an early-exit
+  rule that stops polling immediately when the terminal success state appears.
+- Artifact destination and verification: choose a default output directory that
+  avoids polluting an unrelated repository, use a non-conflicting name such as
+  an original stem plus a suffix, report the actual saved path, and verify the
+  artifact type after download. For transparent image outputs, require a PNG
+  alpha/RGBA check and dimensions check when practical.
 - Failure handling: action-specific stop conditions from schema or metadata,
   plus common auth, permission, billing, schema rejection, inaccessible file,
   timeout, and not-found branches.
@@ -311,7 +348,23 @@ observed metadata, output shape, or documented oo workflow exposes.
 
 Before finishing, check that a future agent can reach the selected capability
 without rediscovery, build a valid payload, read the useful result, and stop on
-common failures. If not, add only the missing execution guidance.
+common failures. For file or artifact connector skills, also check that the
+runbook answers:
+
+- How does the runtime agent obtain a readable source from an explicit path,
+  URL, exposed attachment path, or chat-visible media?
+- What exact command uploads local files, invokes the connector, polls async
+  status when needed, fetches results, and downloads artifacts?
+- What full CLI JSON response path contains the job id, status, result text, or
+  artifact URL?
+- What condition stops polling immediately, and what conditions stop with a
+  failure or bounded timeout?
+- Where is the artifact downloaded by default, and does that avoid polluting an
+  unrelated git workspace?
+- How is the artifact verified after download, and what should be shown or
+  reported to the user?
+
+If any answer is missing, add only the missing execution guidance.
 
 Keep `SKILL.md` concise. Use `references/workflow.md` only when the workflow
 has several steps, decision rules, or examples.

--- a/contrib/skills/shared/oo-create-skill/SKILL.md
+++ b/contrib/skills/shared/oo-create-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oo-create-skill
-description: Author, generate, or scaffold a new local AI agent skill that turns an OOMOL/oo package, connector action, block, or selected workflow into reusable instructions. Use when the user asks to create a skill, write a skill, or make a Codex/Claude/agent skill for an oo-powered workflow, even if capability discovery is needed first.
+description: Author, generate, or scaffold a new local AI agent skill that turns a concrete oo connector action, including OOMOL-hosted Fusion API actions, into reusable instructions. Use when the user asks to create a skill, write a skill, or make a Codex/Claude/agent skill for an oo-powered workflow, even if capability discovery is needed first.
 <!-- agentic:if agent=claude|hermes -->
 allowed-tools: [Bash(oo *)]
 <!-- agentic:endif -->
@@ -8,67 +8,96 @@ allowed-tools: [Bash(oo *)]
 
 # oo Create Skill
 
-Use this skill to create a new local skill around an OOMOL/oo package, block,
-connector action, or selected workflow. This includes turning a known or newly
-discovered capability into reusable agent instructions.
+Use this skill to create a new local skill around a concrete oo connector
+action. This includes turning a known or newly discovered connector capability
+into reusable agent instructions.
 
-If the user only wants to discover or install existing published skills, use
-`oo-find-skills`. If the user wants to publish a finished skill, use
-`oo-publish-skill`.
+This skill only authors local skills. If the user wants to find or install an
+existing skill, or distribute a finished skill, use the dedicated workflow for
+that task instead.
+
+This document has two roles:
+
+- Authoring agent: the current agent creating the skill.
+- Runtime agent: a future agent using the generated skill.
 
 ## Constitution
 
-Use these rules to decide confidently. The workflow below is an application of
-this constitution, not a separate checklist.
+Use these rules to decide confidently. These governing principles define the
+decision model. The workflow below is an application of this constitution, not a
+separate checklist.
 
-1. User intent defines the reusable contract. Ask the user when a business
+1. Scope is local skill authoring. Create local skills around concrete oo
+   connector actions, including OOMOL-hosted Fusion API actions. Do not use this
+   workflow to find, install, update, publish, or distribute existing skills.
+2. User intent defines the reusable contract. Ask the user when a business
    decision would change the skill's repeated-use behavior: skill name or
    scope, workflow ordering, required user inputs, expected outputs, target
    service, account, cost, compliance, data routing, output destination, or a
    metadata ambiguity with multiple user-visible outcomes. Prefer a short
    choice prompt with a recommended option when asking; add a free-form input
    option only when the decision cannot be covered by concrete choices.
-2. `oo` metadata and command output define execution facts. Do not ask the user
+3. `oo` metadata and command output define execution facts. Do not ask the user
    to resolve facts that metadata, schemas, or command output can answer:
-   package/block references, connector service/action identifiers, payload
-   field names, result field paths, command shape, authentication state,
-   defaults, or schema constraints. Use `oo connector schema` for connector
-   contracts; current command output or a safe invocation must confirm
-   connector action availability and observed result paths.
-3. Resolve and test before writing the runbook. Do not predesign the whole
+   connector service/action identifiers, payload field names, result field
+   paths, command shape, authentication state, defaults, or schema constraints.
+   Use `oo connector schema "<service>" --action "<action>"` to prove the
+   selected action contract. Current command output or a safe invocation must
+   confirm action availability; observed result paths are preferred when a safe
+   invocation is proportionate, but result paths may also come from schema; if a
+   field path is inferred from schema rather than observed, label it as
+   untested.
+4. Resolve and test before writing the runbook. Do not predesign the whole
    execution process and then look for metadata that seems to fit it. Discover
    the capability, inspect metadata, run the smallest safe test when command,
    result, status, file, or envelope shape matters, and write from observed
-   facts. Mark schema-only inferences as untested. The generated skill must
-   contain concrete package/block references or connector service/action
-   identifiers plus the minimum payload, result, and failure guidance needed so
-   future agents do not run discovery again.
-4. Choose the most direct capability for the user's outcome. Treat Fusion API,
-   connector actions, packages, and blocks as first-class candidates. Prefer
-   domain fit over result ordering, then prefer Fusion API first, already
-   authenticated connectors second, and packages or blocks after those. When
-   choices are otherwise equivalent, choose Fusion API by default because it
-   avoids user-managed provider credentials. Ask the user to choose only when
-   provider, account, cost, compliance, data-routing, or output-contract
-   differences are material.
-5. Preserve the local/cloud boundary. Generated skills must tell future agents
-   to upload local attachments with `oo file upload "<filePath>" --json`, pass
-   the returned `downloadUrl` into cloud payloads, and save remote artifacts
-   with `oo file download "<url>" [outDir] [--name "<name>"] [--ext "<ext>"]`.
+   facts. Do not spend meaningful user money, mutate external state, disclose
+   sensitive data, or trigger large jobs only to learn a response shape.
+5. Choose the most direct executable connector action for the user's outcome.
+   Use only connector entries as authoring candidates; treat non-connector
+   entries as non-authoring catalog noise. During selection, classify service
+   `fusion-api` as OOMOL-hosted Fusion API, which does not require the user to
+   provide their own provider API key. After discovery, prefer a matching
+   `fusion-api` action by default for generic managed transforms such as
+   background removal, OCR, translation, transcription, TTS, image generation,
+   and document conversion. Choose a non-Fusion connector action when the user
+   explicitly names an external service, account, or provider; when Fusion API
+   is unavailable or does not fit the required output; or when provider,
+   account, cost, compliance, data-routing, or output-contract differences are
+   material enough to require a user decision.
+6. Preserve the local/remote connector file boundary. For connector or Fusion
+   API execution, local files are not remotely addressable. Generated skills
+   must tell future agents to upload a local file by default when the selected
+   action input needs file content and its schema accepts a URI/URL-compatible
+   value; run `oo file upload "<filePath>" --json` and pass the returned
+   `downloadUrl`. Skip upload only when the user already provided a remote URL
+   or when the schema explicitly requires a different supported input shape,
+   such as an inline value or connector-specific file identifier. Save remote
+   artifacts with `oo file download "<url>" [outDir] [--name "<name>"] [--ext
+   "<ext>"]` only when the action schema or description identifies the output
+   field as a downloadable artifact URL and the task needs a local file result.
    `oo file download` prints `Saved to: <path>` and does not support `--json`.
    Do not treat these file-transfer commands as capabilities to rediscover, do
-   not hand-roll transfer logic, and do not pass local filesystem paths to cloud
-   actions unless the schema explicitly supports local paths.
-6. Make file artifacts visible to the user. When a generated skill can produce
-   images, documents, archives, media, or other files, it must tell future
-   agents to preview the artifact when practical, or otherwise deliver it with
-   a clear path, attachment, link, or user-appropriate handoff. A successful
-   file path alone is not enough if the user cannot see or access the result.
-7. Write a runbook, not API documentation. Keep generated skills concise and
-   domain-focused. Include the facts needed to execute reliably; omit broad oo
-   mechanics, full schema dumps, and implementation details that the managed OO
-   notice already covers.
-8. Write generated skills in English regardless of the user's language,
+   not hand-roll transfer logic, and do not pass local filesystem paths or
+   `file://` URLs to remote connector actions unless the schema explicitly
+   supports local paths.
+7. Generated skills are execution runbooks. Write a compact execution runbook,
+   not API documentation. Keep generated skills concise and domain-focused.
+   Include concrete connector service/action identifiers plus the minimum
+   payload, result, file-transfer, artifact handoff, and failure guidance needed
+   so future agents do not run discovery again. Omit broad oo mechanics, full
+   schema dumps, and implementation details that the managed OO notice already
+   covers. Make file artifacts visible to the user: when a generated skill can
+   produce images, documents, archives, media, or other files, it must tell
+   future agents to preview the artifact when practical, or otherwise deliver
+   it with a clear path, attachment, link, or user-appropriate handoff. A
+   successful file path alone is not enough if the user cannot see or access the
+   result.
+8. Native skill commands are mandatory. Run the dedicated preflight, initialize
+   with `oo skills init --agent <!-- agentic:var agent -->`, and validate with
+   `oo skills validate`. Do not substitute manual file creation for native skill
+   initialization.
+9. Write generated skills in English regardless of the user's language,
    including `--description`, `--title`, frontmatter, headings, examples, and
    reference files. Preserve non-English only for literal runtime values,
    product names, language-pair requirements, or necessary sample I/O.
@@ -91,27 +120,26 @@ are:
 
 ```bash
 oo skills init <name> --agent <!-- agentic:var agent --> --description "..."
-oo packages info "<packageName>" --json
 oo search "<query>" --json
+oo connector schema "<service>" --action "<action>"
 ```
 
 If <!-- agentic:var agentTitle --> cannot request the needed permission, or the user denies it, stop and
 ask the user to open the required access. Do not continue in the restricted
-sandbox and do not guess package names, block names, inputs, or outputs.
+sandbox and do not guess service names, action names, inputs, or outputs.
 
 Never work around a blocked `oo skills init --agent <!-- agentic:var agent -->` by manually creating
 a skill directory elsewhere. Manual skeleton creation bypasses the agent-native
 target directory, metadata writing, and OO notice insertion.
 
-### 2. Collect only the information needed
+### 2. Capture reusable contract decisions
 
 Collect these inputs from the user or infer them from existing context and `oo`
 metadata:
 
 - skill name
 - workflow purpose
-- known package names, connector services, or connector actions
-- stable block names, when the user knows them
+- known connector services, connector actions, or provider constraints
 - user inputs the skill should collect
 - workflow ordering and expected outputs
 - likely user requests that should trigger the generated skill
@@ -122,59 +150,60 @@ the reusable workflow; do not ask only for cosmetic details or facts that `oo`
 metadata can resolve. Use a concise title and fitting icon reference: an emoji,
 an image URL, or `:collection:icon:` from https://icones.js.org/.
 
-### 3. Resolve concrete package, block, and connector references
+### 3. Resolve the concrete connector action
 
-Capability discovery is mixed by default. If the user has not provided a
-complete package/block contract or connector action contract, use mixed
-discovery before authoring:
+Capability discovery may return multiple catalog result types. If the user has
+not provided a complete connector action contract, use discovery before
+authoring:
 
 ```bash
 oo search "<goal>" --json
 ```
 
-Do this even when the user mentions a model, product, package-like name, or
-managed API capability, unless the user explicitly requires a known package or
-block workflow. Shape `<goal>` as one short English outcome sentence for the
-current external step, preserving the user's decisive constraints such as target
+Do this even when the user mentions a model, product, provider name, or managed
+API capability, unless the user already provided a complete current connector
+contract. Shape `<goal>` as one short English outcome sentence for the current
+external step, preserving the user's decisive constraints such as target
 service, language pair, file type, and output format. If those decisive business
 constraints are missing and would change the reusable skill contract, ask the
 user before discovery. Inspect the first result set before narrowing the query.
 
-Treat Fusion API, connector, and package/block results as first-class authoring
-candidates. Classify service `fusion-api` as OOMOL built-in Fusion API, which
-does not require the user to provide their own API key. Apply the Constitution
-to select the most direct capability. When domain fit is comparable, choose
-Fusion API first, already authenticated connectors second, and packages or
-blocks after those. Blocks are flexible, but usually have weaker performance
-and higher execution friction.
+Use only connector entries as authoring candidates. Treat non-connector entries
+as non-authoring catalog noise during this workflow: do not inspect them, do not
+select them, and do not put non-connector references in the generated skill.
 
-If the user provides a complete package-level contract, or the selected
-candidate is package-backed, inspect the package before writing the skill:
+During selection, classify service `fusion-api` as OOMOL-hosted Fusion API,
+which does not require the user to provide their own provider API key. When a
+`fusion-api` action and a non-Fusion connector action can both satisfy the same
+generic managed transform, prefer the `fusion-api` action by default. Choose a
+non-Fusion connector only when the user explicitly requested that service,
+account, or provider; when Fusion API is unavailable or does not fit the
+required output; or when material provider, account, cost, compliance,
+data-routing, or output-contract differences require a user decision.
 
-```bash
-oo packages info "<packageName>" --json
-```
-
-Use the returned metadata to identify stable block references, input concepts,
-and output concepts. Prefer the most specific safe reference:
-`oo::packageName::blockName` when a block is clearly part of the intended
-workflow, or `oo::packageName` only when the block must remain a deliberate
-runtime choice based on user intent.
-
-For connector-backed choices, capture the exact `service`, action `name`,
-description, authentication state, and schema-derived input/output concepts.
 Use `oo connector search "<goal>" --json` only to narrow a shortlisted connector
-path, not to restart broad discovery. Do not force a package or block reference
-when the chosen reusable workflow is connector-backed.
-If the task looks like an OOMOL built-in managed API capability but the mixed
-result set has no Fusion API connector candidate, run one connector narrowing pass
-before accepting a package-only path.
+path, not to restart broad discovery. If the task looks like an OOMOL-hosted
+managed API capability but the mixed result set has no `fusion-api` connector
+candidate, run one connector narrowing pass before reporting that no Fusion API
+action is available.
 
 Do not choose a connector action unless current command output exposes it. If
 command output does not expose the candidate action, or a non-destructive test
 reports `unknown action`, choose an exposed action and document any runtime
 shape change, such as async submission plus polling replacing a synchronous
 call.
+
+Keep the chosen connector action concrete in the generated skill.
+
+### 4. Prove the selected action contract
+
+For the selected action, capture the exact `service`, action `name`,
+description, authentication state, and schema-derived input/output concepts.
+Use the schema command before authoring the runbook:
+
+```bash
+oo connector schema "<service>" --action "<action>"
+```
 
 When result shape, status transitions, file return format, or envelope structure
 will affect the runbook, run a minimal representative invocation or status/result
@@ -184,10 +213,7 @@ only to learn a response shape; ask the user or use documented dry-run or
 read-only paths when those risks are material. If a field path is inferred from
 schema rather than observed, label it as untested.
 
-Keep chosen packages, blocks, or connector actions concrete in the generated
-skill.
-
-### 4. Initialize the local skill
+### 5. Initialize the local skill
 
 Run `oo skills init <name> --agent <!-- agentic:var agent -->` with a required `--description`.
 Include `--title` and `--icon` when you have suitable values. Derive title and
@@ -219,15 +245,18 @@ Do not substitute manual file creation for this step. The initialized skill
 directory must come from a successful `oo skills init --agent <!-- agentic:var agent -->`
 invocation before you fill in its workflow instructions or run validation.
 
-### 5. Author the workflow instructions
+### 6. Author the generated skill runbook
 
 Write the generated skill as a compact execution runbook, not API
 documentation: enough for future agents to call the selected capability without
-rediscovery, but not a full schema dump. Reference packages with
-`oo::packageName` and stable blocks with `oo::packageName::blockName`.
+rediscovery, but not a full schema dump.
 
-For connector-backed or Fusion API-backed workflows, use domain-appropriate
-headings but include these execution facts when metadata provides them:
+Keep the generated skill centered on runtime execution. Include authoring-time
+evidence only when it affects runtime behavior, such as an untested schema-only
+result path or an observed async polling requirement.
+
+For selected connector action workflows, use domain-appropriate headings but
+include these execution facts when metadata provides them:
 
 - Runtime input policy: when to use the skill, required inputs, inputs that can
   be inferred or defaulted, optional inputs to omit when absent, and the exact
@@ -255,9 +284,9 @@ Distill schema metadata into required/defaultable inputs and output field
 paths; do not present any local cache path as a stable contract for future
 agents.
 
-When the workflow crosses the local/cloud file boundary, include the
-`oo file upload` and `oo file download` guidance from the Constitution in the
-generated skill.
+When the workflow crosses the local/remote connector file boundary, include the
+schema-driven `oo file upload` and `oo file download` guidance from the
+Constitution in the generated skill.
 
 When generated skill code needs an OOMOL-hosted LLM client, instruct future
 agents to run `oo llm config --json` at runtime and use the returned `apiKey`,
@@ -276,20 +305,18 @@ first heading, keep `metadata.title` aligned. If `metadata.title` or
 
 The final skill must not instruct future agents to run `oo search`, `oo
 connector search`, or discover capabilities at execution time. Include only the
-selected package/block references or connector service/action identity, command
-shape, payload rules, result extraction, common stop conditions, and async or
-idempotency guidance that observed metadata, output shape, or documented oo
-workflow exposes.
+selected connector service/action identity, command shape, payload rules, result
+extraction, common stop conditions, and async or idempotency guidance that
+observed metadata, output shape, or documented oo workflow exposes.
 
 Before finishing, check that a future agent can reach the selected capability
 without rediscovery, build a valid payload, read the useful result, and stop on
 common failures. If not, add only the missing execution guidance.
 
 Keep `SKILL.md` concise. Use `references/workflow.md` only when the workflow
-has several steps, decision rules, or examples. Use `references/packages.json`
-only when captured package metadata will help future maintenance.
+has several steps, decision rules, or examples.
 
-### 6. Validate before finishing
+### 7. Validate before finishing
 
 After authoring the skill, run `oo skills validate "<skill-directory>"`. If
 validation fails, fix the generic skill contract before reporting completion.

--- a/contrib/skills/shared/oo-create-skill/agents/openai.yaml
+++ b/contrib/skills/shared/oo-create-skill/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: oo Create Skill
   short_description: Create local OOMOL workflow skills
-  default_prompt: "Use $oo-create-skill when the user asks to author, scaffold, or generate a new local AI agent skill for an OOMOL/oo package, connector action, block, or workflow, including when capability discovery is needed before authoring. Do not use it for finding/installing published skills or publishing finished skills."
+  default_prompt: "Use $oo-create-skill when the user asks to author, scaffold, or generate a new local AI agent skill for a concrete oo connector action, including OOMOL-hosted Fusion API actions, and when capability discovery is needed before authoring. Do not use it for finding/installing existing skills or distributing finished skills."
 
 policy:
   allow_implicit_invocation: true

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -734,6 +734,9 @@ describe("embedded skill assets", () => {
             expect(content).toContain("Discover");
             expect(content).toContain("the capability");
             expect(content).toContain("run the smallest safe test");
+            expect(content).toContain("cheap, non-sensitive artifact transforms");
+            expect(content).toContain("tiny synthetic inputs");
+            expect(content).toContain("representative invocation before finalizing");
             expect(content).toContain("observed");
             expect(content).toContain("facts");
             expect(content).toContain("Choose the most direct executable connector action");
@@ -790,6 +793,11 @@ describe("embedded skill assets", () => {
             expect(content).toContain("minimal representative invocation");
             expect(content).toContain("status/result poll");
             expect(content).toContain("safe and proportionate");
+            expect(content).toContain("full `oo connector run --json` response paths");
+            expect(content).toContain("not only the connector payload's inner field names");
+            expect(content).toContain("response.data.sessionId");
+            expect(content).toContain("response.data.state");
+            expect(content).toContain("response.data.data.image.url");
             expect(content).toContain("Do not spend");
             expect(content).toContain("meaningful user money");
             expect(content).toContain("mutate external state");
@@ -871,6 +879,14 @@ describe("embedded skill assets", () => {
             );
             expect(content).toContain("A successful");
             expect(content).toContain("file path alone is not enough");
+            expect(content).toContain("Resolve user-provided files into readable runtime sources");
+            expect(content).toContain("environment-exposed attachment paths");
+            expect(content).toContain("chat-visible media that the CLI cannot read directly");
+            expect(content).toContain("recent-file fallback");
+            expect(content).toContain("candidate hashes match");
+            expect(content).toContain("default to the input file's directory");
+            expect(content).toContain("such as Downloads");
+            expect(content).toContain("Do not default generated artifacts into the current repository workspace");
             expect(content).toContain(
                 "local/remote connector file boundary",
             );
@@ -911,12 +927,17 @@ describe("embedded skill assets", () => {
             expect(content).toContain("be inferred or defaulted");
             expect(content).toContain("optional inputs to omit when absent");
             expect(content).toContain("missing runtime values");
+            expect(content).toContain("Source resolution for file-like inputs");
+            expect(content).toContain("chat-visible media with no");
+            expect(content).toContain("multiple candidate files");
             expect(content).toContain("Invocation");
             expect(content).toContain("small payload skeleton");
             expect(content).toContain("`--data @payload.json`");
             expect(content).toContain("Payload rules");
             expect(content).toContain("Result handling");
             expect(content).toContain("JSON field paths");
+            expect(content).toContain("full CLI response paths");
+            expect(content).toContain("schema-only paths as untested");
             expect(content).toContain("what not to treat as the final result");
             expect(content).toContain("files, images, documents");
             expect(content).toContain("preview them or deliver them to the user");
@@ -925,6 +946,12 @@ describe("embedded skill assets", () => {
             expect(content).toContain("save and preview the artifact");
             expect(content).toContain("printing the full");
             expect(content).toContain("encoded payload");
+            expect(content).toContain("Async handling");
+            expect(content).toContain("early-exit");
+            expect(content).toContain("stops polling immediately");
+            expect(content).toContain("Artifact destination and verification");
+            expect(content).toContain("avoids polluting an unrelated repository");
+            expect(content).toContain("PNG alpha/RGBA check");
             expect(content).toContain("Failure handling");
             expect(content).toContain("action-specific stop conditions");
             expect(content).toContain("schema rejection");
@@ -936,6 +963,11 @@ describe("embedded skill assets", () => {
             expect(content).toContain("future agent can reach the selected capability");
             expect(content).toContain("without rediscovery");
             expect(content).toContain("stop on common failures");
+            expect(content).toContain("exposed attachment path");
+            expect(content).toContain("full CLI JSON response path");
+            expect(content).toContain("bounded timeout");
+            expect(content).toContain("unrelated git workspace");
+            expect(content).toContain("verified after download");
             expect(content).not.toContain("Use whatever structure fits the domain");
             expect(content).not.toContain("async polling/idempotency when needed");
             expect(content).not.toContain("future agent can ask less");

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -573,7 +573,6 @@ describe("embedded skill assets", () => {
             expect(content).toContain("`oo` metadata and command output define execution facts");
             expect(content).toContain("Do not ask");
             expect(content).toContain("resolve facts");
-            expect(content).toContain("package/block references");
             expect(content).toContain("connector service/action identifiers");
             expect(content).toContain("field names");
             expect(content).toContain("result field paths");
@@ -593,6 +592,7 @@ describe("embedded skill assets", () => {
             expect(content).toContain("future agents");
             expect(content).toContain("do not run discovery");
             expect(content).toContain("again");
+            expect(content).not.toContain("package/block references");
             expect(content).not.toContain("Operating Principles");
             expect(content).not.toContain("Work like a confident authoring agent");
             expect(content).not.toContain("interrupt the user only for true blockers");
@@ -622,8 +622,9 @@ describe("embedded skill assets", () => {
             expect(content).toContain("capability discovery is needed first");
             expect(content).toContain("oo skills preflight --agent");
             expect(content).toContain("oo skills init <name> --agent");
-            expect(content).toContain("discover or install existing published skills");
-            expect(content).toContain("publish a finished skill");
+            expect(content).toContain("find or install an");
+            expect(content).toContain("existing skill");
+            expect(content).toContain("distribute a finished skill");
             expect(content).not.toContain("Author, generate, scaffold, or update");
             expect(content).not.toContain("create or update a local skill");
             expect(content).not.toContain("default private");
@@ -644,11 +645,12 @@ describe("embedded skill assets", () => {
 
         expect(openAiAgentContent).toContain("$oo-create-skill");
         expect(openAiAgentContent).toContain("author, scaffold, or generate a new local");
-        expect(openAiAgentContent).toContain("connector action");
+        expect(openAiAgentContent).toContain("concrete oo connector action");
+        expect(openAiAgentContent).toContain("OOMOL-hosted Fusion API actions");
         expect(openAiAgentContent).toContain("capability discovery is needed before authoring");
         expect(openAiAgentContent).not.toContain("generate, or update");
         expect(openAiAgentContent).toContain(
-            "finding/installing published skills or publishing finished skills",
+            "finding/installing existing skills or distributing finished skills",
         );
     });
 
@@ -711,7 +713,7 @@ describe("embedded skill assets", () => {
         }
     });
 
-    test("guides oo-create-skill discovery toward connector-aware selection", async () => {
+    test("guides oo-create-skill discovery toward Fusion API selection preference", async () => {
         for (const agentName of availableBundledSkillAgentNames) {
             const skillFile = getBundledSkillFiles("oo-create-skill", agentName).find(
                 file => file.relativePath === "SKILL.md",
@@ -725,9 +727,7 @@ describe("embedded skill assets", () => {
                 await readBundledSkillFileContent(skillFile),
             );
 
-            expect(content).toContain(
-                "Resolve concrete package, block, and connector references",
-            );
+            expect(content).toContain("Resolve the concrete connector action");
             expect(content).toContain("Resolve and test before writing the runbook");
             expect(content).toContain("Do not predesign the whole");
             expect(content).toContain("execution process");
@@ -736,35 +736,46 @@ describe("embedded skill assets", () => {
             expect(content).toContain("run the smallest safe test");
             expect(content).toContain("observed");
             expect(content).toContain("facts");
-            expect(content).toContain("Choose the most direct capability");
-            expect(content).toContain("domain fit over result ordering");
-            expect(content).toContain("Fusion API first");
-            expect(content).toContain("already authenticated connectors second");
-            expect(content).toContain("packages or blocks after those");
-            expect(content).toContain("Capability discovery is mixed by default");
-            expect(content).toContain("complete package/block contract");
-            expect(content).toContain("complete package-level contract");
+            expect(content).toContain("Choose the most direct executable connector action");
+            expect(content).toContain("prefer a matching `fusion-api` action by default");
+            expect(content).toContain("generic managed transforms");
+            expect(content).toContain("background removal");
+            expect(content).toContain("OCR");
+            expect(content).toContain("translation");
+            expect(content).toContain("image generation");
+            expect(content).toContain("document conversion");
+            expect(content).toContain("non-Fusion connector action");
+            expect(content).toContain("explicitly names an external");
+            expect(content).toContain("service, account, or provider");
+            expect(content).toContain("Fusion API is unavailable");
+            expect(content).toContain("does not fit the required output");
+            expect(content).toContain("Capability discovery may return");
+            expect(content).toContain("complete connector action contract");
             expect(content).toContain("Do this even when the user mentions");
-            expect(content).toContain("model, product, package-like name");
-            expect(content).toContain("Treat Fusion API, connector, and package/block results");
-            expect(content).toContain("first-class authoring");
-            expect(content).toContain("connector actions, packages, and blocks");
-            expect(content).toContain("Classify service `fusion-api`");
-            expect(content).toContain("does not require the user");
-            expect(content).toContain("to provide their own API key");
-            expect(content).toContain("choose Fusion API by default");
+            expect(content).toContain("model, product, provider name");
+            expect(content).toContain("Use only connector entries");
+            expect(content).toContain("authoring candidates");
+            expect(content).toContain("non-connector entries");
+            expect(content).toContain("non-authoring catalog noise");
+            expect(content).toContain("During selection");
+            expect(content).toContain("classify service `fusion-api`");
+            expect(content).toContain("OOMOL-hosted Fusion API");
+            expect(content).toContain("provider API key");
+            expect(content).toContain("When a `fusion-api` action and a non-Fusion connector action");
+            expect(content).toContain("can both satisfy the same");
+            expect(content).toContain("prefer the `fusion-api` action by default");
+            expect(content).toContain("Choose a non-Fusion connector only when");
+            expect(content).toContain("material provider");
             expect(content).toContain("account, cost, compliance");
+            expect(content).toContain("data-routing");
             expect(content).toContain("output-contract differences");
-            expect(content).toContain("Use `oo connector schema`");
-            expect(content).toContain("for connector");
-            expect(content).toContain("contracts");
+            expect(content).toContain("oo connector schema");
+            expect(content).toContain("to prove the");
+            expect(content).toContain("selected action contract");
             expect(content).toContain("current command output");
             expect(content).toContain("safe invocation");
-            expect(content).toContain("confirm connector");
+            expect(content).toContain("confirm action availability");
             expect(content).toContain("action availability");
-            expect(content).toContain("Apply the Constitution");
-            expect(content).toContain("Blocks are flexible");
-            expect(content).toContain("weaker performance and higher execution friction");
             expect(content).toContain(
                 "Do not choose a connector action unless current command output exposes it",
             );
@@ -787,10 +798,9 @@ describe("embedded skill assets", () => {
             expect(content).toContain("read-only paths");
             expect(content).toContain("inferred from schema rather than observed");
             expect(content).toContain("label it as untested");
-            expect(content).toContain("Do not force a package or block reference");
-            expect(content).toContain("when the chosen reusable workflow is connector-backed.");
+            expect(content).toContain("Keep the chosen connector action concrete");
             expect(content).toContain("run one connector narrowing pass");
-            expect(content).toContain("before accepting a package-only path");
+            expect(content).toContain("reporting that no Fusion API action is available");
             expect(content).toContain(
                 "connector service/action identifiers",
             );
@@ -801,6 +811,19 @@ describe("embedded skill assets", () => {
             expect(content).not.toContain("If Fusion API and an ordinary connector action both match");
             expect(content).not.toContain("Apply the capability principle above");
             expect(content).not.toContain("If the user provides only package-level information");
+            expect(content).not.toContain("packages or blocks after those");
+            expect(content).not.toContain("complete package/block contract");
+            expect(content).not.toContain("complete package-level contract");
+            expect(content).not.toContain("package-like name");
+            expect(content).not.toContain("package/block results");
+            expect(content).not.toContain("connector actions, packages, and blocks");
+            expect(content).not.toContain("Blocks are flexible");
+            expect(content).not.toContain("Do not force a package or block reference");
+            expect(content).not.toContain("package-only path");
+            expect(content).not.toContain("Treat Connect and");
+            expect(content).not.toContain("Fusion API actions as the only authoring candidates");
+            expect(content).not.toContain("Use only Connect and Fusion API connector entries");
+            expect(content).not.toContain("for Connect and Fusion API contracts");
         }
     });
 
@@ -818,22 +841,41 @@ describe("embedded skill assets", () => {
                 await readBundledSkillFileContent(skillFile),
             );
 
-            expect(content).toContain("Preserve the local/cloud boundary");
+            expect(content).toContain(
+                "Preserve the local/remote connector file boundary",
+            );
             expect(content).toContain("Make file artifacts visible to the user");
+            expect(content).toContain(
+                "local files are not remotely addressable",
+            );
+            expect(content).toContain("upload a local file by default");
             expect(content).toContain("`oo file upload \"<filePath>\" --json`");
             expect(content).toContain("the returned `downloadUrl`");
+            expect(content).toContain(
+                "Skip upload only when the user already provided a remote URL",
+            );
+            expect(content).toContain(
+                "schema explicitly requires a different supported input shape",
+            );
             expect(content).toContain("`oo file download \"<url>\" [outDir]");
+            expect(content).toContain(
+                "downloadable artifact URL and the task needs a local file result",
+            );
             expect(content).toContain("`Saved to: <path>`");
             expect(content).toContain("does not support `--json`");
             expect(content).toContain("file-transfer commands as capabilities");
             expect(content).toContain("hand-roll transfer");
             expect(content).toContain("logic");
             expect(content).toContain(
-                "do not pass local filesystem paths to cloud",
+                "do not pass local filesystem paths or `file://` URLs",
             );
             expect(content).toContain("A successful");
             expect(content).toContain("file path alone is not enough");
-            expect(content).toContain("local/cloud file boundary");
+            expect(content).toContain(
+                "local/remote connector file boundary",
+            );
+            expect(content).not.toContain("local/cloud");
+            expect(content).not.toContain("cloud payloads");
             expect(content).toContain("oo llm config --json");
             expect(content).toContain("OOMOL-hosted LLM client");
             expect(content).toContain("returned `apiKey`");
@@ -863,7 +905,7 @@ describe("embedded skill assets", () => {
             expect(content).toContain("compact execution runbook");
             expect(content).toContain("call the selected capability without rediscovery");
             expect(content).toContain("not a full schema dump");
-            expect(content).toContain("connector-backed or Fusion API-backed workflows");
+            expect(content).toContain("selected connector action workflows");
             expect(content).toContain("Runtime input policy");
             expect(content).toContain("required inputs");
             expect(content).toContain("be inferred or defaulted");


### PR DESCRIPTION
## What changed

- Updated the bundled `oo-create-skill` prompt so newly authored local skills target concrete oo connector actions.
- Kept Fusion API as an OOMOL-hosted connector service, with the default preference stated only in the discovery/selection decision rule.
- Removed package/block authoring guidance from the create-skill workflow, including package metadata inspection and `oo::packageName` references.
- Updated the OpenAI agent entry prompt and embedded asset tests to enforce the connector-action authoring model and Fusion API selection preference.

## Why

The create-skill workflow should guide agents toward the remaining executable capability surface: connector actions. When both a `fusion-api` action and a non-Fusion connector action can satisfy a generic managed transform, agents should prefer `fusion-api` by default unless the user explicitly requests a specific external service/account/provider or material provider, cost, compliance, data-routing, or output-contract differences require a decision.

## Local CLI validation

Validated the remove-background case locally:

- `oo search "remove background from image" --json` returns package, `remove_bg`, and `fusion-api` candidates.
- `oo connector schema "fusion-api" --action "fal_remove_background_submit"` succeeds.
- `oo connector schema "fusion-api" --action "fal_remove_background_result"` succeeds.
- `oo connector schema "fusion-api" --action "fal_remove_background_state"` succeeds.
- `oo connector schema "remove_bg" --action "remove_background"` succeeds.
- `oo connector run "fusion-api" --action "fal_remove_background_submit" --data '{"imageURL":"https://example.com/photo.jpg"}' --dry-run --json` returns `{ "dryRun": true, "ok": true }`.
- `oo connector run "remove_bg" --action "remove_background" --data '{"imageUrl":"https://example.com/photo.jpg"}' --dry-run --json` returns `{ "dryRun": true, "ok": true }`.

## Validation

- `bun run lint:fix`
- `bun run ts-check`
- `bun run test src/application/commands/skills/embedded-assets.test.ts`
- `bun run test`