### PR TITLE
feat(skills): add --skill filter to install, update, check-update

### DIFF
--- a/contrib/skills/shared/oo/SKILL.md
+++ b/contrib/skills/shared/oo/SKILL.md
@@ -116,11 +116,11 @@ proves its output.
    unless a complete capability contract is already known from current evidence.
    A complete contract means connector schema already proves the callable id,
    required inputs, and output semantics; a user-named service is not enough.
-   When running capability discovery, also run at most one
-   `oo skills search "<goal>" --keywords "<keywords>" --json` sidecar query.
-   Record credible installable skill matches as possible future enhancements;
-   do not install or ask about installation before the selected connector
-   capability succeeds.
+   Record the `service` of each connector capability you actually use, building
+   one deduplicated wrap-up list of connector services for this session. You do
+   not need `oo skills search` for this; the wrap-up command derives and
+   verifies the matching `oo-<service>` skill packages. Do not install or ask
+   about installation before the selected connector capability succeeds.
 4. Select
    Inspect the first result set before refining. Keep one primary candidate and
    at most one materially different fallback. Prefer directness, named target
@@ -148,13 +148,16 @@ proves its output.
    Lead with the useful result. For blockers, name the exact blocker and the
    next useful move. If you group or summarize by an attribute, make sure the
    payload or result actually used that attribute.
-   After the first successful result, if a recorded skill match would clearly
-   improve repeated use of the same capability, ask whether the user wants to
-   install that specific skill using numbered choices: `1. Install
-   <skillName> (<packageName>)` and `2. Do not install`. Tell the user to
-   reply with `1` to install or `2` to skip. Treat a `1` response as explicit
-   agreement to install that exact skill. Do not install unless the user
-   explicitly agrees.
+   After the final useful result, run the wrap-up skill recommendation once.
+   Pass the deduplicated wrap-up list of connector services to
+   `oo skills recommend plan <connectorService>... --json`. That single command
+   derives each `oo-<service>` package, confirms it is published, and skips
+   packages that are already installed and current, not published, dismissed, or
+   globally muted. Present its result and persist any "never remind" choice
+   exactly as
+   [references/search-and-selection.md](references/search-and-selection.md)
+   describes. If the plan reports `muted` or returns no `recommendations`, say
+   nothing about skills and finish.
 
 ## Capability contract
 

--- a/contrib/skills/shared/oo/references/search-and-selection.md
+++ b/contrib/skills/shared/oo/references/search-and-selection.md
@@ -44,8 +44,8 @@ Examples:
 
 ## Search keywords
 
-Always pass `1` to `3` keywords through `--keywords` on every `oo search` and
-`oo skills search` call. Never search without keywords.
+Always pass `1` to `3` keywords through `--keywords` on every `oo search` call.
+Never search without keywords.
 
 - Keywords may use the user's original language; the English sentence stays in
   English.
@@ -92,12 +92,6 @@ Canonical form:
 oo search "<text>" --keywords "<comma-separated keywords>" --json
 ```
 
-Skill sidecar:
-
-```bash
-oo skills search "<text>" --keywords "<comma-separated keywords>" --json
-```
-
 Facts:
 
 - `oo search` performs one discovery pass over connector action search.
@@ -105,12 +99,10 @@ Facts:
 - `--json` returns a raw array, not an object wrapper.
 - The array contains `connector` entries.
 - Connector entries include stable fields such as `service`, `name`,
-  `description`, and `authenticated`.
+  `description`, and `authenticated`. Record the `service` of every connector
+  you actually use; the wrap-up recommendation is keyed on it.
 - `--keywords` is required on every call: always pass `1` to `3` keywords. The
   backend tokenizes them while keeping the same free-form text query.
-- `oo skills search` is a sidecar discovery branch, not a callable capability
-  contract. It returns installable workflow helpers that may improve repeated
-  use, but skill installation is a separate user-visible action.
 
 Representative JSON example:
 
@@ -175,22 +167,87 @@ Tie-breakers:
 - If the returned array is empty or no candidate clearly fits, stop the current
   `oo` path and report that the catalog does not expose a good match.
 
-## Skill sidecar policy
+## Record connectors for the wrap-up
 
-During the same discovery step, run at most one `oo skills search "<text>"
---keywords "<comma-separated keywords>" --json` query using the same goal
-sentence and keywords. Keep only the best credible
-installable skill match, identified by both `packageName` and `name`.
+You do not need `oo skills search` for recommendations. Each connector service
+maps to exactly one published skill package by a fixed rule: prepend `oo-` and
+replace underscores with hyphens (service `github` -> `oo-github`, `aliyun_oss`
+-> `oo-aliyun-oss`). The wrap-up command applies that rule and confirms the
+package is published, so you only collect the connector `service` values — never
+assemble or guess package names yourself.
 
-Do not install a skill, do not select it instead of a connector capability, and
-do not ask about installation before the selected connector path has produced
-its first successful useful result. After success,
-if the recorded skill would clearly make repeated use easier or stronger, ask
-whether the user wants to install that specific skill using numbered choices:
-`1. Install <skillName> (<packageName>)` and `2. Do not install`. Tell the user
-to reply with `1` to install or `2` to skip. Treat a `1` response as explicit
-agreement to install that exact skill. If they choose install, use the
-`oo-find-skills` installation flow. If they decline, continue without installing.
+Across the whole session, build one deduplicated list of the connector `service`
+values you actually use. Do not install or ask about installation before the
+selected connector path has produced a successful useful result.
+
+## Wrap-up skill recommendation
+
+After the final useful result, run the recommendation exactly once over the
+deduplicated list of connector services you used:
+
+```bash
+oo skills recommend plan <connectorService>... --json
+```
+
+Pass connector `service` values (for example `github gmail`), not package names.
+The command derives each `oo-<service>` package, confirms it is published, and
+returns:
+
+- `muted`: when `true`, the user globally silenced suggestions. Say nothing
+  about skills and finish.
+- `recommendations`: each entry has a `packageName` and an `action`. `install`
+  means the package is published but not installed locally; `update` means an
+  installed package has a newer version, and the entry also carries
+  `currentVersion` and `latestVersion`.
+- `skipped`: packages excluded because they are already current, not published,
+  dismissed, or muted. Never mention skipped packages.
+
+If `recommendations` is empty, say nothing about skills and finish. Otherwise
+present one short batched prompt that lists the install and update actions and
+offers, at minimum:
+
+1. Apply the suggestions
+2. Not now
+3. Never remind me about these
+
+<!-- agentic:if skillSelectionPromptTool -->
+- Prefer the `<!-- agentic:var skillSelectionPromptTool -->` tool with one short
+  multiple-choice question that includes only the actions that are actually
+  available.
+- If that tool is unavailable in the current mode or its call fails, fall back
+  to plain numbered text.
+- Treat a `None of the above` response the same as `Not now`.
+<!-- agentic:endif -->
+
+Act on the choice with these commands, using the exact `packageName` values from
+the plan output:
+
+- Apply the suggestions: install the `install` packages and update the `update`
+  packages. Run only the command for actions that exist; omit `oo skills add`
+  when there is nothing to install, and omit `oo skills update` when there is
+  nothing to update.
+
+  ```bash
+  oo skills add <installPackageName>...
+  oo skills update <updatePackageName>...
+  ```
+
+- Not now: install and update nothing. Acknowledge briefly and finish.
+- Never remind me about these: persist the choice so later sessions stop
+  suggesting them. Pass specific package names to silence just those packages,
+  or `--all` to silence every future suggestion.
+
+  ```bash
+  oo skills recommend mute <packageName>...
+  oo skills recommend mute --all
+  ```
+
+Only run an `oo skills add`, `oo skills update`, or `oo skills recommend mute`
+command after the user explicitly chooses that action. Never invent package
+names; use only the `packageName` values returned by `oo skills recommend
+plan`. If a wrap-up command fails for any reason other than the explicit HTTP
+`402` billing case, stop and report the exact failure instead of retrying
+blindly or inventing a result.
 
 ## Build the next contract step
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -982,8 +982,22 @@ Install bundled or published skills into supported local skill directories.
 - Arguments: a package name may also use `<packageName>#<shareID>`. In that
   form, the command reads the package skill list from `<packageName>` and
   downloads the package archive through the share identified by `<shareID>`.
-- Behavior: the command installs every published skill in each package. There is
-  no skill-selection prompt and no per-skill or "install all" option.
+- Behavior: the command installs every published skill in each package by
+  default; the optional `-s, --skill` filter narrows which skills are installed.
+- Options: `-s, --skill <skills...>` limits the install to the named skills. The
+  option is optional and accepts multiple values (for example `-s foo bar`).
+  Matching is case-insensitive and accepts either the skill name or its
+  directory name. Names that match no skill are ignored. With several packages
+  the filter spans all of them: a package that publishes none of the requested
+  skills is silently skipped, and the command fails only when **no** package
+  (or, for the no-argument bundled install, no bundled skill) matches any
+  requested name — listing the available skills. An explicitly named bundled
+  skill is already a single-skill selection and is not further narrowed by
+  `--skill`.
+- Options: because `-s, --skill` accepts multiple values, put any package names
+  **before** it (for example `oo skills install @scope/pkg -s foo bar`). Tokens
+  that follow `--skill` are read as skill names, not package names, until the
+  next option such as `--json`.
 - Options: `-f, --force` overrides install when the target directory exists
   with the same skill name but is **not** managed by oo (no readable
   `.oo-metadata.json`). The previous directory contents are removed before the
@@ -1147,6 +1161,17 @@ Update installed oo-managed published skills.
   skills.
 - Non-interactive terminals: prints one status line for each current or failed
   skill, and one success line for each updated host target path.
+- Options: `-s, --skill <skills...>` limits the update to the named skills. The
+  option is optional and accepts multiple values (for example `-s foo bar`).
+  Matching is case-insensitive and accepts either the skill name or its
+  directory name. Names that match no installed skill are ignored. When none of
+  the requested names match the resolved skills, the command fails (text mode
+  aborts with an error listing the resolved skills; `--json` reports
+  `skill_filter_no_match` and exits `1`).
+- Options: because `-s, --skill` accepts multiple values, put any package names
+  **before** it (for example `oo skills update @scope/pkg -s foo`). Tokens that
+  follow `--skill` are read as skill names, not package names, until the next
+  option such as `--json`.
 - Options: `--json` / `--format json` emits a structured payload (see "JSON
   output for mutation commands" above).
 - `skills[].status` (update JSON): `updated | repaired | current | failed`.
@@ -1157,7 +1182,8 @@ Update installed oo-managed published skills.
 - `error.code` enum (update JSON): `not_authenticated` / `no_supported_hosts`
   / `invalid_path` / `bundled_unsupported` / `package_not_installed`
   / `package_lookup_failed` / `package_download_failed` /
-  `invalid_package_archive` / `publication_failed` / `unknown`.
+  `invalid_package_archive` / `publication_failed` / `skill_filter_no_match` /
+  `unknown`.
 
 ### `oo skills check-update [packageName...]`
 
@@ -1167,13 +1193,25 @@ command **never** downloads a package archive or writes to any skill
 directory.
 
 - Arguments: `[packageName...]` accepts zero or more package names. **Breaking
-  change**: the removed `--skill` option (and its skill-id values) is replaced
-  by these positional package-name arguments.
+  change**: in earlier releases `--skill` took skill ids and was the primary
+  selector; that role is now filled by these positional package-name arguments.
+  (`--skill` still exists as an optional filter — see Options.)
 - Arguments: when omitted, the command checks every installed oo-managed
   registry skill.
 - Arguments: when one or more package names are given, the command checks every
   installed skill that belongs to each named package. Duplicate package names
   are de-duplicated; the original input order is preserved in the output.
+- Options: `-s, --skill <skills...>` limits the check to the named skills. The
+  option is optional and accepts multiple values (for example `-s foo bar`).
+  Matching is case-insensitive and accepts either the skill name or its
+  directory name. Names that match no resolved skill are ignored. When none of
+  the requested names match the resolved registry skills, the command fails and
+  exits `1` with an error listing the available skills (no JSON payload is
+  emitted in that case).
+- Options: because `-s, --skill` accepts multiple values, put any package names
+  **before** it (for example `oo skills check-update @scope/pkg -s foo`). Tokens
+  that follow `--skill` are read as skill names, not package names, until the
+  next option such as `--json`.
 - Options: `--format=json` and `--json` switch to a structured payload.
   `--show-schema-version` (only meaningful with JSON) prepends
   `schemaVersion`.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1335,6 +1335,92 @@ Common rules:
 - The JSON payload never includes `apiKey`, raw HTTP request/response bodies,
   stack traces, or unredacted endpoint secrets.
 
+### `oo skills recommend`
+
+End-of-session skill suggestions for the bundled `oo` skill, plus controls to
+silence them. The bundled `oo` skill calls these commands, but they can also be
+run directly. This is a command group with three subcommands.
+
+#### `oo skills recommend plan [connectorService...]`
+
+Given the connector services used during a session, decide which skills to
+suggest installing or updating and which to skip.
+
+- Arguments: `[connectorService...]` accepts zero or more connector service
+  identifiers (the `service` field from `oo search`). Each is mapped to one
+  skill package by prepending `oo-` and replacing underscores with hyphens
+  (`github` → `oo-github`, `aliyun_oss` → `oo-aliyun-oss`). Blank entries are
+  ignored; the derived packages are de-duplicated and their input order is
+  preserved in the output. With no arguments the plan is empty.
+- Options: `--format=json` and `--json` switch to a structured payload.
+  `--show-schema-version` (only meaningful with JSON) prepends `schemaVersion`.
+- Behavior: each derived `oo-<service>` package is confirmed against the
+  registry. It is suggested for `install` when it is published but not installed
+  locally; for `update` when an installed package has a newer published version;
+  and skipped when it is already current, not published, previously dismissed,
+  or globally muted. When suggestions are globally muted, the plan returns
+  `muted: true` with no recommendations.
+- Network: every non-dismissed, non-muted package is verified with a public
+  registry package-info request (existence + latest version). This endpoint
+  needs no login, so no account or API key is required — the active account's
+  endpoint is used when present, otherwise the default. Requests run with a
+  small bounded concurrency. Dismissed and muted packages need no network. A
+  `404` is treated as "not published" (silently skipped); any other failed
+  lookup skips that package instead of failing the command.
+- JSON shape:
+
+  ```json
+  {
+    "muted": false,
+    "recommendations": [
+      { "packageName": "oo-gmail", "action": "install" },
+      {
+        "packageName": "oo-notion",
+        "action": "update",
+        "currentVersion": "1.0.0",
+        "latestVersion": "1.2.0"
+      }
+    ],
+    "skipped": [
+      { "packageName": "oo-drive", "reason": "up-to-date" },
+      { "packageName": "oo-slack", "reason": "dismissed" }
+    ]
+  }
+  ```
+
+- `action` values: `install` / `update`.
+- `reason` values: `up-to-date` / `not-published` / `dismissed` / `muted` /
+  `lookup-failed`.
+- Exit code: `0` even when a lookup fails or a package is unpublished (both are
+  encoded as skips). Argument errors (for example `--format xml`) exit `2`.
+
+#### `oo skills recommend mute [packageName...]`
+
+Stop suggesting packages so later sessions no longer surface them.
+
+- Arguments: `[packageName...]` package names to stop suggesting; they are added
+  to a persisted dismissal list, de-duplicated and sorted.
+- Options: `--all` mutes every future suggestion instead of specific packages.
+  `--format=json` / `--json` / `--show-schema-version` control output.
+- Validation: pass package names **or** `--all`, not both and not neither;
+  either misuse exits `2`.
+- Persistence: the choice is stored in the CLI settings file under
+  `[skills.recommend]` and survives across sessions.
+- JSON shape: `{ "muted": <bool>, "dismissed": ["oo-gmail", ...] }` — the
+  resulting persisted state.
+
+#### `oo skills recommend unmute [packageName...]`
+
+Resume suggesting packages.
+
+- Arguments: `[packageName...]` package names to remove from the dismissal list.
+- Options: `--all` clears the global mute instead of specific packages. Output
+  options match `mute`.
+- Validation: pass package names **or** `--all`, not both and not neither;
+  either misuse exits `2`.
+- JSON shape: `{ "muted": <bool>, "dismissed": [...] }` — the resulting
+  persisted state.
+
 ### `oo skills uninstall [skill]`
 
 Remove oo-managed skills from supported local skill directories.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -1143,6 +1143,75 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - JSON 输出永远不会包含 `apiKey`、原始 HTTP 请求 / 响应体、stack trace 或未
   脱敏的 endpoint secret。
 
+### `oo skills recommend`
+
+为内置 `oo` skill 提供收尾阶段的 skill 推荐，并提供静音控制。内置 `oo` skill 会
+调用这些命令，也可直接运行。这是一个命令组，包含三个子命令。
+
+#### `oo skills recommend plan [connectorService...]`
+
+根据本次会话用到的 connector service，判断哪些 skill 应推荐安装或更新，哪些应跳过。
+
+- 参数：`[connectorService...]` 接受零个或多个 connector service 标识（`oo search`
+  结果中的 `service` 字段）。每个通过"加 `oo-` 前缀并把下划线换成连字符"映射到一个
+  skill 包（`github` → `oo-github`，`aliyun_oss` → `oo-aliyun-oss`）。空白项被忽略；
+  推导出的包会去重，输出保留输入顺序。不传参数时计划为空。
+- 选项：`--format=json` 与 `--json` 切换到结构化 JSON 输出。`--show-schema-version`
+  （仅在 JSON 下有意义）会在顶层添加 `schemaVersion`。
+- 行为：每个推导出的 `oo-<service>` 包都会向 registry 确认。包已发布但本地未安装时推荐
+  `install`；已安装且有更新的已发布版本时推荐 `update`；当包已是最新、未发布、此前被忽略
+  或被全局静音时跳过。当推荐被全局静音时，计划返回 `muted: true` 且无推荐项。
+- 网络：每个未被忽略、未被静音的包都会发一次公开的 registry package-info 请求（确认存在性
+  与最新版本）。该端点无需登录，因此不需要账号或 API key——有账号时用其 endpoint，否则用默认
+  endpoint；请求以较小的并发上限执行。被忽略、被静音的包不需要网络。`404` 视为"未发布"
+  （静默跳过）；其它查询失败则跳过该包，而不会让命令失败。
+- JSON 结构：
+
+  ```json
+  {
+    "muted": false,
+    "recommendations": [
+      { "packageName": "oo-gmail", "action": "install" },
+      {
+        "packageName": "oo-notion",
+        "action": "update",
+        "currentVersion": "1.0.0",
+        "latestVersion": "1.2.0"
+      }
+    ],
+    "skipped": [
+      { "packageName": "oo-drive", "reason": "up-to-date" },
+      { "packageName": "oo-slack", "reason": "dismissed" }
+    ]
+  }
+  ```
+
+- `action` 取值：`install` / `update`。
+- `reason` 取值：`up-to-date` / `not-published` / `dismissed` / `muted` /
+  `lookup-failed`。
+- 退出码：即使查询失败或包未发布也返回 `0`（二者都编码为跳过项）。参数错误（如
+  `--format xml`）以 exit 2 退出。
+
+#### `oo skills recommend mute [packageName...]`
+
+停止推荐指定的包，使后续会话不再提示它们。
+
+- 参数：`[packageName...]` 要停止推荐的包名，会加入持久化的忽略列表，并去重、排序。
+- 选项：`--all` 静音所有后续推荐，而非指定的包。`--format=json` / `--json` /
+  `--show-schema-version` 控制输出。
+- 校验：传包名**或** `--all`，不能同时传也不能都不传；任一误用以 exit 2 退出。
+- 持久化：该选择存储在 CLI 设置文件的 `[skills.recommend]` 段中，跨会话保留。
+- JSON 结构：`{ "muted": <bool>, "dismissed": ["oo-gmail", ...] }`——持久化后的状态。
+
+#### `oo skills recommend unmute [packageName...]`
+
+恢复推荐指定的包。
+
+- 参数：`[packageName...]` 要从忽略列表移除的包名。
+- 选项：`--all` 清除全局静音，而非指定的包。输出选项与 `mute` 一致。
+- 校验：传包名**或** `--all`，不能同时传也不能都不传；任一误用以 exit 2 退出。
+- JSON 结构：`{ "muted": <bool>, "dismissed": [...] }`——持久化后的状态。
+
 ### `oo skills uninstall [skill]`
 
 从受支持的本地 skill 目录移除由 oo 管理的 skill。

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -839,8 +839,18 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 参数：package 名称也可以使用 `<packageName>#<shareID>`。这种形式会从
   `<packageName>` 读取 package 的 skill 列表，并通过 `<shareID>` 对应的 share
   下载 package 归档。
-- 行为：命令会安装每个 package 中的**全部**已发布 skill，不弹选择、也没有
-  按 skill 选择或「安装全部」的选项。
+- 行为：命令默认安装每个 package 中的**全部**已发布 skill；可选的
+  `-s, --skill` 过滤会收窄实际安装的 skill。
+- 选项：`-s, --skill <skills...>` 将安装限定为指定的 skill。该选项可选，可传多个
+  值（例如 `-s foo bar`）。匹配大小写不敏感，可用 skill 名称或其目录名。未匹配到
+  任何 skill 的名称会被忽略。传入多个 package 时，过滤会跨所有 package 生效：某个
+  package 没有任何被请求的 skill 时会被**静默跳过**；只有当**所有** package
+  （对于无参的内置安装，则是任一内置 skill）都不匹配任何请求名称时，命令才会失败
+  并列出可用的 skill。显式命名的内置 skill 本身已是单 skill 选择，不会再被
+  `--skill` 收窄。
+- 选项：由于 `-s, --skill` 接受多个值，请把所有 package 名称放在它**之前**
+  （例如 `oo skills install @scope/pkg -s foo bar`）。`--skill` 之后、直到下一个
+  选项（如 `--json`）之前的 token 都会被当作 skill 名称，而非 package 名称。
 - 选项：`-f, --force` 在目标目录存在同名 skill 但**不受 oo 管理**（缺少可读
   `.oo-metadata.json`）时，允许覆盖安装。覆盖会先移除原目录内容再写入新
   skill，并以 `warn` 日志记录此事件。`--force` **不会**绕过路径校验、
@@ -976,6 +986,14 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 交互式终端：会显示实时进度。
 - 非交互式终端：对每个已是最新或失败的 skill 输出一行状态信息；对每个已更新
   的 Agent 目标路径输出一行成功信息。
+- 选项：`-s, --skill <skills...>` 将更新限定为指定的 skill。该选项可选，可传多个
+  值（例如 `-s foo bar`）。匹配大小写不敏感，可用 skill 名称或其目录名。未匹配到
+  任何已安装 skill 的名称会被忽略。当所请求的名称都不匹配解析出的 skill 时，
+  命令会失败（文本模式报错并列出解析出的 skill；`--json` 上报
+  `skill_filter_no_match` 并以 `1` 退出）。
+- 选项：由于 `-s, --skill` 接受多个值，请把所有 package 名称放在它**之前**
+  （例如 `oo skills update @scope/pkg -s foo`）。`--skill` 之后、直到下一个选项
+  （如 `--json`）之前的 token 都会被当作 skill 名称，而非 package 名称。
 - 选项：`--json` / `--format json` 输出结构化 payload（见下方"mutation 命令的
   JSON 输出"）。
 - `skills[].status`（update JSON）：`updated | repaired | current | failed`。
@@ -986,18 +1004,28 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - `error.code` 枚举（update JSON）：`not_authenticated` / `no_supported_hosts`
   / `invalid_path` / `bundled_unsupported` / `package_not_installed`
   / `package_lookup_failed` / `package_download_failed` /
-  `invalid_package_archive` / `publication_failed` / `unknown`。
+  `invalid_package_archive` / `publication_failed` / `skill_filter_no_match` /
+  `unknown`。
 
 ### `oo skills check-update [packageName...]`
 
 检查由 oo 管理的 registry skill 是否有新版本，或本地内容是否已偏离 canonical。
 **只查询，不下载 package archive，不写入任何 skill 目录**。
 
-- 参数：`[packageName...]` 接受零个或多个包名。**破坏性变更**：已移除的 `--skill`
-  选项（及其 skill id 值）由这些位置包名参数取代。
+- 参数：`[packageName...]` 接受零个或多个包名。**破坏性变更**：早期版本中
+  `--skill` 接受 skill id 并作为主选择器；该职责现由这些位置包名参数承担。
+  （`--skill` 仍作为可选过滤器存在 —— 见选项。）
 - 参数：省略时，会检查所有已安装且由 oo 管理的 registry skill。
 - 参数：提供一个或多个包名时，会检查每个指定包下已安装的全部 skill。重复包名
   会去重，输出按原始输入顺序。
+- 选项：`-s, --skill <skills...>` 将检查限定为指定的 skill。该选项可选，可传多个
+  值（例如 `-s foo bar`）。匹配大小写不敏感，可用 skill 名称或其目录名。未匹配到
+  任何解析出 skill 的名称会被忽略。当所请求的名称都不匹配解析出的 registry skill
+  时，命令会失败并以 `1` 退出，错误信息会列出可用的 skill（此时不输出 JSON
+  payload）。
+- 选项：由于 `-s, --skill` 接受多个值，请把所有 package 名称放在它**之前**
+  （例如 `oo skills check-update @scope/pkg -s foo`）。`--skill` 之后、直到下一个
+  选项（如 `--json`）之前的 token 都会被当作 skill 名称，而非 package 名称。
 - 选项：`--format=json` 与 `--json` 切换到结构化 JSON 输出。
   `--show-schema-version`（仅在 JSON 模式下生效）会向 payload 顶层添加
   `schemaVersion`。

--- a/src/adapters/store/file-settings-store.test.ts
+++ b/src/adapters/store/file-settings-store.test.ts
@@ -168,8 +168,12 @@ describe("FileSettingsStore", () => {
             "utf8",
         );
 
+        // `skills` is a known section (it carries skills.recommend), so its
+        // unknown per-skill subkeys are stripped while the section itself is
+        // recognized; `updateNotifier` remains an unknown top-level key.
         await expect(store.read()).resolves.toEqual({
             lang: "zh",
+            skills: {},
         });
 
         const logs = logCapture.read();
@@ -178,9 +182,9 @@ describe("FileSettingsStore", () => {
         expect(logs).toContain(
             `"msg":"Settings store file contained unknown keys that were ignored."`,
         );
-        expect(logs).toContain(`"unknownKeyCount":2`);
+        expect(logs).toContain(`"unknownKeyCount":3`);
         expect(logs).toContain(
-            `"unknownKeyPaths":["skills","updateNotifier"]`,
+            `"unknownKeyPaths":["skills.oo","skills.oo-find-skills","updateNotifier"]`,
         );
 
         logCapture.close();

--- a/src/application/commands/shared/auth-utils.ts
+++ b/src/application/commands/shared/auth-utils.ts
@@ -9,6 +9,8 @@ const authErrorKeys = {
     required: "errors.auth.required",
 } as const;
 
+const defaultOomolEndpoint = "oomol.com";
+
 export async function requireCurrentAccount(
     context: CliExecutionContext,
 ): Promise<AuthAccount> {
@@ -22,4 +24,20 @@ export async function requireCurrentAccount(
         ? authErrorKeys.required
         : authErrorKeys.activeAccountMissing;
     throw new CliUserError(errorKey, 1);
+}
+
+// Resolves the OOMOL endpoint without requiring a logged-in account. Prefers
+// the active account's endpoint (so non-default environments are honored), then
+// the OOMOL_ENDPOINT override, then the public default. Used by unauthenticated
+// reads such as the skill-recommendation registry existence check.
+export async function resolveCurrentEndpoint(
+    context: CliExecutionContext,
+): Promise<string> {
+    const { currentAccount } = await readCurrentAuth(context);
+
+    if (currentAccount !== undefined) {
+        return currentAccount.endpoint;
+    }
+
+    return context.env.OOMOL_ENDPOINT?.trim() || defaultOomolEndpoint;
 }

--- a/src/application/commands/skills/__tests__/helpers.ts
+++ b/src/application/commands/skills/__tests__/helpers.ts
@@ -1,13 +1,27 @@
+import type { CliSandbox } from "../../../../../__tests__/helpers.ts";
 import type {
     BundledSkillAgentName,
     BundledSkillName,
 } from "../embedded-assets.ts";
-import { mkdir, symlink } from "node:fs/promises";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import process from "node:process";
+import { resolveStorePaths } from "../../../../adapters/store/store-path.ts";
+import { APP_NAME } from "../../../config/app-config.ts";
 import {
     getBundledSkillFiles,
     readBundledSkillFileContent,
 } from "../embedded-assets.ts";
+import { resolveManagedSkillAgentHomeDirectory } from "../managed-skill-agents.ts";
+import {
+    resolveManagedSkillCanonicalDirectoryPath,
+    resolveManagedSkillDirectoryPath,
+    resolveManagedSkillMetadataFilePath,
+} from "../managed-skill-paths.ts";
+import {
+    createRegistrySkillMetadata,
+    renderSkillMetadataJson,
+} from "../skill-metadata.ts";
 
 export type SymbolicLinkKindForTest = "directory" | "file";
 
@@ -68,4 +82,75 @@ export async function createSymbolicLinkForTest(
         linkPath,
         process.platform === "win32" ? "junction" : "dir",
     );
+}
+
+// Builds a registry package-info HTTP response body for fetcher mocks.
+export function packageInfoResponse(
+    packageName: string,
+    version: string,
+    skillName: string,
+): Response {
+    return new Response(JSON.stringify({
+        packageName,
+        version,
+        skills: [
+            {
+                description: "demo",
+                name: skillName,
+                title: skillName,
+            },
+        ],
+    }));
+}
+
+// Seeds an oo-managed registry skill (canonical copy plus one host install) so
+// install/inventory/update/recommend flows observe it as installed.
+export async function seedRegistrySkill(options: {
+    sandbox: CliSandbox;
+    skillName: string;
+    packageName: string;
+    version: string;
+    agent?: "universal" | "claude";
+    hostSkillMd?: string;
+}): Promise<{
+    hostDirectory: string;
+    canonicalDirectory: string;
+}> {
+    const agent = options.agent ?? "universal";
+    const homeDirectory = resolveManagedSkillAgentHomeDirectory(options.sandbox.env, agent);
+    const hostDirectory = resolveManagedSkillDirectoryPath(homeDirectory, options.skillName);
+    const storePaths = resolveStorePaths({
+        appName: APP_NAME,
+        env: options.sandbox.env,
+        platform: process.platform,
+    });
+    const canonicalDirectory = resolveManagedSkillCanonicalDirectoryPath(
+        storePaths.settingsFilePath,
+        options.skillName,
+    );
+
+    await mkdir(homeDirectory, { recursive: true });
+    await mkdir(canonicalDirectory, { recursive: true });
+    await mkdir(hostDirectory, { recursive: true });
+
+    const skillMd = options.hostSkillMd ?? "# Demo\n";
+
+    await writeFile(join(canonicalDirectory, "SKILL.md"), "# Demo\n");
+    await writeFile(join(hostDirectory, "SKILL.md"), skillMd);
+    await writeFile(
+        resolveManagedSkillMetadataFilePath(canonicalDirectory),
+        renderSkillMetadataJson(createRegistrySkillMetadata({
+            packageName: options.packageName,
+            version: options.version,
+        })),
+    );
+    await writeFile(
+        resolveManagedSkillMetadataFilePath(hostDirectory),
+        renderSkillMetadataJson(createRegistrySkillMetadata({
+            packageName: options.packageName,
+            version: options.version,
+        })),
+    );
+
+    return { hostDirectory, canonicalDirectory };
 }

--- a/src/application/commands/skills/check-update.cli.test.ts
+++ b/src/application/commands/skills/check-update.cli.test.ts
@@ -575,4 +575,123 @@ describe("skills check-update CLI", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("--skill narrows the checked skills case-insensitively and ignores unknown names", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.1.0",
+            });
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "bar",
+                packageName: "@alice/bar",
+                version: "1.0.0",
+            });
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["skills", "check-update", "--skill", "FOO", "missing", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/foo", "0.2.0", "foo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            // Only "foo" is checked: the mixed-case token matches it and the
+            // unknown "missing" token is silently ignored; "bar" is excluded.
+            expect(skills.map(entry => entry.skillId)).toEqual(["foo"]);
+            expect(skills[0]?.status).toBe("update-available");
+            expect(requests.every(request => request.url.includes("foo"))).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill with no matching installed skill exits 1 and lists available skills", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.1.0",
+            });
+
+            // The filter excludes every resolved skill before any network call,
+            // so no fetcher is needed.
+            const result = await sandbox.run(
+                ["skills", "check-update", "--skill", "nope"],
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("foo");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill alongside package args narrows registry entries but keeps a bundled failed entry", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.1.0",
+            });
+
+            // Package names BEFORE --skill so the variadic option does not consume
+            // them. `oo` is bundled and becomes a failed entry that survives the
+            // skill filter; the registry entry `foo` is narrowed and checked.
+            const result = await sandbox.run(
+                ["skills", "check-update", "@alice/foo", "oo", "--skill", "foo", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/foo", "0.2.0", "foo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            const fooEntry = skills.find(entry => entry.skillId === "foo");
+            const ooEntry = skills.find(entry => entry.skillId === "oo");
+
+            expect(fooEntry?.status).toBe("update-available");
+            expect((ooEntry?.error as Record<string, unknown>)?.code).toBe("bundled_unsupported");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });

--- a/src/application/commands/skills/check-update.cli.test.ts
+++ b/src/application/commands/skills/check-update.cli.test.ts
@@ -8,84 +8,17 @@ import {
     toRequest,
     writeAuthFile,
 } from "../../../../__tests__/helpers.ts";
-import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
-import { APP_NAME } from "../../config/app-config.ts";
+import { packageInfoResponse, seedRegistrySkill } from "./__tests__/helpers.ts";
 import { resolveManagedSkillAgentHomeDirectory } from "./managed-skill-agents.ts";
 import {
-    resolveManagedSkillCanonicalDirectoryPath,
     resolveManagedSkillDirectoryPath,
     resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
 import {
     createBundledSkillMetadata,
     createLocalSkillMetadata,
-    createRegistrySkillMetadata,
     renderSkillMetadataJson,
 } from "./skill-metadata.ts";
-
-function packageInfoResponse(packageName: string, version: string, skillName: string) {
-    return new Response(JSON.stringify({
-        packageName,
-        version,
-        skills: [
-            {
-                description: "demo",
-                name: skillName,
-                title: skillName,
-            },
-        ],
-    }));
-}
-
-async function seedRegistrySkill(options: {
-    sandbox: Awaited<ReturnType<typeof createCliSandbox>>;
-    skillName: string;
-    packageName: string;
-    version: string;
-    agent?: "universal" | "claude";
-    hostSkillMd?: string;
-}): Promise<{
-    hostDirectory: string;
-    canonicalDirectory: string;
-}> {
-    const agent = options.agent ?? "universal";
-    const homeDirectory = resolveManagedSkillAgentHomeDirectory(options.sandbox.env, agent);
-    const hostDirectory = resolveManagedSkillDirectoryPath(homeDirectory, options.skillName);
-    const storePaths = resolveStorePaths({
-        appName: APP_NAME,
-        env: options.sandbox.env,
-        platform: process.platform,
-    });
-    const canonicalDirectory = resolveManagedSkillCanonicalDirectoryPath(
-        storePaths.settingsFilePath,
-        options.skillName,
-    );
-
-    await mkdir(homeDirectory, { recursive: true });
-    await mkdir(canonicalDirectory, { recursive: true });
-    await mkdir(hostDirectory, { recursive: true });
-
-    const skillMd = options.hostSkillMd ?? "# Demo\n";
-
-    await writeFile(join(canonicalDirectory, "SKILL.md"), "# Demo\n");
-    await writeFile(join(hostDirectory, "SKILL.md"), skillMd);
-    await writeFile(
-        resolveManagedSkillMetadataFilePath(canonicalDirectory),
-        renderSkillMetadataJson(createRegistrySkillMetadata({
-            packageName: options.packageName,
-            version: options.version,
-        })),
-    );
-    await writeFile(
-        resolveManagedSkillMetadataFilePath(hostDirectory),
-        renderSkillMetadataJson(createRegistrySkillMetadata({
-            packageName: options.packageName,
-            version: options.version,
-        })),
-    );
-
-    return { hostDirectory, canonicalDirectory };
-}
 
 describe("skills check-update CLI", () => {
     test("--json reports update-available when remote latest is newer", async () => {

--- a/src/application/commands/skills/check-update.ts
+++ b/src/application/commands/skills/check-update.ts
@@ -13,19 +13,13 @@ import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
 import { writeLine } from "../shared/output.ts";
 import { directoryExists } from "./bundled-skill-observation.ts";
+import { readKnownManagedSkillInstallations } from "./installed-managed-skills.ts";
 import {
     createMissingManagedSkillHostError,
     resolveAvailableManagedSkillHosts,
     resolveManagedSkillHostInstallations,
 } from "./managed-skill-hosts.ts";
-import {
-    listManagedSkillInstallations,
-    listManagedSkillInstallationsForHosts,
-} from "./managed-skill-listings.ts";
 import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
-import {
-    resolveManagedSkillCanonicalRootDirectoryPath,
-} from "./managed-skill-paths.ts";
 import { isManagedSkillPublicationCurrent } from "./managed-skill-publication.ts";
 import { loadRegistryPackageSkillInfo } from "./registry-skill-source.ts";
 import { isBundledSkillName } from "./shared.ts";
@@ -480,32 +474,6 @@ function computeSummary(results: readonly CheckUpdateResultEntry[]): CheckUpdate
         registrySkillsCurrent: results.filter(entry => entry.status === "up-to-date").length,
         registrySkillFailures: results.filter(entry => entry.status === "failed").length,
     };
-}
-
-async function readKnownManagedSkillInstallations(
-    availableHosts: readonly ManagedSkillHost[],
-    settingsFilePath: string,
-): Promise<ManagedSkillListItem[]> {
-    const [canonicalSkills, hostSkills] = await Promise.all([
-        listManagedSkillInstallations(
-            resolveManagedSkillCanonicalRootDirectoryPath(settingsFilePath),
-        ),
-        listManagedSkillInstallationsForHosts(availableHosts),
-    ]);
-    // Host listings take precedence over canonical when a name collides.
-    const byName = new Map<string, ManagedSkillListItem>();
-
-    for (const skill of [...hostSkills, ...canonicalSkills]) {
-        if (skill.metadata !== undefined && !byName.has(skill.name)) {
-            byName.set(skill.name, {
-                metadata: skill.metadata,
-                name: skill.name,
-                path: skill.path,
-            });
-        }
-    }
-
-    return Array.from(byName.values());
 }
 
 function dedupePreserveOrder<T>(values: readonly T[]): T[] {

--- a/src/application/commands/skills/check-update.ts
+++ b/src/application/commands/skills/check-update.ts
@@ -5,6 +5,7 @@ import type { ManagedSkillListItem } from "./managed-skill-listings.ts";
 import type { RegistryPackageSkillInfo } from "./registry-skill-source.ts";
 
 import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
 import { compareSemver } from "../../semver.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
@@ -28,6 +29,10 @@ import {
 import { isManagedSkillPublicationCurrent } from "./managed-skill-publication.ts";
 import { loadRegistryPackageSkillInfo } from "./registry-skill-source.ts";
 import { isBundledSkillName } from "./shared.ts";
+import {
+    normalizeSkillFilterTokens,
+    skillMatchesFilterTokens,
+} from "./skill-filter.ts";
 import { createPackageNamesTelemetryProperties } from "./telemetry.ts";
 
 type CheckUpdateStatus
@@ -71,6 +76,7 @@ interface SkillsCheckUpdateInput {
     format?: (typeof checkUpdateFormatValues)[number];
     showSchemaVersion?: boolean;
     packageNames?: string[];
+    skill?: string[];
 }
 
 interface RegistrySkillTarget {
@@ -104,12 +110,20 @@ export const skillsCheckUpdateCommand: CliCommandDefinition<SkillsCheckUpdateInp
         },
     ],
     options: [
+        {
+            name: "skill",
+            longFlag: "--skill",
+            shortFlag: "-s",
+            valueName: "skills...",
+            descriptionKey: "options.skills.skill",
+        },
         ...jsonOutputOptions,
     ],
     inputSchema: z.object({
         format: z.enum(checkUpdateFormatValues).optional(),
         showSchemaVersion: z.boolean().optional(),
         packageNames: z.array(z.string()).optional(),
+        skill: z.array(z.string()).optional(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
@@ -125,7 +139,18 @@ export const skillsCheckUpdateCommand: CliCommandDefinition<SkillsCheckUpdateInp
             settingsFilePath,
         );
         const packageNames = dedupePreserveOrder(input.packageNames ?? []);
-        const plan = resolveCheckUpdatePlan(packageNames, installedSkills);
+        // Record the skill-filter dimension before the no-match check can throw,
+        // so the telemetry is present even when --skill excludes every entry.
+        context.telemetry?.recordProperties({
+            has_skill_filter: (input.skill?.length ?? 0) > 0,
+        });
+        // The `--skill` filter narrows the resolved registry entries before any
+        // network lookup; unmatched names are ignored, and an error listing the
+        // resolved skills is raised when nothing matches.
+        const plan = applyCheckUpdateSkillFilter(
+            resolveCheckUpdatePlan(packageNames, installedSkills),
+            input.skill,
+        );
 
         const hasRegistryEntry = plan.some(entry => entry.kind === "registry");
         const account = hasRegistryEntry
@@ -231,6 +256,41 @@ function resolveCheckUpdatePlan(
     }
 
     return entries;
+}
+
+// Narrow the resolved registry entries by the optional `--skill` filter,
+// keeping any failed entries (bundled/not-installed package arguments) intact.
+// Returns the plan unchanged when no filter is active, and throws a listing
+// error when the filter excludes every registry entry.
+function applyCheckUpdateSkillFilter(
+    plan: readonly CheckUpdatePlanEntry[],
+    skillFilter: readonly string[] | undefined,
+): CheckUpdatePlanEntry[] {
+    const tokens = normalizeSkillFilterTokens(skillFilter);
+
+    if (tokens === undefined) {
+        return [...plan];
+    }
+
+    const registryEntries = plan.filter(entry => entry.kind === "registry");
+
+    if (registryEntries.length === 0) {
+        return [...plan];
+    }
+
+    const matched = new Set(
+        registryEntries.filter(entry =>
+            skillMatchesFilterTokens({ name: entry.target.skillId }, tokens),
+        ),
+    );
+
+    if (matched.size === 0) {
+        throw new CliUserError("errors.skills.skillFilterNoMatch", 1, {
+            skills: registryEntries.map(entry => entry.target.skillId).join(", "),
+        });
+    }
+
+    return plan.filter(entry => entry.kind !== "registry" || matched.has(entry));
 }
 
 function groupRegistrySkillTargetsByPackageName(
@@ -529,7 +589,10 @@ function writeReportSection(
 function recordTelemetry(
     context: CliExecutionContext,
     outcome: CheckUpdateOutcome,
-    options: { hasPackageFilter: boolean; packageNames: readonly string[] },
+    options: {
+        hasPackageFilter: boolean;
+        packageNames: readonly string[];
+    },
 ): void {
     context.telemetry?.recordProperties({
         has_package_filter: options.hasPackageFilter,

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -382,21 +382,32 @@ describe("embedded skill assets", () => {
             expect(content).not.toContain("package-execution.md");
             expect(content).not.toContain("packageId");
             expect(content).not.toContain("uses `kind` as the");
-            expect(content).toContain("Skill sidecar");
-            expect(content).toContain("oo skills search");
-            expect(content).toContain("sidecar discovery branch");
-            expect(content).toContain("not a callable capability contract");
-            expect(content).toContain("Skill sidecar policy");
-            expect(content).toContain("best credible installable skill match");
-            expect(content).toContain("Do not install a skill");
-            expect(content).toContain("do not ask about installation before");
-            expect(content).toContain("first successful useful result");
-            expect(content).toContain("numbered choices");
-            expect(content).toContain("`1. Install <skillName> (<packageName>)`");
-            expect(content).toContain("`2. Do not install`");
-            expect(content).toContain("reply with `1` to install or `2` to skip");
-            expect(content).toContain("Treat a `1` response as explicit agreement");
-            expect(content).toContain("use the `oo-find-skills` installation flow");
+            // Connector services are recorded for the wrap-up; the oo skill no
+            // longer runs an `oo skills search` sidecar.
+            expect(content).toContain("Record connectors for the wrap-up");
+            expect(content).toContain("do not need `oo skills search`");
+            expect(content).toContain("connector `service` values");
+            expect(content).toContain("service `github` -> `oo-github`");
+            expect(content).toContain("never assemble or guess package names yourself");
+            expect(content).toContain("has produced a successful useful result");
+            // Wrap-up batched recommendation flow.
+            expect(content).toContain("Wrap-up skill recommendation");
+            expect(content).toContain("oo skills recommend plan <connectorService>... --json");
+            expect(content).toContain("oo skills add <installPackageName>...");
+            expect(content).toContain("oo skills update <updatePackageName>...");
+            expect(content).toContain("oo skills recommend mute <packageName>...");
+            expect(content).toContain("oo skills recommend mute --all");
+            expect(content).toContain("not published");
+            expect(content).toContain("Never mention skipped packages");
+            expect(content).toContain("Never invent package names");
+            // The sidecar search and the legacy single-skill prompt are gone.
+            expect(content).not.toContain("sidecar discovery branch");
+            expect(content).not.toContain("Skill sidecar policy");
+            expect(content).not.toContain("best credible installable skill match");
+            expect(content).not.toContain("`1. Install <skillName> (<packageName>)`");
+            expect(content).not.toContain("`2. Do not install`");
+            expect(content).not.toContain("reply with `1` to install or `2` to skip");
+            expect(content).not.toContain("use the `oo-find-skills` installation flow");
             expect(content).toContain("If the user did not name a model or product");
             expect(content).toContain("prefer more capable, modern, reputable candidates");
             expect(content).toContain("older or obscure equivalents");
@@ -404,7 +415,7 @@ describe("embedded skill assets", () => {
         }
     });
 
-    test("guides oo runtime to defer sidecar skill installation", async () => {
+    test("guides oo runtime to record packages and recommend skills at wrap-up", async () => {
         for (const agentName of availableBundledSkillAgentNames) {
             const skillFile = getBundledSkillFiles("oo", agentName).find(
                 file => file.relativePath === "SKILL.md",
@@ -418,22 +429,21 @@ describe("embedded skill assets", () => {
                 await readBundledSkillFileContent(skillFile),
             );
 
-            expect(content).toContain("When running capability discovery");
-            expect(content).toContain("also run at most one");
-            expect(content).toContain("sidecar query");
-            expect(content).toContain("Record credible installable skill matches");
-            expect(content).toContain("possible future enhancements");
-            expect(content).toContain("do not install or ask about installation before");
-            expect(content).toContain("capability succeeds");
-            expect(content).toContain("After the first successful result");
-            expect(content).toContain("ask whether the user wants to");
-            expect(content).toContain("install that specific skill");
-            expect(content).toContain("numbered choices");
-            expect(content).toContain("`1. Install <skillName> (<packageName>)`");
-            expect(content).toContain("`2. Do not install`");
-            expect(content).toContain("reply with `1` to install or `2` to skip");
-            expect(content).toContain("Treat a `1` response as explicit agreement");
-            expect(content).toContain("Do not install unless the user explicitly agrees");
+            expect(content).toContain("Record the `service` of each connector capability");
+            expect(content).toContain("do not need `oo skills search`");
+            expect(content).toContain("deduplicated wrap-up list of connector services");
+            expect(content).toContain(
+                "Do not install or ask about installation before the selected connector capability",
+            );
+            expect(content).toContain("After the final useful result");
+            expect(content).toContain("oo skills recommend plan <connectorService>... --json");
+            expect(content).toContain("say nothing about skills and finish");
+            // The legacy single-skill numbered prompt is gone from SKILL.md.
+            expect(content).not.toContain("After the first successful result");
+            expect(content).not.toContain("Record credible installable skill matches");
+            expect(content).not.toContain("`1. Install <skillName> (<packageName>)`");
+            expect(content).not.toContain("`2. Do not install`");
+            expect(content).not.toContain("Do not install unless the user explicitly agrees");
         }
     });
 

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -2463,6 +2463,138 @@ describe("skills commands", () => {
         }
     });
 
+    test("--skill across packages installs matches and silently skips packages with no match", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+        try {
+            await mkdir(universalHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            // openai publishes "chatgpt"; anthropic publishes "claude".
+            // --skill chatgpt matches openai only. The global rule: a package with
+            // no match (anthropic) is silently skipped because another package
+            // matched, so the run succeeds and installs only chatgpt.
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "anthropic", "--skill", "chatgpt", "--json"],
+                {
+                    fetcher: createMultiPackageRegistryFetcher(),
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.status).toBe("completed");
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills.map(skill => skill.skillId)).toEqual(["chatgpt"]);
+            expect(skills.every(skill => skill.status === "installed")).toBeTrue();
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(errors).toHaveLength(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill across packages fails once when no package publishes any requested skill", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+        try {
+            await mkdir(universalHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            // Neither openai ("chatgpt") nor anthropic ("claude") publishes
+            // "nonexistent": the filter spans both packages and matches nothing, so
+            // the command fails ONCE with a global skill_filter_no_match. No tarball
+            // is fetched because both packages miss before any download.
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "anthropic", "--skill", "nonexistent", "--json"],
+                {
+                    fetcher: createMultiPackageRegistryFetcher(),
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(0);
+            expect(errors.map(error => error.code)).toEqual(["skill_filter_no_match"]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("text mode: --skill across packages installs matches and silently skips the rest", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+        const chatgptSkillDirectoryPath = join(universalHomeDirectory, "skills", "chatgpt");
+        const claudeSkillDirectoryPath = join(universalHomeDirectory, "skills", "claude");
+
+        try {
+            await mkdir(universalHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            // openai matches "chatgpt"; anthropic has no "chatgpt" and is silently
+            // skipped because openai matched. Default (non-json) output path.
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "anthropic", "--skill", "chatgpt"],
+                {
+                    fetcher: createMultiPackageRegistryFetcher(),
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            // Only chatgpt is installed; anthropic produces no selection or
+            // install line at all.
+            expect(result.stdout).toBe(
+                `Skill: chatgpt\nInstalled skill chatgpt to ${chatgptSkillDirectoryPath}.\n`,
+            );
+            expect(await readFile(join(chatgptSkillDirectoryPath, "SKILL.md"), "utf8"))
+                .toContain("# ChatGPT");
+            await expect(readFile(join(claudeSkillDirectoryPath, "SKILL.md"), "utf8"))
+                .rejects
+                .toThrow();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("text mode: --skill matching no package fails once and lists the available skills", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+        try {
+            await mkdir(universalHomeDirectory, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "openai", "anthropic", "--skill", "nonexistent"],
+                {
+                    fetcher: createMultiPackageRegistryFetcher(),
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            // Nothing installed; a single global error is rendered to stderr and
+            // lists the available skills aggregated across the packages.
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toContain("chatgpt");
+            expect(result.stderr).toContain("claude");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("reports partial failure when one of several packages fails in JSON mode", async () => {
         const sandbox = await createCliSandbox();
         const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");

--- a/src/application/commands/skills/index.ts
+++ b/src/application/commands/skills/index.ts
@@ -7,6 +7,7 @@ import { skillsInstallCommand } from "./install.ts";
 import { skillsListCommand } from "./list.ts";
 import { skillsLocateCommand } from "./locate.ts";
 import { skillsPublishCommand } from "./publish.ts";
+import { skillsRecommendCommand } from "./recommend/index.ts";
 import { skillsRepairCommand } from "./repair.ts";
 import { skillsSearchCommand } from "./search.ts";
 import { skillsShareCommand } from "./share.ts";
@@ -34,5 +35,6 @@ export const skillsCommand: CliCommandDefinition = {
         skillsUninstallCommand,
         skillsRepairCommand,
         skillsCheckUpdateCommand,
+        skillsRecommendCommand,
     ],
 };

--- a/src/application/commands/skills/install.cli.test.ts
+++ b/src/application/commands/skills/install.cli.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
     createCliSandbox,
+    toRequest,
     writeAuthFile,
 } from "../../../../__tests__/helpers.ts";
 import { resolveManagedSkillAgentHomeDirectory } from "./managed-skill-agents.ts";
@@ -18,6 +19,14 @@ import {
 } from "./skill-metadata.ts";
 
 const TEST_CLI_VERSION = "9.9.9";
+
+function packageInfoResponse(packageName: string, version: string, skillName: string) {
+    return new Response(JSON.stringify({
+        packageName,
+        version,
+        skills: [{ description: "demo", name: skillName, title: skillName }],
+    }));
+}
 
 describe("skills install --json", () => {
     test("bundled install returns installed skills with targets", async () => {
@@ -258,6 +267,173 @@ describe("skills install --json", () => {
 
             expect(payload.schemaVersion).toBe("1.0.0");
             expect(payload.command).toBe("skills.install");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill narrows the bundled install to the matched skills case-insensitively", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+            await mkdir(homeDirectory, { recursive: true });
+
+            const result = await sandbox.run(
+                ["skills", "install", "--skill", "OO", "missing", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            // Only the matched bundled skill is installed; the unknown "missing"
+            // token is silently ignored and the other bundled skills are skipped.
+            expect(skills.map(skill => skill.skillId)).toEqual(["oo"]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill with no matching bundled skill reports skill_filter_no_match and exits 1", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+            await mkdir(homeDirectory, { recursive: true });
+
+            const result = await sandbox.run(
+                ["skills", "install", "--skill", "nope", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(0);
+            expect(errors[0]).toMatchObject({ code: "skill_filter_no_match" });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill that matches no published skill in a registry package reports skill_filter_no_match", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+            await mkdir(homeDirectory, { recursive: true });
+
+            // The filter excludes every published skill after package-info loads
+            // but before any archive download, so no tarball fetch is needed.
+            const result = await sandbox.run(
+                ["skills", "install", "@alice/demo", "--skill", "nope", "--json"],
+                {
+                    version: TEST_CLI_VERSION,
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/demo", "0.1.0", "demo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(0);
+            expect(errors[0]).toMatchObject({ code: "skill_filter_no_match" });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("multiple packages with --skill matching none fail once globally, not per package", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+            await mkdir(homeDirectory, { recursive: true });
+
+            const lookedUpPackages: string[] = [];
+            // Package names BEFORE -s, so both are positional packages and the
+            // variadic -s collects only the skill tokens.
+            const result = await sandbox.run(
+                ["skills", "install", "@alice/foo", "@alice/bar", "-s", "nope", "--json"],
+                {
+                    version: TEST_CLI_VERSION,
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            if (request.url.includes("foo")) {
+                                lookedUpPackages.push("foo");
+                                return packageInfoResponse("@alice/foo", "0.1.0", "foo");
+                            }
+                            if (request.url.includes("bar")) {
+                                lookedUpPackages.push("bar");
+                                return packageInfoResponse("@alice/bar", "0.1.0", "bar");
+                            }
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            // Both positional args are treated as packages (both looked up), and
+            // "nope" is never treated as a package. The --skill filter spans all
+            // packages: nothing matches anywhere, so the command fails ONCE with a
+            // single global skill_filter_no_match (not one error per package).
+            expect(lookedUpPackages.sort()).toEqual(["bar", "foo"]);
+            expect(skills).toHaveLength(0);
+            expect(errors.map(error => error.code)).toEqual(["skill_filter_no_match"]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("text mode: --skill with no matching bundled skill exits 1 and lists available skills", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+            await mkdir(homeDirectory, { recursive: true });
+
+            // No --json: the no-arg bundled path throws a CliUserError that the
+            // CLI renders to stderr and exits 1.
+            const result = await sandbox.run(
+                ["skills", "install", "--skill", "nope"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(1);
+            // The error lists the available bundled skills.
+            expect(result.stderr).toContain("oo");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -38,6 +38,10 @@ import {
     resolveAvailableBundledSkillHostInstallations,
 } from "./shared.ts";
 import {
+    normalizeSkillFilterTokens,
+    skillMatchesFilterTokens,
+} from "./skill-filter.ts";
+import {
     createPackageNamesTelemetryProperties,
     createSkillIdsTelemetryProperties,
 } from "./telemetry.ts";
@@ -45,6 +49,7 @@ import {
 interface SkillsInstallInput {
     force?: boolean;
     packageNames?: string[];
+    skill?: string[];
     format?: "json";
     showSchemaVersion?: boolean;
 }
@@ -75,6 +80,7 @@ const installErrorMessages: Record<string, string> = {
     name_conflict: "Skill name is already used by a non-OOMOL skill.",
     storage_conflict: "Bundled skill storage is already occupied by non-OOMOL content.",
     publication_failed: "Failed to publish the skill to one or more hosts.",
+    skill_filter_no_match: "None of the requested skills exist in the requested packages.",
     unknown: "Unknown error.",
 };
 
@@ -98,11 +104,19 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
             shortFlag: "-f",
             descriptionKey: "options.skills.install.force",
         },
+        {
+            name: "skill",
+            longFlag: "--skill",
+            shortFlag: "-s",
+            valueName: "skills...",
+            descriptionKey: "options.skills.skill",
+        },
         ...skillOperationOutputOptions,
     ],
     inputSchema: z.object({
         force: z.boolean().optional(),
         packageNames: z.array(z.string()).optional(),
+        skill: z.array(z.string()).optional(),
         format: z.enum(["json"]).optional(),
         showSchemaVersion: z.boolean().optional(),
     }),
@@ -111,6 +125,12 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         await migrateLegacyCanonicalSkillLayout(context);
 
         const force = input.force === true;
+        // Record the skill-filter dimension up front so it is present on every
+        // path, including when a no-match check throws before the detailed
+        // telemetry is recorded.
+        context.telemetry?.recordProperties({
+            has_skill_filter: (input.skill?.length ?? 0) > 0,
+        });
 
         if (input.format === "json") {
             const report = await runInstallJsonReport(input, context, { force });
@@ -131,19 +151,23 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         const packageNames = input.packageNames ?? [];
 
         if (packageNames.length === 0) {
+            // No package argument installs the bundled skills, narrowed by the
+            // optional `--skill` filter.
+            const selectedBundled = selectBundledSkillNamesOrThrow(input.skill);
+
             context.telemetry?.recordProperties({
                 bundled_skill: "__all__",
                 has_bundled_skill: true,
                 has_force: force,
                 has_registry_skill: false,
                 package_kind: "bundled",
-                ...createSkillIdsTelemetryProperties(availableBundledSkillNames),
+                ...createSkillIdsTelemetryProperties(selectedBundled),
                 ...createPackageNamesTelemetryProperties([]),
             });
 
             const summaries: ManagedSkillInstallSummary[] = [];
 
-            for (const skillName of availableBundledSkillNames) {
+            for (const skillName of selectedBundled) {
                 summaries.push(await installBundledSkill(skillName, context, { force }));
             }
 
@@ -158,9 +182,13 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
         recordInstallBaseTelemetry(context, targets, force);
 
         const installedSkillIds: string[] = [];
+        const skillFilterActive = (input.skill?.length ?? 0) > 0;
+        const registryFilterMatch = new RegistrySkillFilterMatchTracker();
 
         for (const target of targets) {
             if (target.kind === "bundled") {
+                // An explicitly named bundled skill is already a single-skill
+                // selection, so `--skill` does not further narrow it.
                 const summary = await installBundledSkill(
                     target.specifier.packageName as BundledSkillName,
                     context,
@@ -178,13 +206,22 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
                         packageShareId: target.specifier.packageShareId,
                         packageVersion: target.specifier.packageVersion,
                         recordTelemetry: false,
-                        // Empty selection installs all published skills; the
-                        // command no longer exposes per-skill selection.
+                        skillFilter: input.skill,
+                        // Across several packages the filter must not fail a
+                        // package that simply does not publish a requested skill;
+                        // record the miss and decide globally after the loop.
+                        reportSkillFilterMiss: names => registryFilterMatch.recordMiss(names),
+                        // The command installs all published skills unless the
+                        // `--skill` filter narrows them; `skillNames` is reserved
+                        // for the explicit `oo skills sync` selection.
                         skillNames: [],
                     },
                     context,
                 );
 
+                if (summaries.length > 0) {
+                    registryFilterMatch.recordMatch();
+                }
                 installedSkillIds.push(...summaries.map(summary => summary.name));
             }
 
@@ -194,8 +231,46 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
                 createSkillIdsTelemetryProperties(installedSkillIds),
             );
         }
+
+        // With a `--skill` filter and one or more registry packages, fail only
+        // when no package published any requested skill; per-package misses are
+        // silently skipped.
+        if (skillFilterActive && registryFilterMatch.isGlobalMiss()) {
+            throw new CliUserError("errors.skills.skillFilterNoMatch", 1, {
+                skills: registryFilterMatch.availableSkillsList(),
+            });
+        }
     },
 };
+
+// Tracks, across the registry packages of a single install run, whether the
+// `--skill` filter matched at least one published skill and which skills were
+// available in the packages that matched nothing. A global miss is when the
+// filter was applied to at least one package (so some skills were available) yet
+// nothing matched; packages that failed to load contribute neither and are
+// reported through their own errors.
+class RegistrySkillFilterMatchTracker {
+    private matched = false;
+    private readonly missedAvailableSkills = new Set<string>();
+
+    recordMatch(): void {
+        this.matched = true;
+    }
+
+    recordMiss(availableSkillNames: readonly string[]): void {
+        for (const name of availableSkillNames) {
+            this.missedAvailableSkills.add(name);
+        }
+    }
+
+    isGlobalMiss(): boolean {
+        return !this.matched && this.missedAvailableSkills.size > 0;
+    }
+
+    availableSkillsList(): string {
+        return [...this.missedAvailableSkills].join(", ");
+    }
+}
 
 function classifySkillsInstallTarget(
     rawPackageName: string,
@@ -276,6 +351,31 @@ function resolveInstallPackageKindLabel(
     return hasRegistry ? "registry" : "bundled";
 }
 
+// Narrow the bundled skill set installed by the no-argument form using the
+// optional `--skill` filter. Returns every bundled skill when no filter is
+// active, and throws a listing error when the filter matches nothing.
+function selectBundledSkillNamesOrThrow(
+    skillFilter: readonly string[] | undefined,
+): readonly BundledSkillName[] {
+    const tokens = normalizeSkillFilterTokens(skillFilter);
+
+    if (tokens === undefined) {
+        return availableBundledSkillNames;
+    }
+
+    const selected = availableBundledSkillNames.filter(name =>
+        skillMatchesFilterTokens({ name }, tokens),
+    );
+
+    if (selected.length === 0) {
+        throw new CliUserError("errors.skills.skillFilterNoMatch", 1, {
+            skills: availableBundledSkillNames.join(", "),
+        });
+    }
+
+    return selected;
+}
+
 async function runInstallJsonReport(
     input: SkillsInstallInput,
     context: CliExecutionContext,
@@ -287,7 +387,23 @@ async function runInstallJsonReport(
     const packageNames = input.packageNames ?? [];
 
     if (packageNames.length === 0) {
-        for (const bundledName of availableBundledSkillNames) {
+        const skillFilterTokens = normalizeSkillFilterTokens(input.skill);
+        const selectedBundled = skillFilterTokens === undefined
+            ? availableBundledSkillNames
+            : availableBundledSkillNames.filter(name =>
+                    skillMatchesFilterTokens({ name }, skillFilterTokens),
+                );
+
+        if (skillFilterTokens !== undefined && selectedBundled.length === 0) {
+            errors.push({
+                code: "skill_filter_no_match",
+                message: installErrorMessages.skill_filter_no_match!,
+            });
+
+            return buildReport(skills, errors, 0);
+        }
+
+        for (const bundledName of selectedBundled) {
             const result = await installBundledSkillForJson(
                 bundledName,
                 context,
@@ -301,6 +417,8 @@ async function runInstallJsonReport(
     }
 
     let requested = 0;
+    const skillFilterActive = (input.skill?.length ?? 0) > 0;
+    const registryFilterMatch = new RegistrySkillFilterMatchTracker();
 
     for (const rawPackageName of packageNames) {
         let packageSpecifier: SkillsInstallPackageSpecifier;
@@ -334,10 +452,21 @@ async function runInstallJsonReport(
         requested += await appendRegistryInstallJsonResults(
             packageSpecifier,
             context,
-            options,
+            { force: options.force, skillFilter: input.skill },
             skills,
             errors,
+            registryFilterMatch,
         );
+    }
+
+    // With a `--skill` filter and one or more registry packages, fail only when
+    // no package published any requested skill; per-package misses are silently
+    // skipped.
+    if (skillFilterActive && registryFilterMatch.isGlobalMiss()) {
+        errors.push({
+            code: "skill_filter_no_match",
+            message: installErrorMessages.skill_filter_no_match!,
+        });
     }
 
     return buildReport(skills, errors, requested);
@@ -346,9 +475,10 @@ async function runInstallJsonReport(
 async function appendRegistryInstallJsonResults(
     packageSpecifier: SkillsInstallPackageSpecifier,
     context: CliExecutionContext,
-    options: { force: boolean },
+    options: { force: boolean; skillFilter?: readonly string[] },
     skills: SkillResult[],
     errors: SkillOperationError[],
+    filterMatch: RegistrySkillFilterMatchTracker,
 ): Promise<number> {
     try {
         const summaries = await installRegistrySkills(
@@ -358,6 +488,8 @@ async function appendRegistryInstallJsonResults(
                 packageShareId: packageSpecifier.packageShareId,
                 packageVersion: packageSpecifier.packageVersion,
                 recordTelemetry: false,
+                skillFilter: options.skillFilter,
+                reportSkillFilterMiss: names => filterMatch.recordMiss(names),
                 skillNames: [],
                 writeOutput: false,
             },
@@ -374,7 +506,11 @@ async function appendRegistryInstallJsonResults(
             ));
         }
 
-        return Math.max(1, summaries.length);
+        if (summaries.length > 0) {
+            filterMatch.recordMatch();
+        }
+
+        return summaries.length;
     }
     catch (error) {
         const errorCode = mapInstallErrorCode(error);
@@ -526,6 +662,8 @@ function mapInstallErrorCode(error: unknown): string {
             return "storage_conflict";
         case "errors.skills.install.invalidPackageSpecifier":
             return "invalid_package_specifier";
+        case "errors.skills.skillFilterNoMatch":
+            return "skill_filter_no_match";
         default:
             return "unknown";
     }

--- a/src/application/commands/skills/installed-managed-skills.ts
+++ b/src/application/commands/skills/installed-managed-skills.ts
@@ -1,0 +1,39 @@
+import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
+import type { ManagedSkillListItem } from "./managed-skill-listings.ts";
+
+import {
+    listManagedSkillInstallations,
+    listManagedSkillInstallationsForHosts,
+} from "./managed-skill-listings.ts";
+import {
+    resolveManagedSkillCanonicalRootDirectoryPath,
+} from "./managed-skill-paths.ts";
+
+// Collects the managed skills oo knows about by merging the canonical install
+// root with the per-host installations. Host listings take precedence over the
+// canonical copy when a skill name collides, and entries without metadata are
+// dropped so callers only ever see managed (bundled/registry/local) skills.
+export async function readKnownManagedSkillInstallations(
+    availableHosts: readonly ManagedSkillHost[],
+    settingsFilePath: string,
+): Promise<ManagedSkillListItem[]> {
+    const [canonicalSkills, hostSkills] = await Promise.all([
+        listManagedSkillInstallations(
+            resolveManagedSkillCanonicalRootDirectoryPath(settingsFilePath),
+        ),
+        listManagedSkillInstallationsForHosts(availableHosts),
+    ]);
+    const byName = new Map<string, ManagedSkillListItem>();
+
+    for (const skill of [...hostSkills, ...canonicalSkills]) {
+        if (skill.metadata !== undefined && !byName.has(skill.name)) {
+            byName.set(skill.name, {
+                metadata: skill.metadata,
+                name: skill.name,
+                path: skill.path,
+            });
+        }
+    }
+
+    return Array.from(byName.values());
+}

--- a/src/application/commands/skills/recommend/index.ts
+++ b/src/application/commands/skills/recommend/index.ts
@@ -1,0 +1,16 @@
+import type { CliCommandDefinition } from "../../../contracts/cli.ts";
+
+import { skillsRecommendMuteCommand } from "./mute.ts";
+import { skillsRecommendPlanCommand } from "./plan.ts";
+import { skillsRecommendUnmuteCommand } from "./unmute.ts";
+
+export const skillsRecommendCommand: CliCommandDefinition = {
+    name: "recommend",
+    summaryKey: "commands.skills.recommend.summary",
+    descriptionKey: "commands.skills.recommend.description",
+    children: [
+        skillsRecommendPlanCommand,
+        skillsRecommendMuteCommand,
+        skillsRecommendUnmuteCommand,
+    ],
+};

--- a/src/application/commands/skills/recommend/mute.cli.test.ts
+++ b/src/application/commands/skills/recommend/mute.cli.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import { createCliSandbox } from "../../../../../__tests__/helpers.ts";
+
+describe("skills recommend mute CLI", () => {
+    test("--json dismisses the given packages, sorted and de-duplicated", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["skills", "recommend", "mute", "oo-notion", "oo-gmail", "oo-notion", "--json"],
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(JSON.parse(result.stdout)).toEqual({
+                muted: false,
+                dismissed: ["oo-gmail", "oo-notion"],
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json accumulates dismissals across runs", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await sandbox.run(["skills", "recommend", "mute", "oo-gmail", "--json"]);
+            const result = await sandbox.run(
+                ["skills", "recommend", "mute", "oo-notion", "--json"],
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(JSON.parse(result.stdout)).toEqual({
+                muted: false,
+                dismissed: ["oo-gmail", "oo-notion"],
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--all sets the global mute flag", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["skills", "recommend", "mute", "--all", "--json"],
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(JSON.parse(result.stdout)).toEqual({
+                muted: true,
+                dismissed: [],
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("combining --all with package names exits 2", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["skills", "recommend", "mute", "oo-gmail", "--all"],
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).not.toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("passing neither packages nor --all exits 2", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["skills", "recommend", "mute"]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).not.toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/recommend/mute.ts
+++ b/src/application/commands/skills/recommend/mute.ts
@@ -1,0 +1,12 @@
+import {
+    addDismissedSkillRecommendations,
+    setSkillRecommendationsMuted,
+} from "../../../schemas/settings.ts";
+import { createSuppressionCommand } from "./suppression-command.ts";
+
+export const skillsRecommendMuteCommand = createSuppressionCommand({
+    name: "mute",
+    applyAll: settings => setSkillRecommendationsMuted(settings, true),
+    applyPackages: (settings, packageNames) =>
+        addDismissedSkillRecommendations(settings, packageNames),
+});

--- a/src/application/commands/skills/recommend/plan.cli.test.ts
+++ b/src/application/commands/skills/recommend/plan.cli.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    createCliSandbox,
+    toRequest,
+    writeAuthFile,
+} from "../../../../../__tests__/helpers.ts";
+import { packageInfoResponse, seedRegistrySkill } from "../__tests__/helpers.ts";
+
+// A fetcher that fails any request, used to prove a path performs no network
+// lookup. If the command were to reach the registry, the assertions on the
+// returned plan would diverge from the offline expectation.
+function throwingFetcher(): never {
+    throw new Error("Unexpected network request");
+}
+
+describe("skills recommend plan CLI", () => {
+    test("--json recommends install for a published service with no local install", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            // No auth file: the public package-info check needs no login, and no
+            // Authorization header is sent.
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["skills", "recommend", "plan", "gmail", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+                        if (request.url.includes("package-info/oo-gmail")) {
+                            return packageInfoResponse("oo-gmail", "1.0.0", "gmail");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const plan = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(plan.muted).toBe(false);
+            expect(plan.recommendations).toEqual([
+                { packageName: "oo-gmail", action: "install" },
+            ]);
+            expect(plan.skipped).toEqual([]);
+            // The package-info request carries no Authorization header.
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.headers.get("authorization")).toBeNull();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json maps underscore services to hyphenated packages", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const requestedUrls: string[] = [];
+            const result = await sandbox.run(
+                ["skills", "recommend", "plan", "aliyun_oss", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requestedUrls.push(request.url);
+                        if (request.url.includes("package-info/oo-aliyun-oss")) {
+                            return packageInfoResponse("oo-aliyun-oss", "1.0.0", "aliyun-oss");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const plan = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(plan.recommendations).toEqual([
+                { packageName: "oo-aliyun-oss", action: "install" },
+            ]);
+            // The transform replaced the underscore before the registry lookup.
+            expect(requestedUrls.some(url => url.includes("oo-aliyun_oss"))).toBe(false);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json recommends update for an outdated install and skips a current one", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "notion",
+                packageName: "oo-notion",
+                version: "1.0.0",
+            });
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "drive",
+                packageName: "oo-drive",
+                version: "2.0.0",
+            });
+
+            const result = await sandbox.run(
+                ["skills", "recommend", "plan", "notion", "drive", "gmail", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("package-info/oo-notion")) {
+                            return packageInfoResponse("oo-notion", "2.0.0", "notion");
+                        }
+                        if (request.url.includes("package-info/oo-drive")) {
+                            return packageInfoResponse("oo-drive", "2.0.0", "drive");
+                        }
+                        if (request.url.includes("package-info/oo-gmail")) {
+                            return packageInfoResponse("oo-gmail", "1.0.0", "gmail");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const plan = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(plan.recommendations).toEqual([
+                {
+                    packageName: "oo-notion",
+                    action: "update",
+                    currentVersion: "1.0.0",
+                    latestVersion: "2.0.0",
+                },
+                { packageName: "oo-gmail", action: "install" },
+            ]);
+            expect(plan.skipped).toEqual([
+                { packageName: "oo-drive", reason: "up-to-date" },
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json silently skips an unpublished service (404)", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "recommend", "plan", "nope", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("package-info/oo-nope")) {
+                            return new Response("", { status: 404 });
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const plan = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(plan.recommendations).toEqual([]);
+            expect(plan.skipped).toEqual([
+                { packageName: "oo-nope", reason: "not-published" },
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json skips a service when the registry lookup errors", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "recommend", "plan", "slack", "--json"],
+                {
+                    fetcher: async () => {
+                        throw new Error("network blip");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const plan = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(plan.recommendations).toEqual([]);
+            expect(plan.skipped).toEqual([
+                { packageName: "oo-slack", reason: "lookup-failed" },
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json degrades a server error (500) to a lookup-failed skip", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "recommend", "plan", "gmail", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("package-info/oo-gmail")) {
+                            return new Response("", { status: 500 });
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            // A non-billing request failure must not block the best-effort
+            // wrap-up; it becomes a silent lookup-failed skip.
+            expect(result.exitCode).toBe(0);
+            const plan = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(plan.recommendations).toEqual([]);
+            expect(plan.skipped).toEqual([
+                { packageName: "oo-gmail", reason: "lookup-failed" },
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json skips a dismissed package without a network lookup", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const muteResult = await sandbox.run(
+                ["skills", "recommend", "mute", "oo-gmail", "--json"],
+            );
+
+            expect(muteResult.exitCode).toBe(0);
+
+            const result = await sandbox.run(
+                ["skills", "recommend", "plan", "gmail", "--json"],
+                { fetcher: throwingFetcher },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const plan = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(plan.recommendations).toEqual([]);
+            expect(plan.skipped).toEqual([
+                { packageName: "oo-gmail", reason: "dismissed" },
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json short-circuits to muted skips without any network lookup", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "notion",
+                packageName: "oo-notion",
+                version: "1.0.0",
+            });
+            const muteResult = await sandbox.run(
+                ["skills", "recommend", "mute", "--all", "--json"],
+            );
+
+            expect(muteResult.exitCode).toBe(0);
+
+            const result = await sandbox.run(
+                ["skills", "recommend", "plan", "notion", "--json"],
+                { fetcher: throwingFetcher },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const plan = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(plan.muted).toBe(true);
+            expect(plan.recommendations).toEqual([]);
+            expect(plan.skipped).toEqual([
+                { packageName: "oo-notion", reason: "muted" },
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("text output lists install suggestions", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "recommend", "plan", "gmail"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("package-info/oo-gmail")) {
+                            return packageInfoResponse("oo-gmail", "1.0.0", "gmail");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("oo-gmail");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--format xml exits 2 with a format error", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["skills", "recommend", "plan", "gmail", "--format", "xml"],
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).not.toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/recommend/plan.ts
+++ b/src/application/commands/skills/recommend/plan.ts
@@ -1,0 +1,325 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../../contracts/cli.ts";
+import type { ManagedSkillListItem } from "../managed-skill-listings.ts";
+import type { CandidateResolution, RecommendationPartition } from "./recommendation-plan.ts";
+
+import { z } from "zod";
+import {
+    getDismissedSkillRecommendations,
+    isSkillRecommendationsMuted,
+} from "../../../schemas/settings.ts";
+import { compareSemver } from "../../../semver.ts";
+import { bucketTelemetryCount } from "../../../telemetry/buckets.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../../json-output.ts";
+import { resolveCurrentEndpoint } from "../../shared/auth-utils.ts";
+import { createFormatInputError } from "../../shared/input-parsing.ts";
+import { writeLine } from "../../shared/output.ts";
+import { readKnownManagedSkillInstallations } from "../installed-managed-skills.ts";
+import { resolveAvailableManagedSkillHosts } from "../managed-skill-hosts.ts";
+import { loadRegistryPackageSkillInfoAllowingMissing } from "../registry-skill-source.ts";
+import { createPackageNamesTelemetryProperties } from "../telemetry.ts";
+import {
+    dedupePreserveOrder,
+    deriveSkillPackageName,
+    partitionRecommendations,
+} from "./recommendation-plan.ts";
+
+const planFormatValues = ["json"] as const;
+// The package-info endpoint has no rate limit, so a small fixed fan-out keeps
+// the wrap-up snappy without hammering the registry.
+const packageExistenceConcurrency = 3;
+
+interface RecommendationPlan extends RecommendationPartition {
+    muted: boolean;
+}
+
+type RemotePackageStatus
+    = | { kind: "exists"; latestVersion: string }
+        | { kind: "not-found" }
+        | { kind: "lookup-failed" };
+
+interface SkillsRecommendPlanInput {
+    connectorServices?: string[];
+    format?: (typeof planFormatValues)[number];
+    showSchemaVersion?: boolean;
+}
+
+export const skillsRecommendPlanCommand: CliCommandDefinition<SkillsRecommendPlanInput> = {
+    name: "plan",
+    summaryKey: "commands.skills.recommend.plan.summary",
+    descriptionKey: "commands.skills.recommend.plan.description",
+    arguments: [
+        {
+            name: "connectorServices",
+            descriptionKey: "arguments.skills.recommend.connectorService",
+            required: false,
+            variadic: true,
+        },
+    ],
+    options: [...jsonOutputOptions],
+    inputSchema: z.object({
+        connectorServices: z.array(z.string()).optional(),
+        format: z.enum(planFormatValues).optional(),
+        showSchemaVersion: z.boolean().optional(),
+    }),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+    handler: async (input, context) => {
+        // Each connector service maps to one published `oo-<service>` package.
+        const packageNames = dedupePreserveOrder(
+            (input.connectorServices ?? [])
+                .map(service => service.trim())
+                .filter(service => service.length > 0)
+                .map(deriveSkillPackageName),
+        );
+        const settings = await context.settingsStore.read();
+        const dismissed = new Set(getDismissedSkillRecommendations(settings));
+        const muted = isSkillRecommendationsMuted(settings);
+
+        const plan: RecommendationPlan = muted
+            ? {
+                    muted: true,
+                    ...partitionRecommendations(
+                        packageNames.map(packageName => ({
+                            packageName,
+                            resolution: { kind: "skip", reason: "muted" },
+                        })),
+                    ),
+                }
+            : {
+                    muted: false,
+                    ...partitionRecommendations(
+                        await resolveCandidates(packageNames, dismissed, context),
+                    ),
+                };
+
+        recordTelemetry(context, plan, packageNames);
+
+        if (input.format === "json") {
+            writeJsonOutput(context.stdout, plan, {
+                showSchemaVersion: input.showSchemaVersion,
+            });
+            return;
+        }
+
+        writeText(context, plan);
+    },
+};
+
+// Resolves each candidate package to install/update/skip. Dismissed packages
+// short-circuit offline; every other package is confirmed against the registry
+// (existence + latest version) with a bounded concurrency, and the local
+// inventory decides install vs update vs up-to-date.
+async function resolveCandidates(
+    packageNames: readonly string[],
+    dismissed: ReadonlySet<string>,
+    context: CliExecutionContext,
+): Promise<{ packageName: string; resolution: CandidateResolution }[]> {
+    const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
+    const installedSkills = await readKnownManagedSkillInstallations(
+        availableHosts,
+        context.settingsStore.getFilePath(),
+    );
+    const installedVersionByPackage = collectInstalledRegistryVersions(installedSkills);
+
+    const resolutionByPackage = new Map<string, CandidateResolution>();
+    const remoteTargets: string[] = [];
+
+    for (const packageName of packageNames) {
+        if (dismissed.has(packageName)) {
+            resolutionByPackage.set(packageName, { kind: "skip", reason: "dismissed" });
+            continue;
+        }
+
+        remoteTargets.push(packageName);
+    }
+
+    // The package-info endpoint is public, so the existence check needs only
+    // the endpoint, not a logged-in account.
+    const endpoint = remoteTargets.length > 0
+        ? await resolveCurrentEndpoint(context)
+        : undefined;
+
+    await mapWithConcurrency(
+        remoteTargets,
+        packageExistenceConcurrency,
+        async (packageName) => {
+            const status = await resolveRemotePackageStatus(
+                packageName,
+                endpoint as string,
+                context,
+            );
+
+            resolutionByPackage.set(
+                packageName,
+                classifyCandidate(status, installedVersionByPackage.get(packageName)),
+            );
+        },
+    );
+
+    return packageNames.map(packageName => ({
+        packageName,
+        // Every package was assigned a resolution above.
+        resolution: resolutionByPackage.get(packageName) as CandidateResolution,
+    }));
+}
+
+function classifyCandidate(
+    status: RemotePackageStatus,
+    currentVersion: string | undefined,
+): CandidateResolution {
+    switch (status.kind) {
+        case "not-found":
+            return { kind: "skip", reason: "not-published" };
+        case "lookup-failed":
+            return { kind: "skip", reason: "lookup-failed" };
+        case "exists":
+            if (currentVersion === undefined) {
+                return { kind: "install" };
+            }
+
+            return compareSemver(status.latestVersion, currentVersion) > 0
+                ? {
+                        kind: "update",
+                        currentVersion,
+                        latestVersion: status.latestVersion,
+                    }
+                : { kind: "skip", reason: "up-to-date" };
+    }
+}
+
+async function resolveRemotePackageStatus(
+    packageName: string,
+    endpoint: string,
+    context: CliExecutionContext,
+): Promise<RemotePackageStatus> {
+    try {
+        const info = await loadRegistryPackageSkillInfoAllowingMissing(
+            packageName,
+            endpoint,
+            context,
+        );
+
+        if (info === "not-found") {
+            return { kind: "not-found" };
+        }
+
+        return { kind: "exists", latestVersion: info.packageVersion };
+    }
+    catch (error) {
+        // The recommendation is best-effort: any lookup failure (server error,
+        // network blip) degrades to a silent lookup-failed skip rather than
+        // blocking the wrap-up.
+        context.logger.warn(
+            { err: error, packageName },
+            "skills recommend plan package lookup failed.",
+        );
+        return { kind: "lookup-failed" };
+    }
+}
+
+// Maps each installed registry package to its installed version. The first
+// installed skill of a package wins when several skills share one package.
+function collectInstalledRegistryVersions(
+    installedSkills: readonly ManagedSkillListItem[],
+): Map<string, string> {
+    const installedVersionByPackage = new Map<string, string>();
+
+    for (const skill of installedSkills) {
+        if (
+            skill.metadata?.kind === "registry"
+            && !installedVersionByPackage.has(skill.metadata.packageName)
+        ) {
+            installedVersionByPackage.set(
+                skill.metadata.packageName,
+                skill.metadata.version,
+            );
+        }
+    }
+
+    return installedVersionByPackage;
+}
+
+// Runs `worker` over `items` with at most `limit` in flight at once.
+async function mapWithConcurrency<T>(
+    items: readonly T[],
+    limit: number,
+    worker: (item: T) => Promise<void>,
+): Promise<void> {
+    let nextIndex = 0;
+    const runners = Array.from(
+        { length: Math.min(limit, items.length) },
+        async () => {
+            while (true) {
+                const index = nextIndex;
+
+                nextIndex += 1;
+
+                if (index >= items.length) {
+                    return;
+                }
+
+                await worker(items[index] as T);
+            }
+        },
+    );
+
+    await Promise.all(runners);
+}
+
+function recordTelemetry(
+    context: CliExecutionContext,
+    plan: RecommendationPlan,
+    packageNames: readonly string[],
+): void {
+    const installCount = plan.recommendations.filter(
+        entry => entry.action === "install",
+    ).length;
+    const updateCount = plan.recommendations.filter(
+        entry => entry.action === "update",
+    ).length;
+
+    context.telemetry?.recordProperties({
+        muted: plan.muted,
+        install_count_bucket: bucketTelemetryCount(installCount),
+        update_count_bucket: bucketTelemetryCount(updateCount),
+        skipped_count_bucket: bucketTelemetryCount(plan.skipped.length),
+        ...createPackageNamesTelemetryProperties(packageNames),
+    });
+}
+
+function writeText(
+    context: CliExecutionContext,
+    plan: RecommendationPlan,
+): void {
+    if (plan.muted) {
+        writeLine(context.stdout, context.translator.t("skills.recommend.plan.muted"));
+        return;
+    }
+
+    if (plan.recommendations.length === 0) {
+        writeLine(context.stdout, context.translator.t("skills.recommend.plan.none"));
+        return;
+    }
+
+    writeLine(context.stdout, context.translator.t("skills.recommend.plan.header"));
+
+    for (const entry of plan.recommendations) {
+        if (entry.action === "install") {
+            writeLine(
+                context.stdout,
+                context.translator.t("skills.recommend.plan.installLine", {
+                    packageName: entry.packageName,
+                }),
+            );
+            continue;
+        }
+
+        writeLine(
+            context.stdout,
+            context.translator.t("skills.recommend.plan.updateLine", {
+                packageName: entry.packageName,
+                currentVersion: entry.currentVersion ?? "",
+                latestVersion: entry.latestVersion ?? "",
+            }),
+        );
+    }
+}

--- a/src/application/commands/skills/recommend/recommendation-plan.test.ts
+++ b/src/application/commands/skills/recommend/recommendation-plan.test.ts
@@ -1,0 +1,95 @@
+import type { ResolvedCandidate } from "./recommendation-plan.ts";
+
+import { describe, expect, test } from "bun:test";
+import {
+    dedupePreserveOrder,
+    deriveSkillPackageName,
+    partitionRecommendations,
+
+} from "./recommendation-plan.ts";
+
+describe("deriveSkillPackageName", () => {
+    test("prefixes oo- for a single-word service", () => {
+        expect(deriveSkillPackageName("github")).toBe("oo-github");
+        expect(deriveSkillPackageName("gmail")).toBe("oo-gmail");
+    });
+
+    test("replaces underscores with hyphens", () => {
+        expect(deriveSkillPackageName("aliyun_oss")).toBe("oo-aliyun-oss");
+        expect(deriveSkillPackageName("asin_data_api")).toBe("oo-asin-data-api");
+    });
+
+    test("trims surrounding whitespace before deriving", () => {
+        expect(deriveSkillPackageName("  github  ")).toBe("oo-github");
+    });
+});
+
+describe("partitionRecommendations", () => {
+    test("routes install and update resolutions into recommendations", () => {
+        const candidates: ResolvedCandidate[] = [
+            { packageName: "oo-gmail", resolution: { kind: "install" } },
+            {
+                packageName: "oo-notion",
+                resolution: { kind: "update", currentVersion: "1.0.0", latestVersion: "2.0.0" },
+            },
+        ];
+
+        const partition = partitionRecommendations(candidates);
+
+        expect(partition.recommendations).toEqual([
+            { packageName: "oo-gmail", action: "install" },
+            {
+                packageName: "oo-notion",
+                action: "update",
+                currentVersion: "1.0.0",
+                latestVersion: "2.0.0",
+            },
+        ]);
+        expect(partition.skipped).toEqual([]);
+    });
+
+    test("routes every skip reason into skipped", () => {
+        const reasons = ["muted", "dismissed", "up-to-date", "not-published", "lookup-failed"] as const;
+        const candidates: ResolvedCandidate[] = reasons.map((reason, index) => ({
+            packageName: `oo-${index}`,
+            resolution: { kind: "skip", reason },
+        }));
+
+        const partition = partitionRecommendations(candidates);
+
+        expect(partition.recommendations).toEqual([]);
+        expect(partition.skipped).toEqual([
+            { packageName: "oo-0", reason: "muted" },
+            { packageName: "oo-1", reason: "dismissed" },
+            { packageName: "oo-2", reason: "up-to-date" },
+            { packageName: "oo-3", reason: "not-published" },
+            { packageName: "oo-4", reason: "lookup-failed" },
+        ]);
+    });
+
+    test("preserves input order across recommendations and skips", () => {
+        const candidates: ResolvedCandidate[] = [
+            { packageName: "a", resolution: { kind: "install" } },
+            { packageName: "b", resolution: { kind: "skip", reason: "not-published" } },
+            {
+                packageName: "c",
+                resolution: { kind: "update", currentVersion: "1.0.0", latestVersion: "1.1.0" },
+            },
+        ];
+
+        const partition = partitionRecommendations(candidates);
+
+        expect(partition.recommendations.map(entry => entry.packageName)).toEqual(["a", "c"]);
+        expect(partition.skipped.map(entry => entry.packageName)).toEqual(["b"]);
+    });
+});
+
+describe("dedupePreserveOrder", () => {
+    test("removes duplicates while preserving first-seen order", () => {
+        expect(dedupePreserveOrder(["b", "a", "b", "c", "a"])).toEqual(["b", "a", "c"]);
+    });
+
+    test("returns an empty array for empty input", () => {
+        expect(dedupePreserveOrder([])).toEqual([]);
+    });
+});

--- a/src/application/commands/skills/recommend/recommendation-plan.ts
+++ b/src/application/commands/skills/recommend/recommendation-plan.ts
@@ -1,0 +1,99 @@
+// Pure helpers for the `oo skills recommend plan` command. All I/O (settings,
+// installed inventory, registry existence/version lookups) is resolved by the
+// command handler and reduced to per-candidate resolutions here, so this stays
+// testable in isolation.
+
+export type RecommendationAction = "install" | "update";
+
+export type RecommendationSkipReason
+    = | "muted"
+        | "dismissed"
+        | "up-to-date"
+        | "not-published"
+        | "lookup-failed";
+
+export interface RecommendationEntry {
+    packageName: string;
+    action: RecommendationAction;
+    currentVersion?: string;
+    latestVersion?: string;
+}
+
+export interface SkippedRecommendation {
+    packageName: string;
+    reason: RecommendationSkipReason;
+}
+
+export interface RecommendationPartition {
+    recommendations: RecommendationEntry[];
+    skipped: SkippedRecommendation[];
+}
+
+// A candidate package's fully resolved outcome.
+export type CandidateResolution
+    = | { kind: "install" }
+        | { kind: "update"; currentVersion: string; latestVersion: string }
+        | { kind: "skip"; reason: RecommendationSkipReason };
+
+export interface ResolvedCandidate {
+    packageName: string;
+    resolution: CandidateResolution;
+}
+
+// Derives the published skill package name for a connector service, following
+// the catalog convention: prepend `oo-` and replace underscores with hyphens
+// (so `aliyun_oss` -> `oo-aliyun-oss`, `github` -> `oo-github`).
+export function deriveSkillPackageName(connectorService: string): string {
+    return `oo-${connectorService.trim().replaceAll("_", "-")}`;
+}
+
+// Splits resolved candidates into install/update suggestions and skips,
+// preserving input order.
+export function partitionRecommendations(
+    candidates: readonly ResolvedCandidate[],
+): RecommendationPartition {
+    const recommendations: RecommendationEntry[] = [];
+    const skipped: SkippedRecommendation[] = [];
+
+    for (const candidate of candidates) {
+        switch (candidate.resolution.kind) {
+            case "install":
+                recommendations.push({
+                    packageName: candidate.packageName,
+                    action: "install",
+                });
+                break;
+            case "update":
+                recommendations.push({
+                    packageName: candidate.packageName,
+                    action: "update",
+                    currentVersion: candidate.resolution.currentVersion,
+                    latestVersion: candidate.resolution.latestVersion,
+                });
+                break;
+            case "skip":
+                skipped.push({
+                    packageName: candidate.packageName,
+                    reason: candidate.resolution.reason,
+                });
+                break;
+        }
+    }
+
+    return { recommendations, skipped };
+}
+
+// De-duplicates strings while preserving first-seen order.
+export function dedupePreserveOrder(values: readonly string[]): string[] {
+    const seen = new Set<string>();
+    const result: string[] = [];
+
+    for (const value of values) {
+        if (!seen.has(value)) {
+            seen.add(value);
+            result.push(value);
+        }
+    }
+
+    return result;
+}

--- a/src/application/commands/skills/recommend/suppression-command.ts
+++ b/src/application/commands/skills/recommend/suppression-command.ts
@@ -1,0 +1,114 @@
+import type { CliCommandDefinition } from "../../../contracts/cli.ts";
+import type { AppSettings } from "../../../schemas/settings.ts";
+
+import { z } from "zod";
+import { CliUserError } from "../../../contracts/cli.ts";
+import {
+    getDismissedSkillRecommendations,
+    isSkillRecommendationsMuted,
+} from "../../../schemas/settings.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../../json-output.ts";
+import { createFormatInputError } from "../../shared/input-parsing.ts";
+import { writeLine } from "../../shared/output.ts";
+import { createPackageNamesTelemetryProperties } from "../telemetry.ts";
+import { dedupePreserveOrder } from "./recommendation-plan.ts";
+
+const suppressionFormatValues = ["json"] as const;
+
+interface SuppressionCommandInput {
+    all?: boolean;
+    packageNames?: string[];
+    format?: (typeof suppressionFormatValues)[number];
+    showSchemaVersion?: boolean;
+}
+
+interface SuppressionCommandConfig {
+    name: "mute" | "unmute";
+    applyAll: (settings: AppSettings) => AppSettings;
+    applyPackages: (
+        settings: AppSettings,
+        packageNames: readonly string[],
+    ) => AppSettings;
+}
+
+// Builds a `mute`/`unmute` style command. Both share the same parsing,
+// validation, telemetry, and output; only the settings mutation differs, so the
+// mutation is injected through `applyAll`/`applyPackages`.
+export function createSuppressionCommand(
+    config: SuppressionCommandConfig,
+): CliCommandDefinition<SuppressionCommandInput> {
+    return {
+        name: config.name,
+        summaryKey: `commands.skills.recommend.${config.name}.summary`,
+        descriptionKey: `commands.skills.recommend.${config.name}.description`,
+        arguments: [
+            {
+                name: "packageNames",
+                descriptionKey: `arguments.skills.recommend.${config.name}.packageName`,
+                required: false,
+                variadic: true,
+            },
+        ],
+        options: [
+            {
+                name: "all",
+                longFlag: "--all",
+                descriptionKey: `options.skills.recommend.${config.name}.all`,
+            },
+            ...jsonOutputOptions,
+        ],
+        inputSchema: z.object({
+            all: z.boolean().optional(),
+            packageNames: z.array(z.string()).optional(),
+            format: z.enum(suppressionFormatValues).optional(),
+            showSchemaVersion: z.boolean().optional(),
+        }),
+        mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+        handler: async (input, context) => {
+            const all = input.all === true;
+            const packageNames = dedupePreserveOrder(input.packageNames ?? []);
+
+            if (all && packageNames.length > 0) {
+                throw new CliUserError("errors.skills.recommend.conflictingScope", 2);
+            }
+
+            if (!all && packageNames.length === 0) {
+                throw new CliUserError("errors.skills.recommend.missingScope", 2);
+            }
+
+            context.telemetry?.recordProperties({
+                target_scope: all ? "all" : "packages",
+                ...createPackageNamesTelemetryProperties(packageNames),
+            });
+
+            const next = await context.settingsStore.update(settings =>
+                all
+                    ? config.applyAll(settings)
+                    : config.applyPackages(settings, packageNames),
+            );
+
+            const state = {
+                muted: isSkillRecommendationsMuted(next),
+                dismissed: [...getDismissedSkillRecommendations(next)],
+            };
+
+            if (input.format === "json") {
+                writeJsonOutput(context.stdout, state, {
+                    showSchemaVersion: input.showSchemaVersion,
+                });
+                return;
+            }
+
+            writeLine(
+                context.stdout,
+                context.translator.t(
+                    `skills.recommend.${config.name}.success.${all ? "all" : "packages"}`,
+                    {
+                        count: packageNames.length,
+                        packages: packageNames.join(", "),
+                    },
+                ),
+            );
+        },
+    };
+}

--- a/src/application/commands/skills/recommend/unmute.cli.test.ts
+++ b/src/application/commands/skills/recommend/unmute.cli.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import { createCliSandbox } from "../../../../../__tests__/helpers.ts";
+
+describe("skills recommend unmute CLI", () => {
+    test("--json removes a package from the dismissal list", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await sandbox.run(
+                ["skills", "recommend", "mute", "oo-gmail", "oo-notion", "--json"],
+            );
+            const result = await sandbox.run(
+                ["skills", "recommend", "unmute", "oo-gmail", "--json"],
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(JSON.parse(result.stdout)).toEqual({
+                muted: false,
+                dismissed: ["oo-notion"],
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json clears the dismissal list when the last package is removed", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await sandbox.run(["skills", "recommend", "mute", "oo-gmail", "--json"]);
+            const result = await sandbox.run(
+                ["skills", "recommend", "unmute", "oo-gmail", "--json"],
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(JSON.parse(result.stdout)).toEqual({
+                muted: false,
+                dismissed: [],
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--all clears the global mute flag", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await sandbox.run(["skills", "recommend", "mute", "--all", "--json"]);
+            const result = await sandbox.run(
+                ["skills", "recommend", "unmute", "--all", "--json"],
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(JSON.parse(result.stdout)).toEqual({
+                muted: false,
+                dismissed: [],
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("passing neither packages nor --all exits 2", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["skills", "recommend", "unmute"]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).not.toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/skills/recommend/unmute.ts
+++ b/src/application/commands/skills/recommend/unmute.ts
@@ -1,0 +1,12 @@
+import {
+    removeDismissedSkillRecommendations,
+    setSkillRecommendationsMuted,
+} from "../../../schemas/settings.ts";
+import { createSuppressionCommand } from "./suppression-command.ts";
+
+export const skillsRecommendUnmuteCommand = createSuppressionCommand({
+    name: "unmute",
+    applyAll: settings => setSkillRecommendationsMuted(settings, false),
+    applyPackages: (settings, packageNames) =>
+        removeDismissedSkillRecommendations(settings, packageNames),
+});

--- a/src/application/commands/skills/registry-skill-install.ts
+++ b/src/application/commands/skills/registry-skill-install.ts
@@ -38,6 +38,10 @@ import {
     loadRegistryPackageSkillInfo,
     tryReportRegistryPackageDownload,
 } from "./registry-skill-source.ts";
+import {
+    normalizeSkillFilterTokens,
+    selectSkillsByFilter,
+} from "./skill-filter.ts";
 import { createSkillIdsTelemetryProperties } from "./telemetry.ts";
 
 interface ManagedSkillPathState {
@@ -51,6 +55,17 @@ export interface RegistrySkillInstallRequest {
     packageShareId?: string;
     packageVersion?: string;
     recordTelemetry?: boolean;
+    // The `--skill` narrowing for the install command. When provided, only the
+    // package's published skills whose name (or directory basename) matches one
+    // of these values are installed; unmatched values are ignored. Ignored when
+    // `skillNames` is non-empty.
+    skillFilter?: readonly string[];
+    // Invoked with this package's published skill names when `skillFilter`
+    // matched none of them. A no-match always installs nothing for the package;
+    // whether an empty result across all packages is an error is decided by the
+    // caller (the install command's cross-package match tracker), which uses
+    // these names to list what was available.
+    reportSkillFilterMiss?: (availableSkillNames: readonly string[]) => void;
     // When non-empty, install exactly these skills (used by `oo skills sync`).
     // When empty, the install command installs all published skills.
     skillNames: string[];
@@ -265,22 +280,70 @@ async function resolveInstallSkillNames(
         );
     }
 
-    if (packageInfo.skills.length === 1) {
-        const firstSkill = packageInfo.skills[0]!;
+    // Default behavior: install every published skill in the package, narrowed
+    // by the optional `--skill` filter.
+    const selectedSkills = applyInstallSkillFilter(
+        packageInfo,
+        request.skillFilter,
+        request.reportSkillFilterMiss,
+    );
 
-        writeInstallSelectionLine(context, shouldWriteOutput, "skills.install.singleSelected", {
-            name: firstSkill.name,
-        });
-
-        return [firstSkill.name];
+    if (selectedSkills.length === 0) {
+        // `--skill` matched nothing in this package; the miss was reported to the
+        // caller, which decides whether this is a global no-match error. Install
+        // nothing here and emit no selection line.
+        return [];
     }
 
-    // Default behavior: install every published skill in the package.
-    writeInstallSelectionLine(context, shouldWriteOutput, "skills.install.allSelected", {
-        count: packageInfo.skills.length,
-    });
+    if (selectedSkills.length === 1) {
+        writeInstallSelectionLine(context, shouldWriteOutput, "skills.install.singleSelected", {
+            name: selectedSkills[0]!.name,
+        });
 
-    return packageInfo.skills.map(skill => skill.name);
+        return [selectedSkills[0]!.name];
+    }
+
+    if (selectedSkills.length < packageInfo.skills.length) {
+        // `--skill` narrowed the package to a strict subset of more than one
+        // skill; avoid the misleading "all" wording.
+        writeInstallSelectionLine(context, shouldWriteOutput, "skills.install.filteredSelected", {
+            count: selectedSkills.length,
+            total: packageInfo.skills.length,
+        });
+    }
+    else {
+        writeInstallSelectionLine(context, shouldWriteOutput, "skills.install.allSelected", {
+            count: selectedSkills.length,
+        });
+    }
+
+    return selectedSkills.map(skill => skill.name);
+}
+
+// Narrow the package's published skills by the `--skill` filter. Returns every
+// skill when no filter is active. When the filter matches nothing, installs
+// nothing and reports the package's published skill names through `reportMiss`;
+// the caller decides whether an empty result across all packages is an error.
+function applyInstallSkillFilter(
+    packageInfo: RegistryPackageSkillInfo,
+    skillFilter: readonly string[] | undefined,
+    reportMiss: ((availableSkillNames: readonly string[]) => void) | undefined,
+): RegistrySkillSummary[] {
+    const tokens = normalizeSkillFilterTokens(skillFilter);
+
+    if (tokens === undefined) {
+        return packageInfo.skills;
+    }
+
+    const selected = selectSkillsByFilter(packageInfo.skills, tokens);
+
+    if (selected.length === 0) {
+        reportMiss?.(packageInfo.skills.map(skill => skill.name));
+
+        return [];
+    }
+
+    return selected;
 }
 
 async function filterConfirmedSkillNames(

--- a/src/application/commands/skills/registry-skill-source.ts
+++ b/src/application/commands/skills/registry-skill-source.ts
@@ -6,6 +6,8 @@ import { CliUserError } from "../../contracts/cli.ts";
 import { withPackageIdentity } from "../../logging/log-fields.ts";
 import { performLoggedRequest, requestText } from "../shared/request.ts";
 
+const registryPackageNotFoundStatus = 404;
+
 const registrySkillSchema = z.object({
     description: z.string().optional().default(""),
     name: z.string().min(1),
@@ -115,6 +117,53 @@ export async function loadRegistryPackageSkillInfo(
     });
 
     return parseRegistryPackageSkillInfo(rawResponse);
+}
+
+// Like loadRegistryPackageSkillInfo, but unauthenticated and 404-aware: the
+// package-info endpoint is public, so no Authorization header is sent, and a
+// 404 is treated as a definitive "the package does not exist" signal instead of
+// an error. Used to confirm a derived `oo-<service>` package is published before
+// recommending it. Other non-success statuses and network errors still throw.
+export async function loadRegistryPackageSkillInfoAllowingMissing(
+    packageName: string,
+    endpoint: string,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
+    packageVersion = "latest",
+): Promise<RegistryPackageSkillInfo | "not-found"> {
+    const requestUrl = createRegistryPackageInfoRequestUrl(
+        endpoint,
+        packageName,
+        packageVersion,
+    );
+    const response = await performLoggedRequest({
+        allowedStatuses: [registryPackageNotFoundStatus],
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.skills.install.packageInfoRequestFailed",
+            1,
+            {
+                status,
+            },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.skills.install.packageInfoRequestError",
+            1,
+            {
+                message: error instanceof Error ? error.message : String(error),
+            },
+        ),
+        fields: {
+            common: withPackageIdentity(packageName, packageVersion),
+        },
+        requestLabel: "Skills recommend package info",
+        requestUrl,
+    });
+
+    if (response.status === registryPackageNotFoundStatus) {
+        return "not-found";
+    }
+
+    return parseRegistryPackageSkillInfo(await response.text());
 }
 
 export async function downloadRegistryPackageTarball(

--- a/src/application/commands/skills/skill-filter.test.ts
+++ b/src/application/commands/skills/skill-filter.test.ts
@@ -1,0 +1,76 @@
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    normalizeSkillFilterTokens,
+    selectSkillsByFilter,
+    skillMatchesFilterTokens,
+} from "./skill-filter.ts";
+
+describe("normalizeSkillFilterTokens", () => {
+    test("returns undefined for undefined input", () => {
+        expect(normalizeSkillFilterTokens(undefined)).toBeUndefined();
+    });
+
+    test("returns undefined when every token is blank", () => {
+        expect(normalizeSkillFilterTokens(["", "   "])).toBeUndefined();
+    });
+
+    test("trims, lowercases, and de-duplicates tokens", () => {
+        const tokens = normalizeSkillFilterTokens([" Foo ", "foo", "BAR"]);
+
+        expect(tokens).toEqual(new Set(["foo", "bar"]));
+    });
+});
+
+describe("skillMatchesFilterTokens", () => {
+    test("matches the skill name case-insensitively", () => {
+        expect(
+            skillMatchesFilterTokens({ name: "Demo" }, new Set(["demo"])),
+        ).toBeTrue();
+    });
+
+    test("matches the path basename when the name differs", () => {
+        const candidate = { name: "logical-name", path: join("a", "b", "Display-Name") };
+
+        expect(
+            skillMatchesFilterTokens(candidate, new Set(["display-name"])),
+        ).toBeTrue();
+    });
+
+    test("does not match when neither name nor basename is requested", () => {
+        expect(
+            skillMatchesFilterTokens(
+                { name: "demo", path: join("x", "demo") },
+                new Set(["other"]),
+            ),
+        ).toBeFalse();
+    });
+});
+
+describe("selectSkillsByFilter", () => {
+    test("keeps only matching candidates and ignores unknown tokens", () => {
+        const candidates = [
+            { name: "foo" },
+            { name: "bar" },
+            { name: "baz" },
+        ];
+        // Tokens flow through normalization (lowercase) before matching, so the
+        // mixed-case "FOO" still matches the "foo" candidate.
+        const tokens = normalizeSkillFilterTokens(["FOO", "baz", "missing"])!;
+
+        const selected = selectSkillsByFilter(candidates, tokens);
+
+        expect(selected.map(candidate => candidate.name)).toEqual(["foo", "baz"]);
+    });
+
+    test("returns an empty array when no candidate matches", () => {
+        const selected = selectSkillsByFilter(
+            [{ name: "foo" }],
+            new Set(["nope"]),
+        );
+
+        expect(selected).toEqual([]);
+    });
+});

--- a/src/application/commands/skills/skill-filter.ts
+++ b/src/application/commands/skills/skill-filter.ts
@@ -1,0 +1,62 @@
+import { basename } from "node:path";
+
+// A skill that can be narrowed by the `--skill` option. Matching is
+// case-insensitive against the skill name and, when a directory path is known,
+// the path basename (the on-disk display name). For registry package skills the
+// name already equals the installed directory basename, so the optional path is
+// only carried for installed skills where the two could in principle differ.
+export interface SkillFilterCandidate {
+    name: string;
+    path?: string;
+}
+
+// Normalize the raw `--skill` values into a lowercase lookup set. Tokens are
+// trimmed, lowercased, and de-duplicated. Returns undefined when no usable
+// token remains, which callers treat as "no filter" (operate on every
+// candidate).
+export function normalizeSkillFilterTokens(
+    tokens: readonly string[] | undefined,
+): Set<string> | undefined {
+    if (tokens === undefined) {
+        return undefined;
+    }
+
+    const normalized = new Set<string>();
+
+    for (const token of tokens) {
+        const trimmed = token.trim().toLowerCase();
+
+        if (trimmed !== "") {
+            normalized.add(trimmed);
+        }
+    }
+
+    return normalized.size === 0 ? undefined : normalized;
+}
+
+// Whether a candidate matches at least one requested token, comparing the
+// skill name and the path basename case-insensitively.
+export function skillMatchesFilterTokens(
+    candidate: SkillFilterCandidate,
+    tokens: ReadonlySet<string>,
+): boolean {
+    if (tokens.has(candidate.name.toLowerCase())) {
+        return true;
+    }
+
+    if (candidate.path !== undefined) {
+        return tokens.has(basename(candidate.path).toLowerCase());
+    }
+
+    return false;
+}
+
+// Keep only the candidates that match at least one requested token. Tokens that
+// match no candidate are silently ignored; deciding what to do when nothing
+// matches is left to the caller (each command lists the available skills).
+export function selectSkillsByFilter<T extends SkillFilterCandidate>(
+    candidates: readonly T[],
+    tokens: ReadonlySet<string>,
+): T[] {
+    return candidates.filter(candidate => skillMatchesFilterTokens(candidate, tokens));
+}

--- a/src/application/commands/skills/update.cli.test.ts
+++ b/src/application/commands/skills/update.cli.test.ts
@@ -486,4 +486,201 @@ describe("skills update --json", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("--skill narrows the updated skills case-insensitively and ignores unknown names", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.2.0",
+            });
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "bar",
+                packageName: "@alice/bar",
+                version: "0.2.0",
+            });
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["skills", "update", "--skill", "FOO", "missing", "--json"],
+                {
+                    version: TEST_CLI_VERSION,
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/foo", "0.2.0", "foo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            // Only "foo" is updated; "bar" is excluded, so only its package is
+            // queried.
+            expect(skills.map(skill => skill.skillId)).toEqual(["foo"]);
+            expect(skills[0]?.status).toBe("current");
+            expect(requests.every(request => request.url.includes("foo"))).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--skill with no matching installed skill reports skill_filter_no_match and exits 1", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.2.0",
+            });
+
+            // The filter excludes every resolved skill before any network call.
+            const result = await sandbox.run(
+                ["skills", "update", "--skill", "nope", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(0);
+            expect(errors[0]).toMatchObject({ code: "skill_filter_no_match" });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("text mode: --skill with no matching installed skill exits 1 and lists the resolved skills", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.2.0",
+            });
+
+            // No --json: the text path throws a CliUserError listing the resolved
+            // skills and exits 1, before any network call.
+            const result = await sandbox.run(
+                ["skills", "update", "--skill", "nope"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("foo");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json with package args + --skill updates the matched package and silently skips the rest", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.2.0",
+            });
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "bar",
+                packageName: "@alice/bar",
+                version: "0.2.0",
+            });
+
+            const requests: Request[] = [];
+            // Package names BEFORE --skill so the variadic option does not consume
+            // them; this routes through the per-package update branch.
+            const result = await sandbox.run(
+                ["skills", "update", "@alice/foo", "@alice/bar", "--skill", "foo", "--json"],
+                {
+                    version: TEST_CLI_VERSION,
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/foo", "0.2.0", "foo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            // @alice/bar contributes nothing (no skill named foo) and is never
+            // queried; only @alice/foo's "foo" is reported.
+            expect(skills.map(skill => skill.skillId)).toEqual(["foo"]);
+            expect(requests.every(request => request.url.includes("foo"))).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json with package args + --skill matching none of their skills reports skill_filter_no_match", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@alice/foo",
+                version: "0.2.0",
+            });
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "bar",
+                packageName: "@alice/bar",
+                version: "0.2.0",
+            });
+
+            // The filter matches no skill in either requested package, so the
+            // per-package gate (anyCandidate && !anyMatched) fires before network.
+            const result = await sandbox.run(
+                ["skills", "update", "@alice/foo", "@alice/bar", "--skill", "missing", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(0);
+            expect(errors[0]).toMatchObject({ code: "skill_filter_no_match" });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -71,6 +71,39 @@ describe("skills update command", () => {
         }
     });
 
+    test("records has_skill_filter on the text no-results path when --skill is given", async () => {
+        const sandbox = await createCliSandbox();
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+        try {
+            // A supported host exists but no registry skills are installed, so the
+            // text path hits the no-results early return; has_skill_filter must
+            // still be recorded.
+            await mkdir(universalHomeDirectory, { recursive: true });
+
+            const result = await sandbox.run(["skills", "update", "--skill", "nope"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toBe("No updatable oo-managed skills were found.\n");
+            expect(parseTelemetryRowPayload(
+                readTelemetryRowsForTest(storePaths.telemetryDirectory)[0]!,
+            )).toMatchObject({
+                properties: {
+                    command_full: "skills.update",
+                    has_skill_filter: true,
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("rejects the bundled oo skill as an explicit update target", async () => {
         const sandbox = await createCliSandbox();
         const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
@@ -269,6 +302,7 @@ describe("skills update command", () => {
             )).toMatchObject({
                 properties: {
                     command_full: "skills.update",
+                    has_skill_filter: false,
                     package_kind: "registry",
                     package_name: "openai",
                     package_names_count_bucket: "1-5",

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -58,6 +58,10 @@ import {
 } from "./registry-skill-source.ts";
 import { isBundledSkillName } from "./shared.ts";
 import {
+    normalizeSkillFilterTokens,
+    selectSkillsByFilter,
+} from "./skill-filter.ts";
+import {
     createPackageNamesTelemetryProperties,
     createSkillIdsTelemetryProperties,
 } from "./telemetry.ts";
@@ -65,6 +69,7 @@ import { SkillsUpdateProgressReporter } from "./update-progress.ts";
 
 interface SkillsUpdateInput {
     packageNames?: string[];
+    skill?: string[];
     format?: "json";
     showSchemaVersion?: boolean;
 }
@@ -79,6 +84,7 @@ const updateErrorMessages: Record<string, string> = {
     package_download_failed: "Failed to download the package archive.",
     invalid_package_archive: "Downloaded package archive is invalid.",
     publication_failed: "Failed to publish the skill to one or more hosts.",
+    skill_filter_no_match: "None of the requested skills are installed for the selected packages.",
     unknown: "Unknown error.",
 };
 
@@ -127,18 +133,33 @@ export const skillsUpdateCommand: CliCommandDefinition<SkillsUpdateInput> = {
         },
     ],
     options: [
+        {
+            name: "skill",
+            longFlag: "--skill",
+            shortFlag: "-s",
+            valueName: "skills...",
+            descriptionKey: "options.skills.skill",
+        },
         ...skillOperationOutputOptions,
     ],
     inputSchema: z.object({
         packageNames: z.array(z.string()).optional(),
+        skill: z.array(z.string()).optional(),
         format: z.enum(["json"]).optional(),
         showSchemaVersion: z.boolean().optional(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
+        // Record the skill-filter dimension up front so it is present on every
+        // path, including the text no-results early return and the no-match
+        // throw, which both happen before the detailed telemetry is recorded.
+        context.telemetry?.recordProperties({
+            has_skill_filter: (input.skill?.length ?? 0) > 0,
+        });
+
         if (input.format === "json") {
             const report = await runUpdateJsonReport(
-                { packageNames: input.packageNames ?? [] },
+                { packageNames: input.packageNames ?? [], skillFilter: input.skill },
                 context,
             );
 
@@ -158,6 +179,7 @@ export const skillsUpdateCommand: CliCommandDefinition<SkillsUpdateInput> = {
         await updateManagedSkills(
             {
                 packageNames: input.packageNames ?? [],
+                skillFilter: input.skill,
             },
             context,
         );
@@ -167,6 +189,7 @@ export const skillsUpdateCommand: CliCommandDefinition<SkillsUpdateInput> = {
 export async function updateManagedSkills(
     request: {
         packageNames: readonly string[];
+        skillFilter?: readonly string[];
     },
     context: CliExecutionContext,
 ): Promise<void> {
@@ -181,15 +204,23 @@ export async function updateManagedSkills(
         availableHosts,
         settingsFilePath,
     );
-    const selectedSkills = resolveSelectedManagedSkillsByPackage(
+    const selectedByPackage = resolveSelectedManagedSkillsByPackage(
         request.packageNames,
         installedSkills,
     );
 
-    if (selectedSkills.length === 0) {
+    if (selectedByPackage.length === 0) {
         writeLine(context.stdout, context.translator.t("skills.update.noResults"));
         return;
     }
+
+    // The `--skill` filter narrows the resolved skills; unmatched names are
+    // ignored, and an error listing the resolved skills is raised when nothing
+    // matches.
+    const selectedSkills = filterManagedSkillsOrThrow(
+        selectedByPackage,
+        request.skillFilter,
+    );
 
     const progressReporter = context.stdout.isTTY === true
         ? new SkillsUpdateProgressReporter(
@@ -440,6 +471,30 @@ function resolveSelectedManagedSkillsByPackage(
     }
 
     return selectedSkills;
+}
+
+// Narrow resolved managed skills by the optional `--skill` filter. Returns
+// every skill when no filter is active, and throws a listing error when the
+// filter matches nothing.
+function filterManagedSkillsOrThrow(
+    skills: readonly ManagedSkillUpdateItem[],
+    skillFilter: readonly string[] | undefined,
+): ManagedSkillUpdateItem[] {
+    const tokens = normalizeSkillFilterTokens(skillFilter);
+
+    if (tokens === undefined) {
+        return [...skills];
+    }
+
+    const matched = selectSkillsByFilter(skills, tokens);
+
+    if (matched.length === 0) {
+        throw new CliUserError("errors.skills.skillFilterNoMatch", 1, {
+            skills: skills.map(skill => skill.name).join(", "),
+        });
+    }
+
+    return matched;
 }
 
 // Index installed registry skills by their package name, preserving the input
@@ -724,10 +779,11 @@ interface HostVersionState {
 }
 
 async function runUpdateJsonReport(
-    request: { packageNames: readonly string[] },
+    request: { packageNames: readonly string[]; skillFilter?: readonly string[] },
     context: CliExecutionContext,
 ): Promise<UpdateReport> {
     const errors: SkillOperationError[] = [];
+    const skillFilterTokens = normalizeSkillFilterTokens(request.skillFilter);
     const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
 
     if (availableHosts.length === 0) {
@@ -765,7 +821,19 @@ async function runUpdateJsonReport(
         if (selected.length === 0) {
             return buildUpdateReport([], errors);
         }
-        const results = await runUpdateForSkills(selected, availableHosts, context);
+
+        const matched = skillFilterTokens === undefined
+            ? selected
+            : selectSkillsByFilter(selected, skillFilterTokens);
+
+        if (matched.length === 0) {
+            errors.push({
+                code: "skill_filter_no_match",
+                message: updateErrorMessages.skill_filter_no_match!,
+            });
+            return buildUpdateReport([], errors);
+        }
+        const results = await runUpdateForSkills(matched, availableHosts, context);
 
         skills.push(...results);
         return buildUpdateReport(skills, errors);
@@ -773,6 +841,8 @@ async function runUpdateJsonReport(
 
     const skillsByPackageName = groupSkillsByPackageName(installedSkills);
     const seenPackageNames = new Set<string>();
+    let anyCandidate = false;
+    let anyMatched = false;
 
     for (const packageName of requestedPackageNames) {
         if (seenPackageNames.has(packageName)) {
@@ -816,10 +886,33 @@ async function runUpdateJsonReport(
             continue;
         }
 
-        // Each requested package updates all of its installed skills together.
-        const results = await runUpdateForSkills(packageSkills, availableHosts, context);
+        anyCandidate = true;
+
+        // The `--skill` filter narrows each package's installed skills; packages
+        // with no matching skill contribute nothing and are silently skipped.
+        const matched = skillFilterTokens === undefined
+            ? packageSkills
+            : selectSkillsByFilter(packageSkills, skillFilterTokens);
+
+        if (matched.length === 0) {
+            continue;
+        }
+
+        anyMatched = true;
+
+        // Each requested package updates all of its matched installed skills together.
+        const results = await runUpdateForSkills(matched, availableHosts, context);
 
         skills.push(...results);
+    }
+
+    // Mirror the text path: when a filter was given and excluded every resolved
+    // skill, surface a command-level error so the run fails.
+    if (skillFilterTokens !== undefined && anyCandidate && !anyMatched) {
+        errors.push({
+            code: "skill_filter_no_match",
+            message: updateErrorMessages.skill_filter_no_match!,
+        });
     }
 
     return buildUpdateReport(skills, errors);

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -259,6 +259,7 @@ const commandTelemetryDecisions = {
             "has_bundled_skill",
             "has_force",
             "has_registry_skill",
+            "has_skill_filter",
             "installed_count_bucket",
             "package_kind",
             "package_name",
@@ -270,7 +271,7 @@ const commandTelemetryDecisions = {
             "skill_ids_sample",
             "skill_ids_truncated",
         ],
-        reason: "Records install source, product-domain package dimensions, bounded skill/package samples, force-flag usage, and JSON-output result buckets.",
+        reason: "Records install source, product-domain package dimensions, bounded skill/package samples, force-flag and skill-filter usage, and JSON-output result buckets.",
     },
     "skills.info": {
         kind: "properties",
@@ -349,6 +350,7 @@ const commandTelemetryDecisions = {
         kind: "properties",
         properties: [
             "has_package_filter",
+            "has_skill_filter",
             "package_count_bucket",
             "checked_count_bucket",
             "update_available_count_bucket",
@@ -358,7 +360,7 @@ const commandTelemetryDecisions = {
             "package_names_sample",
             "package_names_truncated",
         ],
-        reason: "Records bucketed counts and bounded package-name samples; never records skill names, versions, or paths.",
+        reason: "Records bucketed counts, package- and skill-filter usage, and bounded package-name samples; never records skill names, versions, or paths.",
     },
     "skills.uninstall": {
         kind: "properties",
@@ -379,6 +381,7 @@ const commandTelemetryDecisions = {
             "current_count_bucket",
             "failed_count_bucket",
             "format",
+            "has_skill_filter",
             "package_kind",
             "package_name",
             "package_names_count_bucket",
@@ -391,7 +394,7 @@ const commandTelemetryDecisions = {
             "skill_ids_truncated",
             "updated_count_bucket",
         ],
-        reason: "Records artifact identity, bounded skill/package samples, and JSON-output result buckets.",
+        reason: "Records artifact identity, skill-filter usage, bounded skill/package samples, and JSON-output result buckets.",
     },
     "skills.validate": {
         kind: "generic",

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -362,6 +362,43 @@ const commandTelemetryDecisions = {
         ],
         reason: "Records bucketed counts, package- and skill-filter usage, and bounded package-name samples; never records skill names, versions, or paths.",
     },
+    "skills.recommend": {
+        kind: "generic",
+        reason: "Command group; child commands record safe suggestion dimensions.",
+    },
+    "skills.recommend.plan": {
+        kind: "properties",
+        properties: [
+            "muted",
+            "install_count_bucket",
+            "update_count_bucket",
+            "skipped_count_bucket",
+            "package_names_count_bucket",
+            "package_names_sample",
+            "package_names_truncated",
+        ],
+        reason: "Records the global mute flag, bucketed install/update/skip counts, and bounded package-name samples; never records versions or paths.",
+    },
+    "skills.recommend.mute": {
+        kind: "properties",
+        properties: [
+            "target_scope",
+            "package_names_count_bucket",
+            "package_names_sample",
+            "package_names_truncated",
+        ],
+        reason: "Records whether the global or per-package scope was used and bounded package-name samples.",
+    },
+    "skills.recommend.unmute": {
+        kind: "properties",
+        properties: [
+            "target_scope",
+            "package_names_count_bucket",
+            "package_names_sample",
+            "package_names_truncated",
+        ],
+        reason: "Records whether the global or per-package scope was used and bounded package-name samples.",
+    },
     "skills.uninstall": {
         kind: "properties",
         properties: [

--- a/src/application/schemas/settings.test.ts
+++ b/src/application/schemas/settings.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { parse as parseToml } from "smol-toml";
+
+import {
+    addDismissedSkillRecommendations,
+    getDismissedSkillRecommendations,
+    isSkillRecommendationsMuted,
+    removeDismissedSkillRecommendations,
+    renderSettingsFile,
+    setSkillRecommendationsMuted,
+    settingsFileReadSchema,
+} from "./settings.ts";
+
+describe("skill recommendation settings", () => {
+    test("defaults to not muted with no dismissals", () => {
+        expect(isSkillRecommendationsMuted({})).toBe(false);
+        expect(getDismissedSkillRecommendations({})).toEqual([]);
+    });
+
+    test("setting muted to true then false clears the key", () => {
+        const muted = setSkillRecommendationsMuted({}, true);
+
+        expect(isSkillRecommendationsMuted(muted)).toBe(true);
+
+        const cleared = setSkillRecommendationsMuted(muted, false);
+
+        expect(isSkillRecommendationsMuted(cleared)).toBe(false);
+        expect(cleared.skills?.recommend?.muted).toBeUndefined();
+    });
+
+    test("dismissals are de-duplicated and sorted", () => {
+        const settings = addDismissedSkillRecommendations({}, ["oo-notion", "oo-gmail", "oo-notion"]);
+
+        expect(getDismissedSkillRecommendations(settings)).toEqual(["oo-gmail", "oo-notion"]);
+    });
+
+    test("removing the last dismissal prunes the list", () => {
+        const settings = addDismissedSkillRecommendations({}, ["oo-gmail"]);
+        const cleared = removeDismissedSkillRecommendations(settings, ["oo-gmail"]);
+
+        expect(getDismissedSkillRecommendations(cleared)).toEqual([]);
+        expect(cleared.skills?.recommend?.dismissed).toBeUndefined();
+    });
+
+    test("adding dismissals preserves an existing global mute", () => {
+        const muted = setSkillRecommendationsMuted({}, true);
+        const settings = addDismissedSkillRecommendations(muted, ["oo-gmail"]);
+
+        expect(isSkillRecommendationsMuted(settings)).toBe(true);
+        expect(getDismissedSkillRecommendations(settings)).toEqual(["oo-gmail"]);
+    });
+
+    test("renders and round-trips the skills.recommend section", () => {
+        const settings = addDismissedSkillRecommendations(
+            setSkillRecommendationsMuted({}, true),
+            ["oo-gmail"],
+        );
+        const rendered = renderSettingsFile(settings);
+
+        expect(rendered).toContain("[skills.recommend]");
+        expect(rendered).toContain("muted = true");
+        expect(rendered).toContain("dismissed = [\"oo-gmail\"]");
+
+        const parsed = settingsFileReadSchema.parse(parseToml(rendered));
+
+        expect(parsed.skills?.recommend?.muted).toBe(true);
+        expect(parsed.skills?.recommend?.dismissed).toEqual(["oo-gmail"]);
+    });
+
+    test("does not render an active skills.recommend section by default", () => {
+        // The default file only carries the commented documentation block, so
+        // parsing it back yields no active skills settings.
+        const parsed = settingsFileReadSchema.parse(parseToml(renderSettingsFile({})));
+
+        expect(parsed.skills).toBeUndefined();
+    });
+
+    test("never persists the default muted=false value", () => {
+        const rendered = renderSettingsFile({ skills: { recommend: { muted: false } } });
+        const parsed = settingsFileReadSchema.parse(parseToml(rendered));
+
+        expect(parsed.skills).toBeUndefined();
+    });
+});

--- a/src/application/schemas/settings.ts
+++ b/src/application/schemas/settings.ts
@@ -32,15 +32,33 @@ const telemetrySettingsShape = {
 const telemetrySettingsReadSchema = z.object(telemetrySettingsShape);
 const telemetrySettingsSchema = z.object(telemetrySettingsShape).strict();
 
+const skillsRecommendSettingsShape = {
+    muted: z.boolean().optional(),
+    dismissed: z.array(z.string()).optional(),
+};
+
+const skillsRecommendSettingsReadSchema = z.object(skillsRecommendSettingsShape);
+const skillsRecommendSettingsSchema = z.object(skillsRecommendSettingsShape).strict();
+
+const skillsSettingsReadSchema = z.object({
+    recommend: skillsRecommendSettingsReadSchema.optional(),
+});
+
+const skillsSettingsSchema = z.object({
+    recommend: skillsRecommendSettingsSchema.optional(),
+}).strict();
+
 export const settingsFileReadSchema = z.object({
     file: fileSettingsReadSchema.optional(),
     lang: localeSchema.optional(),
+    skills: skillsSettingsReadSchema.optional(),
     telemetry: telemetrySettingsReadSchema.optional(),
 });
 
 export const settingsFileSchema = z.object({
     file: fileSettingsSchema.optional(),
     lang: localeSchema.optional(),
+    skills: skillsSettingsSchema.optional(),
     telemetry: telemetrySettingsSchema.optional(),
 }).strict();
 
@@ -72,6 +90,15 @@ const defaultSettingsCommentBlocks = [
         "# [telemetry]",
         "# enabled = true",
     ],
+    [
+        "# skills.recommend controls the end-of-session skill suggestions surfaced by the bundled `oo` skill.",
+        "# muted: when true, oo never suggests installing or updating skills. Default: false.",
+        "# dismissed: package names oo must never suggest again. Default: none.",
+        "# Manage these with `oo skills recommend mute` and `oo skills recommend unmute`.",
+        "# [skills.recommend]",
+        "# muted = false",
+        "# dismissed = [\"oo-gmail\"]",
+    ],
 ] as const;
 
 export function renderSettingsFile(settings: AppSettings): string {
@@ -96,6 +123,23 @@ export function renderSettingsFile(settings: AppSettings): string {
         persistedSettings.telemetry = {
             enabled: parsedSettings.telemetry.enabled,
         };
+    }
+
+    const recommend = parsedSettings.skills?.recommend;
+    const persistedRecommend: Record<string, unknown> = {};
+
+    // Only persist the global mute when it is on; `false` is the implicit
+    // default and is left out to keep the file at its default shape.
+    if (recommend?.muted === true) {
+        persistedRecommend.muted = true;
+    }
+
+    if (recommend?.dismissed !== undefined && recommend.dismissed.length > 0) {
+        persistedRecommend.dismissed = recommend.dismissed;
+    }
+
+    if (Object.keys(persistedRecommend).length > 0) {
+        persistedSettings.skills = { recommend: persistedRecommend };
     }
 
     const serializedSettings = stringifyToml(persistedSettings).trimEnd();
@@ -173,6 +217,100 @@ export function unsetTelemetryEnabled(
     }
 
     return deleteNestedProperty(settings, ["telemetry", "enabled"]);
+}
+
+export function isSkillRecommendationsMuted(settings: AppSettings): boolean {
+    return settings.skills?.recommend?.muted ?? false;
+}
+
+export function getDismissedSkillRecommendations(
+    settings: AppSettings,
+): readonly string[] {
+    return settings.skills?.recommend?.dismissed ?? [];
+}
+
+// Persists the global mute flag. A `false` value clears the key so the file
+// stays at its default shape instead of recording the implicit default.
+export function setSkillRecommendationsMuted(
+    settings: AppSettings,
+    muted: boolean,
+): AppSettings {
+    if (!muted) {
+        if (settings.skills?.recommend?.muted === undefined) {
+            return settings;
+        }
+
+        return deleteNestedProperty(settings, ["skills", "recommend", "muted"]);
+    }
+
+    return {
+        ...settings,
+        skills: {
+            ...settings.skills,
+            recommend: {
+                ...settings.skills?.recommend,
+                muted: true,
+            },
+        },
+    };
+}
+
+// Adds package names to the per-package dismissal list, keeping the result
+// de-duplicated and sorted for a stable settings file.
+export function addDismissedSkillRecommendations(
+    settings: AppSettings,
+    packageNames: readonly string[],
+): AppSettings {
+    const next = sortUnique([
+        ...getDismissedSkillRecommendations(settings),
+        ...packageNames,
+    ]);
+
+    return {
+        ...settings,
+        skills: {
+            ...settings.skills,
+            recommend: {
+                ...settings.skills?.recommend,
+                dismissed: next,
+            },
+        },
+    };
+}
+
+// Removes package names from the dismissal list, pruning the key entirely when
+// nothing remains.
+export function removeDismissedSkillRecommendations(
+    settings: AppSettings,
+    packageNames: readonly string[],
+): AppSettings {
+    const removal = new Set(packageNames);
+    const next = getDismissedSkillRecommendations(settings).filter(
+        name => !removal.has(name),
+    );
+
+    if (next.length === getDismissedSkillRecommendations(settings).length) {
+        return settings;
+    }
+
+    if (next.length === 0) {
+        return deleteNestedProperty(settings, ["skills", "recommend", "dismissed"]);
+    }
+
+    return {
+        ...settings,
+        skills: {
+            ...settings.skills,
+            recommend: {
+                ...settings.skills?.recommend,
+                dismissed: next,
+            },
+        },
+    };
+}
+
+function sortUnique(values: readonly string[]): string[] {
+    return [...new Set(values)].sort((left, right) => left.localeCompare(right));
 }
 
 // Shallow-clones each level of a nested object along the given path,

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -547,6 +547,8 @@ export const enMessages = {
         "The skills install package info request returned HTTP {status}.",
     "errors.skills.install.skillNotFound":
         "Skill {name} was not found in package {packageName}.",
+    "errors.skills.skillFilterNoMatch":
+        "None of the requested skills exist. Available skills: {skills}.",
     "errors.skills.update.bundledUnsupported":
         "Bundled skill {name} is managed by oo and cannot be updated with skills update. Use oo skills add {name} instead.",
     "errors.skills.update.packageNotInstalled":
@@ -758,6 +760,8 @@ export const enMessages = {
     "options.yes": "Skip confirmation prompts",
     "options.skills.install.force":
         "Force install even when a same-name skill directory exists and is not managed by oo",
+    "options.skills.skill":
+        "Skill name(s) to limit the operation to (case-insensitive; non-matching names are ignored)",
     "options.lang": "Specify the display language",
     "options.version": "Show the current version",
     "selfUpdate.install.success": "Installed oo {version}.",
@@ -800,6 +804,8 @@ export const enMessages = {
         "Updated oo from {currentVersion} to {version}.",
     "skills.install.allSelected":
         "Installing all {count} skills.",
+    "skills.install.filteredSelected":
+        "Installing {count} of {total} skills.",
     "skills.check.success":
         "Local skill editing is ready. Writable storage: {path}. Supported hosts: {count}.",
     "skills.list.noResults":
@@ -1530,6 +1536,8 @@ export const zhMessages = {
         "skills install 的包信息请求返回了 HTTP {status}。",
     "errors.skills.install.skillNotFound":
         "在包 {packageName} 中未找到 skill {name}。",
+    "errors.skills.skillFilterNoMatch":
+        "指定的 skill 都不存在。可用的 skill：{skills}。",
     "errors.skills.update.bundledUnsupported":
         "内置 skill {name} 由 oo 管理，不能通过 skills update 更新。请改用 oo skills add {name}。",
     "errors.skills.update.packageNotInstalled":
@@ -1733,6 +1741,8 @@ export const zhMessages = {
     "options.yes": "跳过确认提示",
     "options.skills.install.force":
         "强制安装，即使同名 skill 目录已存在且不受 oo 管理",
+    "options.skills.skill":
+        "限定操作的 skill 名称（可指定多个；大小写不敏感；不匹配的名称会被忽略）",
     "options.lang": "指定显示语言",
     "options.version": "显示当前版本",
     "selfUpdate.install.success": "已安装 oo {version}。",
@@ -1775,6 +1785,8 @@ export const zhMessages = {
         "已将 oo 从 {currentVersion} 更新到 {version}。",
     "skills.install.allSelected":
         "将安装全部 {count} 个 skill。",
+    "skills.install.filteredSelected":
+        "将安装 {total} 个 skill 中的 {count} 个。",
     "skills.check.success":
         "本地 skill 编辑环境可用。可写存储：{path}。受支持 Agents：{count}。",
     "skills.list.noResults":

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -679,6 +679,48 @@ export const enMessages = {
     "skills.checkUpdate.failuresHeader": "Failures:",
     "skills.checkUpdate.failuresLine":
         "  {skillId}: {message}",
+    "commands.skills.recommend.description":
+        "Plan end-of-session skill suggestions for the bundled oo skill and manage which packages are never suggested.",
+    "commands.skills.recommend.summary": "Manage skill suggestions",
+    "commands.skills.recommend.plan.description":
+        "Given the connector services used this session, derive each oo-<service> skill package, confirm it is published, and report which to install or update — skipping packages that are already current, unpublished, dismissed, or globally muted.",
+    "commands.skills.recommend.plan.summary": "Plan skill suggestions",
+    "commands.skills.recommend.mute.description":
+        "Stop suggesting the given packages, or use --all to stop every skill suggestion.",
+    "commands.skills.recommend.mute.summary": "Mute skill suggestions",
+    "commands.skills.recommend.unmute.description":
+        "Resume suggesting the given packages, or use --all to clear the global mute.",
+    "commands.skills.recommend.unmute.summary": "Unmute skill suggestions",
+    "arguments.skills.recommend.connectorService":
+        "Connector service(s) used this session (the `service` field from oo search); each maps to one oo-<service> skill package",
+    "arguments.skills.recommend.mute.packageName":
+        "Package name(s) to stop suggesting",
+    "arguments.skills.recommend.unmute.packageName":
+        "Package name(s) to resume suggesting",
+    "options.skills.recommend.mute.all":
+        "Mute every skill suggestion instead of specific packages",
+    "options.skills.recommend.unmute.all":
+        "Clear the global mute instead of specific packages",
+    "errors.skills.recommend.conflictingScope":
+        "Pass package names or --all, not both.",
+    "errors.skills.recommend.missingScope":
+        "Pass at least one package name, or --all.",
+    "skills.recommend.plan.muted":
+        "Skill suggestions are muted.",
+    "skills.recommend.plan.none":
+        "No skill suggestions.",
+    "skills.recommend.plan.header": "Suggested skills:",
+    "skills.recommend.plan.installLine": "  install {packageName}",
+    "skills.recommend.plan.updateLine":
+        "  update {packageName}  {currentVersion} -> {latestVersion}",
+    "skills.recommend.mute.success.all":
+        "Muted every skill suggestion.",
+    "skills.recommend.mute.success.packages":
+        "Will no longer suggest {count} package(s): {packages}",
+    "skills.recommend.unmute.success.all":
+        "Cleared the global skill suggestion mute.",
+    "skills.recommend.unmute.success.packages":
+        "Will suggest {count} package(s) again: {packages}",
     "commands.version.description":
         "Print the CLI version. Use --json for a stable machine-readable payload.",
     "commands.version.summary": "Print the CLI version",
@@ -1663,6 +1705,48 @@ export const zhMessages = {
     "skills.checkUpdate.failuresHeader": "失败：",
     "skills.checkUpdate.failuresLine":
         "  {skillId}：{message}",
+    "commands.skills.recommend.description":
+        "为内置 oo skill 规划收尾阶段的 skill 推荐，并管理哪些包永不推荐。",
+    "commands.skills.recommend.summary": "管理 skill 推荐",
+    "commands.skills.recommend.plan.description":
+        "根据本次会话用到的 connector service，推导各自的 oo-<service> skill 包并确认其已发布，给出应安装或更新的 skill；跳过已是最新、未发布、已忽略或已全局静音的包。",
+    "commands.skills.recommend.plan.summary": "规划 skill 推荐",
+    "commands.skills.recommend.mute.description":
+        "停止推荐指定的包；使用 --all 停止所有 skill 推荐。",
+    "commands.skills.recommend.mute.summary": "静音 skill 推荐",
+    "commands.skills.recommend.unmute.description":
+        "恢复推荐指定的包；使用 --all 清除全局静音。",
+    "commands.skills.recommend.unmute.summary": "取消静音 skill 推荐",
+    "arguments.skills.recommend.connectorService":
+        "本次会话用到的 connector service（oo search 结果中的 service 字段，可指定多个）；每个对应一个 oo-<service> skill 包",
+    "arguments.skills.recommend.mute.packageName":
+        "要停止推荐的包名（可指定多个）",
+    "arguments.skills.recommend.unmute.packageName":
+        "要恢复推荐的包名（可指定多个）",
+    "options.skills.recommend.mute.all":
+        "静音所有 skill 推荐，而非指定的包",
+    "options.skills.recommend.unmute.all":
+        "清除全局静音，而非指定的包",
+    "errors.skills.recommend.conflictingScope":
+        "请传入包名或 --all，二者不能同时使用。",
+    "errors.skills.recommend.missingScope":
+        "请至少传入一个包名，或使用 --all。",
+    "skills.recommend.plan.muted":
+        "skill 推荐已静音。",
+    "skills.recommend.plan.none":
+        "没有可推荐的 skill。",
+    "skills.recommend.plan.header": "推荐的 skill：",
+    "skills.recommend.plan.installLine": "  安装 {packageName}",
+    "skills.recommend.plan.updateLine":
+        "  更新 {packageName}  {currentVersion} -> {latestVersion}",
+    "skills.recommend.mute.success.all":
+        "已静音所有 skill 推荐。",
+    "skills.recommend.mute.success.packages":
+        "将不再推荐 {count} 个包：{packages}",
+    "skills.recommend.unmute.success.all":
+        "已清除全局 skill 推荐静音。",
+    "skills.recommend.unmute.success.packages":
+        "将重新推荐 {count} 个包：{packages}",
     "commands.version.description":
         "输出 CLI 版本。使用 --json 输出稳定的机器可读 payload。",
     "commands.version.summary": "输出 CLI 版本",


### PR DESCRIPTION
Introduce a shared skill-filter helper and wire an optional
-s, --skill option into the install, update, and check-update
commands. The filter narrows which skills each command operates
on, matching case-insensitively against skill names or directory
names, while keeping the default behavior of acting on every
skill in a package.

Across multiple packages the filter spans all of them: a package
that publishes none of the requested skills is silently skipped,
and the command fails only when no package matches any requested
name. Add the skill_filter_no_match error code for update/install
JSON output and record a low-cardinality has_skill_filter
telemetry dimension.

Signed-off-by: Kevin Cui <bh@bugs.cc>