### PR TITLE
refactor: remove unused exports, helpers, and dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "oo",
       "dependencies": {
-        "@clack/core": "0.5.0",
         "@wopjs/cast": "^0.1.16",
         "agentic-markdown": "^0.0.4",
         "ajv": "^8.18.0",
@@ -23,7 +22,6 @@
         "@types/bun": "latest",
         "eslint": "^10.0.3",
         "eslint-plugin-format": "^2.0.1",
-        "pino-pretty": "^13.1.3",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -43,7 +41,7 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
+    "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
 
     "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
 
@@ -239,8 +237,6 @@
 
     "clean-regexp": ["clean-regexp@1.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw=="],
 
-    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
-
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "comment-parser": ["comment-parser@1.4.5", "", {}, "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw=="],
@@ -252,8 +248,6 @@
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
-
-    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -270,8 +264,6 @@
     "electron-to-chromium": ["electron-to-chromium@1.5.321", "", {}, "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ=="],
 
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
-
-    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
@@ -357,8 +349,6 @@
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
-    "fast-copy": ["fast-copy@4.0.2", "", {}, "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="],
-
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-diff": ["fast-diff@1.3.0", "", {}, "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="],
@@ -366,8 +356,6 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
-
-    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
@@ -401,8 +389,6 @@
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
 
-    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
-
     "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
@@ -420,8 +406,6 @@
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
-    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
@@ -539,8 +523,6 @@
 
     "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
-    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
-
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
 
     "module-replacements": ["module-replacements@2.11.0", "", {}, "sha512-j5sNQm3VCpQQ7nTqGeOZtoJtV3uKERgCBm9QRhmGRiXiqkf7iRFOkfxdJRZWLkqYY8PNf4cDQF/WfXUYLENrRA=="],
@@ -562,8 +544,6 @@
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -595,8 +575,6 @@
 
     "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 
-    "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
-
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
@@ -616,8 +594,6 @@
     "prettier-linter-helpers": ["prettier-linter-helpers@1.0.1", "", { "dependencies": { "fast-diff": "^1.1.2" } }, "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg=="],
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
-
-    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -647,8 +623,6 @@
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
-    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
-
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
@@ -676,8 +650,6 @@
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
     "strip-indent": ["strip-indent@4.1.1", "", {}, "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA=="],
-
-    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
     "synckit": ["synckit@0.11.12", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ=="],
 
@@ -727,8 +699,6 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
     "xml-name-validator": ["xml-name-validator@4.0.0", "", {}, "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
@@ -740,8 +710,6 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
-
-    "@clack/prompts/@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@clack/core": "0.5.0",
     "@wopjs/cast": "^0.1.16",
     "agentic-markdown": "^0.0.4",
     "ajv": "^8.18.0",
@@ -59,7 +58,6 @@
     "@antfu/eslint-config": "^7.7.3",
     "@types/bun": "latest",
     "eslint": "^10.0.3",
-    "eslint-plugin-format": "^2.0.1",
-    "pino-pretty": "^13.1.3"
+    "eslint-plugin-format": "^2.0.1"
   }
 }

--- a/src/adapters/store/sqlite-file-upload-store.test.ts
+++ b/src/adapters/store/sqlite-file-upload-store.test.ts
@@ -6,7 +6,6 @@ import { describe, expect, test } from "bun:test";
 import { createTemporaryDirectory } from "../../../__tests__/helpers.ts";
 import { APP_NAME } from "../../application/config/app-config.ts";
 import {
-    readFileUploadStatus,
     SqliteFileUploadStore,
     uploadedFilesTableName,
 } from "./sqlite-file-upload-store.ts";
@@ -209,12 +208,5 @@ describe("SqliteFileUploadStore", () => {
         finally {
             store.close();
         }
-    });
-});
-
-describe("readFileUploadStatus", () => {
-    test("marks records as expired when the expiry time has passed", () => {
-        expect(readFileUploadStatus(1_000, 1_000)).toBe("expired");
-        expect(readFileUploadStatus(1_001, 1_000)).toBe("active");
     });
 });

--- a/src/adapters/store/sqlite-file-upload-store.ts
+++ b/src/adapters/store/sqlite-file-upload-store.ts
@@ -5,7 +5,6 @@ import type {
     FileUploadListOptions,
     FileUploadRecord,
     FileUploadRecordStore,
-    FileUploadStatus,
 } from "../../application/contracts/file-upload-store.ts";
 import { withStorePath } from "../../application/logging/log-fields.ts";
 import { validateMillisecondTimestamp } from "../../application/shared/timestamps.ts";
@@ -190,13 +189,6 @@ export class SqliteFileUploadStore implements FileUploadRecordStore {
 
         return this.database;
     }
-}
-
-export function readFileUploadStatus(
-    expiresAtMs: number,
-    now: number,
-): FileUploadStatus {
-    return expiresAtMs <= now ? "expired" : "active";
 }
 
 function ensureUploadTable(database: Database): void {

--- a/src/application/commands/config/shared.ts
+++ b/src/application/commands/config/shared.ts
@@ -22,7 +22,6 @@ interface ConfigDefinition {
     getValue: (settings: AppSettings) => string | undefined;
     parseRawValue: (rawValue: string) => ParsedConfigValue | undefined;
     unsetValue: (settings: AppSettings) => AppSettings;
-    valueChoices: readonly string[];
 }
 
 function createValueErrorFactory(translationKey: string) {
@@ -64,7 +63,6 @@ export const configDefinitions = {
 
             return nextSettings;
         },
-        valueChoices: localeSchema.options,
     } satisfies ConfigDefinition,
     [fileDownloadOutDirConfigKey]: {
         createInvalidValueError: createValueErrorFactory("errors.config.invalidFileDownloadOutDirValue"),
@@ -86,7 +84,6 @@ export const configDefinitions = {
         unsetValue(settings: AppSettings): AppSettings {
             return unsetFileDownloadOutDir(settings);
         },
-        valueChoices: [],
     } satisfies ConfigDefinition,
     [telemetryEnabledConfigKey]: {
         createInvalidValueError: createValueErrorFactory("errors.config.invalidTelemetryEnabledValue"),
@@ -114,7 +111,6 @@ export const configDefinitions = {
         unsetValue(settings: AppSettings): AppSettings {
             return unsetTelemetryEnabled(settings);
         },
-        valueChoices: ["true", "false"],
     } satisfies ConfigDefinition,
 } as const;
 

--- a/src/application/commands/connector/search-provider.ts
+++ b/src/application/commands/connector/search-provider.ts
@@ -75,7 +75,6 @@ export function formatConnectorSearchResultAsText(
     context: ConnectorSearchTextContext,
     options: {
         colors?: TerminalColors;
-        extraLinesAfterDescription?: readonly string[];
     } = {},
 ): string {
     const colors = options.colors ?? createWriterColors(context.stdout);
@@ -85,10 +84,6 @@ export function formatConnectorSearchResultAsText(
 
     if (result.description !== "") {
         lines.push(result.description);
-    }
-
-    if (options.extraLinesAfterDescription !== undefined) {
-        lines.push(...options.extraLinesAfterDescription);
     }
 
     lines.push(

--- a/src/application/commands/file/download/file-system.test.ts
+++ b/src/application/commands/file/download/file-system.test.ts
@@ -17,33 +17,10 @@ import {
     deleteDownloadSessionArtifacts,
     finalizeDownloadedFile,
     openTemporaryDownloadFile,
-    resolveAvailableFileName,
     resolveTemporaryDownloadFileName,
     writeDownloadToTemporaryFile,
 } from "./file-system.ts";
 import { createDownloadProgressReporter } from "./progress.ts";
-
-describe("resolveAvailableFileName", () => {
-    test("appends a numeric suffix when the target name already exists", async () => {
-        const directoryPath = await createTemporaryDirectory("download-file-name");
-
-        try {
-            await Bun.write(join(directoryPath, "report.txt"), "existing");
-            await Bun.write(join(directoryPath, "report_1.txt"), "existing");
-
-            const fileName = await resolveAvailableFileName(
-                directoryPath,
-                "report",
-                "txt",
-            );
-
-            expect(fileName).toBe("report_2.txt");
-        }
-        finally {
-            await rm(directoryPath, { force: true, recursive: true });
-        }
-    });
-});
 
 describe("resolveTemporaryDownloadFileName", () => {
     test("skips reserved and existing temporary file names", async () => {

--- a/src/application/commands/file/download/file-system.ts
+++ b/src/application/commands/file/download/file-system.ts
@@ -29,22 +29,6 @@ export async function deleteDownloadSessionArtifacts(
     }).catch(() => undefined);
 }
 
-export async function resolveAvailableFileName(
-    directoryPath: string,
-    baseName: string,
-    extension?: string,
-): Promise<string> {
-    for (let index = 0; ; index += 1) {
-        const candidateBaseName = appendNumericSuffix(baseName, index);
-        const candidateFileName = buildFileName(candidateBaseName, extension);
-        const candidatePath = join(directoryPath, candidateFileName);
-
-        if (!(await pathExists(candidatePath, lstat))) {
-            return candidateFileName;
-        }
-    }
-}
-
 export async function resolveTemporaryDownloadFileName(
     directoryPath: string,
     finalBaseName: string,

--- a/src/application/commands/shared/json-input.ts
+++ b/src/application/commands/shared/json-input.ts
@@ -3,7 +3,6 @@ import type { CliExecutionContext } from "../../contracts/cli.ts";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { CliUserError } from "../../contracts/cli.ts";
-import { isPlainObject } from "./schema-utils.ts";
 
 interface JsonInputErrorKeys {
     dataFilePathRequired: string;
@@ -36,17 +35,6 @@ export async function readJsonInputValue(
             message: error instanceof Error ? error.message : String(error),
         });
     }
-}
-
-export function requireJsonObjectInput(
-    value: unknown,
-    errorKey: string,
-): Record<string, unknown> {
-    if (!isPlainObject(value)) {
-        throw new CliUserError(errorKey, 2);
-    }
-
-    return value;
 }
 
 async function readJsonInputFile(

--- a/src/application/commands/skills/bundled-skill-observation.test.ts
+++ b/src/application/commands/skills/bundled-skill-observation.test.ts
@@ -10,13 +10,11 @@ import {
     fileExists,
     isManagedBundledSkillInstallation,
     readInstalledBundledSkillMetadata,
-    requireBundledSkillHomeDirectory,
     writeInstalledBundledSkillMetadata,
 } from "./bundled-skill-observation.ts";
 import {
     readManagedSkillAgent,
     resolveManagedSkillAgentHomeDirectory,
-    supportedSkillAgents,
 } from "./managed-skill-agents.ts";
 import {
     createBundledSkillMetadata,
@@ -93,38 +91,6 @@ describe("bundled skill observation", () => {
         }
         finally {
             await rm(rootDirectory, { force: true, recursive: true });
-        }
-    });
-
-    test("requires resolved agent home directories to exist", async () => {
-        for (const agent of supportedSkillAgents) {
-            const rootDirectory = await createTemporaryDirectory("oo-bundled-skill");
-            const homeDirectory = join(rootDirectory, agent.homeDirectoryName);
-            const env = {
-                HOME: rootDirectory,
-            };
-
-            try {
-                await expect(
-                    requireBundledSkillHomeDirectory({ env }, agent.name),
-                ).rejects.toMatchObject({
-                    exitCode: 1,
-                    key: "errors.skills.agentNotInstalled",
-                    params: {
-                        agentName: agent.title,
-                        path: homeDirectory,
-                    },
-                });
-
-                await mkdir(homeDirectory, { recursive: true });
-
-                expect(await requireBundledSkillHomeDirectory({ env }, agent.name)).toBe(
-                    homeDirectory,
-                );
-            }
-            finally {
-                await rm(rootDirectory, { force: true, recursive: true });
-            }
         }
     });
 

--- a/src/application/commands/skills/bundled-skill-observation.ts
+++ b/src/application/commands/skills/bundled-skill-observation.ts
@@ -1,4 +1,3 @@
-import type { BundledSkillAgentName } from "./embedded-assets.ts";
 import type { BundledSkillMetadata } from "./skill-metadata.ts";
 
 import { readFile, stat } from "node:fs/promises";
@@ -9,30 +8,11 @@ import {
 import {
     resolveBundledSkillMetadataFilePath,
 } from "./bundled-skill-paths.ts";
-import {
-    createManagedSkillAgentNotInstalledError,
-    resolveManagedSkillAgentHomeDirectory,
-} from "./managed-skill-agents.ts";
+
 import {
     createBundledSkillMetadata,
     renderSkillMetadataJson,
 } from "./skill-metadata.ts";
-
-export async function requireBundledSkillHomeDirectory(
-    context: Pick<{ env: Record<string, string | undefined> }, "env">,
-    agentName: BundledSkillAgentName,
-): Promise<string> {
-    const homeDirectory = resolveManagedSkillAgentHomeDirectory(
-        context.env,
-        agentName,
-    );
-
-    if (!(await directoryExists(homeDirectory))) {
-        throw createManagedSkillAgentNotInstalledError(agentName, homeDirectory);
-    }
-
-    return homeDirectory;
-}
 
 export async function directoryExists(path: string): Promise<boolean> {
     try {

--- a/src/application/commands/skills/list.test.ts
+++ b/src/application/commands/skills/list.test.ts
@@ -4,10 +4,7 @@ import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import { createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
-import {
-    listLocalSkillInstallations,
-    listManagedSkillInstallations,
-} from "./managed-skill-listings.ts";
+import { listManagedSkillInstallations } from "./managed-skill-listings.ts";
 import {
     createBundledSkillMetadata,
     createRegistrySkillMetadata,
@@ -155,82 +152,6 @@ describe("skills list command helpers", () => {
         }
     });
 
-    test("lists valid local skill directories by name", async () => {
-        const rootDirectory = await createTemporaryDirectory("oo-local-skills-list");
-        const localSkillsDirectoryPath = join(rootDirectory, "skills");
-        const alphaSkillDirectoryPath = join(localSkillsDirectoryPath, "alpha-skill");
-        const betaSkillDirectoryPath = join(localSkillsDirectoryPath, "beta-skill");
-        const mismatchSkillDirectoryPath = join(
-            localSkillsDirectoryPath,
-            "mismatch-skill",
-        );
-        const missingSkillDirectoryPath = join(localSkillsDirectoryPath, "missing-skill");
-
-        try {
-            await mkdir(alphaSkillDirectoryPath, { recursive: true });
-            await mkdir(betaSkillDirectoryPath, { recursive: true });
-            await mkdir(mismatchSkillDirectoryPath, { recursive: true });
-            await mkdir(missingSkillDirectoryPath, { recursive: true });
-
-            await writeSkillFile(
-                alphaSkillDirectoryPath,
-                [
-                    "---",
-                    "name: alpha-skill",
-                    "description: Use an alpha workflow.",
-                    "---",
-                    "",
-                ].join("\n"),
-            );
-            await writeSkillFile(
-                betaSkillDirectoryPath,
-                [
-                    "---",
-                    "name: beta-skill",
-                    "description: Use a beta workflow.",
-                    "metadata:",
-                    "  icon: ':lucide:wrench:'",
-                    "  packageName: '@alice/beta-skill'",
-                    "  version: '1.2.3'",
-                    "---",
-                    "",
-                ].join("\n"),
-            );
-            await writeSkillFile(
-                mismatchSkillDirectoryPath,
-                [
-                    "---",
-                    "name: other-skill",
-                    "description: Use another workflow.",
-                    "---",
-                    "",
-                ].join("\n"),
-            );
-
-            await expect(
-                listLocalSkillInstallations(localSkillsDirectoryPath),
-            ).resolves.toEqual([
-                {
-                    metadata: undefined,
-                    name: "alpha-skill",
-                    path: alphaSkillDirectoryPath,
-                },
-                {
-                    metadata: {
-                        icon: ":lucide:wrench:",
-                        packageName: "@alice/beta-skill",
-                        version: "1.2.3",
-                    },
-                    name: "beta-skill",
-                    path: betaSkillDirectoryPath,
-                },
-            ]);
-        }
-        finally {
-            await rm(rootDirectory, { force: true, recursive: true });
-        }
-    });
-
     test("returns an empty list when the skills directory is missing", async () => {
         const rootDirectory = await createTemporaryDirectory("oo-skills-list");
 
@@ -244,10 +165,3 @@ describe("skills list command helpers", () => {
         }
     });
 });
-
-async function writeSkillFile(
-    skillDirectoryPath: string,
-    content: string,
-): Promise<void> {
-    await Bun.write(join(skillDirectoryPath, "SKILL.md"), content);
-}

--- a/src/application/commands/skills/local-skill-ownership.ts
+++ b/src/application/commands/skills/local-skill-ownership.ts
@@ -3,7 +3,6 @@ import type {
     SkillMetadata,
 } from "./skill-metadata.ts";
 
-import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 
@@ -29,34 +28,6 @@ export async function readSkillFileContent(
 
         throw error;
     }
-}
-
-export async function hasMatchingSkillFileContent(options: {
-    expectedContent: string;
-    skillDirectoryPath: string;
-}): Promise<boolean> {
-    return await readSkillFileContent(options.skillDirectoryPath)
-        === options.expectedContent;
-}
-
-export async function readSkillFileHash(
-    skillDirectoryPath: string,
-): Promise<string | undefined> {
-    const content = await readSkillFileContent(skillDirectoryPath);
-
-    if (content === undefined) {
-        return undefined;
-    }
-
-    return createHash("sha256").update(content).digest("hex");
-}
-
-export async function hasMatchingSkillFileHash(options: {
-    expectedHash: string;
-    skillDirectoryPath: string;
-}): Promise<boolean> {
-    return await readSkillFileHash(options.skillDirectoryPath)
-        === options.expectedHash;
 }
 
 export async function readSkillMetadataFileState(

--- a/src/application/commands/skills/local-skill-source.ts
+++ b/src/application/commands/skills/local-skill-source.ts
@@ -35,20 +35,6 @@ export async function findLocalSkillSources(options: {
     return sources.filter(source => source.name === options.skillName);
 }
 
-export async function findLocalSkillSource(options: {
-    agentName?: BundledSkillAgentName;
-    context: LocalSkillSourceContext;
-    skillName: string;
-}): Promise<LocalSkillSource | undefined> {
-    const sources = await findLocalSkillSources(options);
-
-    if (sources.length === 1) {
-        return sources[0];
-    }
-
-    return undefined;
-}
-
 export async function listLocalSkillSources(
     context: LocalSkillSourceContext,
     options: {

--- a/src/application/commands/skills/managed-skill-listings.ts
+++ b/src/application/commands/skills/managed-skill-listings.ts
@@ -1,8 +1,6 @@
 import type { BundledSkillAgentName } from "./embedded-assets.ts";
 import type { ManagedSkillHost } from "./managed-skill-hosts.ts";
-import type { SkillMarkdownMatter } from "./skill-frontmatter.ts";
 import type {
-    RegistrySkillMetadata,
     SkillMetadata,
 } from "./skill-metadata.ts";
 import { readdir, readFile } from "node:fs/promises";
@@ -11,7 +9,6 @@ import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
 import {
     availableBundledSkillNames,
 } from "./embedded-assets.ts";
-import { listLocalSkillSources } from "./local-skill-source.ts";
 import {
     compareManagedSkillAgentNames,
 } from "./managed-skill-agents.ts";
@@ -20,12 +17,7 @@ import {
     resolveManagedSkillsDirectoryPath,
 } from "./managed-skill-paths.ts";
 import { isBundledSkillName } from "./shared.ts";
-import {
-    hasFrontmatter,
-    isSkillFrontmatterRecord,
-    parseSkillMarkdownMatter,
-    toNonBlankString,
-} from "./skill-frontmatter.ts";
+
 import { parseSkillMetadataContent } from "./skill-metadata.ts";
 
 export const skillListSourceValues = ["bundled", "registry", "local"] as const;
@@ -40,13 +32,6 @@ export interface ManagedSkillListItem {
 
 export interface ManagedSkillHostListItem extends ManagedSkillListItem {
     hostName: BundledSkillAgentName;
-}
-
-export interface LocalSkillListItem {
-    hostName?: BundledSkillAgentName;
-    metadata?: SkillListDisplayMetadata;
-    name: string;
-    path: string;
 }
 
 export interface SkillListDisplayMetadata {
@@ -125,42 +110,6 @@ export async function listManagedSkillInstallations(
         .sort(compareManagedSkillListItems);
 }
 
-export async function listLocalSkillInstallations(
-    localSkillsDirectoryPath: string,
-): Promise<LocalSkillListItem[]> {
-    const entries = await readSkillsDirectoryEntries(localSkillsDirectoryPath);
-    const skills = await Promise.all(
-        entries.map(entryName =>
-            readLocalSkillListItem(localSkillsDirectoryPath, entryName),
-        ),
-    );
-
-    return skills
-        .filter(skill => skill !== undefined)
-        .sort(compareLocalSkillListItems);
-}
-
-export async function listLocalSkillInstallationsForContext(
-    context: {
-        env: Record<string, string | undefined>;
-    },
-    options: {
-        agentName?: BundledSkillAgentName;
-    } = {},
-): Promise<LocalSkillListItem[]> {
-    const sources = await listLocalSkillSources(context, options);
-    const skills = await Promise.all(
-        sources.map(source => readLocalSkillListItemFromPath(source.path, {
-            hostName: source.agentName,
-            name: source.name,
-        })),
-    );
-
-    return skills
-        .filter(skill => skill !== undefined)
-        .sort(compareLocalSkillListItems);
-}
-
 export function readManagedSkillListSource(
     skill: Pick<ManagedSkillListItem, "metadata" | "name">,
 ): SkillListSource {
@@ -177,39 +126,6 @@ export function readManagedSkillListSource(
     }
 
     return isBundledSkillName(skill.name) ? "bundled" : "registry";
-}
-
-export function createSkillListDisplayMetadata(
-    metadata: SkillMetadata | undefined,
-): SkillListDisplayMetadata | undefined {
-    if (metadata === undefined) {
-        return undefined;
-    }
-
-    switch (metadata.kind) {
-        case "bundled":
-            return {
-                kind: metadata.kind,
-                version: metadata.version,
-            };
-        case "local":
-            return {
-                kind: metadata.kind,
-            };
-        case "registry":
-            return createRegistrySkillListDisplayMetadata(metadata);
-    }
-}
-
-function createRegistrySkillListDisplayMetadata(
-    metadata: RegistrySkillMetadata,
-): SkillListDisplayMetadata {
-    return {
-        ...(metadata.icon === undefined ? {} : { icon: metadata.icon }),
-        kind: metadata.kind,
-        packageName: metadata.packageName,
-        version: metadata.version,
-    };
 }
 
 export async function readSkillsDirectoryEntries(
@@ -229,98 +145,6 @@ export async function readSkillsDirectoryEntries(
 
         throw error;
     }
-}
-
-async function readLocalSkillListItem(
-    localSkillsDirectoryPath: string,
-    entryName: string,
-): Promise<LocalSkillListItem | undefined> {
-    return await readLocalSkillListItemFromPath(
-        join(localSkillsDirectoryPath, entryName),
-        { name: entryName },
-    );
-}
-
-async function readLocalSkillListItemFromPath(
-    skillDirectoryPath: string,
-    options: {
-        hostName?: BundledSkillAgentName;
-        name: string;
-    },
-): Promise<LocalSkillListItem | undefined> {
-    let content: string;
-
-    try {
-        content = await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8");
-    }
-    catch (error) {
-        if (isNodeNotFoundError(error)) {
-            return undefined;
-        }
-
-        throw error;
-    }
-
-    const parsed = parseLocalSkillListItem(content, options.name);
-
-    if (parsed === undefined) {
-        return undefined;
-    }
-
-    return {
-        hostName: options.hostName,
-        metadata: parsed.metadata,
-        name: options.name,
-        path: skillDirectoryPath,
-    };
-}
-
-function parseLocalSkillListItem(
-    content: string,
-    skillName: string,
-): Pick<LocalSkillListItem, "metadata"> | undefined {
-    let parsed: SkillMarkdownMatter;
-
-    try {
-        parsed = parseSkillMarkdownMatter(content);
-    }
-    catch {
-        return undefined;
-    }
-
-    if (!hasFrontmatter(content) || !isSkillFrontmatterRecord(parsed.data)) {
-        return undefined;
-    }
-
-    const frontmatterName = toNonBlankString(parsed.data.name);
-    const description = toNonBlankString(parsed.data.description);
-
-    if (frontmatterName !== skillName || description === undefined) {
-        return undefined;
-    }
-
-    const metadata = parsed.data.metadata;
-
-    if (metadata !== undefined && !isSkillFrontmatterRecord(metadata)) {
-        return undefined;
-    }
-
-    const version = toNonBlankString(metadata?.version);
-
-    if (version === undefined) {
-        return {};
-    }
-
-    const icon = toNonBlankString(metadata?.icon);
-    const packageName = toNonBlankString(metadata?.packageName);
-
-    return {
-        metadata: {
-            ...(icon === undefined ? {} : { icon }),
-            ...(packageName === undefined ? {} : { packageName }),
-            version,
-        },
-    };
 }
 
 function compareManagedSkillListItems(
@@ -357,19 +181,6 @@ function readBundledSkillNameOrder(
     }
 
     return availableBundledSkillNames.indexOf(skill.name);
-}
-
-function compareLocalSkillListItems(
-    left: LocalSkillListItem,
-    right: LocalSkillListItem,
-): number {
-    const nameDifference = left.name.localeCompare(right.name);
-
-    if (nameDifference !== 0) {
-        return nameDifference;
-    }
-
-    return (left.hostName ?? "").localeCompare(right.hostName ?? "");
 }
 
 function compareManagedSkillHostListItems(

--- a/src/application/commands/skills/skill-metadata.test.ts
+++ b/src/application/commands/skills/skill-metadata.test.ts
@@ -5,7 +5,6 @@ import {
     createLocalSkillMetadata,
     createRegistrySkillMetadata,
     parseSkillMetadataContent,
-    parseSkillMetadataWithVersion,
     renderSkillMetadataJson,
 } from "./skill-metadata.ts";
 
@@ -54,23 +53,6 @@ describe("skill metadata", () => {
             packageName: "@foo/bar",
             schemaVersion: 1,
         }))).toBeUndefined();
-    });
-
-    test("parses metadata when version is present and trims surrounding whitespace", () => {
-        expect(parseSkillMetadataWithVersion("{\"version\":\" 1.2.3 \"}\n")).toEqual({
-            fields: {
-                version: " 1.2.3 ",
-            },
-            version: "1.2.3",
-        });
-    });
-
-    test("rejects metadata without a non-empty string version", () => {
-        expect(parseSkillMetadataWithVersion("not json")).toBeUndefined();
-        expect(parseSkillMetadataWithVersion("[]")).toBeUndefined();
-        expect(parseSkillMetadataWithVersion("{}")).toBeUndefined();
-        expect(parseSkillMetadataWithVersion("{\"version\":1}")).toBeUndefined();
-        expect(parseSkillMetadataWithVersion("{\"version\":\"\"}")).toBeUndefined();
     });
 
     test("renders metadata as formatted JSON with a trailing newline", () => {

--- a/src/application/commands/skills/skill-metadata.ts
+++ b/src/application/commands/skills/skill-metadata.ts
@@ -26,11 +26,6 @@ export type SkillMetadata
         | LocalSkillMetadata
         | RegistrySkillMetadata;
 
-export interface ParsedSkillMetadataWithVersion {
-    fields: Readonly<Record<string, unknown>>;
-    version: string;
-}
-
 export function createBundledSkillMetadata(
     version: string,
 ): BundledSkillMetadata {
@@ -80,27 +75,6 @@ export function parseSkillMetadataContent(
     // TODO: Remove legacy untyped metadata parsing after existing installs have migrated.
     return parseRegistrySkillMetadataFields(fields)
         ?? parseLegacyBundledSkillMetadata(fields);
-}
-
-export function parseSkillMetadataWithVersion(
-    content: string,
-): ParsedSkillMetadataWithVersion | undefined {
-    const fields = parseSkillMetadataFields(content);
-
-    if (fields === undefined) {
-        return undefined;
-    }
-
-    const version = toNonBlankString(fields.version);
-
-    if (version === undefined) {
-        return undefined;
-    }
-
-    return {
-        fields,
-        version,
-    };
 }
 
 export function renderSkillMetadataJson(

--- a/src/application/display-width.test.ts
+++ b/src/application/display-width.test.ts
@@ -1,20 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-    measureDisplayWidth,
-    truncateDisplayWidth,
-} from "./display-width.ts";
+import { measureDisplayWidth } from "./display-width.ts";
 
 describe("display width", () => {
     test("measures ASCII and wide characters", () => {
         expect(measureDisplayWidth("abc")).toBe(3);
         expect(measureDisplayWidth("你好")).toBe(4);
         expect(measureDisplayWidth("a你b")).toBe(4);
-    });
-
-    test("truncates by visible width", () => {
-        expect(truncateDisplayWidth("hello world", 8)).toBe("hello...");
-        expect(truncateDisplayWidth("你好世界", 5)).toBe("你...");
-        expect(truncateDisplayWidth("abc", 2)).toBe("ab");
     });
 });

--- a/src/application/display-width.ts
+++ b/src/application/display-width.ts
@@ -1,15 +1,3 @@
-export function truncateDisplayWidth(value: string, maxWidth: number): string {
-    if (measureDisplayWidth(value) <= maxWidth) {
-        return value;
-    }
-
-    if (maxWidth <= 3) {
-        return sliceDisplayWidth(value, maxWidth);
-    }
-
-    return `${sliceDisplayWidth(value, maxWidth - 3)}...`;
-}
-
 export function measureDisplayWidth(value: string): number {
     let width = 0;
 
@@ -20,25 +8,6 @@ export function measureDisplayWidth(value: string): number {
     }
 
     return width;
-}
-
-function sliceDisplayWidth(value: string, maxWidth: number): string {
-    let result = "";
-    let width = 0;
-
-    for (const char of value) {
-        const codePoint = char.codePointAt(0)!;
-        const nextWidth = width + (isWideCodePoint(codePoint) ? 2 : 1);
-
-        if (nextWidth > maxWidth) {
-            break;
-        }
-
-        result += char;
-        width = nextWidth;
-    }
-
-    return result;
 }
 
 function isWideCodePoint(codePoint: number): boolean {


### PR DESCRIPTION
These functions, exported options, and npm packages were no longer referenced anywhere in the codebase. Removing the dead code reduces the maintenance surface and trims unused dependencies (@clack/core, pino-pretty) from the lockfile.