### PR TITLE
fix(install): redirect landing page to oomol.com root

### DIFF
--- a/contrib/cloudflare/oo-cli/deploy-install-worker.test.ts
+++ b/contrib/cloudflare/oo-cli/deploy-install-worker.test.ts
@@ -51,8 +51,8 @@ describe("install worker deployment", () => {
         const indexHtml = await readFile(indexHtmlPath, "utf8");
 
         expect(indexHtml).toContain("http-equiv=\"refresh\"");
-        expect(indexHtml).toContain("content=\"0; url=https://oomol.com/cli/\"");
-        expect(indexHtml).toContain("window.location.replace(\"https://oomol.com/cli/\")");
-        expect(indexHtml).toContain("<a href=\"https://oomol.com/cli/\">https://oomol.com/cli/</a>");
+        expect(indexHtml).toContain("content=\"0; url=https://oomol.com/\"");
+        expect(indexHtml).toContain("window.location.replace(\"https://oomol.com/\")");
+        expect(indexHtml).toContain("<a href=\"https://oomol.com/\">https://oomol.com/</a>");
     });
 });

--- a/contrib/install/index.html
+++ b/contrib/install/index.html
@@ -5,13 +5,13 @@
         <title>OO CLI</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="robots" content="noindex" />
-        <meta http-equiv="refresh" content="0; url=https://oomol.com/cli/" />
-        <link rel="canonical" href="https://oomol.com/cli/" />
+        <meta http-equiv="refresh" content="0; url=https://oomol.com/" />
+        <link rel="canonical" href="https://oomol.com/" />
         <script>
-            window.location.replace("https://oomol.com/cli/");
+            window.location.replace("https://oomol.com/");
         </script>
     </head>
     <body>
-        <p>Redirecting to <a href="https://oomol.com/cli/">https://oomol.com/cli/</a>.</p>
+        <p>Redirecting to <a href="https://oomol.com/">https://oomol.com/</a>.</p>
     </body>
 </html>


### PR DESCRIPTION
Point the install landing page at https://oomol.com/ instead of the /cli/ path, so visitors land on the site root. Update the redirect worker test assertions to match the new target URL.