### PR TITLE
feat(skills)!: remove preset gpt-image-2 registry package

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -345,8 +345,7 @@ Install one managed `oo` release into the local self-managed runtime.
   then decide whether to update the failed profiles manually.
 - Notes: after a successful install workflow, the CLI silently runs
   `oo skills add` with the managed executable so bundled skills refresh to the
-  installed CLI version. That command also includes any successfully installed
-  preset registry skills in the same skill summary.
+  installed CLI version.
 - Notes: when the current version is `0.0.0-development`, the CLI prints the
   managed install/update unsupported message and exits successfully.
 
@@ -398,8 +397,7 @@ Update the managed `oo` install to the latest published release.
   then decide whether to update the failed profiles manually.
 - Notes: after a successful update workflow, the CLI silently runs
   `oo skills add` with the managed executable so bundled skills refresh to the
-  installed CLI version. That command also includes any successfully installed
-  preset registry skills in the same skill summary.
+  installed CLI version.
 - Notes: when the current version is `0.0.0-development`, the CLI prints the
   managed install/update unsupported message and exits successfully.
 
@@ -419,16 +417,14 @@ Uninstall the managed `oo` runtime and its built-in skills.
 - Options: `--purge` additionally removes user data (auth, settings, cache,
   logs, telemetry) and **all** oo-managed registry skills.
 - Default removal: the managed executable (`~/.local/bin/oo`), all installed
-  versions, self-update staging and locks, bundled skills, and the preset
-  registry skill package `@alwaysmavs/gpt-image-2` (host installs and canonical
-  source).
-- Default retention: PATH configuration is left untouched; non-preset registry
-  skills, local skills, and any same-name directory that is not oo-managed are
+  versions, self-update staging and locks, and bundled skills.
+- Default retention: PATH configuration is left untouched; registry skills,
+  local skills, and any same-name directory that is not oo-managed are
   retained, as is user data (removed only with `--purge`).
 - Skill safety: a skill is removed only when its `.oo-metadata.json` proves
-  oo ownership (`kind: "bundled"`, or `kind: "registry"` matching the preset
-  list / `--purge`). Directories with missing, invalid, local, or non-matching
-  metadata are never deleted, so user-authored same-name skills are safe.
+  oo ownership (`kind: "bundled"`, or `kind: "registry"` under `--purge`).
+  Directories with missing, invalid, local, or non-matching metadata are never
+  deleted, so user-authored same-name skills are safe.
 - Installation method: when `oo` was installed via a package manager
   (npm/bun/pnpm/yarn), the command removes oo-managed skills, prints the
   matching `npm uninstall -g @oomol-lab/oo-cli` (or equivalent) command, and
@@ -976,8 +972,7 @@ Install bundled or published skills into supported local skill directories.
 
 - Alias: `oo skills add [packageName]`.
 - Arguments: `[packageName]` is optional.
-- Arguments: when omitted, the command installs all bundled skills, then
-  best-effort installs all skills from preset registry skill packages.
+- Arguments: when omitted, the command installs all bundled skills.
 - Arguments: when `[packageName]` is `oo`, `oo-find-skills`,
   `oo-create-skill`, or `oo-publish-skill`, the command installs the
   corresponding bundled skill.
@@ -1008,13 +1003,8 @@ Install bundled or published skills into supported local skill directories.
 - Output: successful non-interactive installs print a compact summary grouped by
   installed skills and target AI agents. When exactly one target is written, the
   summary includes that target path.
-- Output: when omitted `[packageName]` also installs preset registry skills
-  successfully, those skill names are included in the same `Installed ...`
-  summary and `Skills:` list.
 - Notes: when a package publishes exactly one skill and no `--skill` is
   provided, the command installs that skill automatically.
-- Notes: preset registry skill package failures are ignored and do not change
-  the command result.
 - Notes: when a package publishes multiple skills and no `--skill`, `--all`, or
   `-y` is provided, the command opens an interactive picker in a TTY.
 - Notes: in the interactive picker, skills already installed from the same

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -301,8 +301,7 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   ——已配置的 profile 和未能配置的 profile，并附带重启 shell 的提示；用户可据此
   决定是否手动补全未配置的 profile。
 - 说明：install 成功后，CLI 会使用托管的可执行文件静默执行一次
-  `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。该命令也会把
-  安装成功的预设 registry skills 合并进同一份 skill 摘要。
+  `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /
   update 的提示，并以成功状态退出。
 
@@ -342,8 +341,7 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   ——已配置的 profile 和未能配置的 profile，并附带重启 shell 的提示；用户可据此
   决定是否手动补全未配置的 profile。
 - 说明：update 成功后，CLI 会使用托管的可执行文件静默执行一次
-  `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。该命令也会把
-  安装成功的预设 registry skills 合并进同一份 skill 摘要。
+  `oo skills add`，让 bundled skills 刷新到已安装的 CLI 版本。
 - 说明：当当前版本为 `0.0.0-development` 时，CLI 会打印不支持托管 install /
   update 的提示，并以成功状态退出。
 
@@ -361,13 +359,12 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 选项：`--purge` 额外删除用户数据（auth、settings、cache、logs、telemetry）
   以及**全部**由 oo 管理的 registry skills。
 - 默认删除：受管可执行文件（`~/.local/bin/oo`）、所有已安装版本、self-update
-  staging 与 locks、bundled skills，以及 preset registry skill 包
-  `@alwaysmavs/gpt-image-2`（host 安装与 canonical source）。
-- 默认保留：不动 PATH 配置；非 preset 的 registry skills、local skills、以及
-  任何不受 oo 管理的同名目录都保留；用户数据仅在 `--purge` 时删除。
+  staging 与 locks，以及 bundled skills。
+- 默认保留：不动 PATH 配置；registry skills、local skills、以及任何不受 oo
+  管理的同名目录都保留；用户数据仅在 `--purge` 时删除。
 - skill 安全规则：仅当 `.oo-metadata.json` 能证明 oo 所有权（`kind: "bundled"`，
-  或 `kind: "registry"` 且匹配 preset 列表 / `--purge`）时才删除。metadata 缺失、
-  损坏、local 或不匹配的目录一律不删，因此用户手写的同名 skill 是安全的。
+  或 `kind: "registry"` 且在 `--purge` 下）时才删除。metadata 缺失、损坏、local
+  或不匹配的目录一律不删，因此用户手写的同名 skill 是安全的。
 - 安装方式：当 `oo` 是通过包管理器（npm/bun/pnpm/yarn）安装时，命令会删除
   oo 管理的 skills，打印对应的 `npm uninstall -g @oomol-lab/oo-cli`（或等价）命令，
   并以非零状态退出，提示调用方二进制仍需手动删除。当可执行文件位于未知位置时，
@@ -832,8 +829,7 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 
 - 别名：`oo skills add [packageName]`。
 - 参数：`[packageName]` 可选。
-- 参数：未提供时，该命令会安装全部内置 skill，然后尽力安装预设 registry
-  skill packages 里的全部 skill。
+- 参数：未提供时，该命令会安装全部内置 skill。
 - 参数：当 `[packageName]` 为 `oo`、`oo-find-skills`、`oo-create-skill` 或
   `oo-publish-skill` 时，命令安装对应的内置 skill。
 - 参数：当 `[packageName]` 为已发布 package 名称时，命令从该 package 中
@@ -858,11 +854,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   `--all -y` 使用）。
 - 输出：非交互安装成功时，会按已安装 skill 和目标 AI Agent 聚合输出精简摘要；
   当实际只写入一个目标时，摘要会包含该目标路径。
-- 输出：未提供 `[packageName]` 且有预设 registry skills 安装成功时，这些
-  skill 名称会合并到同一份 `Installed ...` 摘要和 `Skills:` 列表里。
 - 说明：如果 package 只发布了一个 skill，且未提供 `--skill`，命令会自动
   安装这个唯一的 skill。
-- 说明：预设 registry skill package 安装失败会被忽略，不改变命令结果。
 - 说明：如果 package 发布了多个 skill，且未提供 `--skill`、`--all` 或
   `-y`，命令会在 TTY 中打开交互选择页面。
 - 说明：在交互选择页面中，同一 package 下已安装的 skill 会默认保持勾选；

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -35,6 +35,7 @@ import { createTranslator } from "../../i18n/translator.ts";
 import { createCliCatalog } from "../commands/catalog.ts";
 import { synchronizeManagedSkillsForAvailableHosts } from "../commands/skills/auto-sync.ts";
 import { removeLegacyCodexManagedSkills } from "../commands/skills/legacy-codex-cleanup.ts";
+import { removeLegacyGptImage2ManagedSkills } from "../commands/skills/legacy-gpt-image-2-cleanup.ts";
 import { APP_NAME } from "../config/app-config.ts";
 import {
     formatCliVersionText,
@@ -278,6 +279,12 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
         // and `legacy-codex-cleanup.ts` once enough releases have shipped that no
         // user still has oo-managed skills under the legacy Codex home.
         await removeLegacyCodexManagedSkills(context);
+        // TODO(gpt-image-2-removal): Temporary compatibility cleanup. Remove this
+        // call and `legacy-gpt-image-2-cleanup.ts` once enough releases have
+        // shipped that no user still has the oo-managed `@alwaysmavs/gpt-image-2`
+        // skills materialized in an AI agent. Must run before the sync below so
+        // the canonical sources are gone before re-publishing could re-create them.
+        await removeLegacyGptImage2ManagedSkills(context);
         await synchronizeManagedSkillsForAvailableHosts(context);
 
         exitCode = await adapter.run({

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -38,7 +38,6 @@ import {
     resolveManagedSkillDirectoryPath,
     resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
-import { presetSkillPackageNames } from "./preset-packages.ts";
 import { installedRegistrySkillCompatibility } from "./registry-skill-markdown.ts";
 import {
     createBundledSkillMetadata,
@@ -170,81 +169,6 @@ describe("skills commands", () => {
             expect(await readFile(publishSkillMetadataFilePath, "utf8")).toBe(
                 renderSkillMetadataJson(createBundledSkillMetadata(resultVersion)),
             );
-        }
-        finally {
-            await sandbox.cleanup();
-        }
-    });
-
-    test("includes successful preset package skills in the bundled install summary", async () => {
-        const sandbox = await createCliSandbox();
-        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
-        const firstPresetSkillDirectoryPath = join(universalHomeDirectory, "skills", "gpt-image-2");
-        const secondPresetSkillDirectoryPath = join(universalHomeDirectory, "skills", "gpt-image-2-edit");
-        const requests: Request[] = [];
-
-        try {
-            await mkdir(universalHomeDirectory, { recursive: true });
-            await writeAuthFile(sandbox);
-
-            const result = await sandbox.run(["skills", "add"], {
-                fetcher: async (input, init) => {
-                    const request = toRequest(input, init);
-
-                    requests.push(request);
-
-                    if (request.url.includes("/package-info/")) {
-                        return new Response(JSON.stringify({
-                            packageName: presetSkillPackageNames[0],
-                            version: "0.0.3",
-                            skills: [
-                                {
-                                    description: "Generate images",
-                                    name: "gpt-image-2",
-                                    title: "GPT Image 2",
-                                },
-                                {
-                                    description: "Edit images",
-                                    name: "gpt-image-2-edit",
-                                    title: "GPT Image 2 Edit",
-                                },
-                            ],
-                        }));
-                    }
-
-                    if (request.url.endsWith("/@alwaysmavs/gpt-image-2/-/meta/gpt-image-2-0.0.3.tgz")) {
-                        return new Response(await createRegistrySkillArchiveBytes({
-                            "package/package/skills/gpt-image-2/SKILL.md": "# GPT Image 2\n",
-                            "package/package/skills/gpt-image-2-edit/SKILL.md": "# GPT Image 2 Edit\n",
-                        }));
-                    }
-
-                    if (isRegistryPackageDownloadCountRequest(request)) {
-                        return new Response(null, { status: 204 });
-                    }
-
-                    throw new Error(`Unexpected request: ${request.url}`);
-                },
-                version: "9.9.9",
-            });
-
-            expect(result.exitCode).toBe(0);
-            expect(result.stdout).toBe(
-                [
-                    "Installed 6 skills to Universal.",
-                    "Skills: oo, oo-find-skills, oo-create-skill, oo-publish-skill, gpt-image-2, gpt-image-2-edit",
-                    "",
-                ].join("\n"),
-            );
-            expect(result.stdout).not.toContain(presetSkillPackageNames[0]!);
-            expect(result.stderr).toBe("");
-            await expect(stat(firstPresetSkillDirectoryPath)).resolves.toMatchObject({
-                isDirectory: expect.any(Function),
-            });
-            await expect(stat(secondPresetSkillDirectoryPath)).resolves.toMatchObject({
-                isDirectory: expect.any(Function),
-            });
-            expect(requests).toHaveLength(3);
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -35,7 +35,6 @@ import {
     skillOperationOutputOptions,
     writeSkillOperationJson,
 } from "./operation-result.ts";
-import { presetSkillPackageNames } from "./preset-packages.ts";
 import { installRegistrySkills } from "./registry-skill-install.ts";
 import {
     installBundledSkill,
@@ -164,12 +163,6 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
                 summaries.push(await installBundledSkill(skillName, context, { force }));
             }
 
-            for (const { summaries: presetSummaries } of await installPresetSkillPackages(
-                context,
-                force,
-            )) {
-                summaries.push(...presetSummaries);
-            }
             writeManagedSkillInstallSummary(context, summaries);
             return;
         }
@@ -231,19 +224,6 @@ async function runInstallJsonReport(
             skills.push(result);
         }
 
-        const settingsFilePath = context.settingsStore.getFilePath();
-        const presetGroups = await installPresetSkillPackages(context, options.force);
-
-        for (const { packageName, summaries } of presetGroups) {
-            for (const summary of summaries) {
-                skills.push(await buildRegistrySkillResult(
-                    summary,
-                    packageName,
-                    undefined,
-                    settingsFilePath,
-                ));
-            }
-        }
         return buildReport(skills, errors, skills.length);
     }
 
@@ -586,48 +566,6 @@ function recordInstallTelemetry(
         has_bundled_skill: hasBundled,
         has_registry_skill: hasRegistry,
     });
-}
-
-interface PresetSkillPackageInstallGroup {
-    packageName: string;
-    summaries: ManagedSkillInstallSummary[];
-}
-
-async function installPresetSkillPackages(
-    context: CliExecutionContext,
-    force: boolean,
-): Promise<PresetSkillPackageInstallGroup[]> {
-    const groups: PresetSkillPackageInstallGroup[] = [];
-
-    for (const packageName of presetSkillPackageNames) {
-        try {
-            const summaries = await installRegistrySkills(
-                {
-                    all: true,
-                    force,
-                    packageName,
-                    recordTelemetry: false,
-                    skillNames: [],
-                    writeOutput: false,
-                    yes: true,
-                },
-                context,
-            );
-
-            groups.push({ packageName, summaries });
-        }
-        catch (error) {
-            context.logger.warn(
-                {
-                    err: error,
-                    packageName,
-                },
-                "Preset skill package install skipped.",
-            );
-        }
-    }
-
-    return groups;
 }
 
 function parseSkillsInstallPackageSpecifier(

--- a/src/application/commands/skills/legacy-gpt-image-2-cleanup.test.ts
+++ b/src/application/commands/skills/legacy-gpt-image-2-cleanup.test.ts
@@ -1,0 +1,208 @@
+import type { Logger } from "pino";
+
+import { mkdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    createLogCapture,
+    createTemporaryDirectory,
+} from "../../../../__tests__/helpers.ts";
+import { removeLegacyGptImage2ManagedSkills } from "./legacy-gpt-image-2-cleanup.ts";
+
+const gptImage2Metadata = {
+    kind: "registry",
+    packageName: "@alwaysmavs/gpt-image-2",
+    schemaVersion: 1,
+    version: "0.0.3",
+};
+const otherRegistryMetadata = {
+    kind: "registry",
+    packageName: "@alice/demo",
+    schemaVersion: 1,
+    version: "1.0.0",
+};
+const bundledMetadata = { kind: "bundled", schemaVersion: 1, version: "1.2.3" };
+const localMetadata = { kind: "local", schemaVersion: 1 };
+
+describe("legacy @alwaysmavs/gpt-image-2 managed skill cleanup", () => {
+    test("removes oo-managed gpt-image-2 skills from AI agents while preserving other, local, and unmanaged skills", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-gpt-image-2");
+        const configDirectoryPath = join(rootDirectory, "config");
+        const settingsFilePath = join(configDirectoryPath, "settings.toml");
+        const universalSkillsDirectoryPath = join(rootDirectory, ".agents", "skills");
+        const gptImage2SkillPath = join(universalSkillsDirectoryPath, "gpt-image-2");
+        const gptImage2EditSkillPath = join(universalSkillsDirectoryPath, "gpt-image-2-edit");
+        const otherRegistrySkillPath = join(universalSkillsDirectoryPath, "demo");
+        const bundledSkillPath = join(universalSkillsDirectoryPath, "oo");
+        const localSkillPath = join(universalSkillsDirectoryPath, "mine");
+        const unmanagedSkillPath = join(universalSkillsDirectoryPath, "custom");
+        const logCapture = createLogCapture();
+
+        try {
+            await writeManagedSkill(gptImage2SkillPath, gptImage2Metadata);
+            await writeManagedSkill(gptImage2EditSkillPath, gptImage2Metadata);
+            await writeManagedSkill(otherRegistrySkillPath, otherRegistryMetadata);
+            await writeManagedSkill(bundledSkillPath, bundledMetadata);
+            await writeManagedSkill(localSkillPath, localMetadata);
+            await writeUnmanagedSkill(unmanagedSkillPath);
+
+            await removeLegacyGptImage2ManagedSkills(
+                createCleanupContext({
+                    env: { HOME: rootDirectory, USERPROFILE: rootDirectory },
+                    logger: logCapture.logger as unknown as Logger,
+                    settingsFilePath,
+                }),
+            );
+
+            await expect(stat(gptImage2SkillPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(gptImage2EditSkillPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            expect((await stat(otherRegistrySkillPath)).isDirectory()).toBe(true);
+            expect((await stat(bundledSkillPath)).isDirectory()).toBe(true);
+            expect((await stat(localSkillPath)).isDirectory()).toBe(true);
+            expect((await stat(unmanagedSkillPath)).isDirectory()).toBe(true);
+        }
+        finally {
+            logCapture.close();
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("removes the canonical registry sources for gpt-image-2 while preserving other packages", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-gpt-image-2");
+        const configDirectoryPath = join(rootDirectory, "config");
+        const settingsFilePath = join(configDirectoryPath, "settings.toml");
+        const canonicalRegistryPath = join(configDirectoryPath, "skills", "registry");
+        const canonicalGptImage2Path = join(canonicalRegistryPath, "gpt-image-2");
+        const canonicalOtherPath = join(canonicalRegistryPath, "demo");
+        const logCapture = createLogCapture();
+
+        try {
+            await writeManagedSkill(canonicalGptImage2Path, gptImage2Metadata);
+            await writeManagedSkill(canonicalOtherPath, otherRegistryMetadata);
+
+            await removeLegacyGptImage2ManagedSkills(
+                createCleanupContext({
+                    env: { HOME: rootDirectory, USERPROFILE: rootDirectory },
+                    logger: logCapture.logger as unknown as Logger,
+                    settingsFilePath,
+                }),
+            );
+
+            await expect(stat(canonicalGptImage2Path)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            expect((await stat(canonicalOtherPath)).isDirectory()).toBe(true);
+        }
+        finally {
+            logCapture.close();
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("is a silent no-op when there is nothing to clean up", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-gpt-image-2");
+        const configDirectoryPath = join(rootDirectory, "config");
+        const settingsFilePath = join(configDirectoryPath, "settings.toml");
+        const logCapture = createLogCapture();
+
+        try {
+            await mkdir(configDirectoryPath, { recursive: true });
+
+            await removeLegacyGptImage2ManagedSkills(
+                createCleanupContext({
+                    env: { HOME: rootDirectory, USERPROFILE: rootDirectory },
+                    logger: logCapture.logger as unknown as Logger,
+                    settingsFilePath,
+                }),
+            );
+
+            logCapture.close();
+            expect(logCapture.read()).toBe("");
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("completes the canonical cleanup even when the host cleanup fails", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-legacy-gpt-image-2");
+        const configDirectoryPath = join(rootDirectory, "config");
+        const settingsFilePath = join(configDirectoryPath, "settings.toml");
+        const universalHomeDirectory = join(rootDirectory, ".agents");
+        const universalSkillsPath = join(universalHomeDirectory, "skills");
+        const canonicalGptImage2Path = join(
+            configDirectoryPath,
+            "skills",
+            "registry",
+            "gpt-image-2",
+        );
+        const logCapture = createLogCapture();
+
+        try {
+            // Make the universal skills path a file so readdir fails with a
+            // non-ENOENT error, forcing the host-cleanup branch to reject.
+            await mkdir(universalHomeDirectory, { recursive: true });
+            await Bun.write(universalSkillsPath, "not a directory\n");
+            await writeManagedSkill(canonicalGptImage2Path, gptImage2Metadata);
+
+            await removeLegacyGptImage2ManagedSkills(
+                createCleanupContext({
+                    env: { HOME: rootDirectory, USERPROFILE: rootDirectory },
+                    logger: logCapture.logger as unknown as Logger,
+                    settingsFilePath,
+                }),
+            );
+
+            // The host branch rejected, but the canonical branch must still have
+            // run to completion (Promise.allSettled, not a fail-fast Promise.all).
+            await expect(stat(canonicalGptImage2Path)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+
+            logCapture.close();
+            expect(logCapture.read()).toContain(
+                "Legacy @alwaysmavs/gpt-image-2 managed skill cleanup failed.",
+            );
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+});
+
+async function writeManagedSkill(
+    skillDirectoryPath: string,
+    metadata: object,
+): Promise<void> {
+    await mkdir(skillDirectoryPath, { recursive: true });
+    await Bun.write(join(skillDirectoryPath, "SKILL.md"), "skill\n");
+    await Bun.write(
+        join(skillDirectoryPath, ".oo-metadata.json"),
+        JSON.stringify(metadata),
+    );
+}
+
+async function writeUnmanagedSkill(skillDirectoryPath: string): Promise<void> {
+    await mkdir(skillDirectoryPath, { recursive: true });
+    await Bun.write(join(skillDirectoryPath, "SKILL.md"), "user authored\n");
+}
+
+function createCleanupContext(options: {
+    env: Record<string, string | undefined>;
+    logger: Logger;
+    settingsFilePath: string;
+}): Parameters<typeof removeLegacyGptImage2ManagedSkills>[0] {
+    return {
+        env: options.env,
+        logger: options.logger,
+        settingsStore: {
+            getFilePath: () => options.settingsFilePath,
+        } as never,
+    };
+}

--- a/src/application/commands/skills/legacy-gpt-image-2-cleanup.ts
+++ b/src/application/commands/skills/legacy-gpt-image-2-cleanup.ts
@@ -1,0 +1,149 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { isNodeNotFoundError, removePath } from "./bundled-skill-filesystem.ts";
+import { resolveAvailableManagedSkillHosts } from "./managed-skill-hosts.ts";
+import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
+import {
+    resolveManagedSkillCanonicalRootDirectoryPath,
+    resolveManagedSkillsDirectoryPath,
+} from "./managed-skill-paths.ts";
+
+// Registry skill package the CLI used to ship as a built-in preset.
+const legacyGptImage2PackageName = "@alwaysmavs/gpt-image-2";
+
+type LegacyGptImage2CleanupContext = Pick<
+    CliExecutionContext,
+    "env" | "logger" | "settingsStore"
+>;
+
+/**
+ * TODO(gpt-image-2-removal): Temporary compatibility cleanup. Remove this file
+ * and its call site in `run-cli.ts` once enough releases have shipped that no
+ * user still has the oo-managed `@alwaysmavs/gpt-image-2` skills materialized in
+ * an AI agent or kept as canonical registry sources.
+ *
+ * `@alwaysmavs/gpt-image-2` used to be a built-in preset: at startup the CLI
+ * downloaded the package and released its skills into every AI agent alongside
+ * the bundled skills, keeping canonical registry sources under
+ * `<config>/skills/registry`. That preset path is gone, so this routine deletes
+ * the skills oo itself materialized for that package — both the per-agent
+ * installs and the canonical sources that `synchronizeManagedSkillsForAvailableHosts`
+ * would otherwise keep re-publishing. Skills are identified strictly by their
+ * `.oo-metadata.json` (registry metadata whose `packageName` matches the legacy
+ * preset package); user-authored and unrelated skills are preserved.
+ */
+export async function removeLegacyGptImage2ManagedSkills(
+    context: LegacyGptImage2CleanupContext,
+): Promise<void> {
+    // Best-effort cleanup: run both branches to completion and never short-circuit
+    // on the first failure, so a failing branch cannot leave the other unfinished.
+    const results = await Promise.allSettled([
+        removeLegacyGptImage2HostInstalls(context),
+        removeLegacyGptImage2CanonicalSources(context),
+    ]);
+
+    for (const result of results) {
+        if (result.status === "rejected") {
+            context.logger.warn(
+                { err: result.reason },
+                "Legacy @alwaysmavs/gpt-image-2 managed skill cleanup failed.",
+            );
+        }
+    }
+}
+
+async function removeLegacyGptImage2HostInstalls(
+    context: LegacyGptImage2CleanupContext,
+): Promise<void> {
+    const hosts = await resolveAvailableManagedSkillHosts(context.env);
+
+    await Promise.all(
+        hosts.map(host =>
+            removeLegacyGptImage2SkillsInDirectory(
+                resolveManagedSkillsDirectoryPath(host.homeDirectory),
+                context,
+            ),
+        ),
+    );
+}
+
+async function removeLegacyGptImage2CanonicalSources(
+    context: LegacyGptImage2CleanupContext,
+): Promise<void> {
+    await removeLegacyGptImage2SkillsInDirectory(
+        resolveManagedSkillCanonicalRootDirectoryPath(
+            context.settingsStore.getFilePath(),
+        ),
+        context,
+    );
+}
+
+async function removeLegacyGptImage2SkillsInDirectory(
+    skillsDirectoryPath: string,
+    context: LegacyGptImage2CleanupContext,
+): Promise<void> {
+    const entryNames = await readSkillDirectoryEntryNames(skillsDirectoryPath);
+
+    await Promise.all(
+        entryNames.map(entryName =>
+            removeLegacyGptImage2Skill(
+                join(skillsDirectoryPath, entryName),
+                entryName,
+                context,
+            ),
+        ),
+    );
+}
+
+async function removeLegacyGptImage2Skill(
+    skillDirectoryPath: string,
+    skillName: string,
+    context: LegacyGptImage2CleanupContext,
+): Promise<void> {
+    try {
+        if (!(await isLegacyGptImage2SkillDirectory(skillDirectoryPath))) {
+            return;
+        }
+
+        await removePath(skillDirectoryPath);
+        context.logger.info(
+            { path: skillDirectoryPath, skillName },
+            "Removed oo-managed @alwaysmavs/gpt-image-2 skill.",
+        );
+    }
+    catch (error) {
+        context.logger.warn(
+            { err: error, path: skillDirectoryPath, skillName },
+            "Failed to remove oo-managed @alwaysmavs/gpt-image-2 skill.",
+        );
+    }
+}
+
+async function isLegacyGptImage2SkillDirectory(
+    skillDirectoryPath: string,
+): Promise<boolean> {
+    // `readManagedSkillMetadata` only returns registry metadata, so bundled and
+    // local skills (and directories without `.oo-metadata.json`) never match.
+    const metadata = await readManagedSkillMetadata(skillDirectoryPath);
+
+    return metadata?.packageName === legacyGptImage2PackageName;
+}
+
+async function readSkillDirectoryEntryNames(
+    skillsDirectoryPath: string,
+): Promise<string[]> {
+    try {
+        return (await readdir(skillsDirectoryPath, { withFileTypes: true }))
+            .filter(entry => entry.isDirectory() || entry.isSymbolicLink())
+            .map(entry => entry.name);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return [];
+        }
+
+        throw error;
+    }
+}

--- a/src/application/commands/skills/preset-packages.ts
+++ b/src/application/commands/skills/preset-packages.ts
@@ -1,8 +1,0 @@
-// Preset registry skill packages that ship with the CLI: they are installed by
-// default during a no-argument `oo skills install` / `oo install`, and removed
-// by default during `oo uninstall`. Keeping this list in one module makes
-// "what install adds by default" and "what uninstall removes by default" a
-// single source of truth.
-export const presetSkillPackageNames = ["@alwaysmavs/gpt-image-2"] as const;
-
-export type PresetSkillPackageName = (typeof presetSkillPackageNames)[number];

--- a/src/application/commands/uninstall.cli.test.ts
+++ b/src/application/commands/uninstall.cli.test.ts
@@ -10,15 +10,12 @@ import { APP_NAME } from "../config/app-config.ts";
 import { resolveSelfUpdatePaths } from "../self-update/paths.ts";
 import { pathExists } from "../shared/fs-utils.ts";
 import { resolveManagedSkillMetadataFilePath } from "./skills/managed-skill-paths.ts";
-import { presetSkillPackageNames } from "./skills/preset-packages.ts";
 import {
     createBundledSkillMetadata,
     createLocalSkillMetadata,
     createRegistrySkillMetadata,
     renderSkillMetadataJson,
 } from "./skills/skill-metadata.ts";
-
-const PRESET_PACKAGE = presetSkillPackageNames[0];
 
 function selfUpdatePaths(sandbox: Awaited<ReturnType<typeof createCliSandbox>>) {
     return resolveSelfUpdatePaths({
@@ -120,7 +117,7 @@ describe("oo uninstall", () => {
         }
     });
 
-    test("--yes removes runtime + bundled + preset, keeps registry/local/unmanaged", async () => {
+    test("--yes removes runtime + bundled, keeps registry/local/unmanaged", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -129,14 +126,6 @@ describe("oo uninstall", () => {
                 sandbox,
                 skillName: "oo",
                 metadataJson: renderSkillMetadataJson(createBundledSkillMetadata("1.2.3")),
-            });
-            const presetSkill = await seedHostSkill({
-                sandbox,
-                skillName: "gpt-image-2",
-                metadataJson: renderSkillMetadataJson(createRegistrySkillMetadata({
-                    packageName: PRESET_PACKAGE,
-                    version: "0.1.0",
-                })),
             });
             const registrySkill = await seedHostSkill({
                 sandbox,
@@ -180,7 +169,6 @@ describe("oo uninstall", () => {
             // every platform.
             expect(await Bun.file(join(runtime.versionsDirectory, "1.2.3", "oo")).exists()).toBe(false);
             expect(await Bun.file(join(ooSkill, "SKILL.md")).exists()).toBe(false);
-            expect(await Bun.file(join(presetSkill, "SKILL.md")).exists()).toBe(false);
             // Retained
             expect(await Bun.file(join(registrySkill, "SKILL.md")).exists()).toBe(true);
             expect(await Bun.file(join(localSkill, "SKILL.md")).exists()).toBe(true);

--- a/src/application/self-update/uninstall.test.ts
+++ b/src/application/self-update/uninstall.test.ts
@@ -8,7 +8,6 @@ import process from "node:process";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { resolveStorePaths } from "../../adapters/store/store-path.ts";
 import { resolveManagedSkillMetadataFilePath } from "../commands/skills/managed-skill-paths.ts";
-import { presetSkillPackageNames } from "../commands/skills/preset-packages.ts";
 import {
     createBundledSkillMetadata,
     createLocalSkillMetadata,
@@ -23,8 +22,6 @@ import {
     performSelfUninstall,
     shouldRemoveManagedSkill,
 } from "./uninstall.ts";
-
-const PRESET_PACKAGE = presetSkillPackageNames[0];
 
 const noopLogger = {
     warn: () => {},
@@ -66,13 +63,7 @@ describe("shouldRemoveManagedSkill", () => {
         expect(shouldRemoveManagedSkill(createBundledSkillMetadata("1.0.0"), { purge: true })).toBe(true);
     });
 
-    test("preset registry is removed by default", () => {
-        const metadata = createRegistrySkillMetadata({ packageName: PRESET_PACKAGE, version: "0.1.0" });
-
-        expect(shouldRemoveManagedSkill(metadata, { purge: false })).toBe(true);
-    });
-
-    test("non-preset registry is kept by default and removed under purge", () => {
+    test("registry is kept by default and removed under purge", () => {
         const metadata = createRegistrySkillMetadata({ packageName: "@alice/demo", version: "0.1.0" });
 
         expect(shouldRemoveManagedSkill(metadata, { purge: false })).toBe(false);
@@ -242,17 +233,13 @@ describe("buildSelfUninstallPlan", () => {
         expect(plan.deferred.every(item => item.category !== "user-data")).toBe(true);
     });
 
-    test("classifies skills by metadata: bundled+preset removed, registry kept, local/unmanaged retained", async () => {
+    test("classifies skills by metadata: bundled removed, registry kept, local/unmanaged retained", async () => {
         const universalSkillsDir = join(tempHome, ".agents", "skills");
 
         await mkdir(join(tempHome, ".agents"), { recursive: true });
         await writeSkill(
             join(universalSkillsDir, "oo"),
             renderSkillMetadataJson(createBundledSkillMetadata("1.2.3")),
-        );
-        await writeSkill(
-            join(universalSkillsDir, "gpt-image-2"),
-            renderSkillMetadataJson(createRegistrySkillMetadata({ packageName: PRESET_PACKAGE, version: "0.1.0" })),
         );
         await writeSkill(
             join(universalSkillsDir, "demo"),
@@ -272,7 +259,6 @@ describe("buildSelfUninstallPlan", () => {
         ));
 
         expect(removedPaths.some(path => path.endsWith(join(".agents", "skills", "oo")))).toBe(true);
-        expect(removedPaths.some(path => path.endsWith(join(".agents", "skills", "gpt-image-2")))).toBe(true);
         expect(removedPaths.some(path => path.endsWith(join(".agents", "skills", "demo")))).toBe(false);
         expect(removedPaths.some(path => path.endsWith(join(".agents", "skills", "mine")))).toBe(false);
         // unmanaged dir never appears in any removal set

--- a/src/application/self-update/uninstall.ts
+++ b/src/application/self-update/uninstall.ts
@@ -18,9 +18,6 @@ import {
 import {
     resolveManagedSkillCanonicalRootDirectoryPath,
 } from "../commands/skills/managed-skill-paths.ts";
-import {
-    presetSkillPackageNames,
-} from "../commands/skills/preset-packages.ts";
 import { APP_NAME } from "../config/app-config.ts";
 import { pathExists } from "../shared/fs-utils.ts";
 import { detectInstallationMethodFromExecPath } from "./installation.ts";
@@ -96,10 +93,7 @@ export function shouldRemoveManagedSkill(
     }
 
     if (metadata.kind === "registry") {
-        return options.purge
-            || (presetSkillPackageNames as readonly string[]).includes(
-                metadata.packageName,
-            );
+        return options.purge;
     }
 
     return false;


### PR DESCRIPTION
The `@alwaysmavs/gpt-image-2` package was auto-installed alongside bundled skills and special-cased during uninstall. Removing the preset mechanism decouples bundled installs from the registry, so `oo skills add` and managed install/update no longer reach out for it.

A temporary cleanup pass removes any oo-managed gpt-image-2 skills already materialized in AI agents along with their canonical registry sources, sparing users who upgrade from leftover orphaned skills. The cleanup is metadata-gated, so other registry, local, and unmanaged skills are left untouched.