### PR TITLE
docs(readme): remove QR code example from quick start

### DIFF
--- a/README-ZH_CN.md
+++ b/README-ZH_CN.md
@@ -70,8 +70,6 @@ oo login
 
 > /oo 总结我最近 5 封 Gmail 邮件。
 
-> /oo 为 https://oomol.com 生成一个二维码。
-
 `/oo` 是内置 skill 约定的触发前缀，Agent 会通过 `oo` 把请求路由到对应的能力。
 
 ## 受支持的 AI Agent

--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ Then talk to your AI agent in natural language — describe intent, not commands
 
 > /oo summarize my latest 5 Gmail messages.
 
-> /oo generate a QR code for https://oomol.com.
-
 `/oo` is the prompt convention picked up by the bundled skill; the agent will
 route the request through `oo` for you.
 


### PR DESCRIPTION
The QR code line was an inaccurate example of what the bundled oo skill routes to a hosted capability, so drop it from both the English and Chinese README to avoid implying an unsupported workflow.