### PR TITLE
feat(auth): add API key login option

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,17 +48,22 @@ conventions:
 
 ### `oo auth login`
 
-Start a device login flow or authenticate with a session token, then save the
-authenticated account.
+Start a device login flow, authenticate with a session token, or authenticate
+with an existing API key, then save the authenticated account.
 
 - Notes: the CLI prints the verification URL with the user code in the
   `user_code` query parameter, then waits up to 10 minutes for the device login
-  to be verified when `--session-token` is not provided. It exits with a
-  timeout error if verification does not complete within that window.
+  to be verified when neither `--session-token` nor `--api-key` is provided. It
+  exits with a timeout error if verification does not complete within that
+  window.
 - Options:
   - `--session-token <session-token>`: Authenticate with an existing session
     token. The CLI does not print a device-login URL or poll for verification
     when this option is provided.
+  - `--api-key <api-key>`: Authenticate with an existing API key. The CLI
+    validates the key against the account profile and saves the account without
+    a device-login URL or polling. Exits with an error if the key is invalid or
+    expired. `--api-key` and `--session-token` cannot be combined.
 
 ### `oo auth logout`
 
@@ -141,7 +146,7 @@ Switch the active auth account.
 ### `oo login`
 
 Alias for `oo auth login`. Supports the same `--session-token <session-token>`
-option.
+and `--api-key <api-key>` options.
 
 ### `oo logout`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -42,14 +42,17 @@
 
 ### `oo auth login`
 
-启动 device login 流程，或使用 session token 登录，并保存登录成功后的账号。
+启动 device login 流程，或使用 session token、API key 登录，并保存登录成功后的账号。
 
-- 说明：未传入 `--session-token` 时，CLI 会打印验证地址，并把用户 code 放在
-  `user_code` query 参数中，然后最多等待 10 分钟，直到 device login 验证成功；
+- 说明：未传入 `--session-token` 也未传入 `--api-key` 时，CLI 会打印验证地址，并把用户
+  code 放在 `user_code` query 参数中，然后最多等待 10 分钟，直到 device login 验证成功；
   如果超过该时间仍未完成验证，会以超时错误退出。
 - 选项：
   - `--session-token <session-token>`：使用已有 session token 登录。传入后 CLI 不会
     打印 device-login URL，也不会轮询验证结果。
+  - `--api-key <api-key>`：使用已有 API key 登录。CLI 会通过账号 profile 校验该 key，
+    校验通过后直接保存账号，不会打印 device-login URL 或轮询；若 key 无效或已过期则以
+    错误退出。`--api-key` 与 `--session-token` 不能同时使用。
 
 ### `oo auth logout`
 
@@ -124,7 +127,8 @@
 
 ### `oo login`
 
-`oo auth login` 的别名。支持相同的 `--session-token <session-token>` 选项。
+`oo auth login` 的别名。支持相同的 `--session-token <session-token>` 与
+`--api-key <api-key>` 选项。
 
 ### `oo logout`
 

--- a/src/application/auth/login-flow.test.ts
+++ b/src/application/auth/login-flow.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../__tests__/helpers.ts";
 import { createTranslator } from "../../i18n/translator.ts";
 import {
+    requestAuthAccountWithApiKey,
     requestAuthAccountWithSessionToken,
     startAuthLoginSession,
 } from "./login-flow.ts";
@@ -354,6 +355,183 @@ describe("startAuthLoginSession", () => {
             expect(logs).not.toContain(encodedSessionToken);
             expect(logs).not.toContain(searchEncodedSessionToken);
             expect(logs).toContain("session_token=<redacted>");
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+});
+
+describe("requestAuthAccountWithApiKey", () => {
+    test("resolves an account from the users profile endpoint", async () => {
+        const logCapture = createLogCapture();
+        const endpoint = "example.test";
+        const apiKey = "api-key-1";
+        const requests: Request[] = [];
+
+        try {
+            const account = await requestAuthAccountWithApiKey({
+                apiKey,
+                endpoint,
+                fetcher: async (input, init) => {
+                    const request = toRequest(input, init);
+                    const requestUrl = new URL(request.url);
+
+                    requests.push(request);
+
+                    if (
+                        request.method === "GET"
+                        && requestUrl.host === `api.${endpoint}`
+                        && requestUrl.pathname === "/v1/users/profile"
+                        && request.headers.get("Authorization") === apiKey
+                    ) {
+                        return new Response(JSON.stringify({
+                            displayname: "Kevin Cui",
+                            email: "bh@bugs.cc",
+                            nickname: "Kevin Cui",
+                            uid: "019343c2-c43d-710f-81b2-dfa68d3079de",
+                            username: "BlackHole1",
+                        }));
+                    }
+
+                    throw new Error(`Unexpected request: ${request.method} ${requestUrl}`);
+                },
+                logger: logCapture.logger,
+                translator: createTranslator("en"),
+            });
+
+            expect(requests).toHaveLength(1);
+            expect(account).toEqual({
+                apiKey,
+                endpoint,
+                id: "019343c2-c43d-710f-81b2-dfa68d3079de",
+                name: "BlackHole1",
+            });
+
+            const request = requests[0];
+
+            expect(request?.method).toBe("GET");
+            expect(request?.url).toBe(`https://api.${endpoint}/v1/users/profile`);
+
+            const logs = logCapture.read();
+
+            expect(logs).toContain("\"msg\":\"Auth api key login request started.\"");
+            expect(logs).toContain("\"msg\":\"Auth api key login completed successfully.\"");
+            expect(logs).not.toContain(apiKey);
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("throws an invalid api key error when the profile request is unauthorized", async () => {
+        const logCapture = createLogCapture();
+
+        try {
+            await expect(requestAuthAccountWithApiKey({
+                apiKey: "api-key-1",
+                endpoint: "example.test",
+                fetcher: async () => new Response(null, { status: 401 }),
+                logger: logCapture.logger,
+                translator: createTranslator("en"),
+            })).rejects.toMatchObject({
+                key: "errors.auth.apiKeyInvalid",
+            });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("throws an invalid api key error when the profile request is forbidden", async () => {
+        const logCapture = createLogCapture();
+
+        try {
+            await expect(requestAuthAccountWithApiKey({
+                apiKey: "api-key-1",
+                endpoint: "example.test",
+                fetcher: async () => new Response(null, { status: 403 }),
+                logger: logCapture.logger,
+                translator: createTranslator("en"),
+            })).rejects.toMatchObject({
+                key: "errors.auth.apiKeyInvalid",
+            });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("throws a generic request error when the profile request fails with a server error", async () => {
+        const logCapture = createLogCapture();
+
+        try {
+            await expect(requestAuthAccountWithApiKey({
+                apiKey: "api-key-1",
+                endpoint: "example.test",
+                fetcher: async () => new Response(null, { status: 500 }),
+                logger: logCapture.logger,
+                translator: createTranslator("en"),
+            })).rejects.toMatchObject({
+                key: "errors.auth.loginRequestFailed",
+                params: {
+                    status: 500,
+                },
+            });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("throws an invalid response error when the profile body is unsupported", async () => {
+        const logCapture = createLogCapture();
+
+        try {
+            await expect(requestAuthAccountWithApiKey({
+                apiKey: "api-key-1",
+                endpoint: "example.test",
+                fetcher: async () => new Response(JSON.stringify({
+                    username: "BlackHole1",
+                })),
+                logger: logCapture.logger,
+                translator: createTranslator("en"),
+            })).rejects.toMatchObject({
+                key: "errors.auth.loginInvalidResponse",
+            });
+        }
+        finally {
+            logCapture.close();
+        }
+    });
+
+    test("redacts the api key from profile request failures", async () => {
+        const logCapture = createLogCapture();
+        const endpoint = "example.test";
+        const apiKey = "super-secret-api-key";
+
+        try {
+            await expect(requestAuthAccountWithApiKey({
+                apiKey,
+                endpoint,
+                fetcher: async () => {
+                    throw new Error(
+                        `Failed to fetch https://api.${endpoint}/v1/users/profile with Authorization ${apiKey}`,
+                    );
+                },
+                logger: logCapture.logger,
+                translator: createTranslator("en"),
+            })).rejects.toMatchObject({
+                key: "errors.auth.loginRequestError",
+                params: {
+                    message:
+                        `Failed to fetch https://api.${endpoint}/v1/users/profile with Authorization <redacted>`,
+                },
+            });
+
+            const logs = logCapture.read();
+
+            expect(logs).not.toContain(apiKey);
         }
         finally {
             logCapture.close();

--- a/src/application/auth/login-flow.ts
+++ b/src/application/auth/login-flow.ts
@@ -46,6 +46,11 @@ const fastLoginProfileResponseSchema = z.object({
     name: z.string().min(1),
 }).passthrough();
 
+const apiKeyProfileResponseSchema = z.object({
+    uid: z.string().min(1),
+    username: z.string().min(1),
+}).passthrough();
+
 type DeviceLoginCodeResponse = z.output<typeof deviceLoginCodeResponseSchema>;
 type DeviceLoginResultResponse = z.output<typeof deviceLoginResultResponseSchema>;
 
@@ -78,6 +83,11 @@ interface StartAuthLoginSessionOptions extends AuthLoginRequestOptions {
 interface RequestAuthAccountWithSessionTokenOptions extends AuthLoginRequestOptions {
     endpoint: string;
     sessionToken: string;
+}
+
+interface RequestAuthAccountWithApiKeyOptions extends AuthLoginRequestOptions {
+    apiKey: string;
+    endpoint: string;
 }
 
 export async function startAuthLoginSession(
@@ -148,6 +158,43 @@ export async function requestAuthAccountWithSessionToken(
     );
 
     return createAuthAccount(profile);
+}
+
+export async function requestAuthAccountWithApiKey(
+    options: RequestAuthAccountWithApiKeyOptions,
+): Promise<AuthAccount> {
+    const requestUrl = createUsersProfileUrl(options.endpoint);
+    const rawResponse = await requestAuthLogin(
+        requestUrl,
+        options,
+        {
+            authorization: options.apiKey,
+            kind: "profile_with_api_key",
+            method: "GET",
+            redactedValues: [options.apiKey],
+            requestDescription: "api key login",
+            unauthorizedErrorKey: "errors.auth.apiKeyInvalid",
+        },
+    );
+    const profile = parseAuthLoginResponse(
+        rawResponse,
+        apiKeyProfileResponseSchema,
+    );
+
+    options.logger.info(
+        {
+            ...withAccountIdentity(profile.uid, options.endpoint),
+            name: profile.username,
+        },
+        "Auth api key login completed successfully.",
+    );
+
+    return {
+        apiKey: options.apiKey,
+        endpoint: options.endpoint,
+        id: profile.uid,
+        name: profile.username,
+    };
 }
 
 async function waitForVerifiedAccount(
@@ -258,12 +305,14 @@ async function requestAuthLogin(
     requestUrl: URL,
     options: AuthLoginRequestOptions,
     requestOptions: {
+        authorization?: string;
         body?: string;
-        kind: "code" | "profile_with_session_token" | "result";
+        kind: "code" | "profile_with_api_key" | "profile_with_session_token" | "result";
         method: "GET" | "POST";
         redactedValues?: readonly string[];
-        requestDescription: "device login" | "fast login";
+        requestDescription: "api key login" | "device login" | "fast login";
         timeoutMs?: number;
+        unauthorizedErrorKey?: string;
     },
 ): Promise<string> {
     const redactedValues = requestOptions.redactedValues ?? [];
@@ -303,11 +352,7 @@ async function requestAuthLogin(
     try {
         const response = await withTimeout(options.fetcher(requestUrl, {
             body: requestOptions.body,
-            headers: requestOptions.body === undefined
-                ? undefined
-                : {
-                        "Content-Type": "application/json",
-                    },
+            headers: buildAuthLoginHeaders(requestOptions),
             method: requestOptions.method,
             signal: abortController?.signal,
         }));
@@ -324,9 +369,14 @@ async function requestAuthLogin(
                 },
                 `Auth ${requestOptions.requestDescription} request returned a non-success status.`,
             );
-            throw new CliUserError("errors.auth.loginRequestFailed", 1, {
-                status: response.status,
-            });
+            const isUnauthorized = response.status === 401
+                || response.status === 403;
+            throw requestOptions.unauthorizedErrorKey !== undefined
+                && isUnauthorized
+                ? new CliUserError(requestOptions.unauthorizedErrorKey, 1)
+                : new CliUserError("errors.auth.loginRequestFailed", 1, {
+                        status: response.status,
+                    });
         }
 
         options.logger.debug(
@@ -387,6 +437,23 @@ async function requestAuthLogin(
     }
 }
 
+function buildAuthLoginHeaders(requestOptions: {
+    authorization?: string;
+    body?: string;
+}): Record<string, string> | undefined {
+    const headers: Record<string, string> = {};
+
+    if (requestOptions.body !== undefined) {
+        headers["Content-Type"] = "application/json";
+    }
+
+    if (requestOptions.authorization !== undefined) {
+        headers.Authorization = requestOptions.authorization;
+    }
+
+    return Object.keys(headers).length === 0 ? undefined : headers;
+}
+
 function parseAuthLoginResponse<TValue>(
     rawResponse: string,
     schema: z.ZodType<TValue>,
@@ -435,6 +502,10 @@ function createDeviceLoginVerificationUrl(
 
     url.searchParams.set("user_code", userCode);
     return url.toString();
+}
+
+function createUsersProfileUrl(endpoint: string): URL {
+    return new URL(`https://api.${endpoint}/v1/users/profile`);
 }
 
 function createFastLoginProfileWithSessionTokenUrl(

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -105,7 +105,7 @@ interface CreateCliExecutionContextOptions {
 }
 
 const redactedCliArgumentValue = "<redacted>";
-const sensitiveCliOptionLongFlags = ["--session-token"] as const;
+const sensitiveCliOptionLongFlags = ["--api-key", "--session-token"] as const;
 
 export async function runCli(argv: string[]): Promise<number> {
     return executeCli({

--- a/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
@@ -36,10 +36,11 @@ exports[`auth CLI renders alias descriptions in login and logout help 1`] = `
     "exitCode": 0,
     "stderr": "",
     "stdout": 
-"Log in with an OOMOL account using device login or a session token. Alias for
-auth login.
+"Log in with an OOMOL account using device login, a session token, or an API key.
+Alias for auth login.
 
 Options:
+  --api-key <api-key>              Log in with an existing API key
   --session-token <session-token>  Log in with a session token
   -h, --help                       Show help for command
 

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -318,6 +318,102 @@ describe("auth CLI", () => {
         }
     });
 
+    test("supports login with an API key", async () => {
+        const sandbox = await createCliSandbox();
+        const apiKey = "secret-api-1";
+        const requests: Request[] = [];
+
+        try {
+            const authFilePath = join(
+                sandbox.env.XDG_CONFIG_HOME!,
+                APP_NAME,
+                "auth.toml",
+            );
+            const result = await sandbox.run(
+                ["login", "--api-key", apiKey],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+                        const requestUrl = new URL(request.url);
+
+                        requests.push(request);
+
+                        if (
+                            request.method === "GET"
+                            && requestUrl.host === `api.${defaultAuthEndpoint}`
+                            && requestUrl.pathname === "/v1/users/profile"
+                            && request.headers.get("Authorization") === apiKey
+                        ) {
+                            return new Response(JSON.stringify({
+                                displayname: "Kevin Cui",
+                                email: "bh@bugs.cc",
+                                nickname: "Kevin Cui",
+                                uid: "019343c2-c43d-710f-81b2-dfa68d3079de",
+                                username: "BlackHole1",
+                            }));
+                        }
+
+                        throw new Error(`Unexpected auth api key login request: ${request.method} ${requestUrl}`);
+                    },
+                },
+            );
+            const authFileContent = await readFile(authFilePath, "utf8");
+            const content = await readLatestLogContent(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(1);
+            expect(result.stdout).not.toContain("Open this login URL");
+            expect(result.stdout).not.toContain("Waiting for the device login");
+            expect(createCliSnapshot(result)).toEqual({
+                exitCode: 0,
+                stderr: "",
+                stdout:
+                    "✓ Logged in to oomol.com account BlackHole1\n  - Active account: true\n",
+            });
+            expect(authFileContent).toContain("id = \"019343c2-c43d-710f-81b2-dfa68d3079de\"");
+            expect(authFileContent).toContain("name = \"BlackHole1\"");
+            expect(authFileContent).toContain("api_key = \"secret-api-1\"");
+            expect(authFileContent).toContain("endpoint = \"oomol.com\"");
+            expect(content).toContain(`"msg":"Auth api key login request started."`);
+            expect(content).toContain(`"msg":"Auth api key login completed successfully."`);
+            expect(content).toContain(`"msg":"Auth account persisted after api key login."`);
+            expect(content).not.toContain(apiKey);
+            expect(result.stdout).not.toContain(apiKey);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects combining --api-key with --session-token", async () => {
+        const sandbox = await createCliSandbox();
+        const authFilePath = join(
+            sandbox.env.XDG_CONFIG_HOME!,
+            APP_NAME,
+            "auth.toml",
+        );
+
+        try {
+            const result = await sandbox.run(
+                ["login", "--api-key", "secret-api-1", "--session-token", "session-1"],
+                {
+                    fetcher: async () => {
+                        throw new Error("No request should be made for conflicting login options.");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("--api-key");
+            expect(result.stderr).toContain("--session-token");
+            expect(await Bun.file(authFilePath).exists()).toBeFalse();
+            expect(result.stdout + result.stderr).not.toContain("secret-api-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("renders the auth login url and success block with color styling when stdout supports colors", async () => {
         const sandbox = await createCliSandbox();
         const colors = createTerminalColors(true);

--- a/src/application/commands/auth/login.ts
+++ b/src/application/commands/auth/login.ts
@@ -6,6 +6,7 @@ import type { AuthAccount } from "../../schemas/auth.ts";
 
 import { z } from "zod";
 import {
+    requestAuthAccountWithApiKey,
     requestAuthAccountWithSessionToken,
     startAuthLoginSession,
 } from "../../auth/login-flow.ts";
@@ -22,9 +23,21 @@ import {
 const loginUrlColor = "#c09ff5";
 const defaultAuthEndpoint = "oomol.com";
 
+type LoginMethod = "api_key" | "device_login" | "session_token";
+
+const persistedLogMessages = {
+    api_key: "Auth account persisted after api key login.",
+    device_login: "Auth account persisted after device login.",
+    session_token: "Auth account persisted after fast login.",
+} as const satisfies Record<LoginMethod, string>;
+
 const authLoginCommandInputSchema = z.object({
+    apiKey: z.string().trim().min(1).optional(),
     sessionToken: z.string().trim().min(1).optional(),
-});
+}).refine(
+    input => !(input.apiKey !== undefined && input.sessionToken !== undefined),
+    { message: "Use only one of --api-key or --session-token." },
+);
 
 export type AuthLoginCommandInput = z.output<typeof authLoginCommandInputSchema>;
 
@@ -34,6 +47,12 @@ export const authLoginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
     descriptionKey: "commands.auth.login.description",
     options: [
         {
+            name: "apiKey",
+            longFlag: "--api-key",
+            valueName: "api-key",
+            descriptionKey: "options.apiKey",
+        },
+        {
             name: "sessionToken",
             longFlag: "--session-token",
             valueName: "session-token",
@@ -41,24 +60,19 @@ export const authLoginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
         },
     ],
     inputSchema: authLoginCommandInputSchema,
-    mapInputError: () => new CliUserError("errors.auth.sessionTokenRequired", 2),
+    mapInputError: (_error, rawInput) => mapLoginInputError(rawInput),
     handler: async (input: AuthLoginCommandInput, context) => {
         const authEndpoint = readAuthEndpoint(context.env);
-        const loginMethod = input.sessionToken === undefined
-            ? "device_login" as const
-            : "session_token" as const;
+        const loginMethod = resolveLoginMethod(input);
 
         context.telemetry?.recordProperties({ auth_method: loginMethod });
 
-        const account = loginMethod === "device_login"
-            ? await runDeviceLogin(authEndpoint, context)
-            : await requestAuthAccountWithSessionToken({
-                    endpoint: authEndpoint,
-                    fetcher: context.fetcher,
-                    logger: context.logger,
-                    sessionToken: input.sessionToken!,
-                    translator: context.translator,
-                });
+        const account = await resolveAuthAccount(
+            loginMethod,
+            input,
+            authEndpoint,
+            context,
+        );
 
         const nextAuthFile = await context.authStore.update(authFile =>
             upsertAuthAccount(authFile, account),
@@ -73,9 +87,7 @@ export const authLoginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
                 loginMethod,
                 name: account.name,
             },
-            loginMethod === "device_login"
-                ? "Auth account persisted after device login."
-                : "Auth account persisted after fast login.",
+            persistedLogMessages[loginMethod],
         );
 
         writeAuthBlock(context, {
@@ -93,6 +105,63 @@ export const authLoginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
         });
     },
 };
+
+function resolveLoginMethod(input: AuthLoginCommandInput): LoginMethod {
+    if (input.apiKey !== undefined) {
+        return "api_key";
+    }
+
+    if (input.sessionToken !== undefined) {
+        return "session_token";
+    }
+
+    return "device_login";
+}
+
+async function resolveAuthAccount(
+    loginMethod: LoginMethod,
+    input: AuthLoginCommandInput,
+    authEndpoint: string,
+    context: CliExecutionContext,
+): Promise<AuthAccount> {
+    switch (loginMethod) {
+        case "api_key":
+            return await requestAuthAccountWithApiKey({
+                apiKey: input.apiKey!,
+                endpoint: authEndpoint,
+                fetcher: context.fetcher,
+                logger: context.logger,
+                translator: context.translator,
+            });
+        case "device_login":
+            return await runDeviceLogin(authEndpoint, context);
+        case "session_token":
+            return await requestAuthAccountWithSessionToken({
+                endpoint: authEndpoint,
+                fetcher: context.fetcher,
+                logger: context.logger,
+                sessionToken: input.sessionToken!,
+                translator: context.translator,
+            });
+    }
+}
+
+function mapLoginInputError(
+    rawInput: Record<string, unknown>,
+): CliUserError {
+    const hasApiKey = typeof rawInput.apiKey === "string";
+    const hasSessionToken = typeof rawInput.sessionToken === "string";
+
+    if (hasApiKey && hasSessionToken) {
+        return new CliUserError("errors.auth.loginMethodConflict", 2);
+    }
+
+    if (hasApiKey) {
+        return new CliUserError("errors.auth.apiKeyRequired", 2);
+    }
+
+    return new CliUserError("errors.auth.sessionTokenRequired", 2);
+}
 
 async function runDeviceLogin(
     authEndpoint: string,

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -22,7 +22,7 @@ export const enMessages = {
     "auth.switch.success": "Switched active account for {endpoint} to {name}",
     "commands.auth.description": "Manage CLI authentication accounts.",
     "commands.auth.login.description":
-        "Log in with an OOMOL account using device login or a session token.",
+        "Log in with an OOMOL account using device login, a session token, or an API key.",
     "commands.auth.login.summary": "Log in with an OOMOL account",
     "commands.auth.logout.description": "Remove the current account from persisted auth data.",
     "commands.auth.logout.summary": "Log out the current account",
@@ -117,7 +117,7 @@ export const enMessages = {
         "Print one previous persisted debug log file by index.",
     "commands.log.print.summary": "Print a previous debug log",
     "commands.login.description":
-        "Log in with an OOMOL account using device login or a session token. Alias for auth login.",
+        "Log in with an OOMOL account using device login, a session token, or an API key. Alias for auth login.",
     "commands.login.summary": "Log in with an OOMOL account (alias for auth login)",
     "commands.logout.description":
         "Remove the current account from persisted auth data. Alias for auth logout.",
@@ -229,8 +229,14 @@ export const enMessages = {
     "errors.commander.suggestion": "Did you mean {value}?",
     "errors.commander.unknownCommand": "Unknown command: {value}.",
     "errors.commander.unknownOption": "Unknown option: {value}.",
+    "errors.auth.apiKeyInvalid":
+        "The API key is invalid or has expired.",
+    "errors.auth.apiKeyRequired":
+        "API key must not be empty.",
     "errors.auth.loginInvalidResponse":
         "The auth login service returned an unsupported response body.",
+    "errors.auth.loginMethodConflict":
+        "Use only one of --api-key or --session-token.",
     "errors.auth.loginRequestError":
         "The auth login request failed: {message}",
     "errors.auth.loginRequestFailed":
@@ -755,6 +761,7 @@ export const enMessages = {
     "options.showUrl": "Include download URLs in text output",
     "options.size": "Specify the number of items per page",
     "options.status": "Filter by task status",
+    "options.apiKey": "Log in with an existing API key",
     "options.sessionToken": "Log in with a session token",
     "options.schema": "Provide response JSON Schema or @path to a JSON file",
     "options.system": "System prompt text or @path to a text file",
@@ -1046,7 +1053,7 @@ export const zhMessages = {
     "auth.status.loggedOut": "当前没有登录任何 OOMOL 账号。",
     "auth.switch.success": "已将 {endpoint} 的当前激活账号切换为 {name}",
     "commands.auth.description": "管理 CLI 的认证账号。",
-    "commands.auth.login.description": "通过 device login 或 session token 登录 OOMOL 账号。",
+    "commands.auth.login.description": "通过 device login、session token 或 API key 登录 OOMOL 账号。",
     "commands.auth.login.summary": "登录 OOMOL 账号",
     "commands.auth.logout.description": "从持久化认证数据中移除当前账号。",
     "commands.auth.logout.summary": "登出当前账号",
@@ -1134,7 +1141,7 @@ export const zhMessages = {
     "commands.log.path.summary": "显示日志目录路径",
     "commands.log.print.description": "按序号打印某一份更早的持久化 debug 日志文件内容。",
     "commands.log.print.summary": "输出某一份更早的 debug 日志",
-    "commands.login.description": "通过 device login 或 session token 登录 OOMOL 账号。是 auth login 的别名。",
+    "commands.login.description": "通过 device login、session token 或 API key 登录 OOMOL 账号。是 auth login 的别名。",
     "commands.login.summary": "登录 OOMOL 账号（auth login 的别名）",
     "commands.logout.description": "从持久化认证数据中移除当前账号。是 auth logout 的别名。",
     "commands.logout.summary": "登出当前账号（auth logout 的别名）",
@@ -1241,7 +1248,10 @@ export const zhMessages = {
     "errors.commander.suggestion": "你是想输入 {value} 吗？",
     "errors.commander.unknownCommand": "未知命令：{value}。",
     "errors.commander.unknownOption": "未知选项：{value}。",
+    "errors.auth.apiKeyInvalid": "API key 无效或已过期。",
+    "errors.auth.apiKeyRequired": "API key 不能为空。",
     "errors.auth.loginInvalidResponse": "auth login 服务返回了不受支持的响应内容。",
+    "errors.auth.loginMethodConflict": "--api-key 与 --session-token 只能使用其中一个。",
     "errors.auth.loginRequestError": "auth login 请求失败：{message}",
     "errors.auth.loginRequestFailed": "auth login 请求返回了 HTTP {status}。",
     "errors.auth.loginTimeout": "等待 device login 完成超过 {timeout}，已超时。",
@@ -1750,6 +1760,7 @@ export const zhMessages = {
     "options.showUrl": "在文本输出中包含下载 URL",
     "options.size": "指定每页数量",
     "options.status": "按任务状态过滤",
+    "options.apiKey": "使用已有 API key 登录",
     "options.sessionToken": "使用 session token 登录",
     "options.schema": "提供响应 JSON Schema，或使用 @路径 读取 JSON 文件",
     "options.system": "System prompt 文本，或使用 @路径 读取文本文件",


### PR DESCRIPTION
Add an `--api-key` option to `oo auth login` and its `oo login` alias so users can authenticate with an existing API key instead of running the device login flow or passing a session token. The key is validated against the users profile endpoint and the account is saved on success.

The option cannot be combined with `--session-token`, and the key is redacted from CLI argument logs and request failures to avoid leaking the secret.