### PR TITLE
feat(skills): add adopt workflow

### DIFF
--- a/contrib/skills/shared/oo-create-skill/SKILL.md
+++ b/contrib/skills/shared/oo-create-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oo-create-skill
-description: Author, generate, or scaffold a new local AI agent skill that turns a concrete oo connector action, including OOMOL-hosted Fusion API actions, into reusable instructions. Use when the user asks to create a skill, write a skill, or make an agent skill for an oo-powered workflow, even if capability discovery is needed first.
+description: Author, generate, adopt, or document a local AI agent skill from either an existing local workflow directory or a concrete oo connector action. Use when the user asks to create a skill, write a skill, adopt an existing workflow, document a local script as a skill, or make an agent skill for an oo-powered workflow.
 <!-- agentic:if agent=claude|hermes -->
 allowed-tools: [Bash(oo *)]
 <!-- agentic:endif -->
@@ -8,9 +8,10 @@ allowed-tools: [Bash(oo *)]
 
 # oo Create Skill
 
-Use this skill to create a new local skill around a concrete `oo` connector
-action. The authoring agent turns a known or newly discovered connector
-capability into reusable runtime instructions for future agents.
+Use this skill to create or adopt a local skill. The authoring agent either
+turns an existing local workflow directory into a reusable runtime runbook, or
+turns a known or newly discovered `oo` connector action into reusable runtime
+instructions for future agents.
 
 This workflow only authors local skills. If the user wants to find or install an
 existing skill, or distribute a finished skill, use the dedicated workflow for
@@ -21,13 +22,17 @@ that task instead.
 Use these rules to decide confidently. They define the governing model; the
 workflow below is an application of this constitution, not a separate checklist.
 When rules appear to compete, use this priority order: safety, local authoring
-scope, proven connector contract, reusable user intent, compact runtime runbook,
-then convenience.
+scope, existing workflow evidence, proven connector contract when applicable,
+reusable user intent, compact runtime runbook, then convenience.
 
-1. Local authoring only. Create new local skills around concrete `oo` connector
-   actions, including OOMOL-hosted Fusion API actions. Do not use this workflow
-   to find, install, update, publish, or distribute existing skills, or bypass
-   native skill commands with manual skeleton creation.
+1. Local authoring only. Create new local skills or adopt existing local
+   workflow directories. For existing scripts, configs, tests, docs, and output
+   conventions, treat the existing directory as the source of truth and use
+   native `oo skills adopt` to add the skill contract. For connector workflows,
+   create skills around concrete `oo` connector actions, including OOMOL-hosted
+   Fusion API actions. Do not use this workflow to find, install, update,
+   publish, or distribute existing skills, or bypass native skill commands with
+   manual skeleton creation.
 2. Ask for reusable intent; prove execution facts. Ask the user only when a
    business decision would change repeated runtime behavior: skill name or
    scope, workflow ordering, required user inputs, expected outputs, target
@@ -38,11 +43,12 @@ then convenience.
    facts that `oo` metadata, schemas, or command output can answer, including
    connector service/action identifiers, payload field names, result field
    paths, command shape, authentication state, defaults, and schema constraints.
-3. Evidence outranks memory. A callable contract exists only when current
-   command output and `oo connector schema "<service>" --action "<action>"`
-   prove the selected service/action, required inputs, and output semantics. Do
-   not invent connector facts from prior knowledge, examples, old runs, or
-   catalog guesses.
+3. Evidence outranks memory. For existing local workflows, inspect current files
+   and use safe local command output or tests when they are proportionate. For
+   connector workflows, a callable contract exists only when current command
+   output and `oo connector schema "<service>" --action "<action>"` prove the
+   selected service/action, required inputs, and output semantics. Do not invent
+   connector facts from prior knowledge, examples, old runs, or catalog guesses.
 4. Resolve before designing. Do not predesign the whole execution process and
    then look for metadata that seems to fit it. Discover the capability, inspect
    metadata, and write from current evidence.
@@ -95,8 +101,12 @@ then convenience.
 
 ## Authoring State Machine
 
-Move through these states. Skip a state only when current evidence already
-proves its exit condition.
+Move through these states. First classify the workflow. Use the local workflow
+path when the user points to an existing directory, says a script/config already
+runs, asks to solidify or document existing work, or asks to adopt an existing
+workflow. Use the connector path only when the reusable behavior depends on an
+OOMOL connector, Fusion API action, or another hosted `oo connector` action.
+Skip a state only when current evidence already proves its exit condition.
 
 ### 1. Permission Probe
 
@@ -154,6 +164,12 @@ connector action without guessing business intent.
 
 ### 3. Capability Discovery
 
+Skip this state for existing local workflow adoption. Do not run `oo search`,
+`oo connector search`, or `oo connector schema` merely to document a local
+script or configuration workflow. Instead inspect the local directory, identify
+entrypoint commands, required files, generated outputs, validation steps, and
+failure modes from current files and safe command output.
+
 Capability discovery may return multiple catalog result types. If the user has
 not provided a complete connector action contract, use discovery before
 authoring:
@@ -209,6 +225,13 @@ fallback reserved for a named blocker.
 
 ### 4. Capability Contract
 
+For existing local workflow adoption, capture the local contract instead of a
+connector contract: source directory, entrypoint scripts or commands, working
+directory, required input files/configuration, environment variables or
+credentials, generated outputs, validation commands, and failure conditions. Run
+only safe local checks that are proportionate and do not mutate user data unless
+the user asked for that behavior.
+
 For the selected action, capture the exact `service`, action `name`,
 description, authentication state, and schema-derived input/output concepts.
 Use the schema command before authoring the runbook:
@@ -237,11 +260,19 @@ runtime path that matters is explicitly marked untested.
 
 ### 5. Initialize Skill
 
-Run `oo skills init <name> --agent <!-- agentic:var agent -->` with a required
-`--description`. Include `--title` and `--icon` when you have suitable values.
-Derive title and icon from the workflow purpose and resolved metadata unless
-the user provided them. If the selected <!-- agentic:var agentTitle --> skill
-directory already exists, ask for a different skill name instead of overwriting.
+For an existing local workflow directory, run `oo skills adopt "<path>" --agent <!-- agentic:var agent -->`
+with a required `--description` unless the existing `SKILL.md` already has one.
+Include `--name`, `--title`, and `--icon` when you have suitable values. Existing
+workflow files are the source of truth; do not overwrite scripts, configs,
+docs, references, tests, or user artifacts.
+
+For a new connector workflow, run `oo skills init <name> --agent <!-- agentic:var agent -->`
+with a required `--description`. Include `--title` and `--icon` when you have
+suitable values. Derive title and icon from the workflow purpose and resolved
+metadata unless the user provided them. If the selected <!-- agentic:var agentTitle -->
+skill directory already exists, use `oo skills adopt` only when it is the
+existing workflow the user wants to solidify; otherwise ask for a different
+skill name instead of overwriting.
 
 Make `--description` a user-facing trigger summary: it becomes the frontmatter
 description and the main signal future agents see before loading the skill.
@@ -260,12 +291,14 @@ Use this description shape when helpful:
 phrases> for <domain objects or input artifacts>, especially when they need
 <expected output/result>.`
 
-Use the path printed by `oo skills init` as the skill directory for authoring
-and validation.
+Use the path printed by `oo skills init` or `oo skills adopt` as the skill
+directory for authoring and validation.
 
-Do not substitute manual file creation for this step. The initialized skill
-directory must come from a successful `oo skills init --agent <!-- agentic:var agent -->`
-invocation before you fill in its workflow instructions or run validation.
+Do not substitute manual file creation for this step. New connector skills must
+come from a successful `oo skills init --agent <!-- agentic:var agent -->`
+invocation. Existing local workflows must come from a successful
+`oo skills adopt "<path>" --agent <!-- agentic:var agent -->` invocation before
+you fill in or patch workflow instructions or run validation.
 
 Write all generated skill prose in English, including frontmatter, headings,
 examples, and reference files. Preserve non-English only for literal runtime
@@ -283,6 +316,11 @@ rediscovery, but not a full schema dump.
 Keep the generated skill centered on runtime execution. Include authoring-time
 evidence only when it affects runtime behavior, such as an untested schema-only
 result path or an observed async polling requirement.
+
+For existing local workflows, use domain-appropriate headings and describe only
+runtime facts future agents need: when to use the skill, required files/configs,
+entrypoint commands, working directory, environment variables, outputs,
+validation, artifact handoff, and failure handling.
 
 For selected connector action workflows, use domain-appropriate headings.
 Include only execution facts that change runtime behavior:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -806,9 +806,9 @@ Initialize one local skill in the selected agent's own skill directory.
 - Generated `SKILL.md` frontmatter includes nested `metadata.title` and
   `metadata.icon`. When `--title` is omitted, the title is generated from the
   skill id. When `--icon` is omitted, a generic local workflow icon is used.
-- Generated `SKILL.md` body includes the managed oo execution notice and
-  editable local workflow placeholder sections for when to use the skill,
-  inputs, execution, result handling, and failure handling.
+- Generated `SKILL.md` body includes editable local workflow placeholder
+  sections for when to use the skill, inputs, execution, result handling, and
+  failure handling.
 - Metadata: the created skill directory includes `.oo-metadata.json`
   identifying the skill as a local skill managed by `oo`.
 - Options: `--icon <icon>` writes a non-empty icon reference to `metadata.icon`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -803,9 +803,12 @@ Initialize one local skill in the selected agent's own skill directory.
   `SKILL.md` frontmatter description.
 - Generated `SKILL.md` frontmatter includes `compatibility: "Requires the oo
   CLI."`.
+- Generated `SKILL.md` frontmatter includes nested `metadata.title` and
+  `metadata.icon`. When `--title` is omitted, the title is generated from the
+  skill id. When `--icon` is omitted, a generic local workflow icon is used.
 - Generated `SKILL.md` body includes the managed oo execution notice and
-  editable placeholder sections for when to use the skill, inputs, execution,
-  result handling, and failure handling.
+  editable local workflow placeholder sections for when to use the skill,
+  inputs, execution, result handling, and failure handling.
 - Metadata: the created skill directory includes `.oo-metadata.json`
   identifying the skill as a local skill managed by `oo`.
 - Options: `--icon <icon>` writes a non-empty icon reference to `metadata.icon`
@@ -813,14 +816,56 @@ Initialize one local skill in the selected agent's own skill directory.
   URL, or `:collection:icon:` where `collection` and `icon` are names from
   <https://icones.js.org/>.
 - Options: `--title <title>` writes `metadata.title` to the generated
-  `SKILL.md` frontmatter. When omitted, `metadata.title` is not generated.
+  `SKILL.md` frontmatter.
 - Target directory: the skill is created at the selected agent's
   `<agent-home>/skills/<skill-id>`.
 - Publication mode: the command does not copy the new local skill to other
   agents.
 - Failure behavior: if the selected agent home does not exist, or if the target
-  directory already exists, the command exits non-zero before writing the skill.
+  directory already exists, the command exits non-zero before writing the skill
+  and suggests `oo skills adopt` for existing workflow directories.
 - Output: text output prints the initialized skill id and target path.
+
+### `oo skills adopt <path>`
+
+Turn an existing local workflow directory into an oo-managed local skill without
+overwriting the workflow implementation.
+
+- Arguments: `<path>` must be an existing directory. Relative paths resolve from
+  the current working directory.
+- Skill id: when `--name <name>` is provided, it is normalized to lowercase
+  hyphen-case and used as the skill id and frontmatter `name`. Otherwise the
+  command uses an existing `SKILL.md` frontmatter `name` when present, falling
+  back to the source directory name.
+- Options: `--agent <agent>` selects an agent skill directory. Accepted values
+  are `universal`, `claude`, `hermes`, `codebuddy`, `workbuddy`, `trae`,
+  `trae-cn`, `openclaw`, `qoderwork`, and `deepseek-tui`.
+- Target behavior: without `--agent`, the command adopts `<path>` in place.
+  With `--agent`, if `<path>` is already the selected agent's
+  `<agent-home>/skills/<skill-id>` directory, the command adopts it in place.
+  Otherwise it copies the existing directory to that target path before
+  adopting it. The source directory is not removed.
+- Content behavior: existing workflow files are preserved. Existing `SKILL.md`
+  body content is preserved; the command only patches frontmatter fields needed
+  for the skill contract. If `SKILL.md` is missing, the command creates one with
+  local workflow placeholder sections.
+- Description: `--description <text>` writes frontmatter `description`. It is
+  required only when the existing `SKILL.md` does not already contain a
+  non-empty frontmatter `description`.
+- Presentation metadata: `--title <title>` writes `metadata.title`, and
+  `--icon <icon>` writes `metadata.icon`. When omitted, existing nested
+  metadata values are preserved; top-level `title` or `icon` are copied into
+  nested `metadata` when present; otherwise default display metadata is used.
+- Metadata: the adopted skill directory includes `.oo-metadata.json`
+  identifying the skill as a local skill managed by `oo`.
+- Safety: the command refuses to adopt a directory whose `.oo-metadata.json`
+  identifies a bundled or registry skill, or whose oo metadata is invalid.
+  With `--agent`, the command refuses to copy over an existing different target
+  directory.
+- Validation: after writing the skill contract and local metadata, the command
+  validates the adopted skill directory and prints validation warnings to
+  stderr.
+- Output: text output prints the adopted skill id and target path.
 
 ### `oo skills validate <path>`
 
@@ -833,7 +878,9 @@ Validate a local skill directory against the generic skill contract.
   dictionary. Nested `metadata.icon` and `metadata.title` are optional, but when
   present they must be non-empty strings.
 - Warnings: missing `metadata.icon` or `metadata.title` prints a warning, but
-  does not make validation fail.
+  does not make validation fail. If top-level `icon` or `title` exists while
+  nested `metadata.icon` or `metadata.title` is missing, the warning explains
+  that top-level fields do not satisfy display metadata.
 - Output: on success, the command prints a concise success message. On failure,
   it prints the validation error and exits non-zero.
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -692,20 +692,54 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 选项：`--description <text>` 为必填项，并写入生成的 `SKILL.md`
   frontmatter description。
 - 生成的 `SKILL.md` frontmatter 包含 `compatibility: "Requires the oo CLI."`。
-- 生成的 `SKILL.md` 正文包含受管理的 oo 执行说明，以及用于描述适用场景、输入、
-  执行、结果处理和失败处理的可编辑占位章节。
+- 生成的 `SKILL.md` frontmatter 包含嵌套的 `metadata.title` 和
+  `metadata.icon`。未提供 `--title` 时，标题会从 skill id 生成。未提供
+  `--icon` 时，会使用通用本地工作流 icon。
+- 生成的 `SKILL.md` 正文包含受管理的 oo 执行说明，以及用于描述本地工作流适用场景、
+  输入、执行、结果处理和失败处理的可编辑占位章节。
 - 元数据：创建出的 skill 目录会包含 `.oo-metadata.json`，用于标记该 skill 是由
   `oo` 管理的 local skill。
 - 选项：`--icon <icon>` 将非空 icon 引用写入生成的 `SKILL.md` frontmatter
   `metadata.icon`。值可以是 emoji、图片 URL，或 `:collection:icon:` 格式，
   其中 `collection` 和 `icon` 是 <https://icones.js.org/> 上的名称。
 - 选项：`--title <title>` 将 `metadata.title` 写入生成的 `SKILL.md`
-  frontmatter。未提供时不会生成 `metadata.title`。
+  frontmatter。
 - 目标目录：skill 会创建在所选 Agent 的 `<agent-home>/skills/<skill-id>`。
 - 发布方式：命令不会把新的 local skill 复制到其他 Agent。
 - 失败行为：如果所选 Agent home 不存在，或目标目录已经存在，命令会在写入 skill
-  前以非零状态退出。
+  前以非零状态退出，并提示已有工作流目录可以使用 `oo skills adopt`。
 - 输出：文本输出会打印已初始化的 skill id 和目标路径。
+
+### `oo skills adopt <path>`
+
+将已有本地工作流目录转换为由 oo 管理的本地 skill，并且不覆盖工作流实现。
+
+- 参数：`<path>` 必须是已存在的目录。相对路径从当前工作目录解析。
+- Skill id：提供 `--name <name>` 时，该值会规范化为小写 hyphen-case，并用作
+  skill id 和 frontmatter `name`。未提供时，命令优先使用已有 `SKILL.md`
+  frontmatter `name`，否则使用源目录名。
+- 选项：`--agent <agent>` 选择 Agent skill 目录。可选值为 `universal`、
+  `claude`、`hermes`、`codebuddy`、`workbuddy`、`trae`、`trae-cn`、
+  `openclaw`、`qoderwork` 和 `deepseek-tui`。
+- 目标行为：不带 `--agent` 时，命令在 `<path>` 原地接管。带 `--agent` 时，如果
+  `<path>` 已经是所选 Agent 的 `<agent-home>/skills/<skill-id>` 目录，命令原地
+  接管；否则先将已有目录复制到该目标路径，再接管。源目录不会被删除。
+- 内容行为：已有工作流文件会被保留。已有 `SKILL.md` 正文会被保留；命令只 patch
+  skill 契约需要的 frontmatter 字段。如果缺少 `SKILL.md`，命令会创建包含本地工作流
+  占位章节的文件。
+- 描述：`--description <text>` 写入 frontmatter `description`。只有当已有
+  `SKILL.md` 没有非空 frontmatter `description` 时才必填。
+- 展示元数据：`--title <title>` 写入 `metadata.title`，`--icon <icon>` 写入
+  `metadata.icon`。未提供时会保留已有嵌套 metadata；如果存在顶层 `title` 或
+  `icon`，会复制到嵌套 `metadata`；否则使用默认展示元数据。
+- 元数据：接管后的 skill 目录包含 `.oo-metadata.json`，用于标识该 skill 是由
+  oo 管理的 local skill。
+- 安全规则：如果目录的 `.oo-metadata.json` 标识 bundled 或 registry skill，或
+  oo metadata 无效，命令会拒绝接管。带 `--agent` 时，如果不同的目标目录已存在，
+  命令会拒绝覆盖。
+- 校验：写入 skill 契约和 local metadata 后，命令会校验接管后的 skill 目录，并将
+  warning 打印到 stderr。
+- 输出：文本输出会打印已接管的 skill id 和目标路径。
 
 ### `oo skills validate <path>`
 
@@ -717,6 +751,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 校验：嵌套的 `metadata` 可以省略；如果提供，则必须是字典。嵌套的
   `metadata.icon` 和 `metadata.title` 可以省略；如果提供，则必须是非空字符串。
 - 警告：缺少 `metadata.icon` 或 `metadata.title` 会打印 warning，但不会导致校验失败。
+  如果存在顶层 `icon` 或 `title`，但缺少嵌套的 `metadata.icon` 或
+  `metadata.title`，warning 会说明顶层字段不等同于展示元数据。
 - 输出：成功时命令会打印简短成功消息。失败时打印校验错误并以非零状态退出。
 
 ### `oo skills publish <path>`

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -695,8 +695,7 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 生成的 `SKILL.md` frontmatter 包含嵌套的 `metadata.title` 和
   `metadata.icon`。未提供 `--title` 时，标题会从 skill id 生成。未提供
   `--icon` 时，会使用通用本地工作流 icon。
-- 生成的 `SKILL.md` 正文包含受管理的 oo 执行说明，以及用于描述本地工作流适用场景、
-  输入、执行、结果处理和失败处理的可编辑占位章节。
+- 生成的 `SKILL.md` 正文包含用于描述本地工作流适用场景、输入、执行、结果处理和失败处理的可编辑占位章节。
 - 元数据：创建出的 skill 目录会包含 `.oo-metadata.json`，用于标记该 skill 是由
   `oo` 管理的 local skill。
 - 选项：`--icon <icon>` 将非空 icon 引用写入生成的 `SKILL.md` frontmatter

--- a/src/application/commands/skills/adopt.test.ts
+++ b/src/application/commands/skills/adopt.test.ts
@@ -14,10 +14,9 @@ import {
 
 describe("skills adopt command", () => {
     test("adopts an existing workflow directory in place", async () => {
-        const sandbox = await createCliSandbox();
-        const skillDirectoryPath = join(sandbox.cwd, "vpn-profile-compiler");
+        await withCliSandbox(async (sandbox) => {
+            const skillDirectoryPath = join(sandbox.cwd, "vpn-profile-compiler");
 
-        try {
             await mkdir(skillDirectoryPath, { recursive: true });
             await Bun.write(
                 join(skillDirectoryPath, "SKILL.md"),
@@ -55,22 +54,18 @@ describe("skills adopt command", () => {
             expect(skillMarkdown).toContain("compatibility: Requires the oo CLI.\n");
             expect(skillMarkdown).toContain("metadata:\n  icon: ':lucide:network:'\n  title: VPN Profile Compiler\n");
             expect(skillMarkdown).toContain("Run the local compiler script.");
-        }
-        finally {
-            await sandbox.cleanup();
-        }
+        });
     });
 
     test("copies an existing workflow into the requested agent skill directory", async () => {
-        const sandbox = await createCliSandbox();
-        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
-        const sourceDirectoryPath = join(sandbox.cwd, "Existing Workflow");
-        const targetDirectoryPath = resolveManagedSkillDirectoryPath(
-            universalHomeDirectory,
-            "vpn-profile-compiler",
-        );
+        await withCliSandbox(async (sandbox) => {
+            const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+            const sourceDirectoryPath = join(sandbox.cwd, "Existing Workflow");
+            const targetDirectoryPath = resolveManagedSkillDirectoryPath(
+                universalHomeDirectory,
+                "vpn-profile-compiler",
+            );
 
-        try {
             await Promise.all([
                 mkdir(universalHomeDirectory, { recursive: true }),
                 mkdir(sourceDirectoryPath, { recursive: true }),
@@ -105,17 +100,13 @@ describe("skills adopt command", () => {
                 "name: vpn-profile-compiler\n",
             );
             await expect(stat(join(sourceDirectoryPath, "compile.ts"))).resolves.toBeDefined();
-        }
-        finally {
-            await sandbox.cleanup();
-        }
+        });
     });
 
     test("rejects directories that already belong to registry skills", async () => {
-        const sandbox = await createCliSandbox();
-        const skillDirectoryPath = join(sandbox.cwd, "registry-skill");
+        await withCliSandbox(async (sandbox) => {
+            const skillDirectoryPath = join(sandbox.cwd, "registry-skill");
 
-        try {
             await mkdir(skillDirectoryPath, { recursive: true });
             await Bun.write(
                 join(skillDirectoryPath, ".oo-metadata.json"),
@@ -141,22 +132,61 @@ describe("skills adopt command", () => {
             await expect(stat(join(skillDirectoryPath, "SKILL.md"))).rejects.toMatchObject({
                 code: "ENOENT",
             });
-        }
-        finally {
-            await sandbox.cleanup();
-        }
+        });
+    });
+
+    test("rejects foreign source metadata before copying to an agent target", async () => {
+        await withCliSandbox(async (sandbox) => {
+            const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+            const sourceDirectoryPath = join(sandbox.cwd, "registry-skill");
+            const targetDirectoryPath = resolveManagedSkillDirectoryPath(
+                universalHomeDirectory,
+                "registry-skill",
+            );
+
+            await Promise.all([
+                mkdir(universalHomeDirectory, { recursive: true }),
+                mkdir(sourceDirectoryPath, { recursive: true }),
+            ]);
+            await Bun.write(join(sourceDirectoryPath, "source.ts"), "export {};\n");
+            await Bun.write(
+                join(sourceDirectoryPath, ".oo-metadata.json"),
+                renderSkillMetadataJson(createRegistrySkillMetadata({
+                    packageName: "@owner/registry-skill",
+                    version: "1.0.0",
+                })),
+            );
+
+            const result = await sandbox.run([
+                "skills",
+                "adopt",
+                sourceDirectoryPath,
+                "--agent",
+                "universal",
+                "--description",
+                "Use this existing workflow.",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                `Cannot adopt skill at ${sourceDirectoryPath} because its .oo-metadata.json belongs to another oo-managed skill or is invalid.\n`,
+            );
+            await expect(stat(targetDirectoryPath)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        });
     });
 
     test("does not overwrite an existing agent target directory", async () => {
-        const sandbox = await createCliSandbox();
-        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
-        const sourceDirectoryPath = join(sandbox.cwd, "source-workflow");
-        const targetDirectoryPath = resolveManagedSkillDirectoryPath(
-            universalHomeDirectory,
-            "target-skill",
-        );
+        await withCliSandbox(async (sandbox) => {
+            const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+            const sourceDirectoryPath = join(sandbox.cwd, "source-workflow");
+            const targetDirectoryPath = resolveManagedSkillDirectoryPath(
+                universalHomeDirectory,
+                "target-skill",
+            );
 
-        try {
             await Promise.all([
                 mkdir(sourceDirectoryPath, { recursive: true }),
                 mkdir(targetDirectoryPath, { recursive: true }),
@@ -185,17 +215,13 @@ describe("skills adopt command", () => {
             await expect(stat(join(targetDirectoryPath, "source.ts"))).rejects.toMatchObject({
                 code: "ENOENT",
             });
-        }
-        finally {
-            await sandbox.cleanup();
-        }
+        });
     });
 
     test("requires a description when no existing SKILL.md description is available", async () => {
-        const sandbox = await createCliSandbox();
-        const skillDirectoryPath = join(sandbox.cwd, "missing-description");
+        await withCliSandbox(async (sandbox) => {
+            const skillDirectoryPath = join(sandbox.cwd, "missing-description");
 
-        try {
             await mkdir(skillDirectoryPath, { recursive: true });
 
             const result = await sandbox.run(["skills", "adopt", skillDirectoryPath]);
@@ -208,9 +234,46 @@ describe("skills adopt command", () => {
             await expect(stat(join(skillDirectoryPath, "SKILL.md"))).rejects.toMatchObject({
                 code: "ENOENT",
             });
-        }
-        finally {
-            await sandbox.cleanup();
-        }
+        });
+    });
+
+    test("rejects an empty override description", async () => {
+        await withCliSandbox(async (sandbox) => {
+            const skillDirectoryPath = join(sandbox.cwd, "empty-description");
+
+            await mkdir(skillDirectoryPath, { recursive: true });
+
+            const result = await sandbox.run([
+                "skills",
+                "adopt",
+                skillDirectoryPath,
+                "--description",
+                " ",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Invalid value for --description. Use a non-empty trigger description for the adopted skill.\n",
+            );
+            await expect(stat(join(skillDirectoryPath, "SKILL.md"))).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        });
     });
 });
+
+type CliSandbox = Awaited<ReturnType<typeof createCliSandbox>>;
+
+async function withCliSandbox(
+    callback: (sandbox: CliSandbox) => Promise<void>,
+): Promise<void> {
+    const sandbox = await createCliSandbox();
+
+    try {
+        await callback(sandbox);
+    }
+    finally {
+        await sandbox.cleanup();
+    }
+}

--- a/src/application/commands/skills/adopt.test.ts
+++ b/src/application/commands/skills/adopt.test.ts
@@ -1,0 +1,216 @@
+import { mkdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { createCliSandbox } from "../../../../__tests__/helpers.ts";
+import { resolveManagedSkillAgentHomeDirectory } from "./managed-skill-agents.ts";
+import { resolveManagedSkillDirectoryPath } from "./managed-skill-paths.ts";
+import {
+    createLocalSkillMetadata,
+    createRegistrySkillMetadata,
+    renderSkillMetadataJson,
+} from "./skill-metadata.ts";
+
+describe("skills adopt command", () => {
+    test("adopts an existing workflow directory in place", async () => {
+        const sandbox = await createCliSandbox();
+        const skillDirectoryPath = join(sandbox.cwd, "vpn-profile-compiler");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(skillDirectoryPath, "SKILL.md"),
+                [
+                    "---",
+                    "name: vpn-profile-compiler",
+                    "description: Compile VPN profiles from local configuration.",
+                    "title: VPN Profile Compiler",
+                    "icon: ':lucide:network:'",
+                    "---",
+                    "",
+                    "# Existing Workflow",
+                    "",
+                    "Run the local compiler script.",
+                    "",
+                ].join("\n"),
+            );
+            await Bun.write(join(skillDirectoryPath, "compile.ts"), "export {};\n");
+
+            const result = await sandbox.run(["skills", "adopt", skillDirectoryPath]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Adopted skill vpn-profile-compiler at ${skillDirectoryPath}.\n`,
+            );
+            expect(result.stderr).toBe("");
+            expect(await readFile(join(skillDirectoryPath, ".oo-metadata.json"), "utf8")).toBe(
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
+
+            const skillMarkdown = await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8");
+
+            expect(skillMarkdown).toContain("name: vpn-profile-compiler\n");
+            expect(skillMarkdown).toContain("description: Compile VPN profiles from local configuration.\n");
+            expect(skillMarkdown).toContain("compatibility: Requires the oo CLI.\n");
+            expect(skillMarkdown).toContain("metadata:\n  icon: ':lucide:network:'\n  title: VPN Profile Compiler\n");
+            expect(skillMarkdown).toContain("Run the local compiler script.");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("copies an existing workflow into the requested agent skill directory", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+        const sourceDirectoryPath = join(sandbox.cwd, "Existing Workflow");
+        const targetDirectoryPath = resolveManagedSkillDirectoryPath(
+            universalHomeDirectory,
+            "vpn-profile-compiler",
+        );
+
+        try {
+            await Promise.all([
+                mkdir(universalHomeDirectory, { recursive: true }),
+                mkdir(sourceDirectoryPath, { recursive: true }),
+            ]);
+            await Bun.write(join(sourceDirectoryPath, "compile.ts"), "export {};\n");
+
+            const result = await sandbox.run([
+                "skills",
+                "adopt",
+                sourceDirectoryPath,
+                "--agent",
+                "universal",
+                "--name",
+                "VPN Profile Compiler",
+                "--description",
+                "Compile VPN profiles from local configuration.",
+                "--title",
+                "VPN Profile Compiler",
+                "--icon",
+                ":lucide:network:",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe(
+                `Adopted skill vpn-profile-compiler at ${targetDirectoryPath}.\n`,
+            );
+            expect(await readFile(join(targetDirectoryPath, "compile.ts"), "utf8")).toBe("export {};\n");
+            expect(await readFile(join(targetDirectoryPath, ".oo-metadata.json"), "utf8")).toBe(
+                renderSkillMetadataJson(createLocalSkillMetadata()),
+            );
+            expect(await readFile(join(targetDirectoryPath, "SKILL.md"), "utf8")).toContain(
+                "name: vpn-profile-compiler\n",
+            );
+            await expect(stat(join(sourceDirectoryPath, "compile.ts"))).resolves.toBeDefined();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects directories that already belong to registry skills", async () => {
+        const sandbox = await createCliSandbox();
+        const skillDirectoryPath = join(sandbox.cwd, "registry-skill");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(skillDirectoryPath, ".oo-metadata.json"),
+                renderSkillMetadataJson(createRegistrySkillMetadata({
+                    packageName: "@owner/registry-skill",
+                    version: "1.0.0",
+                })),
+            );
+
+            const result = await sandbox.run([
+                "skills",
+                "adopt",
+                skillDirectoryPath,
+                "--description",
+                "Use this existing workflow.",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                `Cannot adopt skill at ${skillDirectoryPath} because its .oo-metadata.json belongs to another oo-managed skill or is invalid.\n`,
+            );
+            await expect(stat(join(skillDirectoryPath, "SKILL.md"))).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not overwrite an existing agent target directory", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+        const sourceDirectoryPath = join(sandbox.cwd, "source-workflow");
+        const targetDirectoryPath = resolveManagedSkillDirectoryPath(
+            universalHomeDirectory,
+            "target-skill",
+        );
+
+        try {
+            await Promise.all([
+                mkdir(sourceDirectoryPath, { recursive: true }),
+                mkdir(targetDirectoryPath, { recursive: true }),
+            ]);
+            await Bun.write(join(sourceDirectoryPath, "source.ts"), "export {};\n");
+            await Bun.write(join(targetDirectoryPath, "existing.txt"), "keep\n");
+
+            const result = await sandbox.run([
+                "skills",
+                "adopt",
+                sourceDirectoryPath,
+                "--agent",
+                "universal",
+                "--name",
+                "target-skill",
+                "--description",
+                "Use this existing workflow.",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                `Skill name target-skill is already used by a non-OOMOL skill at ${targetDirectoryPath}.\n`,
+            );
+            expect(await readFile(join(targetDirectoryPath, "existing.txt"), "utf8")).toBe("keep\n");
+            await expect(stat(join(targetDirectoryPath, "source.ts"))).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("requires a description when no existing SKILL.md description is available", async () => {
+        const sandbox = await createCliSandbox();
+        const skillDirectoryPath = join(sandbox.cwd, "missing-description");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+
+            const result = await sandbox.run(["skills", "adopt", skillDirectoryPath]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "Missing required --description. Provide a concise trigger description for the generated skill.\n",
+            );
+            await expect(stat(join(skillDirectoryPath, "SKILL.md"))).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/adopt.ts
+++ b/src/application/commands/skills/adopt.ts
@@ -1,0 +1,375 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+
+import type { BundledSkillAgentName } from "./embedded-assets.ts";
+import { cp, mkdir, realpath, stat } from "node:fs/promises";
+import { basename, dirname, resolve } from "node:path";
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { writeLine } from "../shared/output.ts";
+import {
+    isNodeNotFoundError,
+    removePath,
+} from "./bundled-skill-filesystem.ts";
+import { resolveRequestedManagedSkillHost } from "./check.ts";
+import {
+    isForeignManagedMetadataState,
+    readSkillFileContent,
+    readSkillMetadataFileState,
+    writeLocalSkillMetadata,
+} from "./local-skill-ownership.ts";
+import {
+    createMissingRequiredSkillAgentError,
+    parseManagedSkillAgentOption,
+} from "./managed-skill-agents.ts";
+import {
+    isPathWithinDirectory,
+    resolveManagedSkillDirectoryPath,
+    resolveManagedSkillsDirectoryPath,
+} from "./managed-skill-paths.ts";
+import {
+    readSkillFrontmatterName,
+    writeAdoptedSkillContract,
+} from "./skill-authoring.ts";
+import { normalizeSkillName } from "./skill-id.ts";
+import { validateSkillDirectory } from "./validate.ts";
+
+interface SkillsAdoptInput {
+    agent?: string;
+    description?: string;
+    icon?: string;
+    name?: string;
+    path: string;
+    title?: string;
+}
+
+export const skillsAdoptCommand: CliCommandDefinition<SkillsAdoptInput> = {
+    name: "adopt",
+    summaryKey: "commands.skills.adopt.summary",
+    descriptionKey: "commands.skills.adopt.description",
+    arguments: [
+        {
+            name: "path",
+            descriptionKey: "arguments.filePath",
+            required: true,
+        },
+    ],
+    options: [
+        {
+            name: "agent",
+            longFlag: "--agent",
+            valueName: "agent",
+            descriptionKey: "options.agent",
+        },
+        {
+            name: "name",
+            longFlag: "--name",
+            valueName: "name",
+            descriptionKey: "options.skills.adopt.name",
+        },
+        {
+            name: "description",
+            longFlag: "--description",
+            valueName: "text",
+            descriptionKey: "options.description",
+        },
+        {
+            name: "icon",
+            longFlag: "--icon",
+            valueName: "icon",
+            descriptionKey: "options.icon",
+        },
+        {
+            name: "title",
+            longFlag: "--title",
+            valueName: "title",
+            descriptionKey: "options.title",
+        },
+    ],
+    inputSchema: z.object({
+        agent: z.string().optional(),
+        description: z.string().optional(),
+        icon: z.string().optional(),
+        name: z.string().optional(),
+        path: z.string(),
+        title: z.string().optional(),
+    }),
+    handler: async (input, context) => {
+        await adoptLocalSkill(input, context);
+    },
+};
+
+async function adoptLocalSkill(
+    input: SkillsAdoptInput,
+    context: CliExecutionContext,
+): Promise<void> {
+    const sourceDirectoryPath = resolve(context.cwd, input.path);
+
+    await validateAdoptSourceDirectory(sourceDirectoryPath);
+
+    const sourceSkillFileContent = await readSkillFileContent(sourceDirectoryPath);
+    const skillName = normalizeAdoptedSkillName({
+        name: input.name,
+        sourceDirectoryPath,
+        sourceSkillFileContent,
+    });
+    const description = input.description?.trim();
+    const icon = input.icon?.trim();
+    const title = input.title?.trim();
+
+    if (description !== undefined && description === "") {
+        throw new CliUserError("errors.skills.init.descriptionRequired", 1);
+    }
+
+    if (input.icon !== undefined && icon === "") {
+        throw new CliUserError("errors.skills.init.invalidIcon", 1);
+    }
+
+    if (input.title !== undefined && title === "") {
+        throw new CliUserError("errors.skills.init.invalidTitle", 1);
+    }
+
+    const targetDirectoryPath = await prepareAdoptTargetDirectory({
+        agent: input.agent,
+        context,
+        skillName,
+        sourceDirectoryPath,
+    });
+
+    await validateAdoptMetadata(targetDirectoryPath);
+    await writeAdoptedSkillContract(targetDirectoryPath, {
+        description,
+        icon,
+        name: skillName,
+        title,
+    });
+    await writeLocalSkillMetadata(targetDirectoryPath);
+    await validateAdoptedSkillDirectory(targetDirectoryPath, context);
+
+    writeLine(
+        context.stdout,
+        context.translator.t("skills.adopt.success", {
+            name: skillName,
+            path: targetDirectoryPath,
+        }),
+    );
+
+    context.logger.info(
+        {
+            path: targetDirectoryPath,
+            skillName,
+            sourcePath: sourceDirectoryPath,
+        },
+        "Existing local workflow adopted as a skill.",
+    );
+}
+
+async function validateAdoptSourceDirectory(
+    sourceDirectoryPath: string,
+): Promise<void> {
+    let sourceStats: Awaited<ReturnType<typeof stat>>;
+
+    try {
+        sourceStats = await stat(sourceDirectoryPath);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            throw new CliUserError("errors.skills.adopt.pathMissing", 1, {
+                path: sourceDirectoryPath,
+            });
+        }
+
+        throw error;
+    }
+
+    if (!sourceStats.isDirectory()) {
+        throw new CliUserError("errors.skills.adopt.pathNotDirectory", 1, {
+            path: sourceDirectoryPath,
+        });
+    }
+}
+
+function normalizeAdoptedSkillName(options: {
+    name: string | undefined;
+    sourceDirectoryPath: string;
+    sourceSkillFileContent: string | undefined;
+}): string {
+    const skillName = normalizeSkillName(
+        options.name
+        ?? readSkillFrontmatterName(options.sourceSkillFileContent)
+        ?? basename(options.sourceDirectoryPath),
+    );
+
+    if (skillName === "") {
+        throw new CliUserError("errors.skills.adopt.invalidName", 1, {
+            value: options.name ?? basename(options.sourceDirectoryPath),
+        });
+    }
+
+    return skillName;
+}
+
+async function prepareAdoptTargetDirectory(options: {
+    agent: string | undefined;
+    context: CliExecutionContext;
+    skillName: string;
+    sourceDirectoryPath: string;
+}): Promise<string> {
+    if (options.agent === undefined) {
+        return options.sourceDirectoryPath;
+    }
+
+    const agentName = parseOptionalSkillsAdoptAgent(options.agent);
+    const hosts = await resolveRequestedManagedSkillHost(
+        options.context.env,
+        options.context.translator,
+        agentName,
+    );
+    const host = hosts[0]!;
+    const targetDirectoryPath = resolveManagedSkillDirectoryPath(
+        host.homeDirectory,
+        options.skillName,
+    );
+
+    if (!isPathWithinDirectory(
+        resolveManagedSkillsDirectoryPath(host.homeDirectory),
+        targetDirectoryPath,
+    )) {
+        throw new CliUserError("errors.skills.invalidPath", 1, {
+            name: options.skillName,
+        });
+    }
+
+    if (await areSamePath(options.sourceDirectoryPath, targetDirectoryPath)) {
+        return targetDirectoryPath;
+    }
+
+    await copyAdoptSourceToTarget({
+        skillName: options.skillName,
+        sourceDirectoryPath: options.sourceDirectoryPath,
+        targetDirectoryPath,
+    });
+
+    return targetDirectoryPath;
+}
+
+function parseOptionalSkillsAdoptAgent(value: string): BundledSkillAgentName {
+    const agentName = parseManagedSkillAgentOption(
+        value,
+        "errors.skills.adopt.invalidAgent",
+    );
+
+    if (agentName === undefined) {
+        throw createMissingRequiredSkillAgentError("errors.skills.adopt.invalidAgent");
+    }
+
+    return agentName;
+}
+
+async function copyAdoptSourceToTarget(options: {
+    skillName: string;
+    sourceDirectoryPath: string;
+    targetDirectoryPath: string;
+}): Promise<void> {
+    await rejectExistingAdoptTarget(options.skillName, options.targetDirectoryPath);
+    await mkdir(dirname(options.targetDirectoryPath), { recursive: true });
+
+    try {
+        await cp(options.sourceDirectoryPath, options.targetDirectoryPath, {
+            dereference: true,
+            errorOnExist: true,
+            force: false,
+            recursive: true,
+        });
+    }
+    catch (error) {
+        if (isCopyTargetAlreadyExistsError(error)) {
+            throw new CliUserError("errors.skills.nameConflict", 1, {
+                name: options.skillName,
+                path: options.targetDirectoryPath,
+            });
+        }
+
+        await removePath(options.targetDirectoryPath);
+        throw error;
+    }
+}
+
+async function rejectExistingAdoptTarget(
+    skillName: string,
+    targetDirectoryPath: string,
+): Promise<void> {
+    try {
+        await stat(targetDirectoryPath);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return;
+        }
+
+        throw error;
+    }
+
+    throw new CliUserError("errors.skills.nameConflict", 1, {
+        name: skillName,
+        path: targetDirectoryPath,
+    });
+}
+
+function isCopyTargetAlreadyExistsError(
+    error: unknown,
+): error is NodeJS.ErrnoException {
+    return error instanceof Error
+        && "code" in error
+        && (error.code === "EEXIST" || error.code === "ERR_FS_CP_EEXIST");
+}
+
+async function validateAdoptMetadata(
+    skillDirectoryPath: string,
+): Promise<void> {
+    const metadataState = await readSkillMetadataFileState(skillDirectoryPath);
+
+    if (!isForeignManagedMetadataState(metadataState)) {
+        return;
+    }
+
+    throw new CliUserError("errors.skills.adopt.foreignMetadata", 1, {
+        path: skillDirectoryPath,
+    });
+}
+
+async function validateAdoptedSkillDirectory(
+    skillDirectoryPath: string,
+    context: CliExecutionContext,
+): Promise<void> {
+    const result = await validateSkillDirectory(skillDirectoryPath);
+
+    if (result.error !== undefined) {
+        throw new CliUserError("errors.skills.validate.failed", 1, {
+            message: result.error,
+        });
+    }
+
+    for (const warning of result.warnings ?? []) {
+        writeLine(context.stderr, warning);
+    }
+}
+
+async function areSamePath(
+    leftPath: string,
+    rightPath: string,
+): Promise<boolean> {
+    if (resolve(leftPath) === resolve(rightPath)) {
+        return true;
+    }
+
+    try {
+        return await realpath(leftPath) === await realpath(rightPath);
+    }
+    catch (error) {
+        if (isNodeNotFoundError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+}

--- a/src/application/commands/skills/adopt.ts
+++ b/src/application/commands/skills/adopt.ts
@@ -117,7 +117,7 @@ async function adoptLocalSkill(
     const title = input.title?.trim();
 
     if (description !== undefined && description === "") {
-        throw new CliUserError("errors.skills.init.descriptionRequired", 1);
+        throw new CliUserError("errors.skills.adopt.invalidDescription", 1);
     }
 
     if (input.icon !== undefined && icon === "") {
@@ -128,6 +128,8 @@ async function adoptLocalSkill(
         throw new CliUserError("errors.skills.init.invalidTitle", 1);
     }
 
+    await validateAdoptMetadata(sourceDirectoryPath);
+
     const targetDirectoryPath = await prepareAdoptTargetDirectory({
         agent: input.agent,
         context,
@@ -135,7 +137,6 @@ async function adoptLocalSkill(
         sourceDirectoryPath,
     });
 
-    await validateAdoptMetadata(targetDirectoryPath);
     await writeAdoptedSkillContract(targetDirectoryPath, {
         description,
         icon,

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -614,15 +614,18 @@ describe("embedded skill assets", () => {
                 await readBundledSkillFileContent(skillFile),
             );
 
-            expect(content).toContain("Author, generate, or scaffold a new local AI agent skill");
-            expect(content).toContain("create a skill, write a skill, or make an agent skill");
+            expect(content).toContain("Author, generate, adopt, or document a local AI agent skill");
+            expect(content).toContain("create a skill, write a skill, adopt an existing workflow");
+            expect(content).toContain("existing local workflow directory");
             expect(content).toContain("connector action");
-            expect(content).toContain("capability discovery is needed first");
+            expect(content).toContain("Use the local workflow path");
             expect(content).toContain("oo skills preflight --agent");
+            expect(content).toContain("oo skills adopt \"<path>\" --agent");
             expect(content).toContain("oo skills init <name> --agent");
             expect(content).toContain("find or install an");
             expect(content).toContain("existing skill");
             expect(content).toContain("distribute a finished skill");
+            expect(content).not.toContain("Author, generate, or scaffold a new local AI agent skill");
             expect(content).not.toContain("Author, generate, scaffold, or update");
             expect(content).not.toContain("create or update a local skill");
             expect(content).not.toContain("default private");

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -1,5 +1,6 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
+import { skillsAdoptCommand } from "./adopt.ts";
 import { skillsCheckUpdateCommand } from "./check-update.ts";
 import { skillsCheckCommand } from "./check.ts";
 import { skillsInitCommand } from "./init.ts";
@@ -26,6 +27,7 @@ export const skillsCommand: CliCommandDefinition = {
         skillsSyncCommand,
         skillsCheckCommand,
         skillsInitCommand,
+        skillsAdoptCommand,
         skillsValidateCommand,
         skillsPublishCommand,
         skillsShareCommand,

--- a/src/application/commands/skills/init.test.ts
+++ b/src/application/commands/skills/init.test.ts
@@ -69,20 +69,20 @@ describe("skills init command", () => {
                 "",
                 "## Inputs",
                 "",
-                "- TODO: List required user inputs.",
-                "- TODO: List optional inputs or safe defaults.",
+                "- TODO: List required files, config values, credentials, or user decisions.",
+                "- TODO: List optional inputs and defaults.",
                 "",
                 "## Execution",
                 "",
-                "TODO: Describe the exact oo connector command path, for example an authenticated connector action.",
+                "TODO: Describe the local scripts, commands, working directory, environment variables, and generated files.",
                 "",
                 "## Result Handling",
                 "",
-                "TODO: Describe useful output fields, artifacts, previews, or saved files.",
+                "TODO: Describe output files, validation checks, previews, and what to report to the user.",
                 "",
                 "## Failure Handling",
                 "",
-                "TODO: Describe auth, billing, missing input, unsupported shape, timeout, or action failure blockers.",
+                "TODO: Describe missing files, invalid config, dependency, permission, timeout, and validation failures.",
                 "",
             ].join("\n"));
         }
@@ -91,7 +91,7 @@ describe("skills init command", () => {
         }
     });
 
-    test("omits metadata title when no title is provided", async () => {
+    test("uses default display metadata when no title or icon is provided", async () => {
         const sandbox = await createCliSandbox();
         const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
         const skillDirectoryPath = resolveManagedSkillDirectoryPath(
@@ -120,6 +120,9 @@ describe("skills init command", () => {
                 "name: minimal-skill",
                 "description: Use a known package workflow.",
                 `compatibility: ${installedRegistrySkillCompatibility}`,
+                "metadata:",
+                "  icon: ':lucide:wrench:'",
+                "  title: Minimal Skill",
                 "---",
                 "",
                 "# Minimal Skill",
@@ -130,20 +133,20 @@ describe("skills init command", () => {
                 "",
                 "## Inputs",
                 "",
-                "- TODO: List required user inputs.",
-                "- TODO: List optional inputs or safe defaults.",
+                "- TODO: List required files, config values, credentials, or user decisions.",
+                "- TODO: List optional inputs and defaults.",
                 "",
                 "## Execution",
                 "",
-                "TODO: Describe the exact oo connector command path, for example an authenticated connector action.",
+                "TODO: Describe the local scripts, commands, working directory, environment variables, and generated files.",
                 "",
                 "## Result Handling",
                 "",
-                "TODO: Describe useful output fields, artifacts, previews, or saved files.",
+                "TODO: Describe output files, validation checks, previews, and what to report to the user.",
                 "",
                 "## Failure Handling",
                 "",
-                "TODO: Describe auth, billing, missing input, unsupported shape, timeout, or action failure blockers.",
+                "TODO: Describe missing files, invalid config, dependency, permission, timeout, and validation failures.",
                 "",
             ].join("\n"));
         }
@@ -369,7 +372,7 @@ describe("skills init command", () => {
 
             expect(result.exitCode).toBe(1);
             expect(result.stderr).toBe(
-                `Skill name existing-skill is already used by a non-OOMOL skill at ${skillDirectoryPath}.\n`,
+                `Skill name existing-skill is already used at ${skillDirectoryPath}. To turn that directory into an oo-managed local skill, use oo skills adopt.\n`,
             );
             await expect(
                 stat(join(skillDirectoryPath, "SKILL.md")),

--- a/src/application/commands/skills/init.ts
+++ b/src/application/commands/skills/init.ts
@@ -21,27 +21,14 @@ import {
     resolveManagedSkillDirectoryPath,
     resolveManagedSkillsDirectoryPath,
 } from "./managed-skill-paths.ts";
-import { installedRegistrySkillCompatibility } from "./registry-skill-markdown.ts";
-import { stringifySkillMarkdownMatter } from "./skill-frontmatter.ts";
-import { renderSkillTitle } from "./skill-title.ts";
+import { renderInitializedSkillMarkdown } from "./skill-authoring.ts";
+import { normalizeSkillName } from "./skill-id.ts";
 
 interface SkillsInitInput {
     agent?: string;
     description?: string;
     icon?: string;
     name: string;
-    title?: string;
-}
-
-interface OOSkillFrontmatter {
-    compatibility: string;
-    description: string;
-    metadata?: OOSkillFrontmatterMetadata;
-    name: string;
-}
-
-interface OOSkillFrontmatterMetadata {
-    icon?: string;
     title?: string;
 }
 
@@ -152,7 +139,12 @@ async function initializeLocalSkill(
         createdDirectory = true;
         await Bun.write(
             join(skillDirectoryPath, "SKILL.md"),
-            renderInitializedSkillMarkdown(skillName, description, icon, title),
+            renderInitializedSkillMarkdown({
+                description,
+                icon,
+                name: skillName,
+                title,
+            }),
         );
         await writeLocalSkillMetadata(skillDirectoryPath);
 
@@ -209,7 +201,7 @@ function createLocalSkillInitTargetError(
     skillName: string,
     skillDirectoryPath: string,
 ): CliUserError {
-    return new CliUserError("errors.skills.nameConflict", 1, {
+    return new CliUserError("errors.skills.init.nameConflict", 1, {
         name: skillName,
         path: skillDirectoryPath,
     });
@@ -223,96 +215,4 @@ function isPathWithinAgentSkillsDirectory(
         resolveManagedSkillsDirectoryPath(homeDirectory),
         skillDirectoryPath,
     );
-}
-
-function renderInitializedSkillMarkdown(
-    skillName: string,
-    description: string,
-    icon: string | undefined,
-    title: string | undefined,
-): string {
-    const frontmatter: OOSkillFrontmatter = {
-        name: skillName,
-        description,
-        compatibility: installedRegistrySkillCompatibility,
-    };
-
-    if (icon !== undefined || title !== undefined) {
-        frontmatter.metadata = {};
-
-        if (icon !== undefined) {
-            frontmatter.metadata.icon = icon;
-        }
-
-        if (title !== undefined) {
-            frontmatter.metadata.title = title;
-        }
-    }
-
-    const body = [
-        "",
-        `# ${title ?? renderSkillTitle(skillName)}`,
-        "",
-        "## When to Use",
-        "",
-        "TODO: Describe the user requests and outcomes that should trigger this skill.",
-        "",
-        "## Inputs",
-        "",
-        "- TODO: List required user inputs.",
-        "- TODO: List optional inputs or safe defaults.",
-        "",
-        "## Execution",
-        "",
-        "TODO: Describe the exact oo connector command path, for example an authenticated connector action.",
-        "",
-        "## Result Handling",
-        "",
-        "TODO: Describe useful output fields, artifacts, previews, or saved files.",
-        "",
-        "## Failure Handling",
-        "",
-        "TODO: Describe auth, billing, missing input, unsupported shape, timeout, or action failure blockers.",
-        "",
-    ].join("\n");
-
-    return stringifySkillMarkdownMatter(body, frontmatter);
-}
-
-function normalizeSkillName(value: string): string {
-    const normalizedCharacters: string[] = [];
-    let previousWasHyphen = false;
-
-    for (const char of value.trim().toLowerCase()) {
-        if (isLowercaseAsciiLetter(char) || isAsciiDigit(char)) {
-            normalizedCharacters.push(char);
-            previousWasHyphen = false;
-            continue;
-        }
-
-        if (!previousWasHyphen && normalizedCharacters.length > 0) {
-            normalizedCharacters.push("-");
-            previousWasHyphen = true;
-        }
-    }
-
-    if (normalizedCharacters.at(-1) === "-") {
-        normalizedCharacters.pop();
-    }
-
-    let result = normalizedCharacters.join("").slice(0, 64);
-
-    while (result.endsWith("-")) {
-        result = result.slice(0, -1);
-    }
-
-    return result;
-}
-
-function isLowercaseAsciiLetter(char: string): boolean {
-    return char >= "a" && char <= "z";
-}
-
-function isAsciiDigit(char: string): boolean {
-    return char >= "0" && char <= "9";
 }

--- a/src/application/commands/skills/skill-authoring.ts
+++ b/src/application/commands/skills/skill-authoring.ts
@@ -1,0 +1,160 @@
+import type { SkillFrontmatterRecord } from "./skill-frontmatter.ts";
+
+import { join } from "node:path";
+import { CliUserError } from "../../contracts/cli.ts";
+import { readSkillFileContent } from "./local-skill-ownership.ts";
+import { installedRegistrySkillCompatibility } from "./registry-skill-markdown.ts";
+import {
+    isSkillFrontmatterRecord,
+    parseSkillMarkdownMatter,
+    stringifySkillMarkdownMatter,
+    toNonBlankString,
+} from "./skill-frontmatter.ts";
+import { renderSkillTitle } from "./skill-title.ts";
+
+const defaultSkillIcon = ":lucide:wrench:";
+
+export interface SkillAuthoringFields {
+    description?: string;
+    icon?: string;
+    name: string;
+    title?: string;
+}
+
+export function renderInitializedSkillMarkdown(
+    fields: SkillAuthoringFields,
+): string {
+    const completeFields = resolveCompleteSkillFields(fields, {});
+
+    return stringifySkillMarkdownMatter(
+        renderLocalWorkflowSkillBody(completeFields.title),
+        createSkillFrontmatter(completeFields, {}),
+    );
+}
+
+export async function writeAdoptedSkillContract(
+    skillDirectoryPath: string,
+    fields: SkillAuthoringFields,
+): Promise<void> {
+    const currentContent = await readSkillFileContent(skillDirectoryPath);
+    const content = currentContent === undefined
+        ? renderInitializedSkillMarkdown(resolveCompleteSkillFields(fields, {}))
+        : renderPatchedSkillMarkdown(currentContent, fields);
+
+    await Bun.write(join(skillDirectoryPath, "SKILL.md"), content);
+}
+
+export function readSkillFrontmatterName(
+    content: string | undefined,
+): string | undefined {
+    if (content === undefined) {
+        return undefined;
+    }
+
+    try {
+        const parsedMatter = parseSkillMarkdownMatter(content);
+
+        return toNonBlankString(parsedMatter.data.name);
+    }
+    catch {
+        return undefined;
+    }
+}
+
+function renderPatchedSkillMarkdown(
+    content: string,
+    fields: SkillAuthoringFields,
+): string {
+    let parsedMatter: ReturnType<typeof parseSkillMarkdownMatter>;
+
+    try {
+        parsedMatter = parseSkillMarkdownMatter(content);
+    }
+    catch {
+        throw new CliUserError("errors.skills.adopt.invalidSkillMarkdown", 1);
+    }
+
+    const frontmatter = createSkillFrontmatter(fields, parsedMatter.data);
+
+    return stringifySkillMarkdownMatter(parsedMatter.content, frontmatter);
+}
+
+function createSkillFrontmatter(
+    fields: SkillAuthoringFields,
+    currentFrontmatter: SkillFrontmatterRecord,
+): SkillFrontmatterRecord {
+    const completeFields = resolveCompleteSkillFields(fields, currentFrontmatter);
+    const currentMetadata = isSkillFrontmatterRecord(currentFrontmatter.metadata)
+        ? currentFrontmatter.metadata
+        : {};
+
+    return {
+        ...currentFrontmatter,
+        name: completeFields.name,
+        description: completeFields.description,
+        compatibility: toNonBlankString(currentFrontmatter.compatibility)
+            ?? installedRegistrySkillCompatibility,
+        metadata: {
+            ...currentMetadata,
+            icon: completeFields.icon,
+            title: completeFields.title,
+        },
+    };
+}
+
+function resolveCompleteSkillFields(
+    fields: SkillAuthoringFields,
+    currentFrontmatter: SkillFrontmatterRecord,
+): Required<SkillAuthoringFields> {
+    const currentMetadata = isSkillFrontmatterRecord(currentFrontmatter.metadata)
+        ? currentFrontmatter.metadata
+        : {};
+    const description = fields.description
+        ?? toNonBlankString(currentFrontmatter.description);
+
+    if (description === undefined) {
+        throw new CliUserError("errors.skills.init.descriptionRequired", 1);
+    }
+
+    return {
+        description,
+        icon: fields.icon
+            ?? toNonBlankString(currentMetadata.icon)
+            ?? toNonBlankString(currentFrontmatter.icon)
+            ?? defaultSkillIcon,
+        name: fields.name,
+        title: fields.title
+            ?? toNonBlankString(currentMetadata.title)
+            ?? toNonBlankString(currentFrontmatter.title)
+            ?? renderSkillTitle(fields.name),
+    };
+}
+
+function renderLocalWorkflowSkillBody(title: string): string {
+    return [
+        "",
+        `# ${title}`,
+        "",
+        "## When to Use",
+        "",
+        "TODO: Describe the user requests and outcomes that should trigger this skill.",
+        "",
+        "## Inputs",
+        "",
+        "- TODO: List required files, config values, credentials, or user decisions.",
+        "- TODO: List optional inputs and defaults.",
+        "",
+        "## Execution",
+        "",
+        "TODO: Describe the local scripts, commands, working directory, environment variables, and generated files.",
+        "",
+        "## Result Handling",
+        "",
+        "TODO: Describe output files, validation checks, previews, and what to report to the user.",
+        "",
+        "## Failure Handling",
+        "",
+        "TODO: Describe missing files, invalid config, dependency, permission, timeout, and validation failures.",
+        "",
+    ].join("\n");
+}

--- a/src/application/commands/skills/skill-id.ts
+++ b/src/application/commands/skills/skill-id.ts
@@ -8,3 +8,41 @@ export function isSkillIdReference(value: string): boolean {
         && trimmedValue !== ".."
         && basename(trimmedValue) === trimmedValue;
 }
+
+export function normalizeSkillName(value: string): string {
+    const normalizedCharacters: string[] = [];
+    let previousWasHyphen = false;
+
+    for (const char of value.trim().toLowerCase()) {
+        if (isLowercaseAsciiLetter(char) || isAsciiDigit(char)) {
+            normalizedCharacters.push(char);
+            previousWasHyphen = false;
+            continue;
+        }
+
+        if (!previousWasHyphen && normalizedCharacters.length > 0) {
+            normalizedCharacters.push("-");
+            previousWasHyphen = true;
+        }
+    }
+
+    if (normalizedCharacters.at(-1) === "-") {
+        normalizedCharacters.pop();
+    }
+
+    let result = normalizedCharacters.join("").slice(0, 64);
+
+    while (result.endsWith("-")) {
+        result = result.slice(0, -1);
+    }
+
+    return result;
+}
+
+function isLowercaseAsciiLetter(char: string): boolean {
+    return char >= "a" && char <= "z";
+}
+
+function isAsciiDigit(char: string): boolean {
+    return char >= "0" && char <= "9";
+}

--- a/src/application/commands/skills/validate.test.ts
+++ b/src/application/commands/skills/validate.test.ts
@@ -93,6 +93,37 @@ describe("skills validate command", () => {
         }
     });
 
+    test("explains that top-level icon and title do not satisfy display metadata", async () => {
+        const rootDirectory = await createTemporaryDirectory("oo-skills-validate");
+        const skillDirectoryPath = join(rootDirectory, "top-level-display-skill");
+
+        try {
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(
+                join(skillDirectoryPath, "SKILL.md"),
+                [
+                    "---",
+                    "name: top-level-display-skill",
+                    "description: Use this skill for a workflow.",
+                    "icon: ':lucide:wand:'",
+                    "title: Top Level Display Skill",
+                    "---",
+                    "",
+                ].join("\n"),
+            );
+
+            await expect(validateSkillDirectory(skillDirectoryPath)).resolves.toEqual({
+                warnings: [
+                    "Warning: Frontmatter metadata.icon is missing. Top-level icon is not used as skill display metadata; move it to metadata.icon.",
+                    "Warning: Frontmatter metadata.title is missing. Top-level title is not used as skill display metadata; move it to metadata.title.",
+                ],
+            });
+        }
+        finally {
+            await rm(rootDirectory, { force: true, recursive: true });
+        }
+    });
+
     test("warns about missing metadata icon only", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-skills-validate");
         const skillDirectoryPath = join(rootDirectory, "missing-icon-skill");

--- a/src/application/commands/skills/validate.ts
+++ b/src/application/commands/skills/validate.ts
@@ -32,6 +32,8 @@ interface ParsedFrontmatter {
     metadataIcon: unknown;
     metadataTitle: unknown;
     name: unknown;
+    topLevelIcon: unknown;
+    topLevelTitle: unknown;
 }
 
 export const skillsValidateCommand: CliCommandDefinition<SkillsValidateInput> = {
@@ -132,6 +134,8 @@ function parseSkillFrontmatter(content: string): ParsedFrontmatter | string {
         metadataIcon: metadata?.icon,
         metadataTitle: metadata?.title,
         name: parsedMatter.data.name,
+        topLevelIcon: parsedMatter.data.icon,
+        topLevelTitle: parsedMatter.data.title,
     };
 }
 
@@ -164,13 +168,17 @@ function readSkillFrontmatterWarnings(
 
     if (!isNonEmptyString(frontmatter.metadataIcon)) {
         (warnings ??= []).push(
-            "Warning: Frontmatter metadata.icon is missing.",
+            isNonEmptyString(frontmatter.topLevelIcon)
+                ? "Warning: Frontmatter metadata.icon is missing. Top-level icon is not used as skill display metadata; move it to metadata.icon."
+                : "Warning: Frontmatter metadata.icon is missing.",
         );
     }
 
     if (!isNonEmptyString(frontmatter.metadataTitle)) {
         (warnings ??= []).push(
-            "Warning: Frontmatter metadata.title is missing.",
+            isNonEmptyString(frontmatter.topLevelTitle)
+                ? "Warning: Frontmatter metadata.title is missing. Top-level title is not used as skill display metadata; move it to metadata.title."
+                : "Warning: Frontmatter metadata.title is missing.",
         );
     }
 

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -246,6 +246,10 @@ const commandTelemetryDecisions = {
         kind: "generic",
         reason: "Command group; child commands record skill dimensions where safe.",
     },
+    "skills.adopt": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; local skill paths and content are not recorded.",
+    },
     "skills.init": {
         kind: "generic",
         reason: "Generic command telemetry is enough; local skill content is not recorded.",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -155,6 +155,9 @@ export const enMessages = {
     "commands.skills.init.description":
         "Initialize a local skill in the selected agent's skill directory.",
     "commands.skills.init.summary": "Initialize a local skill",
+    "commands.skills.adopt.description":
+        "Turn an existing local workflow directory into an oo-managed local skill.",
+    "commands.skills.adopt.summary": "Adopt an existing skill workflow",
     "commands.skills.validate.description":
         "Validate a local skill directory against the generic skill contract.",
     "commands.skills.validate.summary": "Validate a skill directory",
@@ -399,6 +402,20 @@ export const enMessages = {
         "Missing required --description. Provide a concise trigger description for the generated skill.",
     "errors.skills.init.invalidName":
         "Invalid skill name: {value}. Use a name that can be normalized to lowercase hyphen-case.",
+    "errors.skills.init.nameConflict":
+        "Skill name {name} is already used at {path}. To turn that directory into an oo-managed local skill, use oo skills adopt.",
+    "errors.skills.adopt.foreignMetadata":
+        "Cannot adopt skill at {path} because its .oo-metadata.json belongs to another oo-managed skill or is invalid.",
+    "errors.skills.adopt.invalidAgent":
+        "Unsupported skill agent: {value}. Use {agents}.",
+    "errors.skills.adopt.invalidName":
+        "Invalid skill name: {value}. Use --name with a value that can be normalized to lowercase hyphen-case.",
+    "errors.skills.adopt.invalidSkillMarkdown":
+        "Cannot adopt the existing SKILL.md because its frontmatter is invalid YAML.",
+    "errors.skills.adopt.pathMissing":
+        "Cannot adopt missing directory {path}.",
+    "errors.skills.adopt.pathNotDirectory":
+        "Cannot adopt {path} because it is not a directory.",
     "errors.skills.check.agentRequired":
         "Missing required --agent. Choose {agents}.",
     "errors.skills.check.invalidAgent":
@@ -737,6 +754,8 @@ export const enMessages = {
         "Select the skill sync source (registry; default registry)",
     "options.skillSyncIgnore":
         "Ignore registry skills by package or skill name pattern",
+    "options.skills.adopt.name":
+        "Set the adopted skill id; defaults to existing frontmatter name or directory name",
     "options.icon": "Set the generated skill icon reference",
     "options.title": "Set the generated skill display title",
     "options.visibility":
@@ -838,6 +857,7 @@ export const enMessages = {
     "labels.status": "Status",
     "labels.version": "Version",
     "skills.init.success": "Initialized skill {name} at {path}.",
+    "skills.adopt.success": "Adopted skill {name} at {path}.",
     "skills.publish.success":
         "Published skill {name} as {visibility} package {packageName}@{version}. View it at {hubUrl}.",
     "skills.publish.confirm.invalid":
@@ -1153,6 +1173,9 @@ export const zhMessages = {
     "commands.skills.init.description":
         "在指定 Agent 的 skill 目录中初始化本地 skill。",
     "commands.skills.init.summary": "初始化本地 skill",
+    "commands.skills.adopt.description":
+        "将已有本地工作流目录转换为由 oo 管理的本地 skill。",
+    "commands.skills.adopt.summary": "接管已有 skill 工作流",
     "commands.skills.validate.description":
         "按照通用 skill 契约校验本地 skill 目录。",
     "commands.skills.validate.summary": "校验 skill 目录",
@@ -1382,6 +1405,20 @@ export const zhMessages = {
         "缺少必填的 --description。请为生成的 skill 提供简洁的触发描述。",
     "errors.skills.init.invalidName":
         "无效的 skill 名称：{value}。请使用可规范化为小写短横线格式的名称。",
+    "errors.skills.init.nameConflict":
+        "skill 名称 {name} 已被 {path} 使用。如需将该目录转换为由 oo 管理的本地 skill，请使用 oo skills adopt。",
+    "errors.skills.adopt.foreignMetadata":
+        "无法接管 {path} 中的 skill，因为其 .oo-metadata.json 属于其他由 oo 管理的 skill 或无效。",
+    "errors.skills.adopt.invalidAgent":
+        "不支持的 skill Agent：{value}。请使用 {agents}。",
+    "errors.skills.adopt.invalidName":
+        "无效 skill 名称：{value}。请使用 --name 并提供可规范化为小写短横线格式的值。",
+    "errors.skills.adopt.invalidSkillMarkdown":
+        "无法接管已有 SKILL.md，因为其 frontmatter 不是有效 YAML。",
+    "errors.skills.adopt.pathMissing":
+        "无法接管不存在的目录 {path}。",
+    "errors.skills.adopt.pathNotDirectory":
+        "无法接管 {path}，因为它不是目录。",
     "errors.skills.check.agentRequired":
         "缺少必填的 --agent。请使用 {agents}。",
     "errors.skills.check.invalidAgent":
@@ -1713,6 +1750,8 @@ export const zhMessages = {
         "选择 skill 同步来源（registry；默认 registry）",
     "options.skillSyncIgnore":
         "按 package 或 skill 名称模式忽略 registry skill",
+    "options.skills.adopt.name":
+        "设置接管后的 skill id；默认使用已有 frontmatter name 或目录名",
     "options.icon": "设置生成的 skill icon 引用",
     "options.title": "设置生成的 skill 显示标题",
     "options.visibility":
@@ -1813,6 +1852,7 @@ export const zhMessages = {
     "labels.status": "状态",
     "labels.version": "版本",
     "skills.init.success": "已在 {path} 初始化 skill {name}。",
+    "skills.adopt.success": "已在 {path} 接管 skill {name}。",
     "skills.publish.success":
         "已将 skill {name} 以{visibility}发布为 {packageName}@{version}。可在 {hubUrl} 查看。",
     "skills.publish.confirm.invalid":

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -408,6 +408,8 @@ export const enMessages = {
         "Cannot adopt skill at {path} because its .oo-metadata.json belongs to another oo-managed skill or is invalid.",
     "errors.skills.adopt.invalidAgent":
         "Unsupported skill agent: {value}. Use {agents}.",
+    "errors.skills.adopt.invalidDescription":
+        "Invalid value for --description. Use a non-empty trigger description for the adopted skill.",
     "errors.skills.adopt.invalidName":
         "Invalid skill name: {value}. Use --name with a value that can be normalized to lowercase hyphen-case.",
     "errors.skills.adopt.invalidSkillMarkdown":
@@ -1411,6 +1413,8 @@ export const zhMessages = {
         "无法接管 {path} 中的 skill，因为其 .oo-metadata.json 属于其他由 oo 管理的 skill 或无效。",
     "errors.skills.adopt.invalidAgent":
         "不支持的 skill Agent：{value}。请使用 {agents}。",
+    "errors.skills.adopt.invalidDescription":
+        "--description 的值无效。请为接管的 skill 提供非空触发描述。",
     "errors.skills.adopt.invalidName":
         "无效 skill 名称：{value}。请使用 --name 并提供可规范化为小写短横线格式的值。",
     "errors.skills.adopt.invalidSkillMarkdown":


### PR DESCRIPTION
## Summary

This PR adds a first-class `oo skills adopt <path>` workflow for turning an existing local workflow directory into an oo-managed local skill without overwriting the workflow implementation.

The motivating user path is different from the current `oo skills init` happy path: users often build and validate scripts, configs, docs, and generated outputs first, then want to solidify that working directory as a skill. The old flow treated `init` as the only entry point, failed when the target directory already existed, and the bundled `oo-create-skill` guidance pushed authoring toward connector discovery/schema even for local-script skills.

## Root Cause

`oo skills init` was designed as a new-directory initializer. If the selected agent target already existed, it reported a name conflict before writing anything. The initialized template also used connector-oriented placeholder language, and `oo-create-skill` treated connector action discovery as the central authoring path. That made local workflow adoption feel heavier than necessary and left users without a safe way to add only `SKILL.md`, frontmatter metadata, docs, and oo local ownership metadata to an existing directory.

`oo skills validate` also warned about missing `metadata.title` and `metadata.icon`, but did not explain that top-level `title` and `icon` do not satisfy display metadata.

## Changes

- Added `oo skills adopt <path>`.
  - Adopts in place when no `--agent` is provided.
  - Copies into `<agent-home>/skills/<skill-id>` when `--agent` is provided and the source is not already that target.
  - Preserves existing workflow files and existing `SKILL.md` body content.
  - Patches only the skill contract frontmatter and writes local `.oo-metadata.json`.
  - Rejects bundled/registry/invalid oo metadata and refuses to overwrite an existing different agent target.
  - Runs skill validation after adoption and surfaces validation warnings.
- Refactored skill markdown/frontmatter generation into a shared authoring helper.
- Moved skill name normalization into the shared skill id module.
- Updated `oo skills init` to use a local workflow template, emit default display metadata, and point existing-directory users toward `oo skills adopt`.
- Updated `oo skills validate` warnings to explain top-level `title`/`icon` versus nested `metadata.title`/`metadata.icon`.
- Updated `oo-create-skill` bundled guidance to choose between existing local workflow adoption and connector-action authoring.
- Updated English and Chinese command docs and i18n strings.
- Added telemetry decision coverage for `skills.adopt` with generic telemetry only.
- Added tests for adopt behavior, init template changes, validate warnings, embedded skill guidance, and telemetry coverage.

## Validation

- `bun run lint:fix`
- `bun run ts-check`
- `bun run test`

Final full test run:

```text
1219 pass
5 skip
0 fail
97 snapshots
8575 expect() calls
```
