### PR TITLE
feat(skills): add --skill filter to install, update, check-update

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -982,8 +982,22 @@ Install bundled or published skills into supported local skill directories.
 - Arguments: a package name may also use `<packageName>#<shareID>`. In that
   form, the command reads the package skill list from `<packageName>` and
   downloads the package archive through the share identified by `<shareID>`.
-- Behavior: the command installs every published skill in each package. There is
-  no skill-selection prompt and no per-skill or "install all" option.
+- Behavior: the command installs every published skill in each package by
+  default; the optional `-s, --skill` filter narrows which skills are installed.
+- Options: `-s, --skill <skills...>` limits the install to the named skills. The
+  option is optional and accepts multiple values (for example `-s foo bar`).
+  Matching is case-insensitive and accepts either the skill name or its
+  directory name. Names that match no skill are ignored. With several packages
+  the filter spans all of them: a package that publishes none of the requested
+  skills is silently skipped, and the command fails only when **no** package
+  (or, for the no-argument bundled install, no bundled skill) matches any
+  requested name — listing the available skills. An explicitly named bundled
+  skill is already a single-skill selection and is not further narrowed by
+  `--skill`.
+- Options: because `-s, --skill` accepts multiple values, put any package names
+  **before** it (for example `oo skills install @scope/pkg -s foo bar`). Tokens
+  that follow `--skill` are read as skill names, not package names, until the
+  next option such as `--json`.
 - Options: `-f, --force` overrides install when the target directory exists
   with the same skill name but is **not** managed by oo (no readable
   `.oo-metadata.json`). The previous directory contents are removed before the
@@ -1147,6 +1161,17 @@ Update installed oo-managed published skills.
   skills.
 - Non-interactive terminals: prints one status line for each current or failed
   skill, and one success line for each updated host target path.
+- Options: `-s, --skill <skills...>` limits the update to the named skills. The
+  option is optional and accepts multiple values (for example `-s foo bar`).
+  Matching is case-insensitive and accepts either the skill name or its
+  directory name. Names that match no installed skill are ignored. When none of
+  the requested names match the resolved skills, the command fails (text mode
+  aborts with an error listing the resolved skills; `--json` reports
+  `skill_filter_no_match` and exits `1`).
+- Options: because `-s, --skill` accepts multiple values, put any package names
+  **before** it (for example `oo skills update @scope/pkg -s foo`). Tokens that
+  follow `--skill` are read as skill names, not package names, until the next
+  option such as `--json`.
 - Options: `--json` / `--format json` emits a structured payload (see "JSON
   output for mutation commands" above).
 - `skills[].status` (update JSON): `updated | repaired | current | failed`.
@@ -1157,7 +1182,8 @@ Update installed oo-managed published skills.
 - `error.code` enum (update JSON): `not_authenticated` / `no_supported_hosts`
   / `invalid_path` / `bundled_unsupported` / `package_not_installed`
   / `package_lookup_failed` / `package_download_failed` /
-  `invalid_package_archive` / `publication_failed` / `unknown`.
+  `invalid_package_archive` / `publication_failed` / `skill_filter_no_match` /
+  `unknown`.
 
 ### `oo skills check-update [packageName...]`
 
@@ -1167,13 +1193,25 @@ command **never** downloads a package archive or writes to any skill
 directory.
 
 - Arguments: `[packageName...]` accepts zero or more package names. **Breaking
-  change**: the removed `--skill` option (and its skill-id values) is replaced
-  by these positional package-name arguments.
+  change**: in earlier releases `--skill` took skill ids and was the primary
+  selector; that role is now filled by these positional package-name arguments.
+  (`--skill` still exists as an optional filter — see Options.)
 - Arguments: when omitted, the command checks every installed oo-managed
   registry skill.
 - Arguments: when one or more package names are given, the command checks every
   installed skill that belongs to each named package. Duplicate package names
   are de-duplicated; the original input order is preserved in the output.
+- Options: `-s, --skill <skills...>` limits the check to the named skills. The
+  option is optional and accepts multiple values (for example `-s foo bar`).
+  Matching is case-insensitive and accepts either the skill name or its
+  directory name. Names that match no resolved skill are ignored. When none of
+  the requested names match the resolved registry skills, the command fails and
+  exits `1` with an error listing the available skills (no JSON payload is
+  emitted in that case).
+- Options: because `-s, --skill` accepts multiple values, put any package names
+  **before** it (for example `oo skills check-update @scope/pkg -s foo`). Tokens
+  that follow `--skill` are read as skill names, not package names, until the
+  next option such as `--json`.
 - Options: `--format=json` and `--json` switch to a structured payload.
   `--show-schema-version` (only meaningful with JSON) prepends
   `schemaVersion`.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1067,7 +1067,7 @@ Install bundled or published skills into supported local skill directories.
   `invalid_path` / `invalid_package_specifier` / `package_lookup_failed` /
   `package_download_failed` / `invalid_package_archive` /
   `skill_not_found_in_package` / `name_conflict` / `storage_conflict` /
-  `publication_failed` / `unknown`.
+  `publication_failed` / `skill_filter_no_match` / `unknown`.
 - `targets[].previousState` is one of `absent | managed | unmanaged | unknown`.
   With `--force`, an overwritten unmanaged target is reported as `installed`
   with `previousState: "unmanaged"`.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -906,7 +906,7 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   / `invalid_path` / `invalid_package_specifier` / `package_lookup_failed`
   / `package_download_failed` / `invalid_package_archive`
   / `skill_not_found_in_package` / `name_conflict` / `storage_conflict`
-  / `publication_failed` / `unknown`。
+  / `publication_failed` / `skill_filter_no_match` / `unknown`。
 - `targets[].previousState` 取值为 `absent | managed | unmanaged | unknown`。
   当 `--force` 覆盖一个非受管目录时，target 仍报告为 `installed`，但
   `previousState` 为 `"unmanaged"`。

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -839,8 +839,18 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 参数：package 名称也可以使用 `<packageName>#<shareID>`。这种形式会从
   `<packageName>` 读取 package 的 skill 列表，并通过 `<shareID>` 对应的 share
   下载 package 归档。
-- 行为：命令会安装每个 package 中的**全部**已发布 skill，不弹选择、也没有
-  按 skill 选择或「安装全部」的选项。
+- 行为：命令默认安装每个 package 中的**全部**已发布 skill；可选的
+  `-s, --skill` 过滤会收窄实际安装的 skill。
+- 选项：`-s, --skill <skills...>` 将安装限定为指定的 skill。该选项可选，可传多个
+  值（例如 `-s foo bar`）。匹配大小写不敏感，可用 skill 名称或其目录名。未匹配到
+  任何 skill 的名称会被忽略。传入多个 package 时，过滤会跨所有 package 生效：某个
+  package 没有任何被请求的 skill 时会被**静默跳过**；只有当**所有** package
+  （对于无参的内置安装，则是任一内置 skill）都不匹配任何请求名称时，命令才会失败
+  并列出可用的 skill。显式命名的内置 skill 本身已是单 skill 选择，不会再被
+  `--skill` 收窄。
+- 选项：由于 `-s, --skill` 接受多个值，请把所有 package 名称放在它**之前**
+  （例如 `oo skills install @scope/pkg -s foo bar`）。`--skill` 之后、直到下一个
+  选项（如 `--json`）之前的 token 都会被当作 skill 名称，而非 package 名称。
 - 选项：`-f, --force` 在目标目录存在同名 skill 但**不受 oo 管理**（缺少可读
   `.oo-metadata.json`）时，允许覆盖安装。覆盖会先移除原目录内容再写入新
   skill，并以 `warn` 日志记录此事件。`--force` **不会**绕过路径校验、
@@ -976,6 +986,14 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 交互式终端：会显示实时进度。
 - 非交互式终端：对每个已是最新或失败的 skill 输出一行状态信息；对每个已更新
   的 Agent 目标路径输出一行成功信息。
+- 选项：`-s, --skill <skills...>` 将更新限定为指定的 skill。该选项可选，可传多个
+  值（例如 `-s foo bar`）。匹配大小写不敏感，可用 skill 名称或其目录名。未匹配到
+  任何已安装 skill 的名称会被忽略。当所请求的名称都不匹配解析出的 skill 时，
+  命令会失败（文本模式报错并列出解析出的 skill；`--json` 上报
+  `skill_filter_no_match` 并以 `1` 退出）。
+- 选项：由于 `-s, --skill` 接受多个值，请把所有 package 名称放在它**之前**
+  （例如 `oo skills update @scope/pkg -s foo`）。`--skill` 之后、直到下一个选项
+  （如 `--json`）之前的 token 都会被当作 skill 名称，而非 package 名称。
 - 选项：`--json` / `--format json` 输出结构化 payload（见下方"mutation 命令的
   JSON 输出"）。
 - `skills[].status`（update JSON）：`updated | repaired | current | failed`。
@@ -986,18 +1004,28 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - `error.code` 枚举（update JSON）：`not_authenticated` / `no_supported_hosts`
   / `invalid_path` / `bundled_unsupported` / `package_not_installed`
   / `package_lookup_failed` / `package_download_failed` /
-  `invalid_package_archive` / `publication_failed` / `unknown`。
+  `invalid_package_archive` / `publication_failed` / `skill_filter_no_match` /
+  `unknown`。
 
 ### `oo skills check-update [packageName...]`
 
 检查由 oo 管理的 registry skill 是否有新版本，或本地内容是否已偏离 canonical。
 **只查询，不下载 package archive，不写入任何 skill 目录**。
 
-- 参数：`[packageName...]` 接受零个或多个包名。**破坏性变更**：已移除的 `--skill`
-  选项（及其 skill id 值）由这些位置包名参数取代。
+- 参数：`[packageName...]` 接受零个或多个包名。**破坏性变更**：早期版本中
+  `--skill` 接受 skill id 并作为主选择器；该职责现由这些位置包名参数承担。
+  （`--skill` 仍作为可选过滤器存在 —— 见选项。）
 - 参数：省略时，会检查所有已安装且由 oo 管理的 registry skill。
 - 参数：提供一个或多个包名时，会检查每个指定包下已安装的全部 skill。重复包名
   会去重，输出按原始输入顺序。
+- 选项：`-s, --skill <skills...>` 将检查限定为指定的 skill。该选项可选，可传多个
+  值（例如 `-s foo bar`）。匹配大小写不敏感，可用 skill 名称或其目录名。未匹配到
+  任何解析出 skill 的名称会被忽略。当所请求的名称都不匹配解析出的 registry skill
+  时，命令会失败并以 `1` 退出，错误信息会列出可用的 skill（此时不输出 JSON
+  payload）。
+- 选项：由于 `-s, --skill` 接受多个值，请把所有 package 名称放在它**之前**
+  （例如 `oo skills check-update @scope/pkg -s foo`）。`--skill` 之后、直到下一个
+  选项（如 `--json`）之前的 token 都会被当作 skill 名称，而非 package 名称。
 - 选项：`--format=json` 与 `--json` 切换到结构化 JSON 输出。
   `--show-schema-version`（仅在 JSON 模式下生效）会向 payload 顶层添加
   `schemaVersion`。

--- a/src/application/commands/skills/check-update.cli.test.ts
+++ b/src/application/commands/skills/check-update.cli.test.ts
@@ -575,4 +575,123 @@ describe("skills check-update CLI", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("--skill narrows the checked skills case-insensitively and ignores unknown names", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.1.0",
+            });
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "bar",
+                packageName: "@alice/bar",
+                version: "1.0.0",
+            });
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["skills", "check-update", "--skill", "FOO", "missing", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/foo", "0.2.0", "foo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            // Only "foo" is checked: the mixed-case token matches it and the
+            // unknown "missing" token is silently ignored; "bar" is excluded.
+            expect(skills.map(entry => entry.skillId)).toEqual(["foo"]);
+            expect(skills[0]?.status).toBe("update-available");
+            expect(requests.every(request => request.url.includes("foo"))).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill with no matching installed skill exits 1 and lists available skills", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.1.0",
+            });
+
+            // The filter excludes every resolved skill before any network call,
+            // so no fetcher is needed.
+            const result = await sandbox.run(
+                ["skills", "check-update", "--skill", "nope"],
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("foo");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill alongside package args narrows registry entries but keeps a bundled failed entry", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.1.0",
+            });
+
+            // Package names BEFORE --skill so the variadic option does not consume
+            // them. `oo` is bundled and becomes a failed entry that survives the
+            // skill filter; the registry entry `foo` is narrowed and checked.
+            const result = await sandbox.run(
+                ["skills", "check-update", "@alice/foo", "oo", "--skill", "foo", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/foo", "0.2.0", "foo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            const fooEntry = skills.find(entry => entry.skillId === "foo");
+            const ooEntry = skills.find(entry => entry.skillId === "oo");
+
+            expect(fooEntry?.status).toBe("update-available");
+            expect((ooEntry?.error as Record<string, unknown>)?.code).toBe("bundled_unsupported");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });

--- a/src/application/commands/skills/check-update.ts
+++ b/src/application/commands/skills/check-update.ts
@@ -141,8 +141,10 @@ export const skillsCheckUpdateCommand: CliCommandDefinition<SkillsCheckUpdateInp
         const packageNames = dedupePreserveOrder(input.packageNames ?? []);
         // Record the skill-filter dimension before the no-match check can throw,
         // so the telemetry is present even when --skill excludes every entry.
+        // Derive it from the normalized tokens so blank values are not reported
+        // as an active filter.
         context.telemetry?.recordProperties({
-            has_skill_filter: (input.skill?.length ?? 0) > 0,
+            has_skill_filter: normalizeSkillFilterTokens(input.skill) !== undefined,
         });
         // The `--skill` filter narrows the resolved registry entries before any
         // network lookup; unmatched names are ignored, and an error listing the

--- a/src/application/commands/skills/check-update.ts
+++ b/src/application/commands/skills/check-update.ts
@@ -5,6 +5,7 @@ import type { ManagedSkillListItem } from "./managed-skill-listings.ts";
 import type { RegistryPackageSkillInfo } from "./registry-skill-source.ts";
 
 import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
 import { compareSemver } from "../../semver.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
@@ -28,6 +29,10 @@ import {
 import { isManagedSkillPublicationCurrent } from "./managed-skill-publication.ts";
 import { loadRegistryPackageSkillInfo } from "./registry-skill-source.ts";
 import { isBundledSkillName } from "./shared.ts";
+import {
+    normalizeSkillFilterTokens,
+    skillMatchesFilterTokens,
+} from "./skill-filter.ts";
 import { createPackageNamesTelemetryProperties } from "./telemetry.ts";
 
 type CheckUpdateStatus
@@ -71,6 +76,7 @@ interface SkillsCheckUpdateInput {
     format?: (typeof checkUpdateFormatValues)[number];
     showSchemaVersion?: boolean;
     packageNames?: string[];
+    skill?: string[];
 }
 
 interface RegistrySkillTarget {
@@ -104,12 +110,20 @@ export const skillsCheckUpdateCommand: CliCommandDefinition<SkillsCheckUpdateInp
         },
     ],
     options: [
+        {
+            name: "skill",
+            longFlag: "--skill",
+            shortFlag: "-s",
+            valueName: "skills...",
+            descriptionKey: "options.skills.skill",
+        },
         ...jsonOutputOptions,
     ],
     inputSchema: z.object({
         format: z.enum(checkUpdateFormatValues).optional(),
         showSchemaVersion: z.boolean().optional(),
         packageNames: z.array(z.string()).optional(),
+        skill: z.array(z.string()).optional(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
@@ -125,7 +139,18 @@ export const skillsCheckUpdateCommand: CliCommandDefinition<SkillsCheckUpdateInp
             settingsFilePath,
         );
         const packageNames = dedupePreserveOrder(input.packageNames ?? []);
-        const plan = resolveCheckUpdatePlan(packageNames, installedSkills);
+        // Record the skill-filter dimension before the no-match check can throw,
+        // so the telemetry is present even when --skill excludes every entry.
+        context.telemetry?.recordProperties({
+            has_skill_filter: (input.skill?.length ?? 0) > 0,
+        });
+        // The `--skill` filter narrows the resolved registry entries before any
+        // network lookup; unmatched names are ignored, and an error listing the
+        // resolved skills is raised when nothing matches.
+        const plan = applyCheckUpdateSkillFilter(
+            resolveCheckUpdatePlan(packageNames, installedSkills),
+            input.skill,
+        );
 
         const hasRegistryEntry = plan.some(entry => entry.kind === "registry");
         const account = hasRegistryEntry
@@ -231,6 +256,41 @@ function resolveCheckUpdatePlan(
     }
 
     return entries;
+}
+
+// Narrow the resolved registry entries by the optional `--skill` filter,
+// keeping any failed entries (bundled/not-installed package arguments) intact.
+// Returns the plan unchanged when no filter is active, and throws a listing
+// error when the filter excludes every registry entry.
+function applyCheckUpdateSkillFilter(
+    plan: readonly CheckUpdatePlanEntry[],
+    skillFilter: readonly string[] | undefined,
+): CheckUpdatePlanEntry[] {
+    const tokens = normalizeSkillFilterTokens(skillFilter);
+
+    if (tokens === undefined) {
+        return [...plan];
+    }
+
+    const registryEntries = plan.filter(entry => entry.kind === "registry");
+
+    if (registryEntries.length === 0) {
+        return [...plan];
+    }
+
+    const matched = new Set(
+        registryEntries.filter(entry =>
+            skillMatchesFilterTokens({ name: entry.target.skillId }, tokens),
+        ),
+    );
+
+    if (matched.size === 0) {
+        throw new CliUserError("errors.skills.skillFilterNoMatch", 1, {
+            skills: registryEntries.map(entry => entry.target.skillId).join(", "),
+        });
+    }
+
+    return plan.filter(entry => entry.kind !== "registry" || matched.has(entry));
 }
 
 function groupRegistrySkillTargetsByPackageName(
@@ -529,7 +589,10 @@ function writeReportSection(
 function recordTelemetry(
     context: CliExecutionContext,
     outcome: CheckUpdateOutcome,
-    options: { hasPackageFilter: boolean; packageNames: readonly string[] },
+    options: {
+        hasPackageFilter: boolean;
+        packageNames: readonly string[];
+    },
 ): void {
     context.telemetry?.recordProperties({
         has_package_filter: options.hasPackageFilter,

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -2463,6 +2463,138 @@ describe("skills commands", () => {
         }
     });
 
+    test("--skill across packages installs matches and silently skips packages with no match", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+        try {
+            await mkdir(universalHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            // openai publishes "chatgpt"; anthropic publishes "claude".
+            // --skill chatgpt matches openai only. The global rule: a package with
+            // no match (anthropic) is silently skipped because another package
+            // matched, so the run succeeds and installs only chatgpt.
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "anthropic", "--skill", "chatgpt", "--json"],
+                {
+                    fetcher: createMultiPackageRegistryFetcher(),
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.status).toBe("completed");
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills.map(skill => skill.skillId)).toEqual(["chatgpt"]);
+            expect(skills.every(skill => skill.status === "installed")).toBeTrue();
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(errors).toHaveLength(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill across packages fails once when no package publishes any requested skill", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+        try {
+            await mkdir(universalHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            // Neither openai ("chatgpt") nor anthropic ("claude") publishes
+            // "nonexistent": the filter spans both packages and matches nothing, so
+            // the command fails ONCE with a global skill_filter_no_match. No tarball
+            // is fetched because both packages miss before any download.
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "anthropic", "--skill", "nonexistent", "--json"],
+                {
+                    fetcher: createMultiPackageRegistryFetcher(),
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(0);
+            expect(errors.map(error => error.code)).toEqual(["skill_filter_no_match"]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("text mode: --skill across packages installs matches and silently skips the rest", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+        const chatgptSkillDirectoryPath = join(universalHomeDirectory, "skills", "chatgpt");
+        const claudeSkillDirectoryPath = join(universalHomeDirectory, "skills", "claude");
+
+        try {
+            await mkdir(universalHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            // openai matches "chatgpt"; anthropic has no "chatgpt" and is silently
+            // skipped because openai matched. Default (non-json) output path.
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "anthropic", "--skill", "chatgpt"],
+                {
+                    fetcher: createMultiPackageRegistryFetcher(),
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            // Only chatgpt is installed; anthropic produces no selection or
+            // install line at all.
+            expect(result.stdout).toBe(
+                `Skill: chatgpt\nInstalled skill chatgpt to ${chatgptSkillDirectoryPath}.\n`,
+            );
+            expect(await readFile(join(chatgptSkillDirectoryPath, "SKILL.md"), "utf8"))
+                .toContain("# ChatGPT");
+            await expect(readFile(join(claudeSkillDirectoryPath, "SKILL.md"), "utf8"))
+                .rejects
+                .toThrow();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("text mode: --skill matching no package fails once and lists the available skills", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+        try {
+            await mkdir(universalHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "anthropic", "--skill", "nonexistent"],
+                {
+                    fetcher: createMultiPackageRegistryFetcher(),
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            // Nothing installed; a single global error is rendered to stderr and
+            // lists the available skills aggregated across the packages.
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toContain("chatgpt");
+            expect(result.stderr).toContain("claude");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("reports partial failure when one of several packages fails in JSON mode", async () => {
         const sandbox = await createCliSandbox();
         const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");

--- a/src/application/commands/skills/install.cli.test.ts
+++ b/src/application/commands/skills/install.cli.test.ts
@@ -416,6 +416,49 @@ describe("skills install --json", () => {
         }
     });
 
+    test("an explicitly named bundled target keeps the install successful when --skill misses the registry package", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+            await mkdir(homeDirectory, { recursive: true });
+
+            // `oo` is an explicit bundled target (never narrowed by --skill) and
+            // installs; @alice/demo is a registry package whose only skill does
+            // not match "nope". Because the bundled skill installed, the run does
+            // NOT fail with skill_filter_no_match.
+            const result = await sandbox.run(
+                ["skills", "install", "oo", "@alice/demo", "--skill", "nope", "--json"],
+                {
+                    version: TEST_CLI_VERSION,
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/demo", "0.1.0", "demo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(payload.status).toBe("completed");
+            expect(skills.map(skill => skill.skillId)).toEqual(["oo"]);
+            expect(skills[0]).toMatchObject({ kind: "bundled", status: "installed" });
+            expect(errors).toHaveLength(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("text mode: --skill with no matching bundled skill exits 1 and lists available skills", async () => {
         const sandbox = await createCliSandbox();
 

--- a/src/application/commands/skills/install.cli.test.ts
+++ b/src/application/commands/skills/install.cli.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
     createCliSandbox,
+    toRequest,
     writeAuthFile,
 } from "../../../../__tests__/helpers.ts";
 import { resolveManagedSkillAgentHomeDirectory } from "./managed-skill-agents.ts";
@@ -18,6 +19,14 @@ import {
 } from "./skill-metadata.ts";
 
 const TEST_CLI_VERSION = "9.9.9";
+
+function packageInfoResponse(packageName: string, version: string, skillName: string) {
+    return new Response(JSON.stringify({
+        packageName,
+        version,
+        skills: [{ description: "demo", name: skillName, title: skillName }],
+    }));
+}
 
 describe("skills install --json", () => {
     test("bundled install returns installed skills with targets", async () => {
@@ -258,6 +267,173 @@ describe("skills install --json", () => {
 
             expect(payload.schemaVersion).toBe("1.0.0");
             expect(payload.command).toBe("skills.install");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill narrows the bundled install to the matched skills case-insensitively", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+            await mkdir(homeDirectory, { recursive: true });
+
+            const result = await sandbox.run(
+                ["skills", "install", "--skill", "OO", "missing", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            // Only the matched bundled skill is installed; the unknown "missing"
+            // token is silently ignored and the other bundled skills are skipped.
+            expect(skills.map(skill => skill.skillId)).toEqual(["oo"]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill with no matching bundled skill reports skill_filter_no_match and exits 1", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+            await mkdir(homeDirectory, { recursive: true });
+
+            const result = await sandbox.run(
+                ["skills", "install", "--skill", "nope", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(0);
+            expect(errors[0]).toMatchObject({ code: "skill_filter_no_match" });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill that matches no published skill in a registry package reports skill_filter_no_match", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+            await mkdir(homeDirectory, { recursive: true });
+
+            // The filter excludes every published skill after package-info loads
+            // but before any archive download, so no tarball fetch is needed.
+            const result = await sandbox.run(
+                ["skills", "install", "@alice/demo", "--skill", "nope", "--json"],
+                {
+                    version: TEST_CLI_VERSION,
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/demo", "0.1.0", "demo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(0);
+            expect(errors[0]).toMatchObject({ code: "skill_filter_no_match" });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("multiple packages with --skill matching none fail once globally, not per package", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+            await mkdir(homeDirectory, { recursive: true });
+
+            const lookedUpPackages: string[] = [];
+            // Package names BEFORE -s, so both are positional packages and the
+            // variadic -s collects only the skill tokens.
+            const result = await sandbox.run(
+                ["skills", "install", "@alice/foo", "@alice/bar", "-s", "nope", "--json"],
+                {
+                    version: TEST_CLI_VERSION,
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            if (request.url.includes("foo")) {
+                                lookedUpPackages.push("foo");
+                                return packageInfoResponse("@alice/foo", "0.1.0", "foo");
+                            }
+                            if (request.url.includes("bar")) {
+                                lookedUpPackages.push("bar");
+                                return packageInfoResponse("@alice/bar", "0.1.0", "bar");
+                            }
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            // Both positional args are treated as packages (both looked up), and
+            // "nope" is never treated as a package. The --skill filter spans all
+            // packages: nothing matches anywhere, so the command fails ONCE with a
+            // single global skill_filter_no_match (not one error per package).
+            expect(lookedUpPackages.sort()).toEqual(["bar", "foo"]);
+            expect(skills).toHaveLength(0);
+            expect(errors.map(error => error.code)).toEqual(["skill_filter_no_match"]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("text mode: --skill with no matching bundled skill exits 1 and lists available skills", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+            await mkdir(homeDirectory, { recursive: true });
+
+            // No --json: the no-arg bundled path throws a CliUserError that the
+            // CLI renders to stderr and exits 1.
+            const result = await sandbox.run(
+                ["skills", "install", "--skill", "nope"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(1);
+            // The error lists the available bundled skills.
+            expect(result.stderr).toContain("oo");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -125,11 +125,14 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         await migrateLegacyCanonicalSkillLayout(context);
 
         const force = input.force === true;
+        // Derive the filter flag from the normalized tokens so blank/whitespace
+        // values (which collapse away) are not reported as an active filter.
+        const skillFilterActive = normalizeSkillFilterTokens(input.skill) !== undefined;
         // Record the skill-filter dimension up front so it is present on every
         // path, including when a no-match check throws before the detailed
         // telemetry is recorded.
         context.telemetry?.recordProperties({
-            has_skill_filter: (input.skill?.length ?? 0) > 0,
+            has_skill_filter: skillFilterActive,
         });
 
         if (input.format === "json") {
@@ -182,7 +185,6 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         recordInstallBaseTelemetry(context, targets, force);
 
         const installedSkillIds: string[] = [];
-        const skillFilterActive = (input.skill?.length ?? 0) > 0;
         const registryFilterMatch = new RegistrySkillFilterMatchTracker();
 
         for (const target of targets) {
@@ -232,10 +234,15 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
             );
         }
 
-        // With a `--skill` filter and one or more registry packages, fail only
-        // when no package published any requested skill; per-package misses are
-        // silently skipped.
-        if (skillFilterActive && registryFilterMatch.isGlobalMiss()) {
+        // With a `--skill` filter, fail only when nothing was installed at all:
+        // per-package registry misses are silently skipped, and an explicitly
+        // named bundled skill (which `--skill` never narrows) keeps the command
+        // successful even when no registry package matched.
+        if (
+            skillFilterActive
+            && registryFilterMatch.isGlobalMiss()
+            && installedSkillIds.length === 0
+        ) {
             throw new CliUserError("errors.skills.skillFilterNoMatch", 1, {
                 skills: registryFilterMatch.availableSkillsList(),
             });
@@ -417,7 +424,7 @@ async function runInstallJsonReport(
     }
 
     let requested = 0;
-    const skillFilterActive = (input.skill?.length ?? 0) > 0;
+    const skillFilterActive = normalizeSkillFilterTokens(input.skill) !== undefined;
     const registryFilterMatch = new RegistrySkillFilterMatchTracker();
 
     for (const rawPackageName of packageNames) {
@@ -459,10 +466,15 @@ async function runInstallJsonReport(
         );
     }
 
-    // With a `--skill` filter and one or more registry packages, fail only when
-    // no package published any requested skill; per-package misses are silently
-    // skipped.
-    if (skillFilterActive && registryFilterMatch.isGlobalMiss()) {
+    // With a `--skill` filter, fail only when nothing was installed at all:
+    // per-package registry misses are silently skipped, and an explicitly named
+    // bundled skill (which `--skill` never narrows) keeps the command successful
+    // even when no registry package matched.
+    if (
+        skillFilterActive
+        && registryFilterMatch.isGlobalMiss()
+        && !skills.some(skill => skill.status === "installed")
+    ) {
         errors.push({
             code: "skill_filter_no_match",
             message: installErrorMessages.skill_filter_no_match!,

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -38,6 +38,10 @@ import {
     resolveAvailableBundledSkillHostInstallations,
 } from "./shared.ts";
 import {
+    normalizeSkillFilterTokens,
+    skillMatchesFilterTokens,
+} from "./skill-filter.ts";
+import {
     createPackageNamesTelemetryProperties,
     createSkillIdsTelemetryProperties,
 } from "./telemetry.ts";
@@ -45,6 +49,7 @@ import {
 interface SkillsInstallInput {
     force?: boolean;
     packageNames?: string[];
+    skill?: string[];
     format?: "json";
     showSchemaVersion?: boolean;
 }
@@ -75,6 +80,7 @@ const installErrorMessages: Record<string, string> = {
     name_conflict: "Skill name is already used by a non-OOMOL skill.",
     storage_conflict: "Bundled skill storage is already occupied by non-OOMOL content.",
     publication_failed: "Failed to publish the skill to one or more hosts.",
+    skill_filter_no_match: "None of the requested skills exist in the requested packages.",
     unknown: "Unknown error.",
 };
 
@@ -98,11 +104,19 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
             shortFlag: "-f",
             descriptionKey: "options.skills.install.force",
         },
+        {
+            name: "skill",
+            longFlag: "--skill",
+            shortFlag: "-s",
+            valueName: "skills...",
+            descriptionKey: "options.skills.skill",
+        },
         ...skillOperationOutputOptions,
     ],
     inputSchema: z.object({
         force: z.boolean().optional(),
         packageNames: z.array(z.string()).optional(),
+        skill: z.array(z.string()).optional(),
         format: z.enum(["json"]).optional(),
         showSchemaVersion: z.boolean().optional(),
     }),
@@ -111,6 +125,12 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         await migrateLegacyCanonicalSkillLayout(context);
 
         const force = input.force === true;
+        // Record the skill-filter dimension up front so it is present on every
+        // path, including when a no-match check throws before the detailed
+        // telemetry is recorded.
+        context.telemetry?.recordProperties({
+            has_skill_filter: (input.skill?.length ?? 0) > 0,
+        });
 
         if (input.format === "json") {
             const report = await runInstallJsonReport(input, context, { force });
@@ -131,19 +151,23 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         const packageNames = input.packageNames ?? [];
 
         if (packageNames.length === 0) {
+            // No package argument installs the bundled skills, narrowed by the
+            // optional `--skill` filter.
+            const selectedBundled = selectBundledSkillNamesOrThrow(input.skill);
+
             context.telemetry?.recordProperties({
                 bundled_skill: "__all__",
                 has_bundled_skill: true,
                 has_force: force,
                 has_registry_skill: false,
                 package_kind: "bundled",
-                ...createSkillIdsTelemetryProperties(availableBundledSkillNames),
+                ...createSkillIdsTelemetryProperties(selectedBundled),
                 ...createPackageNamesTelemetryProperties([]),
             });
 
             const summaries: ManagedSkillInstallSummary[] = [];
 
-            for (const skillName of availableBundledSkillNames) {
+            for (const skillName of selectedBundled) {
                 summaries.push(await installBundledSkill(skillName, context, { force }));
             }
 
@@ -158,9 +182,13 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         recordInstallBaseTelemetry(context, targets, force);
 
         const installedSkillIds: string[] = [];
+        const skillFilterActive = (input.skill?.length ?? 0) > 0;
+        const registryFilterMatch = new RegistrySkillFilterMatchTracker();
 
         for (const target of targets) {
             if (target.kind === "bundled") {
+                // An explicitly named bundled skill is already a single-skill
+                // selection, so `--skill` does not further narrow it.
                 const summary = await installBundledSkill(
                     target.specifier.packageName as BundledSkillName,
                     context,
@@ -178,13 +206,22 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
                         packageShareId: target.specifier.packageShareId,
                         packageVersion: target.specifier.packageVersion,
                         recordTelemetry: false,
-                        // Empty selection installs all published skills; the
-                        // command no longer exposes per-skill selection.
+                        skillFilter: input.skill,
+                        // Across several packages the filter must not fail a
+                        // package that simply does not publish a requested skill;
+                        // record the miss and decide globally after the loop.
+                        reportSkillFilterMiss: names => registryFilterMatch.recordMiss(names),
+                        // The command installs all published skills unless the
+                        // `--skill` filter narrows them; `skillNames` is reserved
+                        // for the explicit `oo skills sync` selection.
                         skillNames: [],
                     },
                     context,
                 );
 
+                if (summaries.length > 0) {
+                    registryFilterMatch.recordMatch();
+                }
                 installedSkillIds.push(...summaries.map(summary => summary.name));
             }
 
@@ -194,8 +231,46 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
                 createSkillIdsTelemetryProperties(installedSkillIds),
             );
         }
+
+        // With a `--skill` filter and one or more registry packages, fail only
+        // when no package published any requested skill; per-package misses are
+        // silently skipped.
+        if (skillFilterActive && registryFilterMatch.isGlobalMiss()) {
+            throw new CliUserError("errors.skills.skillFilterNoMatch", 1, {
+                skills: registryFilterMatch.availableSkillsList(),
+            });
+        }
     },
 };
+
+// Tracks, across the registry packages of a single install run, whether the
+// `--skill` filter matched at least one published skill and which skills were
+// available in the packages that matched nothing. A global miss is when the
+// filter was applied to at least one package (so some skills were available) yet
+// nothing matched; packages that failed to load contribute neither and are
+// reported through their own errors.
+class RegistrySkillFilterMatchTracker {
+    private matched = false;
+    private readonly missedAvailableSkills = new Set<string>();
+
+    recordMatch(): void {
+        this.matched = true;
+    }
+
+    recordMiss(availableSkillNames: readonly string[]): void {
+        for (const name of availableSkillNames) {
+            this.missedAvailableSkills.add(name);
+        }
+    }
+
+    isGlobalMiss(): boolean {
+        return !this.matched && this.missedAvailableSkills.size > 0;
+    }
+
+    availableSkillsList(): string {
+        return [...this.missedAvailableSkills].join(", ");
+    }
+}
 
 function classifySkillsInstallTarget(
     rawPackageName: string,
@@ -276,6 +351,31 @@ function resolveInstallPackageKindLabel(
     return hasRegistry ? "registry" : "bundled";
 }
 
+// Narrow the bundled skill set installed by the no-argument form using the
+// optional `--skill` filter. Returns every bundled skill when no filter is
+// active, and throws a listing error when the filter matches nothing.
+function selectBundledSkillNamesOrThrow(
+    skillFilter: readonly string[] | undefined,
+): readonly BundledSkillName[] {
+    const tokens = normalizeSkillFilterTokens(skillFilter);
+
+    if (tokens === undefined) {
+        return availableBundledSkillNames;
+    }
+
+    const selected = availableBundledSkillNames.filter(name =>
+        skillMatchesFilterTokens({ name }, tokens),
+    );
+
+    if (selected.length === 0) {
+        throw new CliUserError("errors.skills.skillFilterNoMatch", 1, {
+            skills: availableBundledSkillNames.join(", "),
+        });
+    }
+
+    return selected;
+}
+
 async function runInstallJsonReport(
     input: SkillsInstallInput,
     context: CliExecutionContext,
@@ -287,7 +387,23 @@ async function runInstallJsonReport(
     const packageNames = input.packageNames ?? [];
 
     if (packageNames.length === 0) {
-        for (const bundledName of availableBundledSkillNames) {
+        const skillFilterTokens = normalizeSkillFilterTokens(input.skill);
+        const selectedBundled = skillFilterTokens === undefined
+            ? availableBundledSkillNames
+            : availableBundledSkillNames.filter(name =>
+                    skillMatchesFilterTokens({ name }, skillFilterTokens),
+                );
+
+        if (skillFilterTokens !== undefined && selectedBundled.length === 0) {
+            errors.push({
+                code: "skill_filter_no_match",
+                message: installErrorMessages.skill_filter_no_match!,
+            });
+
+            return buildReport(skills, errors, 0);
+        }
+
+        for (const bundledName of selectedBundled) {
             const result = await installBundledSkillForJson(
                 bundledName,
                 context,
@@ -301,6 +417,8 @@ async function runInstallJsonReport(
     }
 
     let requested = 0;
+    const skillFilterActive = (input.skill?.length ?? 0) > 0;
+    const registryFilterMatch = new RegistrySkillFilterMatchTracker();
 
     for (const rawPackageName of packageNames) {
         let packageSpecifier: SkillsInstallPackageSpecifier;
@@ -334,10 +452,21 @@ async function runInstallJsonReport(
         requested += await appendRegistryInstallJsonResults(
             packageSpecifier,
             context,
-            options,
+            { force: options.force, skillFilter: input.skill },
             skills,
             errors,
+            registryFilterMatch,
         );
+    }
+
+    // With a `--skill` filter and one or more registry packages, fail only when
+    // no package published any requested skill; per-package misses are silently
+    // skipped.
+    if (skillFilterActive && registryFilterMatch.isGlobalMiss()) {
+        errors.push({
+            code: "skill_filter_no_match",
+            message: installErrorMessages.skill_filter_no_match!,
+        });
     }
 
     return buildReport(skills, errors, requested);
@@ -346,9 +475,10 @@ async function runInstallJsonReport(
 async function appendRegistryInstallJsonResults(
     packageSpecifier: SkillsInstallPackageSpecifier,
     context: CliExecutionContext,
-    options: { force: boolean },
+    options: { force: boolean; skillFilter?: readonly string[] },
     skills: SkillResult[],
     errors: SkillOperationError[],
+    filterMatch: RegistrySkillFilterMatchTracker,
 ): Promise<number> {
     try {
         const summaries = await installRegistrySkills(
@@ -358,6 +488,8 @@ async function appendRegistryInstallJsonResults(
                 packageShareId: packageSpecifier.packageShareId,
                 packageVersion: packageSpecifier.packageVersion,
                 recordTelemetry: false,
+                skillFilter: options.skillFilter,
+                reportSkillFilterMiss: names => filterMatch.recordMiss(names),
                 skillNames: [],
                 writeOutput: false,
             },
@@ -374,7 +506,11 @@ async function appendRegistryInstallJsonResults(
             ));
         }
 
-        return Math.max(1, summaries.length);
+        if (summaries.length > 0) {
+            filterMatch.recordMatch();
+        }
+
+        return summaries.length;
     }
     catch (error) {
         const errorCode = mapInstallErrorCode(error);
@@ -526,6 +662,8 @@ function mapInstallErrorCode(error: unknown): string {
             return "storage_conflict";
         case "errors.skills.install.invalidPackageSpecifier":
             return "invalid_package_specifier";
+        case "errors.skills.skillFilterNoMatch":
+            return "skill_filter_no_match";
         default:
             return "unknown";
     }

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -38,6 +38,10 @@ import {
     loadRegistryPackageSkillInfo,
     tryReportRegistryPackageDownload,
 } from "./registry-skill-source.ts";
+import {
+    normalizeSkillFilterTokens,
+    selectSkillsByFilter,
+} from "./skill-filter.ts";
 import { createSkillIdsTelemetryProperties } from "./telemetry.ts";
 
 interface ManagedSkillPathState {
@@ -51,6 +55,17 @@ export interface RegistrySkillInstallRequest {
     packageShareId?: string;
     packageVersion?: string;
     recordTelemetry?: boolean;
+    // The `--skill` narrowing for the install command. When provided, only the
+    // package's published skills whose name (or directory basename) matches one
+    // of these values are installed; unmatched values are ignored. Ignored when
+    // `skillNames` is non-empty.
+    skillFilter?: readonly string[];
+    // Invoked with this package's published skill names when `skillFilter`
+    // matched none of them. A no-match always installs nothing for the package;
+    // whether an empty result across all packages is an error is decided by the
+    // caller (the install command's cross-package match tracker), which uses
+    // these names to list what was available.
+    reportSkillFilterMiss?: (availableSkillNames: readonly string[]) => void;
     // When non-empty, install exactly these skills (used by `oo skills sync`).
     // When empty, the install command installs all published skills.
     skillNames: string[];
@@ -265,22 +280,70 @@ async function resolveInstallSkillNames(
         );
     }
 
-    if (packageInfo.skills.length === 1) {
-        const firstSkill = packageInfo.skills[0]!;
+    // Default behavior: install every published skill in the package, narrowed
+    // by the optional `--skill` filter.
+    const selectedSkills = applyInstallSkillFilter(
+        packageInfo,
+        request.skillFilter,
+        request.reportSkillFilterMiss,
+    );
 
-        writeInstallSelectionLine(context, shouldWriteOutput, "skills.install.singleSelected", {
-            name: firstSkill.name,
-        });
-
-        return [firstSkill.name];
+    if (selectedSkills.length === 0) {
+        // `--skill` matched nothing in this package; the miss was reported to the
+        // caller, which decides whether this is a global no-match error. Install
+        // nothing here and emit no selection line.
+        return [];
     }
 
-    // Default behavior: install every published skill in the package.
-    writeInstallSelectionLine(context, shouldWriteOutput, "skills.install.allSelected", {
-        count: packageInfo.skills.length,
-    });
+    if (selectedSkills.length === 1) {
+        writeInstallSelectionLine(context, shouldWriteOutput, "skills.install.singleSelected", {
+            name: selectedSkills[0]!.name,
+        });
 
-    return packageInfo.skills.map(skill => skill.name);
+        return [selectedSkills[0]!.name];
+    }
+
+    if (selectedSkills.length < packageInfo.skills.length) {
+        // `--skill` narrowed the package to a strict subset of more than one
+        // skill; avoid the misleading "all" wording.
+        writeInstallSelectionLine(context, shouldWriteOutput, "skills.install.filteredSelected", {
+            count: selectedSkills.length,
+            total: packageInfo.skills.length,
+        });
+    }
+    else {
+        writeInstallSelectionLine(context, shouldWriteOutput, "skills.install.allSelected", {
+            count: selectedSkills.length,
+        });
+    }
+
+    return selectedSkills.map(skill => skill.name);
+}
+
+// Narrow the package's published skills by the `--skill` filter. Returns every
+// skill when no filter is active. When the filter matches nothing, installs
+// nothing and reports the package's published skill names through `reportMiss`;
+// the caller decides whether an empty result across all packages is an error.
+function applyInstallSkillFilter(
+    packageInfo: RegistryPackageSkillInfo,
+    skillFilter: readonly string[] | undefined,
+    reportMiss: ((availableSkillNames: readonly string[]) => void) | undefined,
+): RegistrySkillSummary[] {
+    const tokens = normalizeSkillFilterTokens(skillFilter);
+
+    if (tokens === undefined) {
+        return packageInfo.skills;
+    }
+
+    const selected = selectSkillsByFilter(packageInfo.skills, tokens);
+
+    if (selected.length === 0) {
+        reportMiss?.(packageInfo.skills.map(skill => skill.name));
+
+        return [];
+    }
+
+    return selected;
 }
 
 async function filterConfirmedSkillNames(

--- a/src/application/commands/skills/skill-filter.test.ts
+++ b/src/application/commands/skills/skill-filter.test.ts
@@ -1,0 +1,76 @@
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    normalizeSkillFilterTokens,
+    selectSkillsByFilter,
+    skillMatchesFilterTokens,
+} from "./skill-filter.ts";
+
+describe("normalizeSkillFilterTokens", () => {
+    test("returns undefined for undefined input", () => {
+        expect(normalizeSkillFilterTokens(undefined)).toBeUndefined();
+    });
+
+    test("returns undefined when every token is blank", () => {
+        expect(normalizeSkillFilterTokens(["", "   "])).toBeUndefined();
+    });
+
+    test("trims, lowercases, and de-duplicates tokens", () => {
+        const tokens = normalizeSkillFilterTokens([" Foo ", "foo", "BAR"]);
+
+        expect(tokens).toEqual(new Set(["foo", "bar"]));
+    });
+});
+
+describe("skillMatchesFilterTokens", () => {
+    test("matches the skill name case-insensitively", () => {
+        expect(
+            skillMatchesFilterTokens({ name: "Demo" }, new Set(["demo"])),
+        ).toBeTrue();
+    });
+
+    test("matches the path basename when the name differs", () => {
+        const candidate = { name: "logical-name", path: join("a", "b", "Display-Name") };
+
+        expect(
+            skillMatchesFilterTokens(candidate, new Set(["display-name"])),
+        ).toBeTrue();
+    });
+
+    test("does not match when neither name nor basename is requested", () => {
+        expect(
+            skillMatchesFilterTokens(
+                { name: "demo", path: join("x", "demo") },
+                new Set(["other"]),
+            ),
+        ).toBeFalse();
+    });
+});
+
+describe("selectSkillsByFilter", () => {
+    test("keeps only matching candidates and ignores unknown tokens", () => {
+        const candidates = [
+            { name: "foo" },
+            { name: "bar" },
+            { name: "baz" },
+        ];
+        // Tokens flow through normalization (lowercase) before matching, so the
+        // mixed-case "FOO" still matches the "foo" candidate.
+        const tokens = normalizeSkillFilterTokens(["FOO", "baz", "missing"])!;
+
+        const selected = selectSkillsByFilter(candidates, tokens);
+
+        expect(selected.map(candidate => candidate.name)).toEqual(["foo", "baz"]);
+    });
+
+    test("returns an empty array when no candidate matches", () => {
+        const selected = selectSkillsByFilter(
+            [{ name: "foo" }],
+            new Set(["nope"]),
+        );
+
+        expect(selected).toEqual([]);
+    });
+});

--- a/src/application/commands/skills/skill-filter.ts
+++ b/src/application/commands/skills/skill-filter.ts
@@ -1,0 +1,62 @@
+import { basename } from "node:path";
+
+// A skill that can be narrowed by the `--skill` option. Matching is
+// case-insensitive against the skill name and, when a directory path is known,
+// the path basename (the on-disk display name). For registry package skills the
+// name already equals the installed directory basename, so the optional path is
+// only carried for installed skills where the two could in principle differ.
+export interface SkillFilterCandidate {
+    name: string;
+    path?: string;
+}
+
+// Normalize the raw `--skill` values into a lowercase lookup set. Tokens are
+// trimmed, lowercased, and de-duplicated. Returns undefined when no usable
+// token remains, which callers treat as "no filter" (operate on every
+// candidate).
+export function normalizeSkillFilterTokens(
+    tokens: readonly string[] | undefined,
+): Set<string> | undefined {
+    if (tokens === undefined) {
+        return undefined;
+    }
+
+    const normalized = new Set<string>();
+
+    for (const token of tokens) {
+        const trimmed = token.trim().toLowerCase();
+
+        if (trimmed !== "") {
+            normalized.add(trimmed);
+        }
+    }
+
+    return normalized.size === 0 ? undefined : normalized;
+}
+
+// Whether a candidate matches at least one requested token, comparing the
+// skill name and the path basename case-insensitively.
+export function skillMatchesFilterTokens(
+    candidate: SkillFilterCandidate,
+    tokens: ReadonlySet<string>,
+): boolean {
+    if (tokens.has(candidate.name.toLowerCase())) {
+        return true;
+    }
+
+    if (candidate.path !== undefined) {
+        return tokens.has(basename(candidate.path).toLowerCase());
+    }
+
+    return false;
+}
+
+// Keep only the candidates that match at least one requested token. Tokens that
+// match no candidate are silently ignored; deciding what to do when nothing
+// matches is left to the caller (each command lists the available skills).
+export function selectSkillsByFilter<T extends SkillFilterCandidate>(
+    candidates: readonly T[],
+    tokens: ReadonlySet<string>,
+): T[] {
+    return candidates.filter(candidate => skillMatchesFilterTokens(candidate, tokens));
+}

--- a/src/application/commands/skills/update.cli.test.ts
+++ b/src/application/commands/skills/update.cli.test.ts
@@ -486,4 +486,201 @@ describe("skills update --json", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("--skill narrows the updated skills case-insensitively and ignores unknown names", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.2.0",
+            });
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "bar",
+                packageName: "@alice/bar",
+                version: "0.2.0",
+            });
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["skills", "update", "--skill", "FOO", "missing", "--json"],
+                {
+                    version: TEST_CLI_VERSION,
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/foo", "0.2.0", "foo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            // Only "foo" is updated; "bar" is excluded, so only its package is
+            // queried.
+            expect(skills.map(skill => skill.skillId)).toEqual(["foo"]);
+            expect(skills[0]?.status).toBe("current");
+            expect(requests.every(request => request.url.includes("foo"))).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill with no matching installed skill reports skill_filter_no_match and exits 1", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.2.0",
+            });
+
+            // The filter excludes every resolved skill before any network call.
+            const result = await sandbox.run(
+                ["skills", "update", "--skill", "nope", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(0);
+            expect(errors[0]).toMatchObject({ code: "skill_filter_no_match" });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("text mode: --skill with no matching installed skill exits 1 and lists the resolved skills", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.2.0",
+            });
+
+            // No --json: the text path throws a CliUserError listing the resolved
+            // skills and exits 1, before any network call.
+            const result = await sandbox.run(
+                ["skills", "update", "--skill", "nope"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("foo");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json with package args + --skill updates the matched package and silently skips the rest", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.2.0",
+            });
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "bar",
+                packageName: "@alice/bar",
+                version: "0.2.0",
+            });
+
+            const requests: Request[] = [];
+            // Package names BEFORE --skill so the variadic option does not consume
+            // them; this routes through the per-package update branch.
+            const result = await sandbox.run(
+                ["skills", "update", "@alice/foo", "@alice/bar", "--skill", "foo", "--json"],
+                {
+                    version: TEST_CLI_VERSION,
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/foo", "0.2.0", "foo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            // @alice/bar contributes nothing (no skill named foo) and is never
+            // queried; only @alice/foo's "foo" is reported.
+            expect(skills.map(skill => skill.skillId)).toEqual(["foo"]);
+            expect(requests.every(request => request.url.includes("foo"))).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json with package args + --skill matching none of their skills reports skill_filter_no_match", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.2.0",
+            });
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "bar",
+                packageName: "@alice/bar",
+                version: "0.2.0",
+            });
+
+            // The filter matches no skill in either requested package, so the
+            // per-package gate (anyCandidate && !anyMatched) fires before network.
+            const result = await sandbox.run(
+                ["skills", "update", "@alice/foo", "@alice/bar", "--skill", "missing", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(0);
+            expect(errors[0]).toMatchObject({ code: "skill_filter_no_match" });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -71,6 +71,39 @@ describe("skills update command", () => {
         }
     });
 
+    test("records has_skill_filter on the text no-results path when --skill is given", async () => {
+        const sandbox = await createCliSandbox();
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+        try {
+            // A supported host exists but no registry skills are installed, so the
+            // text path hits the no-results early return; has_skill_filter must
+            // still be recorded.
+            await mkdir(universalHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "update", "--skill", "nope"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe("No updatable oo-managed skills were found.\n");
+            expect(parseTelemetryRowPayload(
+                readTelemetryRowsForTest(storePaths.telemetryDirectory)[0]!,
+            )).toMatchObject({
+                properties: {
+                    command_full: "skills.update",
+                    has_skill_filter: true,
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("rejects the bundled oo skill as an explicit update target", async () => {
         const sandbox = await createCliSandbox();
         const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
@@ -269,6 +302,7 @@ describe("skills update command", () => {
             )).toMatchObject({
                 properties: {
                     command_full: "skills.update",
+                    has_skill_filter: false,
                     package_kind: "registry",
                     package_name: "openai",
                     package_names_count_bucket: "1-5",

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -84,7 +84,7 @@ const updateErrorMessages: Record<string, string> = {
     package_download_failed: "Failed to download the package archive.",
     invalid_package_archive: "Downloaded package archive is invalid.",
     publication_failed: "Failed to publish the skill to one or more hosts.",
-    skill_filter_no_match: "None of the requested skills are installed for the selected packages.",
+    skill_filter_no_match: "None of the requested skills are installed.",
     unknown: "Unknown error.",
 };
 
@@ -153,8 +153,10 @@ export const skillsUpdateCommand: CliCommandDefinition<SkillsUpdateInput> = {
         // Record the skill-filter dimension up front so it is present on every
         // path, including the text no-results early return and the no-match
         // throw, which both happen before the detailed telemetry is recorded.
+        // Derive it from the normalized tokens so blank values are not reported
+        // as an active filter.
         context.telemetry?.recordProperties({
-            has_skill_filter: (input.skill?.length ?? 0) > 0,
+            has_skill_filter: normalizeSkillFilterTokens(input.skill) !== undefined,
         });
 
         if (input.format === "json") {

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -58,6 +58,10 @@ import {
 } from "./registry-skill-source.ts";
 import { isBundledSkillName } from "./shared.ts";
 import {
+    normalizeSkillFilterTokens,
+    selectSkillsByFilter,
+} from "./skill-filter.ts";
+import {
     createPackageNamesTelemetryProperties,
     createSkillIdsTelemetryProperties,
 } from "./telemetry.ts";
@@ -65,6 +69,7 @@ import { SkillsUpdateProgressReporter } from "./update-progress.ts";
 
 interface SkillsUpdateInput {
     packageNames?: string[];
+    skill?: string[];
     format?: "json";
     showSchemaVersion?: boolean;
 }
@@ -79,6 +84,7 @@ const updateErrorMessages: Record<string, string> = {
     package_download_failed: "Failed to download the package archive.",
     invalid_package_archive: "Downloaded package archive is invalid.",
     publication_failed: "Failed to publish the skill to one or more hosts.",
+    skill_filter_no_match: "None of the requested skills are installed for the selected packages.",
     unknown: "Unknown error.",
 };
 
@@ -127,18 +133,33 @@ export const skillsUpdateCommand: CliCommandDefinition<SkillsUpdateInput> = {
         },
     ],
     options: [
+        {
+            name: "skill",
+            longFlag: "--skill",
+            shortFlag: "-s",
+            valueName: "skills...",
+            descriptionKey: "options.skills.skill",
+        },
         ...skillOperationOutputOptions,
     ],
     inputSchema: z.object({
         packageNames: z.array(z.string()).optional(),
+        skill: z.array(z.string()).optional(),
         format: z.enum(["json"]).optional(),
         showSchemaVersion: z.boolean().optional(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
+        // Record the skill-filter dimension up front so it is present on every
+        // path, including the text no-results early return and the no-match
+        // throw, which both happen before the detailed telemetry is recorded.
+        context.telemetry?.recordProperties({
+            has_skill_filter: (input.skill?.length ?? 0) > 0,
+        });
+
         if (input.format === "json") {
             const report = await runUpdateJsonReport(
-                { packageNames: input.packageNames ?? [] },
+                { packageNames: input.packageNames ?? [], skillFilter: input.skill },
                 context,
             );
 
@@ -158,6 +179,7 @@ export const skillsUpdateCommand: CliCommandDefinition<SkillsUpdateInput> = {
         await updateManagedSkills(
             {
                 packageNames: input.packageNames ?? [],
+                skillFilter: input.skill,
             },
             context,
         );
@@ -167,6 +189,7 @@ export const skillsUpdateCommand: CliCommandDefinition<SkillsUpdateInput> = {
 export async function updateManagedSkills(
     request: {
         packageNames: readonly string[];
+        skillFilter?: readonly string[];
     },
     context: CliExecutionContext,
 ): Promise<void> {
@@ -181,15 +204,23 @@ export async function updateManagedSkills(
         availableHosts,
         settingsFilePath,
     );
-    const selectedSkills = resolveSelectedManagedSkillsByPackage(
+    const selectedByPackage = resolveSelectedManagedSkillsByPackage(
         request.packageNames,
         installedSkills,
     );
 
-    if (selectedSkills.length === 0) {
+    if (selectedByPackage.length === 0) {
         writeLine(context.stdout, context.translator.t("skills.update.noResults"));
         return;
     }
+
+    // The `--skill` filter narrows the resolved skills; unmatched names are
+    // ignored, and an error listing the resolved skills is raised when nothing
+    // matches.
+    const selectedSkills = filterManagedSkillsOrThrow(
+        selectedByPackage,
+        request.skillFilter,
+    );
 
     const progressReporter = context.stdout.isTTY === true
         ? new SkillsUpdateProgressReporter(
@@ -440,6 +471,30 @@ function resolveSelectedManagedSkillsByPackage(
     }
 
     return selectedSkills;
+}
+
+// Narrow resolved managed skills by the optional `--skill` filter. Returns
+// every skill when no filter is active, and throws a listing error when the
+// filter matches nothing.
+function filterManagedSkillsOrThrow(
+    skills: readonly ManagedSkillUpdateItem[],
+    skillFilter: readonly string[] | undefined,
+): ManagedSkillUpdateItem[] {
+    const tokens = normalizeSkillFilterTokens(skillFilter);
+
+    if (tokens === undefined) {
+        return [...skills];
+    }
+
+    const matched = selectSkillsByFilter(skills, tokens);
+
+    if (matched.length === 0) {
+        throw new CliUserError("errors.skills.skillFilterNoMatch", 1, {
+            skills: skills.map(skill => skill.name).join(", "),
+        });
+    }
+
+    return matched;
 }
 
 // Index installed registry skills by their package name, preserving the input
@@ -724,10 +779,11 @@ interface HostVersionState {
 }
 
 async function runUpdateJsonReport(
-    request: { packageNames: readonly string[] },
+    request: { packageNames: readonly string[]; skillFilter?: readonly string[] },
     context: CliExecutionContext,
 ): Promise<UpdateReport> {
     const errors: SkillOperationError[] = [];
+    const skillFilterTokens = normalizeSkillFilterTokens(request.skillFilter);
     const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
 
     if (availableHosts.length === 0) {
@@ -765,7 +821,19 @@ async function runUpdateJsonReport(
         if (selected.length === 0) {
             return buildUpdateReport([], errors);
         }
-        const results = await runUpdateForSkills(selected, availableHosts, context);
+
+        const matched = skillFilterTokens === undefined
+            ? selected
+            : selectSkillsByFilter(selected, skillFilterTokens);
+
+        if (matched.length === 0) {
+            errors.push({
+                code: "skill_filter_no_match",
+                message: updateErrorMessages.skill_filter_no_match!,
+            });
+            return buildUpdateReport([], errors);
+        }
+        const results = await runUpdateForSkills(matched, availableHosts, context);
 
         skills.push(...results);
         return buildUpdateReport(skills, errors);
@@ -773,6 +841,8 @@ async function runUpdateJsonReport(
 
     const skillsByPackageName = groupSkillsByPackageName(installedSkills);
     const seenPackageNames = new Set<string>();
+    let anyCandidate = false;
+    let anyMatched = false;
 
     for (const packageName of requestedPackageNames) {
         if (seenPackageNames.has(packageName)) {
@@ -816,10 +886,33 @@ async function runUpdateJsonReport(
             continue;
         }
 
-        // Each requested package updates all of its installed skills together.
-        const results = await runUpdateForSkills(packageSkills, availableHosts, context);
+        anyCandidate = true;
+
+        // The `--skill` filter narrows each package's installed skills; packages
+        // with no matching skill contribute nothing and are silently skipped.
+        const matched = skillFilterTokens === undefined
+            ? packageSkills
+            : selectSkillsByFilter(packageSkills, skillFilterTokens);
+
+        if (matched.length === 0) {
+            continue;
+        }
+
+        anyMatched = true;
+
+        // Each requested package updates all of its matched installed skills together.
+        const results = await runUpdateForSkills(matched, availableHosts, context);
 
         skills.push(...results);
+    }
+
+    // Mirror the text path: when a filter was given and excluded every resolved
+    // skill, surface a command-level error so the run fails.
+    if (skillFilterTokens !== undefined && anyCandidate && !anyMatched) {
+        errors.push({
+            code: "skill_filter_no_match",
+            message: updateErrorMessages.skill_filter_no_match!,
+        });
     }
 
     return buildUpdateReport(skills, errors);

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -259,6 +259,7 @@ const commandTelemetryDecisions = {
             "has_bundled_skill",
             "has_force",
             "has_registry_skill",
+            "has_skill_filter",
             "installed_count_bucket",
             "package_kind",
             "package_name",
@@ -270,7 +271,7 @@ const commandTelemetryDecisions = {
             "skill_ids_sample",
             "skill_ids_truncated",
         ],
-        reason: "Records install source, product-domain package dimensions, bounded skill/package samples, force-flag usage, and JSON-output result buckets.",
+        reason: "Records install source, product-domain package dimensions, bounded skill/package samples, force-flag and skill-filter usage, and JSON-output result buckets.",
     },
     "skills.info": {
         kind: "properties",
@@ -349,6 +350,7 @@ const commandTelemetryDecisions = {
         kind: "properties",
         properties: [
             "has_package_filter",
+            "has_skill_filter",
             "package_count_bucket",
             "checked_count_bucket",
             "update_available_count_bucket",
@@ -358,7 +360,7 @@ const commandTelemetryDecisions = {
             "package_names_sample",
             "package_names_truncated",
         ],
-        reason: "Records bucketed counts and bounded package-name samples; never records skill names, versions, or paths.",
+        reason: "Records bucketed counts, package- and skill-filter usage, and bounded package-name samples; never records skill names, versions, or paths.",
     },
     "skills.uninstall": {
         kind: "properties",
@@ -379,6 +381,7 @@ const commandTelemetryDecisions = {
             "current_count_bucket",
             "failed_count_bucket",
             "format",
+            "has_skill_filter",
             "package_kind",
             "package_name",
             "package_names_count_bucket",
@@ -391,7 +394,7 @@ const commandTelemetryDecisions = {
             "skill_ids_truncated",
             "updated_count_bucket",
         ],
-        reason: "Records artifact identity, bounded skill/package samples, and JSON-output result buckets.",
+        reason: "Records artifact identity, skill-filter usage, bounded skill/package samples, and JSON-output result buckets.",
     },
     "skills.validate": {
         kind: "generic",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -547,6 +547,8 @@ export const enMessages = {
         "The skills install package info request returned HTTP {status}.",
     "errors.skills.install.skillNotFound":
         "Skill {name} was not found in package {packageName}.",
+    "errors.skills.skillFilterNoMatch":
+        "None of the requested skills exist. Available skills: {skills}.",
     "errors.skills.update.bundledUnsupported":
         "Bundled skill {name} is managed by oo and cannot be updated with skills update. Use oo skills add {name} instead.",
     "errors.skills.update.packageNotInstalled":
@@ -758,6 +760,8 @@ export const enMessages = {
     "options.yes": "Skip confirmation prompts",
     "options.skills.install.force":
         "Force install even when a same-name skill directory exists and is not managed by oo",
+    "options.skills.skill":
+        "Skill name(s) to limit the operation to (case-insensitive; non-matching names are ignored)",
     "options.lang": "Specify the display language",
     "options.version": "Show the current version",
     "selfUpdate.install.success": "Installed oo {version}.",
@@ -800,6 +804,8 @@ export const enMessages = {
         "Updated oo from {currentVersion} to {version}.",
     "skills.install.allSelected":
         "Installing all {count} skills.",
+    "skills.install.filteredSelected":
+        "Installing {count} of {total} skills.",
     "skills.check.success":
         "Local skill editing is ready. Writable storage: {path}. Supported hosts: {count}.",
     "skills.list.noResults":
@@ -1530,6 +1536,8 @@ export const zhMessages = {
         "skills install 的包信息请求返回了 HTTP {status}。",
     "errors.skills.install.skillNotFound":
         "在包 {packageName} 中未找到 skill {name}。",
+    "errors.skills.skillFilterNoMatch":
+        "指定的 skill 都不存在。可用的 skill：{skills}。",
     "errors.skills.update.bundledUnsupported":
         "内置 skill {name} 由 oo 管理，不能通过 skills update 更新。请改用 oo skills add {name}。",
     "errors.skills.update.packageNotInstalled":
@@ -1733,6 +1741,8 @@ export const zhMessages = {
     "options.yes": "跳过确认提示",
     "options.skills.install.force":
         "强制安装，即使同名 skill 目录已存在且不受 oo 管理",
+    "options.skills.skill":
+        "限定操作的 skill 名称（可指定多个；大小写不敏感；不匹配的名称会被忽略）",
     "options.lang": "指定显示语言",
     "options.version": "显示当前版本",
     "selfUpdate.install.success": "已安装 oo {version}。",
@@ -1775,6 +1785,8 @@ export const zhMessages = {
         "已将 oo 从 {currentVersion} 更新到 {version}。",
     "skills.install.allSelected":
         "将安装全部 {count} 个 skill。",
+    "skills.install.filteredSelected":
+        "将安装 {total} 个 skill 中的 {count} 个。",
     "skills.check.success":
         "本地 skill 编辑环境可用。可写存储：{path}。受支持 Agents：{count}。",
     "skills.list.noResults":


### PR DESCRIPTION
Introduce a shared skill-filter helper and wire an optional -s, --skill option into the install, update, and check-update commands. The filter narrows which skills each command operates on, matching case-insensitively against skill names or directory names, while keeping the default behavior of acting on every skill in a package.

Across multiple packages the filter spans all of them: a package that publishes none of the requested skills is silently skipped, and the command fails only when no package matches any requested name. Add the skill_filter_no_match error code for update/install JSON output and record a low-cardinality has_skill_filter telemetry dimension.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#262** 👈 current
2. #266
<!-- stack:links:end -->