### PR TITLE
fix(skills): drop unsupported -y flag from install docs

### DIFF
--- a/contrib/skills/shared/oo-find-skills/SKILL.md
+++ b/contrib/skills/shared/oo-find-skills/SKILL.md
@@ -180,20 +180,20 @@ Install examples:
 - Single skill install:
 
 ```bash
-oo skills install "<packageName>" -s "<skillName>" -y
+oo skills install "<packageName>" -s "<skillName>"
 ```
 
 - Two skills from the same package:
 
 ```bash
-oo skills install "<packageName>" -s "<skillName1>" -s "<skillName2>" -y
+oo skills install "<packageName>" -s "<skillName1>" -s "<skillName2>"
 ```
 
 - Two skills from different packages:
 
 ```bash
-oo skills install "<packageName1>" -s "<skillName1>" -y
-oo skills install "<packageName2>" -s "<skillName2>" -y
+oo skills install "<packageName1>" -s "<skillName1>"
+oo skills install "<packageName2>" -s "<skillName2>"
 ```
 
 11. Use each search result's `name` field as the `-s` value. Use

--- a/contrib/skills/shared/oo-find-skills/references/oo-cli-contract.md
+++ b/contrib/skills/shared/oo-find-skills/references/oo-cli-contract.md
@@ -34,11 +34,11 @@ Facts:
 Canonical forms:
 
 ```bash
-oo skills install <packageName> -s "<skillName>" -y
+oo skills install <packageName> -s "<skillName>"
 ```
 
 ```bash
-oo skills install <packageName> -s "<skillName1>" -s "<skillName2>" -y
+oo skills install <packageName> -s "<skillName1>" -s "<skillName2>"
 ```
 
 Facts:

--- a/contrib/skills/shared/oo-publish-skill/SKILL.md
+++ b/contrib/skills/shared/oo-publish-skill/SKILL.md
@@ -37,7 +37,7 @@ Match the user's language when generating the prompt: use
 meant for recipients to follow a language-specific general install preparation
 guide before running the final install command. It should include the package
 name, skill name when applicable, Hub URL, the general install preparation URL,
-and the exact `oo skills install ... -y` command. In the final response, put the
+and the exact `oo skills install ...` command. In the final response, put the
 complete recipient-facing share prompt in one copyable `text` code block. Do not
 use nested fenced code blocks inside it. Do not split the hub URL, guide URL, or
 install command outside the block.

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -976,7 +976,7 @@ describe("embedded skill assets", () => {
             expect(content).toContain("general install preparation");
             expect(content).toContain("guide before running the final install command");
             expect(content).toContain("general install preparation URL");
-            expect(content).toContain("exact `oo skills install ... -y` command");
+            expect(content).toContain("exact `oo skills install ...` command");
             expect(content).toContain("existing AI agent skill");
             expect(content).toContain("it does not need to be an oo-specific skill");
             expect(content).toContain("oo skills publish");
@@ -994,6 +994,37 @@ describe("embedded skill assets", () => {
             expect(content).not.toContain("oo skills preflight");
             expect(content).not.toContain("oo skills publish <skill-id> --agent");
             expect(content).not.toContain("Use `--agent` only as a source hint");
+        }
+    });
+
+    test("keeps removed oo skills install confirmation flags out of bundled skill docs", async () => {
+        // `oo skills install` never exposes `-y`/`--yes`. Guard every rendered
+        // bundled skill asset so agent-facing docs cannot drift back to the dead
+        // syntax that makes agents confidently run a command that errors with
+        // `Unknown option: -y`. The check is position-aware so prose that warns
+        // against the flag (e.g. "Never append `-y` ... to `oo skills install`")
+        // is not mistaken for a command that appends it.
+        const forbiddenInstallFlags = [" -y", " --yes"];
+        for (const skillName of availableBundledSkillNames) {
+            for (const agentName of availableBundledSkillAgentNames) {
+                for (const file of getBundledSkillFiles(skillName, agentName)) {
+                    const content = normalizeLineEndingsForAssertion(
+                        await readBundledSkillFileContent(file),
+                    );
+                    for (const line of content.split("\n")) {
+                        const installIndex = line.indexOf("oo skills install");
+                        if (installIndex === -1) {
+                            continue;
+                        }
+                        for (const flag of forbiddenInstallFlags) {
+                            expect(
+                                line.indexOf(flag, installIndex),
+                                `${skillName}/${agentName}/${file.relativePath} appends '${flag.trim()}' to 'oo skills install': ${line.trim()}`,
+                            ).toBe(-1);
+                        }
+                    }
+                }
+            }
         }
     });
 


### PR DESCRIPTION
The `oo skills install` command never exposed a `-y`/`--yes` confirmation flag, but several bundled skill assets appended it to the canonical install commands. Agents following those docs would confidently run a command that errors with `Unknown option: -y`.

Remove the dead flag from oo-find-skills and oo-publish-skill markdown, and add a position-aware test guard so agent-facing docs cannot drift back to the unsupported syntax. The guard is aware of flag position so prose warning against the flag is not mistaken for a command that appends it.

fixed: #268