### PR TITLE
feat(connector): add organization auth identity to run

### DIFF
--- a/contrib/skills/shared/oo/references/connector-execution.md
+++ b/contrib/skills/shared/oo/references/connector-execution.md
@@ -95,6 +95,35 @@ Facts:
 - The schema returned by `oo connector schema` is the public contract used to
   build payloads and inspect the action result shape.
 
+## Choose the run identity
+
+A connector action runs under one identity. Pick it from what the user said:
+
+- If the user does not mention any organization, run under their personal
+  identity: add nothing extra. This is the default.
+- If the user asks to run as a specific organization (for example "run this as
+  Acme" or "use my Acme org"), add `--organization "<name>"` (the `--org`
+  alias is equivalent), using the organization name the user gave:
+
+```bash
+oo connector run "<serviceName>" \
+  --action "<actionName>" \
+  --data '<json object>' \
+  --organization "<organizationName>" \
+  --json
+```
+
+- If the user has a configured default organization but explicitly asks for this
+  one run to be personal, add `--personal`.
+
+Facts:
+
+- `--organization` and `--personal` cannot be combined.
+- Do not guess an organization name. If the user is vague about which
+  organization to use, ask before running.
+- The action schema itself is identity-independent, so `oo connector schema`
+  never needs an organization argument.
+
 Expected execution JSON:
 
 ```json

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -216,7 +216,7 @@ List persisted configuration values that are currently set.
 Read one persisted configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported values:
-  `lang`, `file.download.out_dir`, `telemetry.enabled`.
+  `lang`, `file.download.out_dir`, `telemetry.enabled`, `identity.organization`.
 
 ### `oo config path`
 
@@ -227,7 +227,7 @@ Print the path to the persisted configuration file.
 Persist one configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported values:
-  `lang`, `file.download.out_dir`, `telemetry.enabled`.
+  `lang`, `file.download.out_dir`, `telemetry.enabled`, `identity.organization`.
 - Arguments: `<value>` is the value for the selected key.
 - Value rules: for `lang`, supported values are `en` and `zh`.
 - Value rules: for `file.download.out_dir`, use any non-empty path string. Relative
@@ -238,13 +238,16 @@ Persist one configuration value.
   are rejected. Setting `telemetry.enabled` to `false` also attempts to purge
   pending telemetry events immediately and the current `config set` invocation is
   not recorded as telemetry.
+- Value rules: for `identity.organization`, use any non-empty organization name.
+  It sets the default organization identity used by `oo connector run` when
+  neither `--organization` nor `--personal` is passed.
 
 ### `oo config unset <key>`
 
 Remove one persisted configuration value.
 
 - Arguments: `<key>` is the configuration key. Supported values:
-  `lang`, `file.download.out_dir`, `telemetry.enabled`.
+  `lang`, `file.download.out_dir`, `telemetry.enabled`, `identity.organization`.
 
 ## Telemetry
 
@@ -578,6 +581,14 @@ Validate input data and run one connector action.
 - Options: `--wait-result` submits an async submit action and then polls its
   configured result action. This option is only valid when the selected action
   schema declares an async submit lifecycle.
+- Options: `--organization <name>` runs the action under the given organization
+  identity instead of your personal identity. `--org <name>` is an alias for
+  `--organization <name>`. When omitted, the action runs under the
+  `identity.organization` config default if set, otherwise your personal
+  identity.
+- Options: `--personal` runs the action under your personal identity and
+  ignores any configured default organization. It cannot be combined with
+  `--organization`.
 - Options: `--format=json` and `--json` print a JSON object.
 - Output: non-dry-run JSON output mirrors the stable response shape
   `{ data, meta: { executionId } }`.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -192,7 +192,7 @@
 读取一个持久化配置值。
 
 - 参数：`<key>` 为配置键。目前支持
-  `lang`、`file.download.out_dir`、`telemetry.enabled`。
+  `lang`、`file.download.out_dir`、`telemetry.enabled`、`identity.organization`。
 
 ### `oo config path`
 
@@ -203,7 +203,7 @@
 写入一个持久化配置值。
 
 - 参数：`<key>` 为配置键。目前支持
-  `lang`、`file.download.out_dir`、`telemetry.enabled`。
+  `lang`、`file.download.out_dir`、`telemetry.enabled`、`identity.organization`。
 - 参数：`<value>` 为对应配置值。
 - 取值规则：当 `<key>` 为 `lang` 时，支持的值为 `en` 和 `zh`。
 - 取值规则：当 `<key>` 为 `file.download.out_dir` 时，支持任意非空路径字符串。
@@ -213,13 +213,15 @@
   `1`、`0`、`True`、`yes` 等其他 boolean-like 写法会被拒绝。设置为 `false` 时，
   CLI 还会立即尝试清空待发送 telemetry 事件，并且本次 `config set` 调用自身不会被记录为
   telemetry。
+- 取值规则：当 `<key>` 为 `identity.organization` 时，支持任意非空的组织名称。
+  它设置 `oo connector run` 在未传 `--organization` 或 `--personal` 时使用的默认组织身份。
 
 ### `oo config unset <key>`
 
 删除一个持久化配置值。
 
 - 参数：`<key>` 为配置键。目前支持
-  `lang`、`file.download.out_dir`、`telemetry.enabled`。
+  `lang`、`file.download.out_dir`、`telemetry.enabled`、`identity.organization`。
 
 ## Telemetry
 
@@ -499,6 +501,11 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   schema 声明了异步结果 lifecycle 时，这个选项才有效。
 - 选项：`--wait-result` 会提交异步 submit action，然后轮询它配置的结果
   action。只有选中 action 的 schema 声明了异步 submit lifecycle 时，这个选项才有效。
+- 选项：`--organization <name>` 以指定组织身份运行该 action，而非个人身份。
+  `--org <name>` 是 `--organization <name>` 的 alias。省略时，若配置了
+  `identity.organization` 默认值则使用该组织，否则使用个人身份。
+- 选项：`--personal` 以个人身份运行该 action，并忽略已配置的默认组织。
+  不能与 `--organization` 同时使用。
 - 选项：`--format=json` 和 `--json` 会输出 JSON 对象。
 - 输出：非 dry-run 的 JSON 输出会保持稳定结构
   `{ data, meta: { executionId } }`。

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -345,3 +345,45 @@ exports[`config CLI ignores unknown persisted settings keys and logs a warning 1
 ,
 }
 `;
+
+exports[`config CLI supports the identity organization config key 1`] = `
+{
+  "get": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"acme
+"
+,
+  },
+  "getAfterUnset": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": "",
+  },
+  "list": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"identity.organization=acme
+"
+,
+  },
+  "set": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Set identity.organization to acme.
+"
+,
+  },
+  "unset": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Removed identity.organization.
+"
+,
+  },
+}
+`;

--- a/src/application/commands/config/index.cli.test.ts
+++ b/src/application/commands/config/index.cli.test.ts
@@ -125,6 +125,69 @@ describe("config CLI", () => {
         }
     });
 
+    test("supports the identity organization config key", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const setResult = await sandbox.run([
+                "config",
+                "set",
+                "identity.organization",
+                "acme",
+            ]);
+            const listResult = await sandbox.run(["config", "list"]);
+            const getResult = await sandbox.run([
+                "config",
+                "get",
+                "identity.organization",
+            ]);
+            const unsetResult = await sandbox.run([
+                "config",
+                "unset",
+                "identity.organization",
+            ]);
+            const getAfterUnsetResult = await sandbox.run([
+                "config",
+                "get",
+                "identity.organization",
+            ]);
+
+            expect({
+                get: createCliSnapshot(getResult),
+                getAfterUnset: createCliSnapshot(getAfterUnsetResult),
+                list: createCliSnapshot(listResult),
+                set: createCliSnapshot(setResult),
+                unset: createCliSnapshot(unsetResult),
+            }).toMatchSnapshot();
+            expect(setResult.stdout).toContain("Set identity.organization to acme.");
+            expect(listResult.stdout).toContain("identity.organization=acme");
+            expect(getResult.stdout).toContain("acme");
+            expect(getAfterUnsetResult.stdout).not.toContain("acme");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects an empty identity organization config value", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run([
+                "config",
+                "set",
+                "identity.organization",
+                "   ",
+            ]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("Invalid identity.organization value");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("renders config list help with configured wording", async () => {
         const sandbox = await createCliSandbox();
 

--- a/src/application/commands/config/shared.ts
+++ b/src/application/commands/config/shared.ts
@@ -4,11 +4,14 @@ import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import {
     getConfiguredFileDownloadOutDir,
+    getConfiguredIdentityOrganization,
     getConfiguredTelemetryEnabled,
     localeSchema,
     setFileDownloadOutDir,
+    setIdentityOrganization,
     setTelemetryEnabled,
     unsetFileDownloadOutDir,
+    unsetIdentityOrganization,
     unsetTelemetryEnabled,
 } from "../../schemas/settings.ts";
 
@@ -33,6 +36,7 @@ function createValueErrorFactory(translationKey: string) {
 }
 
 const fileDownloadOutDirConfigKey = "file.download.out_dir" as const;
+const identityOrganizationConfigKey = "identity.organization" as const;
 export const telemetryEnabledConfigKey = "telemetry.enabled" as const;
 
 export const configDefinitions = {
@@ -110,6 +114,27 @@ export const configDefinitions = {
         },
         unsetValue(settings: AppSettings): AppSettings {
             return unsetTelemetryEnabled(settings);
+        },
+    } satisfies ConfigDefinition,
+    [identityOrganizationConfigKey]: {
+        createInvalidValueError: createValueErrorFactory("errors.config.invalidIdentityOrganizationValue"),
+        getValue(settings: AppSettings): string | undefined {
+            return getConfiguredIdentityOrganization(settings);
+        },
+        parseRawValue(rawValue: string): ParsedConfigValue | undefined {
+            const value = rawValue.trim();
+
+            if (value === "") {
+                return undefined;
+            }
+
+            return {
+                apply: settings => setIdentityOrganization(settings, value),
+                renderedValue: value,
+            };
+        },
+        unsetValue(settings: AppSettings): AppSettings {
+            return unsetIdentityOrganization(settings);
         },
     } satisfies ConfigDefinition,
 } as const;

--- a/src/application/commands/connector/identity.test.ts
+++ b/src/application/commands/connector/identity.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    applyConnectorIdentityToUrl,
+    connectorIdentityHeaders,
+    resolveConnectorIdentity,
+} from "./identity.ts";
+
+describe("resolveConnectorIdentity", () => {
+    test("defaults to personal when nothing is provided", () => {
+        expect(resolveConnectorIdentity({
+            configOrganization: undefined,
+            organizationFlag: undefined,
+            personalFlag: false,
+        })).toEqual({
+            identity: {},
+            source: "personal",
+        });
+    });
+
+    test("uses the organization flag over the configured default", () => {
+        expect(resolveConnectorIdentity({
+            configOrganization: "config-org",
+            organizationFlag: "flag-org",
+            personalFlag: false,
+        })).toEqual({
+            identity: { organization: "flag-org" },
+            source: "flag",
+        });
+    });
+
+    test("falls back to the configured organization when no flag is set", () => {
+        expect(resolveConnectorIdentity({
+            configOrganization: "config-org",
+            organizationFlag: undefined,
+            personalFlag: false,
+        })).toEqual({
+            identity: { organization: "config-org" },
+            source: "config",
+        });
+    });
+
+    test("personal flag overrides both the organization flag and the configured default", () => {
+        expect(resolveConnectorIdentity({
+            configOrganization: "config-org",
+            organizationFlag: "flag-org",
+            personalFlag: true,
+        })).toEqual({
+            identity: {},
+            source: "personal",
+        });
+    });
+
+    test("treats an empty organization flag as absent and falls back to config", () => {
+        expect(resolveConnectorIdentity({
+            configOrganization: "config-org",
+            organizationFlag: "",
+            personalFlag: false,
+        })).toEqual({
+            identity: { organization: "config-org" },
+            source: "config",
+        });
+    });
+});
+
+describe("applyConnectorIdentityToUrl", () => {
+    test("adds the organization query parameter for an organization identity", () => {
+        const url = new URL("https://connector.oomol.com/v1/actions/gmail.send_mail");
+
+        applyConnectorIdentityToUrl(url, { organization: "acme" });
+
+        expect(url.toString()).toBe(
+            "https://connector.oomol.com/v1/actions/gmail.send_mail?organization=acme",
+        );
+    });
+
+    test("leaves the URL untouched for the personal identity", () => {
+        const url = new URL("https://connector.oomol.com/v1/actions/gmail.send_mail");
+
+        applyConnectorIdentityToUrl(url, {});
+
+        expect(url.toString()).toBe(
+            "https://connector.oomol.com/v1/actions/gmail.send_mail",
+        );
+    });
+});
+
+describe("connectorIdentityHeaders", () => {
+    test("returns the organization header for an organization identity", () => {
+        expect(connectorIdentityHeaders({ organization: "acme" })).toEqual({
+            "x-oo-organization": "acme",
+        });
+    });
+
+    test("returns no headers for the personal identity", () => {
+        expect(connectorIdentityHeaders({})).toEqual({});
+        expect(connectorIdentityHeaders(undefined)).toEqual({});
+    });
+});

--- a/src/application/commands/connector/identity.ts
+++ b/src/application/commands/connector/identity.ts
@@ -1,0 +1,79 @@
+// Connector authentication identity.
+//
+// A connector run executes under exactly one identity:
+//   personal => {}               (no organization)
+//   org      => { organization }
+//
+// The identity is resolved once per `connector run` invocation and then applied
+// only to the action run requests (POST /v1/actions/...). The action schema /
+// metadata layer is identity-independent and is intentionally left untouched.
+//
+// This struct is the extension point for additional identity dimensions: a new
+// field here plus a branch in the request helpers below is all a future
+// dimension needs.
+export interface ConnectorIdentity {
+    organization?: string;
+}
+
+// Where the resolved organization came from. Recorded as privacy-safe telemetry;
+// it never carries the organization or team name itself.
+type ConnectorIdentitySource = "config" | "flag" | "personal";
+
+interface ResolvedConnectorIdentity {
+    identity: ConnectorIdentity;
+    source: ConnectorIdentitySource;
+}
+
+// Resolves the effective identity from the per-run flags and the configured
+// default. Precedence: --personal > --organization > config default > personal.
+// A flag identity fully replaces the configured default (no field-level merge).
+export function resolveConnectorIdentity(input: {
+    configOrganization: string | undefined;
+    organizationFlag: string | undefined;
+    personalFlag: boolean;
+}): ResolvedConnectorIdentity {
+    if (input.personalFlag) {
+        return { identity: {}, source: "personal" };
+    }
+
+    if (input.organizationFlag !== undefined && input.organizationFlag !== "") {
+        return {
+            identity: { organization: input.organizationFlag },
+            source: "flag",
+        };
+    }
+
+    if (input.configOrganization !== undefined && input.configOrganization !== "") {
+        return {
+            identity: { organization: input.configOrganization },
+            source: "config",
+        };
+    }
+
+    return { identity: {}, source: "personal" };
+}
+
+// Adds the identity query parameters to a connector action request URL. This is
+// the single place that maps identity fields to query parameters.
+export function applyConnectorIdentityToUrl(
+    url: URL,
+    identity: ConnectorIdentity | undefined,
+): void {
+    if (identity?.organization !== undefined) {
+        url.searchParams.set("organization", identity.organization);
+    }
+}
+
+// Builds the identity request headers (`x-oo-organization`). Returns an empty
+// object for the personal identity so callers can spread it unconditionally.
+export function connectorIdentityHeaders(
+    identity: ConnectorIdentity | undefined,
+): Record<string, string> {
+    const headers: Record<string, string> = {};
+
+    if (identity?.organization !== undefined) {
+        headers["x-oo-organization"] = identity.organization;
+    }
+
+    return headers;
+}

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -470,21 +470,30 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("renders connector run help with the wait option", async () => {
+    test("renders connector run help with the wait and identity options", async () => {
         const sandbox = await createCliSandbox();
 
         try {
             const result = await sandbox.run(["connector", "run", "--help"]);
+            // Help descriptions wrap across lines, so compare against a
+            // whitespace-collapsed copy to stay independent of column widths.
+            const help = collapseWhitespace(result.stdout);
 
             expect(result.exitCode).toBe(0);
             expect(result.stderr).toBe("");
             expect(result.stdout).toContain("--wait");
-            expect(result.stdout).toContain(
-                "Poll until an async result action reaches a terminal",
+            expect(help).toContain(
+                "Poll until an async result action reaches a terminal state",
             );
             expect(result.stdout).toContain("--wait-result");
-            expect(result.stdout).toContain(
+            expect(help).toContain(
                 "Submit an async action and wait for its result action",
+            );
+            expect(result.stdout).toContain("--organization");
+            expect(result.stdout).toContain("--org ");
+            expect(result.stdout).toContain("--personal");
+            expect(help).toContain(
+                "Run the action under the given organization identity",
             );
         }
         finally {
@@ -587,6 +596,7 @@ describe("connectorCommand CLI", () => {
                     command_full: "connector.run",
                     data_size_bucket: "<1KB",
                     dry_run: false,
+                    identity_source: "personal",
                     service: "gmail",
                     wait: false,
                 },
@@ -2699,6 +2709,357 @@ describe("connectorCommand CLI", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("runs a connector action under an organization identity from --organization", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--organization",
+                    "acme",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.method).toBe("POST");
+            expect(requests[0]?.url).toBe(
+                "https://connector.oomol.com/v1/actions/gmail.send_mail?organization=acme",
+            );
+            expect(requests[0]?.headers.get("x-oo-organization")).toBe("acme");
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    command_full: "connector.run",
+                    identity_source: "flag",
+                },
+            });
+            expect(telemetryPayload?.properties).not.toHaveProperty("organization");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("accepts the --org alias and keeps the action schema request identity-free", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--org",
+                    "acme",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.method === "GET") {
+                            return new Response(JSON.stringify({
+                                data: {
+                                    description: "Send a Gmail message.",
+                                    id: "gmail.send_mail",
+                                    inputSchema: {
+                                        properties: {
+                                            to: {
+                                                type: "string",
+                                            },
+                                        },
+                                        required: ["to"],
+                                        type: "object",
+                                    },
+                                    name: "send_mail",
+                                    outputSchema: {
+                                        type: "object",
+                                    },
+                                    providerPermissions: [],
+                                    requiredScopes: [],
+                                    service: "gmail",
+                                },
+                            }));
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(2);
+            // The schema metadata GET stays identity-free (shared schema cache).
+            expect(requests[0]?.method).toBe("GET");
+            expect(requests[0]?.url).toBe(
+                "https://connector.oomol.com/v1/actions/gmail.send_mail",
+            );
+            expect(requests[0]?.headers.get("x-oo-organization")).toBeNull();
+            // The run POST carries the organization identity.
+            expect(requests[1]?.method).toBe("POST");
+            expect(requests[1]?.url).toBe(
+                "https://connector.oomol.com/v1/actions/gmail.send_mail?organization=acme",
+            );
+            expect(requests[1]?.headers.get("x-oo-organization")).toBe("acme");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("uses the configured default organization when no identity flag is provided", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
+            await sandbox.run(["config", "set", "identity.organization", "acme"]);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+            const telemetryRows = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            );
+            const runTelemetryPayload = telemetryRows
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "connector.run");
+
+            expect(result.exitCode).toBe(0);
+            expect(requests[0]?.url).toBe(
+                "https://connector.oomol.com/v1/actions/gmail.send_mail?organization=acme",
+            );
+            expect(requests[0]?.headers.get("x-oo-organization")).toBe("acme");
+            expect(runTelemetryPayload).toMatchObject({
+                properties: {
+                    identity_source: "config",
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("forces the personal identity with --personal even when a default organization is configured", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
+            await sandbox.run(["config", "set", "identity.organization", "acme"]);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--personal",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+            const telemetryRows = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            );
+            const runTelemetryPayload = telemetryRows
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "connector.run");
+
+            expect(result.exitCode).toBe(0);
+            expect(requests[0]?.url).toBe(
+                "https://connector.oomol.com/v1/actions/gmail.send_mail",
+            );
+            expect(requests[0]?.headers.get("x-oo-organization")).toBeNull();
+            expect(runTelemetryPayload).toMatchObject({
+                properties: {
+                    identity_source: "personal",
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects an empty --organization value before sending requests", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            let requestCount = 0;
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--organization",
+                    "   ",
+                    "--json",
+                ],
+                {
+                    fetcher: async () => {
+                        requestCount += 1;
+
+                        return new Response(JSON.stringify({
+                            data: {},
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toContain(
+                "The --organization value cannot be empty.",
+            );
+            expect(requestCount).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects combining --organization and --personal before sending requests", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            let requestCount = 0;
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--organization",
+                    "acme",
+                    "--personal",
+                    "--json",
+                ],
+                {
+                    fetcher: async () => {
+                        requestCount += 1;
+
+                        return new Response(JSON.stringify({
+                            data: {},
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toContain(
+                "Use either --organization or --personal, not both.",
+            );
+            expect(requestCount).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });
 
 type SeedConnectorAction = ConnectorActionDefinition & Partial<Pick<
@@ -2848,4 +3209,15 @@ function createSettingsStoreForSandbox(sandbox: {
             updater(emptySettings),
         write: async (value: AppSettings) => value,
     };
+}
+
+// Collapses every run of whitespace (including the line wraps commander inserts
+// into help output) into single spaces so assertions stay column-width agnostic.
+function collapseWhitespace(value: string): string {
+    return value
+        .split("\n")
+        .join(" ")
+        .split(" ")
+        .filter(Boolean)
+        .join(" ");
 }

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -1,4 +1,5 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+import type { ConnectorIdentity } from "./identity.ts";
 import type {
     ConnectorActionAsyncLifecycle,
     ConnectorActionRunResponse,
@@ -7,6 +8,7 @@ import type {
 import { Buffer } from "node:buffer";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
+import { getConfiguredIdentityOrganization } from "../../schemas/settings.ts";
 import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
@@ -14,6 +16,7 @@ import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
 import { readJsonInputValue } from "../shared/json-input.ts";
 import { TerminalProgressRenderer } from "../shared/terminal-progress-renderer.ts";
+import { resolveConnectorIdentity } from "./identity.ts";
 import {
     deleteConnectorActionSchemaCache,
     isConnectorActionSchemaNotFoundError,
@@ -55,6 +58,8 @@ interface ConnectorRunInput {
     data?: string;
     dryRun?: boolean;
     format?: (typeof connectorFormatValues)[number];
+    organization?: string;
+    personal?: boolean;
     serviceName: string;
     showSchemaVersion?: boolean;
     wait?: boolean;
@@ -104,6 +109,18 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             longFlag: "--wait-result",
             descriptionKey: "options.connectorRunWaitResult",
         },
+        {
+            name: "organization",
+            longFlag: "--organization",
+            aliasFlags: ["--org"],
+            valueName: "organization",
+            descriptionKey: "options.connectorRunOrganization",
+        },
+        {
+            name: "personal",
+            longFlag: "--personal",
+            descriptionKey: "options.connectorRunPersonal",
+        },
         ...jsonOutputOptions,
     ],
     inputSchema: z.object({
@@ -111,6 +128,8 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
         data: z.string().optional(),
         dryRun: z.boolean().optional(),
         format: z.enum(connectorFormatValues).optional(),
+        organization: z.string().optional(),
+        personal: z.boolean().optional(),
         serviceName: z.string(),
         showSchemaVersion: z.boolean().optional(),
         wait: z.boolean().optional(),
@@ -124,7 +143,22 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             throw new CliUserError("errors.connectorRun.waitModeConflict", 2);
         }
 
+        if (input.personal === true && input.organization !== undefined) {
+            throw new CliUserError("errors.connectorRun.identityConflict", 2);
+        }
+
+        const organizationFlag = input.organization?.trim();
+        if (input.organization !== undefined && organizationFlag === "") {
+            throw new CliUserError("errors.connectorRun.organizationEmpty", 2);
+        }
+
         const account = await requireCurrentAccount(context);
+        const settings = await context.settingsStore.read();
+        const { identity, source: identitySource } = resolveConnectorIdentity({
+            configOrganization: getConfiguredIdentityOrganization(settings),
+            organizationFlag,
+            personalFlag: input.personal === true,
+        });
         const inputData = await readJsonInputValue(
             input.data,
             context,
@@ -138,6 +172,7 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
                 Buffer.byteLength(JSON.stringify(inputData)),
             ),
             dry_run: input.dryRun === true,
+            identity_source: identitySource,
             service: input.serviceName,
             wait: input.wait === true,
             wait_result: input.waitResult === true,
@@ -223,6 +258,7 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
                     actionName,
                     apiKey: account.apiKey,
                     endpoint: account.endpoint,
+                    identity,
                     inputData,
                     progressReporter,
                     resultLifecycle,
@@ -270,6 +306,7 @@ async function runConnectorActionWithDefaultMode(
         actionName: string;
         apiKey: string;
         endpoint: string;
+        identity: ConnectorIdentity;
         inputData: unknown;
         progressReporter: ConnectorAsyncLifecycleProgressReporter | undefined;
         resultLifecycle: ConnectorActionAsyncResultLifecycle | undefined;
@@ -285,6 +322,7 @@ async function runConnectorActionWithDefaultMode(
                 actionName: options.actionName,
                 apiKey: options.apiKey,
                 endpoint: options.endpoint,
+                identity: options.identity,
                 inputData: options.inputData,
                 progressReporter: options.progressReporter,
                 resultLifecycle: options.resultLifecycle,
@@ -302,6 +340,7 @@ async function runConnectorActionWithDefaultMode(
                 actionName: options.actionName,
                 apiKey: options.apiKey,
                 endpoint: options.endpoint,
+                identity: options.identity,
                 inputData: options.inputData,
                 lifecycle: options.resultLifecycle,
                 progressReporter: options.progressReporter,
@@ -322,6 +361,7 @@ async function runConnectorActionWithDefaultMode(
             actionName: options.actionName,
             apiKey: options.apiKey,
             endpoint: options.endpoint,
+            identity: options.identity,
             inputData: options.inputData,
             serviceName: options.serviceName,
         },
@@ -334,6 +374,7 @@ async function runConnectorAsyncSubmitAndWaitForResult(
         actionName: string;
         apiKey: string;
         endpoint: string;
+        identity: ConnectorIdentity;
         inputData: unknown;
         progressReporter: ConnectorAsyncLifecycleProgressReporter | undefined;
         resultLifecycle: ConnectorActionAsyncResultLifecycle;
@@ -353,6 +394,7 @@ async function runConnectorAsyncSubmitAndWaitForResult(
             actionName: options.actionName,
             apiKey: options.apiKey,
             endpoint: options.endpoint,
+            identity: options.identity,
             inputData: options.inputData,
             serviceName: options.serviceName,
         },
@@ -374,6 +416,7 @@ async function runConnectorAsyncSubmitAndWaitForResult(
             actionName: options.submitLifecycle.resultAction,
             apiKey: options.apiKey,
             endpoint: options.endpoint,
+            identity: options.identity,
             inputData: {
                 [options.submitLifecycle.handle.inputField]: handle,
             },
@@ -400,6 +443,7 @@ async function waitForConnectorAsyncResult(
         actionName: string;
         apiKey: string;
         endpoint: string;
+        identity: ConnectorIdentity;
         inputData: unknown;
         lifecycle: ConnectorActionAsyncResultLifecycle;
         progressReporter: ConnectorAsyncLifecycleProgressReporter | undefined;
@@ -431,6 +475,7 @@ async function waitForConnectorAsyncResult(
                 actionName: options.actionName,
                 apiKey: options.apiKey,
                 endpoint: options.endpoint,
+                identity: options.identity,
                 inputData: options.inputData,
                 serviceName: options.serviceName,
             },

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -187,6 +187,114 @@ describe("connector shared requests", () => {
         });
     });
 
+    test("runConnectorAction sends the organization query and header for an organization identity", async () => {
+        const requests: Request[] = [];
+        await runConnectorAction(
+            {
+                actionName: "send_mail",
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                identity: {
+                    organization: "acme",
+                },
+                inputData: {
+                    to: "foo@bar.com",
+                },
+                serviceName: "gmail",
+            },
+            createRequestContext({
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+
+                    return new Response(JSON.stringify({
+                        data: {
+                            messageId: "message-1",
+                        },
+                        meta: {
+                            executionId: "exec-1",
+                        },
+                    }));
+                },
+            }),
+        );
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0]?.url).toBe(
+            "https://connector.oomol.com/v1/actions/gmail.send_mail?organization=acme",
+        );
+        expect(requests[0]?.headers.get("x-oo-organization")).toBe("acme");
+    });
+
+    test("runConnectorAction omits the organization query and header for the personal identity", async () => {
+        const requests: Request[] = [];
+        await runConnectorAction(
+            {
+                actionName: "send_mail",
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                inputData: {
+                    to: "foo@bar.com",
+                },
+                serviceName: "gmail",
+            },
+            createRequestContext({
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+
+                    return new Response(JSON.stringify({
+                        data: {
+                            messageId: "message-1",
+                        },
+                        meta: {
+                            executionId: "exec-1",
+                        },
+                    }));
+                },
+            }),
+        );
+
+        expect(requests[0]?.url).toBe(
+            "https://connector.oomol.com/v1/actions/gmail.send_mail",
+        );
+        expect(requests[0]?.headers.get("x-oo-organization")).toBeNull();
+    });
+
+    test("getConnectorActionMetadata never sends an organization query or header", async () => {
+        const requests: Request[] = [];
+        await getConnectorActionMetadata(
+            {
+                actionName: "get_message",
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                serviceName: "gmail",
+            },
+            createRequestContext({
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+
+                    return new Response(JSON.stringify({
+                        data: {
+                            description: "Get one Gmail message.",
+                            inputSchema: {
+                                type: "object",
+                            },
+                            name: "get_message",
+                            outputSchema: {
+                                type: "object",
+                            },
+                            service: "gmail",
+                        },
+                    }));
+                },
+            }),
+        );
+
+        expect(requests[0]?.url).toBe(
+            "https://connector.oomol.com/v1/actions/gmail.get_message",
+        );
+        expect(requests[0]?.headers.get("x-oo-organization")).toBeNull();
+    });
+
     test("runConnectorAction surfaces errorCode when the failure response omits a message", async () => {
         const error = await expectCliUserError(runConnectorAction(
             {

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -1,5 +1,6 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 
+import type { ConnectorIdentity } from "./identity.ts";
 import { Buffer } from "node:buffer";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
@@ -9,6 +10,10 @@ import {
     isInsufficientCreditFailure,
 } from "../shared/billing.ts";
 import { getUnexpectedRequestErrorMessage, requestText } from "../shared/request.ts";
+import {
+    applyConnectorIdentityToUrl,
+    connectorIdentityHeaders,
+} from "./identity.ts";
 
 export const connectorActionDefinitionSchema = z.object({
     description: z.string().optional().default(""),
@@ -290,6 +295,7 @@ export async function runConnectorAction(
         actionName: string;
         apiKey: string;
         endpoint: string;
+        identity?: ConnectorIdentity;
         inputData: unknown;
         serviceName: string;
     },
@@ -299,6 +305,7 @@ export async function runConnectorAction(
         options.endpoint,
         options.serviceName,
         options.actionName,
+        options.identity,
     );
     const requestBody = JSON.stringify({
         input: options.inputData,
@@ -324,6 +331,7 @@ export async function runConnectorAction(
             headers: {
                 "Authorization": options.apiKey,
                 "Content-Type": "application/json",
+                ...connectorIdentityHeaders(options.identity),
             },
             method: "POST",
         });
@@ -412,13 +420,18 @@ function createConnectorActionRequestUrl(
     endpoint: string,
     serviceName: string,
     actionName: string,
+    identity?: ConnectorIdentity,
 ): URL {
     const qualifiedActionName
         = `${encodeURIComponent(serviceName)}.${encodeURIComponent(actionName)}`;
 
-    return new URL(
+    const requestUrl = new URL(
         `https://connector.${endpoint}/v1/actions/${qualifiedActionName}`,
     );
+
+    applyConnectorIdentityToUrl(requestUrl, identity);
+
+    return requestUrl;
 }
 
 function parseConnectorFailureResponse(

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -139,11 +139,12 @@ const commandTelemetryDecisions = {
             "dry_run",
             "error_code",
             "http_status",
+            "identity_source",
             "service",
             "wait",
             "wait_result",
         ],
-        reason: "Records connector product dimensions, bucketed payload size, async wait modes, and stable error code.",
+        reason: "Records connector product dimensions, bucketed payload size, async wait modes, stable error code, and identity source (personal/flag/config) without the organization name.",
     },
     "connector.search": {
         kind: "properties",

--- a/src/application/schemas/settings.ts
+++ b/src/application/schemas/settings.ts
@@ -32,6 +32,14 @@ const telemetrySettingsShape = {
 const telemetrySettingsReadSchema = z.object(telemetrySettingsShape);
 const telemetrySettingsSchema = z.object(telemetrySettingsShape).strict();
 
+const identitySettingsShape = {
+    // The default organization used to authenticate `oo connector run`.
+    organization: z.string().trim().min(1).optional(),
+};
+
+const identitySettingsReadSchema = z.object(identitySettingsShape);
+const identitySettingsSchema = z.object(identitySettingsShape).strict();
+
 const skillsRecommendSettingsShape = {
     muted: z.boolean().optional(),
     dismissed: z.array(z.string()).optional(),
@@ -50,6 +58,7 @@ const skillsSettingsSchema = z.object({
 
 export const settingsFileReadSchema = z.object({
     file: fileSettingsReadSchema.optional(),
+    identity: identitySettingsReadSchema.optional(),
     lang: localeSchema.optional(),
     skills: skillsSettingsReadSchema.optional(),
     telemetry: telemetrySettingsReadSchema.optional(),
@@ -57,6 +66,7 @@ export const settingsFileReadSchema = z.object({
 
 export const settingsFileSchema = z.object({
     file: fileSettingsSchema.optional(),
+    identity: identitySettingsSchema.optional(),
     lang: localeSchema.optional(),
     skills: skillsSettingsSchema.optional(),
     telemetry: telemetrySettingsSchema.optional(),
@@ -99,6 +109,14 @@ const defaultSettingsCommentBlocks = [
         "# muted = false",
         "# dismissed = [\"oo-gmail\"]",
     ],
+    [
+        "# identity.organization sets the default organization used to authenticate `oo connector run`.",
+        "# Default: unset (runs under your personal identity).",
+        "# Supported values: any non-empty organization name.",
+        "# Override per run with `--organization <name>` (alias `--org`), or force personal with `--personal`.",
+        "# [identity]",
+        "# organization = \"acme\"",
+    ],
 ] as const;
 
 export function renderSettingsFile(settings: AppSettings): string {
@@ -122,6 +140,12 @@ export function renderSettingsFile(settings: AppSettings): string {
     if (parsedSettings.telemetry?.enabled !== undefined) {
         persistedSettings.telemetry = {
             enabled: parsedSettings.telemetry.enabled,
+        };
+    }
+
+    if (parsedSettings.identity?.organization !== undefined) {
+        persistedSettings.identity = {
+            organization: parsedSettings.identity.organization,
         };
     }
 
@@ -217,6 +241,35 @@ export function unsetTelemetryEnabled(
     }
 
     return deleteNestedProperty(settings, ["telemetry", "enabled"]);
+}
+
+export function getConfiguredIdentityOrganization(
+    settings: AppSettings,
+): string | undefined {
+    return settings.identity?.organization;
+}
+
+export function setIdentityOrganization(
+    settings: AppSettings,
+    value: string,
+): AppSettings {
+    return {
+        ...settings,
+        identity: {
+            ...settings.identity,
+            organization: value,
+        },
+    };
+}
+
+export function unsetIdentityOrganization(
+    settings: AppSettings,
+): AppSettings {
+    if (settings.identity?.organization === undefined) {
+        return settings;
+    }
+
+    return deleteNestedProperty(settings, ["identity", "organization"]);
 }
 
 export function isSkillRecommendationsMuted(settings: AppSettings): boolean {

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -324,6 +324,10 @@ export const enMessages = {
         "The --wait option is only supported for connector actions with an async result lifecycle.",
     "errors.connectorRun.waitModeConflict":
         "Use either --wait or --wait-result, not both.",
+    "errors.connectorRun.identityConflict":
+        "Use either --organization or --personal, not both.",
+    "errors.connectorRun.organizationEmpty":
+        "The --organization value cannot be empty.",
     "errors.connectorRun.waitResultActionUnsupported":
         "The result action {action} configured for --wait-result must declare an async result lifecycle.",
     "errors.connectorRun.waitResultUnsupported":
@@ -386,6 +390,8 @@ export const enMessages = {
         "Invalid file.download.out_dir value: {value}. Use a non-empty path.",
     "errors.config.invalidTelemetryEnabledValue":
         "Invalid telemetry.enabled value: {value}. Use true or false.",
+    "errors.config.invalidIdentityOrganizationValue":
+        "Invalid identity.organization value: {value}. Use a non-empty organization name.",
     "errors.skills.invalidName":
         "Unsupported skill: {value}. Use {choices}.",
     "errors.skills.invalidPath":
@@ -769,6 +775,10 @@ export const enMessages = {
         "Poll until an async result action reaches a terminal state",
     "options.connectorRunWaitResult":
         "Submit an async action and wait for its result action",
+    "options.connectorRunOrganization":
+        "Run the action under the given organization identity (alias: --org)",
+    "options.connectorRunPersonal":
+        "Run the action under your personal identity, ignoring any configured default organization",
     "options.debug": "Print the current log file path when the CLI exits",
     "options.description": "Set the required generated skill description",
     "options.days":
@@ -1380,6 +1390,10 @@ export const zhMessages = {
         "--wait 选项仅支持带有异步结果 lifecycle 的 connector action。",
     "errors.connectorRun.waitModeConflict":
         "--wait 和 --wait-result 只能使用其中一个。",
+    "errors.connectorRun.identityConflict":
+        "--organization 和 --personal 只能使用其中一个。",
+    "errors.connectorRun.organizationEmpty":
+        "--organization 的值不能为空。",
     "errors.connectorRun.waitResultActionUnsupported":
         "--wait-result 配置的结果 action {action} 必须声明异步结果 lifecycle。",
     "errors.connectorRun.waitResultUnsupported":
@@ -1442,6 +1456,8 @@ export const zhMessages = {
         "无效的 file.download.out_dir 值：{value}。请使用非空路径。",
     "errors.config.invalidTelemetryEnabledValue":
         "无效的 telemetry.enabled 值：{value}。请使用 true 或 false。",
+    "errors.config.invalidIdentityOrganizationValue":
+        "无效的 identity.organization 值：{value}。请使用非空的组织名称。",
     "errors.skills.invalidName":
         "不支持的 skill：{value}。请使用 {choices}。",
     "errors.skills.invalidPath":
@@ -1820,6 +1836,10 @@ export const zhMessages = {
         "轮询异步结果 action，直到进入终态",
     "options.connectorRunWaitResult":
         "提交异步 action，并等待它的结果 action",
+    "options.connectorRunOrganization":
+        "以指定组织身份运行该 action（别名：--org）",
+    "options.connectorRunPersonal":
+        "以个人身份运行该 action，忽略已配置的默认组织",
     "options.debug": "在 CLI 退出时打印当前日志文件路径",
     "options.description": "设置必填的生成 skill 描述",
     "options.days": "设置私有包临时分享天数（默认 7，最长 7）",


### PR DESCRIPTION
The business layer introduced organizations: a user can belong to
multiple orgs and authenticate as one. `oo connector run` now picks
the run identity via `--organization` (alias `--org`), an
`identity.organization` config default, or `--personal` to force the
personal identity. Precedence is flag, then config, then personal.

Only the action run request carries the identity (an `organization`
query parameter plus an `x-oo-organization` header). The schema
metadata request and its cache stay identity-free because the action
schema is identity-independent. Telemetry records only a privacy-safe
`identity_source` enum, never the organization name.