### PR TITLE
docs(skills): require keywords on every skill and connector search

### DIFF
--- a/contrib/skills/shared/oo-create-skill/SKILL.md
+++ b/contrib/skills/shared/oo-create-skill/SKILL.md
@@ -137,7 +137,7 @@ are:
 
 ```bash
 oo skills init <name> --agent <!-- agentic:var agent --> --description "..."
-oo search "<query>" --json
+oo search "<query>" --keywords "<keywords>" --json
 oo connector schema "<service>" --action "<action>"
 ```
 
@@ -174,14 +174,18 @@ not provided a complete connector action contract, use discovery before
 authoring:
 
 ```bash
-oo search "<goal>" --json
+oo search "<goal>" --keywords "<comma-separated keywords>" --json
 ```
 
 Do this even when the user mentions a model, product, provider name, or managed
 API capability, unless the user already provided a complete current connector
 contract. Shape `<goal>` as one short English outcome sentence for the current
 external step, preserving the user's decisive constraints such as target
-service, language pair, file type, and output format. If those decisive business
+service, language pair, file type, and output format. Always pass `1` to `3`
+keywords. Keywords may use the user's original language and must keep product,
+brand, and proper names untranslated, for example keep `滴答清单` and do not
+turn it into `TickTick`; the backend tokenizes keywords, while the free-text
+query alone runs an untokenized semantic search. If those decisive business
 constraints are missing and would change the reusable skill contract, ask the
 user before discovery. Inspect the first result set before narrowing the query.
 

--- a/contrib/skills/shared/oo-find-skills/SKILL.md
+++ b/contrib/skills/shared/oo-find-skills/SKILL.md
@@ -18,32 +18,40 @@ expectations, output-shape rules, or failure-handling details.
 
 ## Workflow
 
-### 1. Normalize the request into English search terms
+### 1. Normalize the request into a search sentence and keywords
 
 Convert the user request into:
 
 - one short internal intent statement
 - one concise English sentence for the search text
-- `0` to `3` English keywords or short phrases for the optional `--keywords`
-  filter
+- `1` to `3` required keywords or short phrases for the `--keywords` filter
 
 Rules:
 
-- The sentence and keywords must always be in English, regardless of the
-  user's language.
+- The sentence must always be in English, regardless of the user's language.
+- Keywords are required on every search. Always provide `1` to `3` keywords and
+  never run a search without `--keywords`.
+- Keywords may use the user's original language. Keep product names, brand
+  names, and proper nouns exactly as the user wrote them and do not translate
+  them. For example, keep `滴答清单` as `滴答清单`; do not turn it into
+  `TickTick`.
+- The backend tokenizes `--keywords`, so original-language and product-name
+  keywords reach the catalog entry the user actually wants. The free-text
+  sentence alone runs an untokenized semantic search that can map a localized
+  product onto a different global product.
 - The sentence should describe only the user's need itself.
 - Prefer a short sentence built from task + capability + domain or constraint.
 - Do not add meta words such as `skill`, `skills`, `search`, `install`, or
   `Codex` unless the user's actual need depends on those words.
 - Avoid filler words.
-- Use keywords only when they add extra filtering signal that the sentence does
-  not already capture.
-- Prefer `0` to `3` keywords. Do not exceed `3`.
+- Do not exceed `3` keywords.
 
 Examples:
 
 - Sentence: `translate scanned images from Japanese to English`
   Keywords: `Japanese`, `image translation`
+- Sentence: `create a task in the dida365 to-do app`
+  Keywords: `滴答清单`, `dida365`
 - Sentence: `generate a QR code from text`
   Keywords: `QR code`
 - Sentence: `convert speech to text`
@@ -51,18 +59,12 @@ Examples:
 - Sentence: `write Markdown more effectively`
   Keywords: `Markdown`, `writing`
 
-Use the sentence as the main search text. Add `--keywords` only when the extra
-keywords help narrow the search.
+Use the sentence as the main search text and always pass the `1` to `3`
+keywords through `--keywords`.
 
 ### 2. Search for candidate skills
 
-Run:
-
-```bash
-oo skills search "<english query>" --json
-```
-
-Or, when helpful:
+Always run the keyword-refined form:
 
 ```bash
 oo skills search "<english sentence>" --keywords "<comma-separated keywords>" --json

--- a/contrib/skills/shared/oo-find-skills/references/oo-cli-contract.md
+++ b/contrib/skills/shared/oo-find-skills/references/oo-cli-contract.md
@@ -5,13 +5,7 @@ and installing skills.
 
 ## `oo skills search`
 
-Canonical form:
-
-```bash
-oo skills search "<text>" --json
-```
-
-Optional keyword-refined form:
+Canonical form (always pass `--keywords`):
 
 ```bash
 oo skills search "<text>" --keywords "<comma-separated keywords>" --json
@@ -20,7 +14,12 @@ oo skills search "<text>" --keywords "<comma-separated keywords>" --json
 Facts:
 
 - `--json` is an alias for `--format=json`.
-- `--keywords` is optional and accepts a comma-separated list.
+- `--keywords` is required for skill discovery. Always pass `1` to `3`
+  comma-separated keywords and never run discovery without it.
+- Keywords may use the user's original language. Keep product, brand, and
+  proper names exactly as written and do not translate them (for example, keep
+  `滴答清单`; do not turn it into `TickTick`). The backend tokenizes keywords,
+  while the free-text query alone runs an untokenized semantic search.
 - The command returns a raw JSON array.
 - Search results may include `description`, `name`, `packageName`,
   `packageVersion`, and `skillDisplayName`.

--- a/contrib/skills/shared/oo/SKILL.md
+++ b/contrib/skills/shared/oo/SKILL.md
@@ -106,19 +106,23 @@ proves its output.
    prechecks; let the first substantive `oo` command surface availability or
    account problems.
 2. Search goal
-   For a single-step task, write one concise English goal sentence. For a
-   short multi-step task, write 2 to 4 ordered subgoals and activate only the
-   current unresolved external step.
+   For a single-step task, write one concise English goal sentence plus `1` to
+   `3` keywords. Keywords may use the user's original language and must keep
+   product, brand, and proper names untranslated. For a short multi-step task,
+   write 2 to 4 ordered subgoals and activate only the current unresolved
+   external step.
 3. Discover
    Read [references/search-and-selection.md](references/search-and-selection.md)
-   before the first search. Run `oo search "<goal>" --json` unless a complete
-   capability contract is already known from current evidence.
+   before the first search. Run
+   `oo search "<goal>" --keywords "<keywords>" --json` with `1` to `3` keywords
+   unless a complete capability contract is already known from current evidence.
    A complete contract means connector schema already proves the callable id,
    required inputs, and output semantics; a user-named service is not enough.
    When running capability discovery, also run at most one
-   `oo skills search "<goal>" --json` sidecar query. Record credible
-   installable skill matches as possible future enhancements; do not install or
-   ask about installation before the selected connector capability succeeds.
+   `oo skills search "<goal>" --keywords "<keywords>" --json` sidecar query.
+   Record credible installable skill matches as possible future enhancements;
+   do not install or ask about installation before the selected connector
+   capability succeeds.
 4. Select
    Inspect the first result set before refining. Keep one primary candidate and
    at most one materially different fallback. Prefer directness, named target

--- a/contrib/skills/shared/oo/references/search-and-selection.md
+++ b/contrib/skills/shared/oo/references/search-and-selection.md
@@ -43,6 +43,22 @@ Examples:
 - `collect Gmail messages from yesterday`
 - `create a Notion page from prepared content`
 
+## Search keywords
+
+Always pass `1` to `3` keywords through `--keywords` on every `oo search` and
+`oo skills search` call. Never search without keywords.
+
+- Keywords may use the user's original language; the English sentence stays in
+  English.
+- Keep product names, brand names, and proper nouns exactly as the user wrote
+  them and do not translate them. For example, keep `滴答清单`; do not turn it
+  into `TickTick`.
+- The backend tokenizes `--keywords`, so original-language and product-name
+  keywords reach the catalog entry the user actually wants. The free-text query
+  alone runs an untokenized semantic search that can map a localized product
+  onto a different global product.
+- Pass keywords only through `--keywords`, never as extra positional arguments.
+
 ## Repair weak first queries
 
 Revise the query only when the first result set shows that the query was too
@@ -74,13 +90,13 @@ Examples:
 Canonical form:
 
 ```bash
-oo search "<text>" --json
+oo search "<text>" --keywords "<comma-separated keywords>" --json
 ```
 
 Skill sidecar:
 
 ```bash
-oo skills search "<text>" --json
+oo skills search "<text>" --keywords "<comma-separated keywords>" --json
 ```
 
 Facts:
@@ -96,8 +112,8 @@ Facts:
   execute a package or block.
 - Connector entries include stable fields such as `service`, `name`,
   `description`, and `authenticated`.
-- `--keywords` is optional and refines the connector side while keeping the
-  same free-form text query.
+- `--keywords` is required on every call: always pass `1` to `3` keywords. The
+  backend tokenizes them while keeping the same free-form text query.
 - `oo skills search` is a sidecar discovery branch, not a callable capability
   contract. It returns installable workflow helpers that may improve repeated
   use, but skill installation is a separate user-visible action.
@@ -168,7 +184,8 @@ Tie-breakers:
 ## Skill sidecar policy
 
 During the same discovery step, run at most one `oo skills search "<text>"
---json` query using the same goal sentence. Keep only the best credible
+--keywords "<comma-separated keywords>" --json` query using the same goal
+sentence and keywords. Keep only the best credible
 installable skill match, identified by both `packageName` and `name`.
 
 Do not install a skill, do not select it instead of a connector capability, and
@@ -200,9 +217,11 @@ complete.
 ## Refinement policy
 
 - Refine only after inspecting the first result set.
-- Use `--keywords` when the first search captured the general task but missed
-  an important connector service, format, language, or destination constraint.
-- Do not pass normalized keywords as extra positional arguments.
+- The first search already carries `1` to `3` keywords. When it captured the
+  general task but missed an important connector service, format, language, or
+  destination constraint, adjust or add keywords (still `1` to `3`) and search
+  again.
+- Do not pass keywords as extra positional arguments.
 - If the task looks like a managed API capability but the mixed result set has
   no suitable connector candidate, run one connector refinement before reporting
   that no executable capability is available.


### PR DESCRIPTION
The `--keywords` filter is now required on every `oo search` and `oo skills search` call instead of being optional. The backend tokenizes keywords, so original-language and product names reach the intended catalog entry, while the free-text query alone runs an untokenized semantic search that can map a localized product onto a different global product (for example 滴答清单 mapped to TickTick).

Keywords may stay in the user's original language and must keep product, brand, and proper names untranslated. Callers should always pass 1 to 3 keywords.