### PR TITLE
feat(skills): uninstall a package's skills and accept many names

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1468,18 +1468,32 @@ Resume suggesting packages.
 - JSON shape: `{ "muted": <bool>, "dismissed": [...] }` — the resulting
   persisted state.
 
-### `oo skills uninstall [skill]`
+### `oo skills uninstall [skills...]`
 
 Remove oo-managed skills from supported local skill directories.
 
-- Alias: `oo skills remove [skill]`.
-- Arguments: when `[skill]` is omitted, the command removes all bundled skills.
+- Alias: `oo skills remove [skills...]`.
+- Arguments: when no name is provided, the command removes all bundled skills.
+- Arguments: one or more names may be provided and may mix skill names and
+  package names, e.g. `oo skills remove @scope/pkg other-skill`.
 - Options: `--agent <agent>` narrows local skill removal to one supported
   agent. It is used to disambiguate same-name local skills across agents.
-- Arguments: when `[skill]` is provided, the command checks published registry
-  installations and agent-native local skills for that skill name. If both
-  match, both are removed. Registry installations are removed before local
+- Name resolution: each name is first treated as a skill name. The command
+  checks bundled skills, agent-native local skills, and published registry
+  installations for that name. When a registry and a local skill share the
+  name, both are removed, and registry installations are removed before local
   installations.
+- Package fallback: when a name matches no installed skill, it is treated as a
+  package name and every installed registry skill that belongs to that package
+  is removed. A name that starts with `@` and contains `/` (a scoped package
+  identity, e.g. `@scope/pkg`) is always treated as a package and is never
+  tried as a skill name.
+- Package ownership: package matching uses each installed skill's recorded
+  package identity. A skill installed from a different package is never removed,
+  even when another package publishes a skill with the same name.
+- Multiple names: with `--json` every name is attempted and per-name outcomes
+  are aggregated into the report. In text output the names are processed in
+  order and the first failure stops the run.
 - Ownership rule: a bundled skill is removable from a supported host only when
   that host's installed directory has a `.oo-metadata.json` file that
   identifies bundled ownership.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -1247,17 +1247,26 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 校验：传包名**或** `--all`，不能同时传也不能都不传；任一误用以 exit 2 退出。
 - JSON 结构：`{ "muted": <bool>, "dismissed": [...] }`——持久化后的状态。
 
-### `oo skills uninstall [skill]`
+### `oo skills uninstall [skills...]`
 
 从受支持的本地 skill 目录移除由 oo 管理的 skill。
 
-- 别名：`oo skills remove [skill]`。
-- 参数：省略 `[skill]` 时，命令会移除全部内置 skill。
+- 别名：`oo skills remove [skills...]`。
+- 参数：未提供任何名称时，命令会移除全部内置 skill。
+- 参数：可提供一个或多个名称，并且可以混用 skill 名与包名，例如
+  `oo skills remove @scope/pkg other-skill`。
 - 选项：`--agent <agent>` 将 local skill 删除限制到一个受支持 Agent，用于消除
   多个 Agent 中存在同名 local skill 时的歧义。
-- 参数：提供 `[skill]` 时，命令会同时检查已发布的 registry 安装和 agent-native
-  local skill；如果两者都匹配同一个名称，会同时移除。registry 安装会先于本地安装
-  移除。
+- 名称解析：每个名称会先按 skill 名处理，命令会检查内置 skill、agent-native
+  local skill 以及已发布的 registry 安装；当 registry 与 local 同名时会同时移除，
+  且 registry 安装先于本地安装移除。
+- 包名回退：当某个名称匹配不到任何已安装的 skill 时，会将其当作包名处理，并移除
+  属于该包的全部已安装 registry skill。以 `@` 开头且包含 `/` 的名称（即带 scope
+  的包标识，如 `@scope/pkg`）始终被当作包名处理，不会再尝试作为 skill 名。
+- 包归属：包匹配依据每个已安装 skill 记录的包标识。即使另一个包发布了同名 skill，
+  来自其他包的 skill 也不会被移除。
+- 多名称：使用 `--json` 时会尝试每个名称，并将各名称的结果汇总进报告；文本输出
+  会按顺序处理名称，遇到第一个失败即停止。
 - 所有权规则：对内置 skill 来说，只有当某个受支持 Agent 中的安装目录包含能识别
   bundled 所有权的 `.oo-metadata.json` 时，才允许从该 Agent 移除。
 - 所有权规则：local skill 目录包含能识别 local 所有权的 `.oo-metadata.json` 时，

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -1854,6 +1854,113 @@ describe("skills commands", () => {
         }
     });
 
+    test("removes every installed skill of a package when given a package name", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const first = await seedRegistrySkillInstallation({
+                env: sandbox.env,
+                packageName: "@scope/bundle",
+                skillName: "alpha",
+                version: "1.0.0",
+            });
+            const second = await seedRegistrySkillInstallation({
+                env: sandbox.env,
+                packageName: "@scope/bundle",
+                skillName: "beta",
+                version: "1.0.0",
+            });
+
+            const result = await sandbox.run(["skills", "remove", "@scope/bundle"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    `Removed skill alpha from ${first.hostDirectory}.`,
+                    `Removed skill beta from ${second.hostDirectory}.`,
+                    "",
+                ].join("\n"),
+            );
+            await expect(stat(first.hostDirectory)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(second.hostDirectory)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("does not remove a skill owned by a different package", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const seeded = await seedRegistrySkillInstallation({
+                env: sandbox.env,
+                packageName: "@owner/pkg-one",
+                skillName: "foo",
+                version: "1.0.0",
+            });
+
+            const result = await sandbox.run(["skills", "remove", "pkg-two"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "No installed oo-managed skill belongs to pkg-two.\n",
+            );
+            await expect(stat(seeded.hostDirectory)).resolves.toMatchObject({
+                isDirectory: expect.any(Function),
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("removes mixed skill and package names in one invocation", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const inner = await seedRegistrySkillInstallation({
+                env: sandbox.env,
+                packageName: "@scope/bundle",
+                skillName: "inner",
+                version: "1.0.0",
+            });
+            const bar = await seedRegistrySkillInstallation({
+                env: sandbox.env,
+                packageName: "@scope/bar",
+                skillName: "bar",
+                version: "1.0.0",
+            });
+
+            const result = await sandbox.run(["skills", "remove", "@scope/bundle", "bar"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                [
+                    `Removed skill inner from ${inner.hostDirectory}.`,
+                    `Removed skill bar from ${bar.hostDirectory}.`,
+                    "",
+                ].join("\n"),
+            );
+            await expect(stat(inner.hostDirectory)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(bar.hostDirectory)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("does not uninstall a same-name skill without oo metadata", async () => {
         const sandbox = await createCliSandbox();
         const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
@@ -3655,6 +3762,40 @@ async function writeLocalSkillDirectory(
         resolveManagedSkillMetadataFilePath(skillDirectoryPath),
         renderSkillMetadataJson(createLocalSkillMetadata()),
     );
+}
+
+async function seedRegistrySkillInstallation(options: {
+    env: Record<string, string | undefined>;
+    packageName: string;
+    skillName: string;
+    version: string;
+    agent?: "universal" | "claude";
+}): Promise<{ canonicalDirectory: string; hostDirectory: string }> {
+    const agent = options.agent ?? "universal";
+    const homeDirectory = resolveManagedSkillAgentHomeDirectory(options.env, agent);
+    const hostDirectory = resolveManagedSkillDirectoryPath(homeDirectory, options.skillName);
+    const storePaths = resolveStorePaths({
+        appName: APP_NAME,
+        env: options.env,
+        platform: process.platform,
+    });
+    const canonicalDirectory = resolveManagedSkillCanonicalDirectoryPath(
+        storePaths.settingsFilePath,
+        options.skillName,
+    );
+    const metadata = renderSkillMetadataJson(createRegistrySkillMetadata({
+        packageName: options.packageName,
+        version: options.version,
+    }));
+
+    await mkdir(hostDirectory, { recursive: true });
+    await mkdir(canonicalDirectory, { recursive: true });
+    await Bun.write(join(hostDirectory, "SKILL.md"), "# Registry\n");
+    await Bun.write(join(canonicalDirectory, "SKILL.md"), "# Registry\n");
+    await Bun.write(resolveManagedSkillMetadataFilePath(hostDirectory), metadata);
+    await Bun.write(resolveManagedSkillMetadataFilePath(canonicalDirectory), metadata);
+
+    return { canonicalDirectory, hostDirectory };
 }
 
 function isRegistryPackageDownloadCountRequest(request: Request): boolean {

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -17,7 +17,7 @@ import {
     parseTelemetryRowPayload,
     readTelemetryRowsForTest,
 } from "../../telemetry/outbox.ts";
-import { readBundledSkillSourceContent } from "./__tests__/helpers.ts";
+import { readBundledSkillSourceContent, seedRegistrySkill } from "./__tests__/helpers.ts";
 import { bundledSkillDevelopmentVersion } from "./bundled-skill-model.ts";
 import {
     canonicalLocalSkillsDirectoryName,
@@ -1858,14 +1858,14 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
 
         try {
-            const first = await seedRegistrySkillInstallation({
-                env: sandbox.env,
+            const first = await seedRegistrySkill({
+                sandbox,
                 packageName: "@scope/bundle",
                 skillName: "alpha",
                 version: "1.0.0",
             });
-            const second = await seedRegistrySkillInstallation({
-                env: sandbox.env,
+            const second = await seedRegistrySkill({
+                sandbox,
                 packageName: "@scope/bundle",
                 skillName: "beta",
                 version: "1.0.0",
@@ -1898,8 +1898,8 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
 
         try {
-            const seeded = await seedRegistrySkillInstallation({
-                env: sandbox.env,
+            const seeded = await seedRegistrySkill({
+                sandbox,
                 packageName: "@owner/pkg-one",
                 skillName: "foo",
                 version: "1.0.0",
@@ -1925,14 +1925,14 @@ describe("skills commands", () => {
         const sandbox = await createCliSandbox();
 
         try {
-            const inner = await seedRegistrySkillInstallation({
-                env: sandbox.env,
+            const inner = await seedRegistrySkill({
+                sandbox,
                 packageName: "@scope/bundle",
                 skillName: "inner",
                 version: "1.0.0",
             });
-            const bar = await seedRegistrySkillInstallation({
-                env: sandbox.env,
+            const bar = await seedRegistrySkill({
+                sandbox,
                 packageName: "@scope/bar",
                 skillName: "bar",
                 version: "1.0.0",
@@ -1954,6 +1954,53 @@ describe("skills commands", () => {
             });
             await expect(stat(bar.hostDirectory)).rejects.toMatchObject({
                 code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails the package uninstall when a member is unmanaged on a host", async () => {
+        const sandbox = await createCliSandbox();
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: sandbox.env,
+            platform: process.platform,
+        });
+        // The package owns "orphan" per canonical metadata, but the host copy was
+        // replaced by unmanaged content, so it cannot be removed.
+        const canonicalDirectory = resolveManagedSkillCanonicalDirectoryPath(
+            storePaths.settingsFilePath,
+            "orphan",
+        );
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+        const hostDirectory = resolveManagedSkillDirectoryPath(universalHomeDirectory, "orphan");
+
+        try {
+            await mkdir(canonicalDirectory, { recursive: true });
+            await Bun.write(join(canonicalDirectory, "SKILL.md"), "# Registry\n");
+            await Bun.write(
+                resolveManagedSkillMetadataFilePath(canonicalDirectory),
+                renderSkillMetadataJson(createRegistrySkillMetadata({
+                    packageName: "@scope/orphan",
+                    version: "1.0.0",
+                })),
+            );
+            await mkdir(hostDirectory, { recursive: true });
+            await Bun.write(join(hostDirectory, "SKILL.md"), "# Custom user content\n");
+
+            const result = await sandbox.run(["skills", "remove", "@scope/orphan"]);
+
+            // Without surfacing the per-member result the command would report
+            // success while leaving the unmanaged copy in place.
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "orphan is not managed by oo and cannot be removed.\n",
+            );
+            await expect(stat(hostDirectory)).resolves.toMatchObject({
+                isDirectory: expect.any(Function),
             });
         }
         finally {
@@ -3762,40 +3809,6 @@ async function writeLocalSkillDirectory(
         resolveManagedSkillMetadataFilePath(skillDirectoryPath),
         renderSkillMetadataJson(createLocalSkillMetadata()),
     );
-}
-
-async function seedRegistrySkillInstallation(options: {
-    env: Record<string, string | undefined>;
-    packageName: string;
-    skillName: string;
-    version: string;
-    agent?: "universal" | "claude";
-}): Promise<{ canonicalDirectory: string; hostDirectory: string }> {
-    const agent = options.agent ?? "universal";
-    const homeDirectory = resolveManagedSkillAgentHomeDirectory(options.env, agent);
-    const hostDirectory = resolveManagedSkillDirectoryPath(homeDirectory, options.skillName);
-    const storePaths = resolveStorePaths({
-        appName: APP_NAME,
-        env: options.env,
-        platform: process.platform,
-    });
-    const canonicalDirectory = resolveManagedSkillCanonicalDirectoryPath(
-        storePaths.settingsFilePath,
-        options.skillName,
-    );
-    const metadata = renderSkillMetadataJson(createRegistrySkillMetadata({
-        packageName: options.packageName,
-        version: options.version,
-    }));
-
-    await mkdir(hostDirectory, { recursive: true });
-    await mkdir(canonicalDirectory, { recursive: true });
-    await Bun.write(join(hostDirectory, "SKILL.md"), "# Registry\n");
-    await Bun.write(join(canonicalDirectory, "SKILL.md"), "# Registry\n");
-    await Bun.write(resolveManagedSkillMetadataFilePath(hostDirectory), metadata);
-    await Bun.write(resolveManagedSkillMetadataFilePath(canonicalDirectory), metadata);
-
-    return { canonicalDirectory, hostDirectory };
 }
 
 function isRegistryPackageDownloadCountRequest(request: Request): boolean {

--- a/src/application/commands/skills/installed-managed-skills.ts
+++ b/src/application/commands/skills/installed-managed-skills.ts
@@ -37,3 +37,25 @@ export async function readKnownManagedSkillInstallations(
 
     return Array.from(byName.values());
 }
+
+// Resolve the names of installed registry skills that belong to a package.
+// Ownership is read from each skill's recorded `.oo-metadata.json` package
+// identity, so a same-name skill installed from a different package is never
+// matched. Bundled and local skills carry no package identity and are excluded.
+export async function findInstalledRegistrySkillNamesForPackage(options: {
+    availableHosts: readonly ManagedSkillHost[];
+    packageName: string;
+    settingsFilePath: string;
+}): Promise<string[]> {
+    const installations = await readKnownManagedSkillInstallations(
+        options.availableHosts,
+        options.settingsFilePath,
+    );
+
+    return installations
+        .filter(installation =>
+            installation.metadata?.kind === "registry"
+            && installation.metadata.packageName === options.packageName)
+        .map(installation => installation.name)
+        .sort((left, right) => left.localeCompare(right));
+}

--- a/src/application/commands/skills/managed-skill-uninstall.ts
+++ b/src/application/commands/skills/managed-skill-uninstall.ts
@@ -19,6 +19,7 @@ import {
     readInstalledBundledSkillMetadata,
 } from "./bundled-skill-observation.ts";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
+import { findInstalledRegistrySkillNamesForPackage } from "./installed-managed-skills.ts";
 import { readLocalSkillMetadata } from "./local-skill-ownership.ts";
 import {
     findLocalSkillSources,
@@ -35,6 +36,7 @@ import {
 } from "./managed-skill-paths.ts";
 import {
     isBundledSkillName,
+    isScopedPackageName,
     resolveAvailableBundledSkillHostInstallations,
 } from "./shared.ts";
 
@@ -52,17 +54,37 @@ export interface ManagedSkillUninstallResult {
     unmanagedInstallations: readonly ManagedSkillHostInstallation[];
 }
 
-export async function uninstallRequestedSkill(
-    skillName: string | undefined,
+export async function uninstallRequestedSkills(
+    skillNames: readonly string[],
     context: CliExecutionContext,
     options: {
         agentName?: BundledSkillAgentName;
     } = {},
 ): Promise<void> {
-    if (skillName === undefined) {
+    if (skillNames.length === 0) {
         for (const bundledSkillName of availableBundledSkillNames) {
             await uninstallBundledSkill(bundledSkillName, context);
         }
+        return;
+    }
+
+    // Names are processed in order; the first failure propagates and stops the
+    // run, mirroring `oo skills install`. The `--json` path is best-effort and
+    // aggregates per-name outcomes instead.
+    for (const skillName of skillNames) {
+        await uninstallRequestedSkillName(skillName, context, options);
+    }
+}
+
+async function uninstallRequestedSkillName(
+    skillName: string,
+    context: CliExecutionContext,
+    options: {
+        agentName?: BundledSkillAgentName;
+    },
+): Promise<void> {
+    if (isScopedPackageName(skillName)) {
+        await uninstallPackageSkills(skillName, context);
         return;
     }
 
@@ -97,17 +119,48 @@ export async function uninstallRequestedSkill(
         });
     }
 
-    const result = registryResult.unmanagedInstallations.length > 0
-        ? registryResult
-        : localResult;
+    // An existing same-name directory that oo does not manage is a conflict to
+    // surface, not a reason to reinterpret the argument as a package.
+    if (registryResult.unmanagedInstallations.length > 0) {
+        throw createManagedSkillUninstallResultError({
+            context,
+            logMessage:
+                "Managed registry skill uninstall skipped because no OOMOL metadata was found.",
+            result: registryResult,
+            skillName,
+        });
+    }
 
-    throw createManagedSkillUninstallResultError({
-        context,
-        logMessage:
-            "Managed registry skill uninstall skipped because no OOMOL metadata was found.",
-        result,
-        skillName,
+    // No skill is installed under this name; treat it as a package and remove
+    // every installed skill that belongs to it.
+    await uninstallPackageSkills(skillName, context);
+}
+
+async function uninstallPackageSkills(
+    packageName: string,
+    context: CliExecutionContext,
+): Promise<void> {
+    const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
+
+    if (availableHosts.length === 0) {
+        throw createMissingManagedSkillHostError(context.env);
+    }
+
+    const skillNames = await findInstalledRegistrySkillNamesForPackage({
+        availableHosts,
+        packageName,
+        settingsFilePath: context.settingsStore.getFilePath(),
     });
+
+    if (skillNames.length === 0) {
+        throw new CliUserError("errors.skills.uninstall.packageNotInstalled", 1, {
+            name: packageName,
+        });
+    }
+
+    for (const skillName of skillNames) {
+        await uninstallRegistrySkill(skillName, context);
+    }
 }
 
 export async function uninstallBundledSkill(

--- a/src/application/commands/skills/managed-skill-uninstall.ts
+++ b/src/application/commands/skills/managed-skill-uninstall.ts
@@ -159,7 +159,21 @@ async function uninstallPackageSkills(
     }
 
     for (const skillName of skillNames) {
-        await uninstallRegistrySkill(skillName, context);
+        const result = await uninstallRegistrySkill(skillName, context);
+
+        // The skill name came from this package's recorded metadata, so a
+        // non-removal means the installation could not actually be cleaned up
+        // (e.g. a canonical-only or unmanaged remnant). Surface it instead of
+        // reporting success.
+        if (!result.removed) {
+            throw createManagedSkillUninstallResultError({
+                context,
+                logMessage:
+                    "Package skill uninstall skipped because the target could not be removed.",
+                result,
+                skillName,
+            });
+        }
     }
 }
 

--- a/src/application/commands/skills/shared.ts
+++ b/src/application/commands/skills/shared.ts
@@ -133,6 +133,14 @@ export function isBundledSkillName(value: string): value is BundledSkillName {
     return availableBundledSkillNames.includes(value as BundledSkillName);
 }
 
+// A bare argument is treated directly as a registry package specifier (rather
+// than a skill name) when it is a scoped package identity: it starts with "@"
+// and contains a "/" separator. Skill names never contain a path separator, so
+// this disambiguation never collides with a real skill name.
+export function isScopedPackageName(value: string): boolean {
+    return value.startsWith("@") && value.includes("/");
+}
+
 async function writeBundledSkillCanonicalInstallation(options: {
     agentName: BundledSkillAgentName;
     homeDirectory: string;

--- a/src/application/commands/skills/uninstall.cli.test.ts
+++ b/src/application/commands/skills/uninstall.cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
@@ -329,6 +329,176 @@ describe("skills uninstall --json", () => {
             expect(skills[0]).toMatchObject({
                 kind: "local",
                 status: "removed",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("scoped package name removes every installed skill that belongs to it", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const first = await seedRegistrySkill({
+                sandbox,
+                skillName: "alpha",
+                packageName: "@scope/pkg",
+                version: "1.0.0",
+            });
+            const second = await seedRegistrySkill({
+                sandbox,
+                skillName: "beta",
+                packageName: "@scope/pkg",
+                version: "1.0.0",
+            });
+
+            const result = await sandbox.run(
+                ["skills", "uninstall", "@scope/pkg", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.status).toBe("completed");
+            const summary = payload.summary as Record<string, number>;
+
+            expect(summary.requestedSkills).toBe(1);
+            expect(summary.removed).toBe(2);
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(2);
+            expect(skills.map(skill => skill.skillId).sort()).toEqual(["alpha", "beta"]);
+            for (const skill of skills) {
+                expect(skill).toMatchObject({
+                    kind: "registry",
+                    packageName: "@scope/pkg",
+                    status: "removed",
+                });
+            }
+            await expect(stat(first.hostDirectory)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(second.hostDirectory)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("a name that matches no skill falls back to package removal", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const seeded = await seedRegistrySkill({
+                sandbox,
+                skillName: "solo",
+                packageName: "toolbox",
+                version: "2.0.0",
+            });
+
+            const result = await sandbox.run(
+                ["skills", "uninstall", "toolbox", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect((payload.summary as Record<string, number>).removed).toBe(1);
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills[0]).toMatchObject({
+                skillId: "solo",
+                kind: "registry",
+                packageName: "toolbox",
+                status: "removed",
+            });
+            await expect(stat(seeded.hostDirectory)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("removing a package leaves same-name skills owned by other packages intact", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const seeded = await seedRegistrySkill({
+                sandbox,
+                skillName: "foo",
+                packageName: "@owner/pkg-one",
+                version: "1.0.0",
+            });
+
+            const result = await sandbox.run(
+                ["skills", "uninstall", "pkg-two", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.status).toBe("failed");
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills[0]).toMatchObject({
+                skillId: "pkg-two",
+                status: "failed",
+                error: { code: "not_installed" },
+            });
+            // foo belongs to a different package and must remain installed.
+            await expect(stat(seeded.hostDirectory)).resolves.toMatchObject({
+                isDirectory: expect.any(Function),
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("mixed skill and package names are each resolved", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const inner = await seedRegistrySkill({
+                sandbox,
+                skillName: "inner",
+                packageName: "@scope/bundle",
+                version: "1.0.0",
+            });
+            const bar = await seedRegistrySkill({
+                sandbox,
+                skillName: "bar",
+                packageName: "@scope/bar",
+                version: "1.0.0",
+            });
+
+            const result = await sandbox.run(
+                ["skills", "uninstall", "@scope/bundle", "bar", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const summary = payload.summary as Record<string, number>;
+
+            expect(summary.requestedSkills).toBe(2);
+            expect(summary.removed).toBe(2);
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills.map(skill => skill.skillId).sort()).toEqual(["bar", "inner"]);
+            await expect(stat(inner.hostDirectory)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(bar.hostDirectory)).rejects.toMatchObject({
+                code: "ENOENT",
             });
         }
         finally {

--- a/src/application/commands/skills/uninstall.cli.test.ts
+++ b/src/application/commands/skills/uninstall.cli.test.ts
@@ -6,17 +6,16 @@ import { describe, expect, test } from "bun:test";
 import { createCliSandbox } from "../../../../__tests__/helpers.ts";
 import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../config/app-config.ts";
+import { seedRegistrySkill } from "./__tests__/helpers.ts";
 import { resolveBundledSkillCanonicalDirectoryPath } from "./bundled-skill-paths.ts";
 import { resolveManagedSkillAgentHomeDirectory } from "./managed-skill-agents.ts";
 import {
-    resolveManagedSkillCanonicalDirectoryPath,
     resolveManagedSkillDirectoryPath,
     resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
 import {
     createBundledSkillMetadata,
     createLocalSkillMetadata,
-    createRegistrySkillMetadata,
     renderSkillMetadataJson,
 } from "./skill-metadata.ts";
 
@@ -51,49 +50,6 @@ async function seedBundledSkill(
     await writeFile(
         resolveManagedSkillMetadataFilePath(canonicalDirectory),
         renderSkillMetadataJson(createBundledSkillMetadata(TEST_CLI_VERSION)),
-    );
-
-    return { hostDirectory, canonicalDirectory };
-}
-
-async function seedRegistrySkill(options: {
-    sandbox: Awaited<ReturnType<typeof createCliSandbox>>;
-    skillName: string;
-    packageName: string;
-    version: string;
-    agent?: "universal" | "claude";
-}): Promise<{ hostDirectory: string; canonicalDirectory: string }> {
-    const agent = options.agent ?? "universal";
-    const homeDirectory = resolveManagedSkillAgentHomeDirectory(options.sandbox.env, agent);
-    const hostDirectory = resolveManagedSkillDirectoryPath(homeDirectory, options.skillName);
-    const storePaths = resolveStorePaths({
-        appName: APP_NAME,
-        env: options.sandbox.env,
-        platform: process.platform,
-    });
-    const canonicalDirectory = resolveManagedSkillCanonicalDirectoryPath(
-        storePaths.settingsFilePath,
-        options.skillName,
-    );
-
-    await mkdir(homeDirectory, { recursive: true });
-    await mkdir(canonicalDirectory, { recursive: true });
-    await mkdir(hostDirectory, { recursive: true });
-    await writeFile(join(canonicalDirectory, "SKILL.md"), "# r\n");
-    await writeFile(join(hostDirectory, "SKILL.md"), "# r\n");
-    await writeFile(
-        resolveManagedSkillMetadataFilePath(canonicalDirectory),
-        renderSkillMetadataJson(createRegistrySkillMetadata({
-            packageName: options.packageName,
-            version: options.version,
-        })),
-    );
-    await writeFile(
-        resolveManagedSkillMetadataFilePath(hostDirectory),
-        renderSkillMetadataJson(createRegistrySkillMetadata({
-            packageName: options.packageName,
-            version: options.version,
-        })),
     );
 
     return { hostDirectory, canonicalDirectory };
@@ -498,6 +454,51 @@ describe("skills uninstall --json", () => {
                 code: "ENOENT",
             });
             await expect(stat(bar.hostDirectory)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("removes both a registry and a same-name local skill", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const registry = await seedRegistrySkill({
+                sandbox,
+                skillName: "dual",
+                packageName: "@scope/dual",
+                version: "1.0.0",
+                agent: "claude",
+            });
+            const local = await seedLocalSkill({
+                sandbox,
+                skillName: "dual",
+                agent: "universal",
+            });
+
+            const result = await sandbox.run(
+                ["skills", "uninstall", "dual", "--json"],
+                { version: TEST_CLI_VERSION },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.status).toBe("completed");
+            expect((payload.summary as Record<string, number>).removed).toBe(2);
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills.map(skill => skill.kind).sort()).toEqual(["local", "registry"]);
+            for (const skill of skills) {
+                expect(skill.status).toBe("removed");
+            }
+            await expect(stat(registry.hostDirectory)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+            await expect(stat(local.path)).rejects.toMatchObject({
                 code: "ENOENT",
             });
         }

--- a/src/application/commands/skills/uninstall.ts
+++ b/src/application/commands/skills/uninstall.ts
@@ -7,6 +7,7 @@ import type {
     BundledSkillName,
 } from "./embedded-assets.ts";
 
+import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
 import type {
     SkillKind,
     SkillOperationError,
@@ -25,6 +26,7 @@ import {
     readInstalledBundledSkillMetadata,
 } from "./bundled-skill-observation.ts";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
+import { findInstalledRegistrySkillNamesForPackage } from "./installed-managed-skills.ts";
 import { readLocalSkillMetadata } from "./local-skill-ownership.ts";
 import { findLocalSkillSources } from "./local-skill-source.ts";
 import { parseManagedSkillAgentOption } from "./managed-skill-agents.ts";
@@ -37,7 +39,7 @@ import {
     isManagedSkillPathContained,
     resolveManagedSkillCanonicalDirectoryPath,
 } from "./managed-skill-paths.ts";
-import { uninstallRequestedSkill } from "./managed-skill-uninstall.ts";
+import { uninstallRequestedSkills } from "./managed-skill-uninstall.ts";
 import {
     computeCommandStatus,
     skillOperationOutputOptions,
@@ -45,12 +47,13 @@ import {
 } from "./operation-result.ts";
 import {
     isBundledSkillName,
+    isScopedPackageName,
     resolveAvailableBundledSkillHostInstallations,
 } from "./shared.ts";
 
 interface SkillsUninstallInput {
     agent?: string;
-    skill?: string;
+    skills?: string[];
     format?: "json";
     showSchemaVersion?: boolean;
 }
@@ -81,9 +84,10 @@ export const skillsUninstallCommand: CliCommandDefinition<SkillsUninstallInput> 
     descriptionKey: "commands.skills.uninstall.description",
     arguments: [
         {
-            name: "skill",
-            descriptionKey: "arguments.skill",
+            name: "skills",
+            descriptionKey: "arguments.skills.uninstall.name",
             required: false,
+            variadic: true,
         },
     ],
     options: [
@@ -97,21 +101,25 @@ export const skillsUninstallCommand: CliCommandDefinition<SkillsUninstallInput> 
     ],
     inputSchema: z.object({
         agent: z.string().optional(),
-        skill: z.string().optional(),
+        skills: z.array(z.string()).optional(),
         format: z.enum(["json"]).optional(),
         showSchemaVersion: z.boolean().optional(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         const agentName = parseSkillsUninstallAgent(input.agent);
+        const skillNames = input.skills ?? [];
 
         if (input.format === "json") {
-            const report = await runUninstallJsonReport(
-                { skillName: input.skill, agentName },
+            const { report, hasPackageTarget } = await runUninstallJsonReport(
+                { skillNames, agentName },
                 context,
             );
 
-            recordUninstallTelemetry(context, report, { format: "json" });
+            recordUninstallTelemetry(context, report, {
+                format: "json",
+                hasPackageTarget,
+            });
             writeSkillOperationJson(context.stdout, report, {
                 showSchemaVersion: input.showSchemaVersion,
             });
@@ -124,7 +132,7 @@ export const skillsUninstallCommand: CliCommandDefinition<SkillsUninstallInput> 
             return;
         }
 
-        await uninstallRequestedSkill(input.skill, context, {
+        await uninstallRequestedSkills(skillNames, context, {
             agentName,
         });
     },
@@ -138,24 +146,27 @@ function parseSkillsUninstallAgent(
 
 async function runUninstallJsonReport(
     request: {
-        skillName: string | undefined;
+        skillNames: readonly string[];
         agentName: BundledSkillAgentName | undefined;
     },
     context: CliExecutionContext,
-): Promise<UninstallReport> {
+): Promise<{ report: UninstallReport; hasPackageTarget: boolean }> {
     const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
 
     if (availableHosts.length === 0) {
-        return buildReport([], [{
-            code: "no_supported_hosts",
-            message: uninstallErrorMessages.no_supported_hosts,
-        }], 0);
+        return {
+            report: buildReport([], [{
+                code: "no_supported_hosts",
+                message: uninstallErrorMessages.no_supported_hosts,
+            }], 0),
+            hasPackageTarget: false,
+        };
     }
 
-    const skills: SkillResult[] = [];
-    let requested = 0;
+    if (request.skillNames.length === 0) {
+        const skills: SkillResult[] = [];
+        let requested = 0;
 
-    if (request.skillName === undefined) {
         for (const bundledName of availableBundledSkillNames) {
             requested += 1;
             const entry = await uninstallBundledSkillForJson(bundledName, context, {
@@ -166,44 +177,113 @@ async function runUninstallJsonReport(
                 skills.push(entry);
             }
         }
-        return buildReport(skills, [], requested);
+        return { report: buildReport(skills, [], requested), hasPackageTarget: false };
     }
 
-    requested = 1;
+    const settingsFilePath = context.settingsStore.getFilePath();
+    const skills: SkillResult[] = [];
+    let hasPackageTarget = false;
 
-    if (isBundledSkillName(request.skillName)) {
-        const entry = await uninstallBundledSkillForJson(request.skillName, context, {
+    for (const name of request.skillNames) {
+        const resolution = await uninstallNameForJson(name, request.agentName, context, {
+            availableHosts,
+            settingsFilePath,
+        });
+
+        skills.push(...resolution.skills);
+
+        if (resolution.usedPackage) {
+            hasPackageTarget = true;
+        }
+    }
+
+    // Each positional argument counts as one requested target regardless of how
+    // many installed skills a package name expands to.
+    return {
+        report: buildReport(skills, [], request.skillNames.length),
+        hasPackageTarget,
+    };
+}
+
+interface UninstallNameResolution {
+    skills: SkillResult[];
+    usedPackage: boolean;
+}
+
+// Resolve a single positional argument. A scoped `@scope/name` value is always
+// treated as a package; any other value is tried as a skill name first
+// (bundled, local, then registry) and only falls back to a package lookup when
+// no skill is installed under that name.
+async function uninstallNameForJson(
+    name: string,
+    agentName: BundledSkillAgentName | undefined,
+    context: CliExecutionContext,
+    options: { availableHosts: readonly ManagedSkillHost[]; settingsFilePath: string },
+): Promise<UninstallNameResolution> {
+    if (isScopedPackageName(name)) {
+        return {
+            skills: await uninstallPackageForJson(name, context, options),
+            usedPackage: true,
+        };
+    }
+
+    if (isBundledSkillName(name)) {
+        const entry = await uninstallBundledSkillForJson(name, context, {
             includeNotInstalledAsFailure: true,
         });
-        if (entry !== undefined) {
-            skills.push(entry);
-        }
-        return buildReport(skills, [], requested);
+
+        return { skills: entry === undefined ? [] : [entry], usedPackage: false };
     }
 
     // Try local first so a local skill at <host>/skills/<name> is not
     // misclassified as an "unmanaged registry directory" by the registry
     // path (which only matches kind=registry metadata).
-    const localEntry = await uninstallLocalSkillForJson(
-        request.skillName,
-        request.agentName,
-        context,
-    );
+    const localEntry = await uninstallLocalSkillForJson(name, agentName, context);
 
     if (localEntry !== undefined) {
-        skills.push(localEntry);
-        return buildReport(skills, [], requested);
+        return { skills: [localEntry], usedPackage: false };
     }
 
-    const registryEntry = await uninstallRegistrySkillForJson(request.skillName, context);
+    const registryEntry = await uninstallRegistrySkillForJson(name, context);
 
     if (registryEntry.outcome === "removed" || registryEntry.outcome === "failed") {
-        skills.push(registryEntry.entry);
-        return buildReport(skills, [], requested);
+        return { skills: [registryEntry.entry], usedPackage: false };
     }
 
-    skills.push(buildNotInstalledSkillResult(request.skillName));
-    return buildReport(skills, [], requested);
+    // The name matches no installed skill; treat it as a package and remove
+    // every installed skill that belongs to it.
+    return {
+        skills: await uninstallPackageForJson(name, context, options),
+        usedPackage: true,
+    };
+}
+
+async function uninstallPackageForJson(
+    packageName: string,
+    context: CliExecutionContext,
+    options: { availableHosts: readonly ManagedSkillHost[]; settingsFilePath: string },
+): Promise<SkillResult[]> {
+    const skillNames = await findInstalledRegistrySkillNamesForPackage({
+        availableHosts: options.availableHosts,
+        packageName,
+        settingsFilePath: options.settingsFilePath,
+    });
+
+    if (skillNames.length === 0) {
+        return [buildNotInstalledSkillResult(packageName)];
+    }
+
+    const results: SkillResult[] = [];
+
+    for (const skillName of skillNames) {
+        const outcome = await uninstallRegistrySkillForJson(skillName, context);
+
+        results.push(outcome.outcome === "not-applicable"
+            ? buildNotInstalledSkillResult(skillName, "registry")
+            : outcome.entry);
+    }
+
+    return results;
 }
 
 function buildReport(
@@ -720,7 +800,7 @@ function buildNotInstalledSkillResult(
 function recordUninstallTelemetry(
     context: CliExecutionContext,
     report: UninstallReport,
-    options: { format: "json" | "text" },
+    options: { format: "json" | "text"; hasPackageTarget: boolean },
 ): void {
     const hasBundled = report.skills.some(skill => skill.kind === "bundled");
     const hasRegistry = report.skills.some(skill => skill.kind === "registry");
@@ -734,5 +814,6 @@ function recordUninstallTelemetry(
         has_bundled_skill: hasBundled,
         has_registry_skill: hasRegistry,
         has_local_skill: hasLocal,
+        has_package_target: options.hasPackageTarget,
     });
 }

--- a/src/application/commands/skills/uninstall.ts
+++ b/src/application/commands/skills/uninstall.ts
@@ -235,19 +235,37 @@ async function uninstallNameForJson(
         return { skills: entry === undefined ? [] : [entry], usedPackage: false };
     }
 
-    // Try local first so a local skill at <host>/skills/<name> is not
-    // misclassified as an "unmanaged registry directory" by the registry
+    // Remove the local skill first so a local skill at <host>/skills/<name> is
+    // not misclassified as an "unmanaged registry directory" by the registry
     // path (which only matches kind=registry metadata).
     const localEntry = await uninstallLocalSkillForJson(name, agentName, context);
+    const localRemoved = localEntry?.status === "removed";
 
-    if (localEntry !== undefined) {
+    // A local skill that could not be removed (ambiguous or failed) is the
+    // terminal outcome for this name: surface it as-is and skip the registry
+    // path, which would otherwise flag the still-present local directory.
+    if (localEntry !== undefined && !localRemoved) {
         return { skills: [localEntry], usedPackage: false };
     }
 
+    // Mirror the text path: a registry and a local skill that share a name are
+    // both removed. After a local removal, a registry-side failure (e.g. an
+    // unmanaged same-name directory on another host) does not fail the command,
+    // so only a successful registry removal is reported alongside the local one.
     const registryEntry = await uninstallRegistrySkillForJson(name, context);
+    const directSkills: SkillResult[] = [];
 
-    if (registryEntry.outcome === "removed" || registryEntry.outcome === "failed") {
-        return { skills: [registryEntry.entry], usedPackage: false };
+    if (localEntry !== undefined) {
+        directSkills.push(localEntry);
+    }
+    if (
+        registryEntry.outcome === "removed"
+        || (registryEntry.outcome === "failed" && !localRemoved)
+    ) {
+        directSkills.push(registryEntry.entry);
+    }
+    if (directSkills.length > 0) {
+        return { skills: directSkills, usedPackage: false };
     }
 
     // The name matches no installed skill; treat it as a package and remove

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -410,11 +410,12 @@ const commandTelemetryDecisions = {
             "format",
             "has_bundled_skill",
             "has_local_skill",
+            "has_package_target",
             "has_registry_skill",
             "removed_count_bucket",
             "skill_count_bucket",
         ],
-        reason: "Records JSON-output buckets and skill-kind flags; never records skill names or paths.",
+        reason: "Records JSON-output buckets, skill-kind flags, and whether any argument was resolved as a package; never records skill names, package names, or paths.",
     },
     "skills.update": {
         kind: "properties",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -174,7 +174,7 @@ export const enMessages = {
         "Update installed oo-managed published skills to the latest available version.",
     "commands.skills.update.summary": "Update oo-managed skills",
     "commands.skills.uninstall.description":
-        "Remove oo-managed skills from supported local skill directories.",
+        "Remove oo-managed skills from supported local skill directories. A package name removes every installed skill that belongs to it.",
     "commands.skills.uninstall.summary": "Remove a managed skill",
     "commands.skills.repair.description":
         "Force re-deploy one or more oo-managed skills from their trusted source into one or more agent skill directories.",
@@ -572,6 +572,8 @@ export const enMessages = {
         "Bundled skill {name} is managed by oo and cannot be updated with skills update. Use oo skills add {name} instead.",
     "errors.skills.update.packageNotInstalled":
         "No installed oo-managed skill belongs to package {packageName}.",
+    "errors.skills.uninstall.packageNotInstalled":
+        "No installed oo-managed skill belongs to {name}.",
     "errors.skills.nameConflict":
         "Skill name {name} is already used by a non-OOMOL skill at {path}.",
     "errors.skills.storageConflict":
@@ -1011,6 +1013,7 @@ export const enMessages = {
     "arguments.packageName": "Package name(s) to install",
     "arguments.skills.update.packageName": "Package name(s) to update; updates every installed skill of each package",
     "arguments.skills.checkUpdate.packageName": "Package name(s) to check; checks every installed skill of each package",
+    "arguments.skills.uninstall.name": "Skill or package name(s) to remove; a package name removes every installed skill that belongs to it",
     "arguments.serviceName": "Service name",
     "arguments.shell": "Target shell",
     "arguments.skill": "Skill name",
@@ -1241,7 +1244,7 @@ export const zhMessages = {
     "commands.skills.update.description":
         "将已安装且由 oo 管理的已发布 skill 更新到最新可用版本。",
     "commands.skills.update.summary": "更新由 oo 管理的 skill",
-    "commands.skills.uninstall.description": "从受支持的本地 skill 目录移除由 oo 管理的 skill。",
+    "commands.skills.uninstall.description": "从受支持的本地 skill 目录移除由 oo 管理的 skill。传入包名会移除该包已安装的全部 skill。",
     "commands.skills.uninstall.summary": "移除一个受管理的 skill",
     "commands.skills.repair.description":
         "从可信 source 强制将一个或多个由 oo 管理的 skill 重新部署到一个或多个 Agent 的 skill 目录。",
@@ -1625,6 +1628,8 @@ export const zhMessages = {
         "内置 skill {name} 由 oo 管理，不能通过 skills update 更新。请改用 oo skills add {name}。",
     "errors.skills.update.packageNotInstalled":
         "没有任何已安装的 oo 管理 skill 属于包 {packageName}。",
+    "errors.skills.uninstall.packageNotInstalled":
+        "没有任何已安装的 oo 管理 skill 属于 {name}。",
     "errors.skills.nameConflict":
         "Skill 名称 {name} 已被 {path} 中的非 OOMOL skill 占用。",
     "errors.skills.storageConflict":
@@ -2056,6 +2061,7 @@ export const zhMessages = {
     "arguments.packageName": "要安装的包名（可指定多个）",
     "arguments.skills.update.packageName": "要更新的包名（可指定多个）；会更新每个包已安装的全部 skill",
     "arguments.skills.checkUpdate.packageName": "要检查的包名（可指定多个）；会检查每个包已安装的全部 skill",
+    "arguments.skills.uninstall.name": "要移除的 skill 或包名（可指定多个）；传入包名会移除该包已安装的全部 skill",
     "arguments.serviceName": "服务名",
     "arguments.shell": "目标 shell",
     "arguments.skill": "skill 名称",


### PR DESCRIPTION
`oo skills remove/uninstall` now accepts multiple names and treats a name as a package when no skill is installed under it, removing every installed registry skill that belongs to that package. A name that is a scoped package identity (starts with "@" and contains "/") is always treated as a package.

Package matching reads each installed skill's recorded package identity, so a skill installed from a different package is never removed even when another package publishes a same-name skill.

Adds the has_package_target telemetry dimension, the packageNotInstalled message, and updates the command docs.