### PR TITLE
Improve connector auth blocker guidance

### DIFF
--- a/contrib/skills/shared/oo/SKILL.md
+++ b/contrib/skills/shared/oo/SKILL.md
@@ -80,10 +80,18 @@ These rules override every local heuristic.
    destination, or timing choices.
 9. Stop at real blockers. Stop and report clearly on auth, billing, catalog
    miss, unsupported input shape, missing required values, terminal task
-   failure, or an unsafe side effect. If a shortlisted fallback directly avoids
-   the named blocker without changing the user's intent, try that fallback once.
-   Otherwise do not retry blindly, and do not replace a remote `oo` capability
-   with local code or direct third-party APIs.
+   failure, or an unsafe side effect. Connector authorization blockers are
+   terminal for the current turn: when evidence shows the selected connector is
+   not connected, not authorized, missing scopes, expired, or otherwise blocked
+   by connector authentication, return only a short blocker summary, the direct
+   connection or re-authorization URL, and one concise next step. Do not inspect
+   more schemas, enumerate actions, browse provider docs, provide usage
+   examples, or run more connector commands until the user confirms the service
+   is connected, unless the user explicitly asks for offline docs or setup
+   details. If a shortlisted fallback directly avoids a non-auth blocker without
+   changing the user's intent, try that fallback once. Otherwise do not retry
+   blindly, and do not replace a remote `oo` capability with local code or
+   direct third-party APIs.
 10. Reference reads are non-negotiable. Before invoking the first command in
     an `oo` command domain during a turn, read the corresponding file under
     `references/` unless it was already read in this turn. References are the

--- a/contrib/skills/shared/oo/references/connector-execution.md
+++ b/contrib/skills/shared/oo/references/connector-execution.md
@@ -194,24 +194,40 @@ If the same connector offers several find-style actions, prefer the one whose
 filters match the user's locator by name, id, folder, type, or time range so
 the result is as narrow as possible.
 
-## Re-authorization branches
+## Authorization blocker fast exit
 
-Inspect `errorCode` before broader troubleshooting:
+Inspect `errorCode` before broader troubleshooting. These error codes are
+terminal for the current connector workflow:
 
-- `scope_missing`: explain that the connector authorization is missing the
-  required scope and must be re-authorized
-- `credential_expired`: explain that the connector authorization has expired
-  and must be re-authorized
-- `app_not_ready` / `app_not_found`: explain that the connector has not been
-  authorized yet and must be authorized before retrying
+- `connection_required`
+- `app_not_found`
+- `app_not_ready`
+- `credential_expired`
+- `scope_missing`
 
-For those cases, guide the user to:
+When one appears, stop immediately. Do not inspect additional schemas, run
+adjacent actions, enumerate capabilities, produce usage examples, or browse
+third-party docs unless the user explicitly asks for offline docs.
+
+Return only:
+
+- one short blocker sentence
+- the connection or re-authorization URL
+- one concise next step
+
+Use this URL:
 
 ```text
 https://console.oomol.com/app-connections?provider=${serviceName}
 ```
 
 Replace `${serviceName}` with the selected connector service.
+
+For `connection_required`, `app_not_found`, or `app_not_ready`, explain that
+the connector has not been connected or authorized yet. For
+`credential_expired`, explain that the connector authorization has expired. For
+`scope_missing`, explain that the connector authorization is missing the
+required permission scope.
 
 ## Known connector caveats
 

--- a/contrib/skills/shared/oo/references/search-and-selection.md
+++ b/contrib/skills/shared/oo/references/search-and-selection.md
@@ -168,6 +168,14 @@ Tie-breakers:
   when the user explicitly requested that service or Fusion API cannot satisfy
   the schema, output, provider, account, compliance, data-routing, or side-effect
   requirements.
+- If the selected non-Fusion connector has `authenticated: false` and the user
+  explicitly requested that service, or no authenticated fallback can satisfy
+  the same outcome, stop before schema inspection. Report that the connector is
+  not connected, provide
+  `https://console.oomol.com/app-connections?provider=<service>`, and ask the
+  user to connect it first. Do not run `oo connector schema`, inspect adjacent
+  actions, or provide usage examples until the user confirms the service is
+  connected.
 - If both `fusion-api` and an authenticated non-Fusion connector are suitable,
   choose the one whose output contract best matches the user's requested result.
   Ask the user only when the choice changes provider, account, cost, compliance,

--- a/contrib/skills/shared/oo/references/search-and-selection.md
+++ b/contrib/skills/shared/oo/references/search-and-selection.md
@@ -142,8 +142,10 @@ decide. Rank results in this order:
 1. Directness of the action relative to the user's goal
 2. Whether the target service, destination, or output is explicitly named or
    strongly implied
-3. Setup cost. Treat `fusion-api` as OOMOL-hosted Fusion API and treat an
-   already authenticated non-Fusion connector as out-of-box.
+3. Setup cost and prior user readiness. Treat `fusion-api` as OOMOL-hosted
+   Fusion API and treat an already authenticated non-Fusion connector as
+   out-of-box. Authentication is strong evidence that the user has registered,
+   connected, and likely used that provider before.
 4. How many required inputs and follow-up questions it adds
 5. How closely the documented output matches the user's desired outcome
 6. If the user did not name a model or product, prefer more capable, modern,
@@ -162,6 +164,14 @@ Tie-breakers:
   service, destination, account, workspace, channel, folder, repository, or
   external side effect, or when that connector directly matches the requested
   external account workflow.
+- When the user did not name a provider and several connectors can satisfy the
+  same external account workflow, prefer authenticated non-Fusion connectors
+  over unauthenticated providers. Among authenticated candidates, choose the one
+  whose action and schema most directly satisfy the requested outcome with the
+  fewest missing inputs. If two or more authenticated candidates are materially
+  equivalent and the provider choice changes the account, sender identity,
+  workspace, compliance, data routing, or externally visible side effect, ask
+  one focused provider-selection question before schema inspection or execution.
 - Treat an unauthenticated non-Fusion connector as higher setup cost. Do not ask
   the user to connect it when a matching `fusion-api` action can complete the
   core task with the requested output. Use the unauthenticated connector only


### PR DESCRIPTION
## Summary

This updates the bundled `oo` skill guidance so connector authorization failures are handled as terminal blockers for the current turn.

When an agent discovers that a selected connector is not connected, not authorized, missing scopes, or has expired credentials, it should stop immediately and return the OO connection URL instead of continuing into schema inspection, adjacent action enumeration, or usage walkthroughs.

## Root Cause

The existing connector execution reference described re-authorization cases, but it did not make them an explicit fast-exit condition. Search results with `authenticated: false` could still lead the agent into deeper connector exploration before asking the user to authorize the service.

## Changes

- Makes connector authorization blockers terminal in the top-level `oo` skill constitution.
- Stops before schema inspection when the selected non-Fusion connector is unauthenticated and no connected fallback can satisfy the same outcome.
- Expands the execution reference to treat `connection_required`, `app_not_found`, `app_not_ready`, `credential_expired`, and `scope_missing` as fast-exit authorization blockers.

## Verification

- `bun run lint:fix`
- `bun run ts-check`
