### PR TITLE
feat(env): add environment overrides for embedded use

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,6 +12,31 @@ Project overview: [README.md](../README.md)
 - `-h, --help`: Show help for the current command.
 - `-V, --version`: Show the current CLI version, build time, and commit hash.
 
+## Environment Variables
+
+The CLI reads these environment variables to support embedded and automated
+use. Truthy values are `1`, `true`, `yes`, or `on` (case-insensitive).
+
+- `OO_CONFIG_DIR`: Override the configuration root directory that holds
+  `auth.toml`, `settings.toml`, and telemetry data (and, unless `OO_DATA_DIR`
+  is set, the `data` subdirectory). Takes precedence over `XDG_CONFIG_HOME`.
+- `OO_DATA_DIR`: Override the data directory that holds the local cache,
+  uploads, and download-session state. Defaults to `<config-root>/data`.
+- `OO_LOG_DIR`: Override the debug-log directory. Takes precedence over every
+  platform default.
+- `OO_API_KEY`: Run execution commands with this API key without an interactive
+  login. When set, the CLI builds an in-memory account and does not read,
+  require, or write `auth.toml`, and it takes precedence over any saved account.
+- `OO_ENDPOINT`: Base endpoint domain (for example `oomol.com` or `oomol.dev`)
+  used to derive every service URL for execution commands. It pairs with
+  `OO_API_KEY` and also overrides the endpoint of a saved account. Takes
+  precedence over the legacy `OOMOL_ENDPOINT`.
+- `OO_SKILLS_SYNC_DISABLED`: A truthy value disables the startup managed-skill
+  synchronization and legacy-cleanup side effects, so the CLI writes no skill
+  files into agent home directories such as `~/.agents` or `~/.claude`.
+- `OO_NO_SELF_UPDATE`: A truthy value disables `oo update`, `oo install`, and
+  `oo check-update` and forces self-update PATH modification off.
+
 ## JSON Output
 
 Commands that document `--format=json` and `--json` share the following

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -11,6 +11,28 @@
 - `-h, --help`：显示当前命令的帮助信息。
 - `-V, --version`：显示当前 CLI 版本、构建时间和 commit hash。
 
+## 环境变量
+
+CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、`true`、`yes` 或 `on`
+（大小写不敏感）。
+
+- `OO_CONFIG_DIR`：覆盖配置根目录，其中包含 `auth.toml`、`settings.toml` 和
+  telemetry 数据（在未设置 `OO_DATA_DIR` 时也包含 `data` 子目录）。优先级高于
+  `XDG_CONFIG_HOME`。
+- `OO_DATA_DIR`：覆盖数据目录，其中包含本地缓存、上传和下载会话状态。默认值为
+  `<配置根目录>/data`。
+- `OO_LOG_DIR`：覆盖 debug 日志目录。优先级高于所有平台默认值。
+- `OO_API_KEY`：使用该 API key 执行命令，无需交互式登录。设置后 CLI 会构造一个
+  内存账号，不读取、不要求、也不写入 `auth.toml`，且优先级高于任何已保存的账号。
+- `OO_ENDPOINT`：基础域名（例如 `oomol.com` 或 `oomol.dev`），用于派生执行命令的
+  所有服务 URL。它与 `OO_API_KEY` 搭配使用，也会覆盖已保存账号的 endpoint。优先级
+  高于历史遗留的 `OOMOL_ENDPOINT`。
+- `OO_SKILLS_SYNC_DISABLED`：设为真值会禁用启动时的 managed skill 同步与 legacy
+  清理副作用，使 CLI 不会向 `~/.agents`、`~/.claude` 等代理主目录写入任何 skill
+  文件。
+- `OO_NO_SELF_UPDATE`：设为真值会禁用 `oo update`、`oo install` 和
+  `oo check-update`，并强制关闭 self-update 的 PATH 改写。
+
 ## JSON 输出
 
 文档中带有 `--format=json` 和 `--json` 的命令遵循以下约定：

--- a/src/adapters/store/store-path.test.ts
+++ b/src/adapters/store/store-path.test.ts
@@ -41,6 +41,96 @@ describe("resolveStorePaths", () => {
         });
     });
 
+    test("prefers OO_CONFIG_DIR over XDG_CONFIG_HOME for the config root", () => {
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: {
+                HOME: "/tmp/home",
+                OO_CONFIG_DIR: "/tmp/app/config",
+                XDG_CONFIG_HOME: "/tmp/xdg",
+            },
+            platform: "linux",
+        });
+
+        expect(storePaths.rootDirectory).toBe("/tmp/app/config");
+        expect(storePaths.authFilePath).toBe(
+            join("/tmp/app/config", "auth.toml"),
+        );
+        expect(storePaths.settingsFilePath).toBe(
+            join("/tmp/app/config", "settings.toml"),
+        );
+        expect(storePaths.telemetryDirectory).toBe(
+            join("/tmp/app/config", "telemetry"),
+        );
+        expect(storePaths.dataDirectory).toBe(
+            join("/tmp/app/config", "data"),
+        );
+    });
+
+    test("overrides the data directory with OO_DATA_DIR independently of the config root", () => {
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: {
+                HOME: "/tmp/home",
+                OO_CONFIG_DIR: "/tmp/app/config",
+                OO_DATA_DIR: "/tmp/app/data",
+            },
+            platform: "linux",
+        });
+
+        expect(storePaths.rootDirectory).toBe("/tmp/app/config");
+        expect(storePaths.dataDirectory).toBe("/tmp/app/data");
+        expect(storePaths.cacheFilePath).toBe(
+            join("/tmp/app/data", "cache.sqlite"),
+        );
+        expect(storePaths.uploadsFilePath).toBe(
+            join("/tmp/app/data", "uploads.sqlite"),
+        );
+        expect(storePaths.downloadSessionsDirectoryPath).toBe(
+            join("/tmp/app/data", "download-sessions"),
+        );
+    });
+
+    test("overrides the log directory with OO_LOG_DIR on every platform", () => {
+        for (const platform of ["linux", "darwin", "win32"] as const) {
+            const storePaths = resolveStorePaths({
+                appName: APP_NAME,
+                env: {
+                    APPDATA: "C:\\Users\\kevin\\AppData\\Roaming",
+                    HOME: "/tmp/home",
+                    LOCALAPPDATA: "C:\\Users\\kevin\\AppData\\Local",
+                    OO_LOG_DIR: "/tmp/app/logs",
+                    USERPROFILE: "C:\\Users\\kevin",
+                    XDG_STATE_HOME: "/tmp/xdg-state",
+                },
+                platform,
+            });
+
+            expect(storePaths.logDirectoryPath).toBe("/tmp/app/logs");
+        }
+    });
+
+    test("treats empty OO_CONFIG_DIR/OO_DATA_DIR/OO_LOG_DIR as unset and uses defaults", () => {
+        const storePaths = resolveStorePaths({
+            appName: APP_NAME,
+            env: {
+                HOME: "/tmp/home",
+                OO_CONFIG_DIR: "",
+                OO_DATA_DIR: "",
+                OO_LOG_DIR: "",
+                XDG_CONFIG_HOME: "/tmp/xdg",
+                XDG_STATE_HOME: "/tmp/xdg-state",
+            },
+            platform: "linux",
+        });
+
+        expect(storePaths.rootDirectory).toBe(join("/tmp/xdg", APP_NAME));
+        expect(storePaths.dataDirectory).toBe(join("/tmp/xdg", APP_NAME, "data"));
+        expect(storePaths.logDirectoryPath).toBe(
+            join("/tmp/xdg-state", APP_NAME, "logs"),
+        );
+    });
+
     test("falls back to the default Linux state directory for logs", () => {
         const storePaths = resolveStorePaths({
             appName: APP_NAME,

--- a/src/adapters/store/store-path.ts
+++ b/src/adapters/store/store-path.ts
@@ -37,6 +37,13 @@ export function resolveStoreDirectory(
     const homeDirectory = resolveHomeDirectory(options.env, options.homeDirectory);
     const appName = options.appName;
 
+    // OO_CONFIG_DIR overrides the config root directly (no app-name segment
+    // appended) and takes precedence over XDG_CONFIG_HOME so embedded callers
+    // can pin the config root to a private directory.
+    if (options.env.OO_CONFIG_DIR) {
+        return options.env.OO_CONFIG_DIR;
+    }
+
     if (options.env.XDG_CONFIG_HOME) {
         return join(options.env.XDG_CONFIG_HOME, appName);
     }
@@ -62,6 +69,12 @@ function resolveLogDirectory(
     const homeDirectory = resolveHomeDirectory(options.env, options.homeDirectory);
     const appName = options.appName;
 
+    // OO_LOG_DIR overrides the log directory directly and takes precedence over
+    // every platform-specific default.
+    if (options.env.OO_LOG_DIR) {
+        return options.env.OO_LOG_DIR;
+    }
+
     if (options.platform === "darwin") {
         return join(homeDirectory, "Library", "Logs", appName);
     }
@@ -85,7 +98,9 @@ export function resolveStorePaths(
     options: FileStoreLocationOptions,
 ): StorePaths {
     const rootDirectory = resolveStoreDirectory(options);
-    const dataDirectory = join(rootDirectory, "data");
+    // OO_DATA_DIR overrides the data directory directly; otherwise it follows the
+    // config root, preserving the historical `<root>/data` layout.
+    const dataDirectory = options.env.OO_DATA_DIR || join(rootDirectory, "data");
 
     return {
         authFilePath: join(rootDirectory, defaultAuthFileName),

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -241,6 +241,63 @@ describe("runCli bootstrap", () => {
         }
     });
 
+    test("skips managed skill synchronization when OO_SKILLS_SYNC_DISABLED is set", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+
+        try {
+            const universalHome = resolveManagedSkillAgentHomeDirectory(
+                sandbox.env,
+                "universal",
+            );
+
+            const result = await sandbox.run(["--help"]);
+
+            expect(result.exitCode).toBe(0);
+            // The always-provisioned universal host (~/.agents) must not be
+            // materialized when synchronization is disabled.
+            await expect(stat(universalHome)).rejects.toMatchObject({
+                code: "ENOENT",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("preserves legacy managed skills when OO_SKILLS_SYNC_DISABLED is set", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+
+        try {
+            const managedBundledPath = join(
+                sandbox.env.HOME!,
+                ".codex",
+                "skills",
+                "oo",
+            );
+
+            await mkdir(managedBundledPath, { recursive: true });
+            await writeFile(join(managedBundledPath, "SKILL.md"), "skill\n");
+            await writeFile(
+                join(managedBundledPath, ".oo-metadata.json"),
+                JSON.stringify({ kind: "bundled", schemaVersion: 1, version: "1.2.3" }),
+            );
+
+            const result = await sandbox.run(["--help"]);
+
+            expect(result.exitCode).toBe(0);
+            // Legacy cleanup is part of the guarded block, so the managed skill
+            // must remain untouched.
+            expect((await stat(managedBundledPath)).isDirectory()).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("writes debug logs to the log directory during cli startup", async () => {
         const sandbox = await createCliSandbox();
 

--- a/src/application/bootstrap/run-cli.ts
+++ b/src/application/bootstrap/run-cli.ts
@@ -45,6 +45,7 @@ import { CliUserError } from "../contracts/cli.ts";
 import { logCategory } from "../logging/log-categories.ts";
 import { withCategory, withErrorKey, withStorePath } from "../logging/log-fields.ts";
 import { initializeCurrentVersionActiveMarker } from "../self-update/core.ts";
+import { readEnvBoolean } from "../shared/env-boolean.ts";
 import { createRetryingFetcher } from "../shared/retrying-fetcher.ts";
 import {
     telemetryInternalCommand,
@@ -275,17 +276,22 @@ export async function executeCli(invocation: CliInvocation): Promise<number> {
 
         const adapter = new CommanderCliAdapter();
 
-        // TODO(codex-removal): Temporary compatibility cleanup. Remove this call
-        // and `legacy-codex-cleanup.ts` once enough releases have shipped that no
-        // user still has oo-managed skills under the legacy Codex home.
-        await removeLegacyCodexManagedSkills(context);
-        // TODO(gpt-image-2-removal): Temporary compatibility cleanup. Remove this
-        // call and `legacy-gpt-image-2-cleanup.ts` once enough releases have
-        // shipped that no user still has the oo-managed `@alwaysmavs/gpt-image-2`
-        // skills materialized in an AI agent. Must run before the sync below so
-        // the canonical sources are gone before re-publishing could re-create them.
-        await removeLegacyGptImage2ManagedSkills(context);
-        await synchronizeManagedSkillsForAvailableHosts(context);
+        // OO_SKILLS_SYNC_DISABLED suppresses the startup skills synchronization
+        // and legacy-cleanup side effects so embedded callers never write skill
+        // files into other agents' home directories (e.g. ~/.agents, ~/.claude).
+        if (readEnvBoolean(invocation.env.OO_SKILLS_SYNC_DISABLED) !== true) {
+            // TODO(codex-removal): Temporary compatibility cleanup. Remove this call
+            // and `legacy-codex-cleanup.ts` once enough releases have shipped that no
+            // user still has oo-managed skills under the legacy Codex home.
+            await removeLegacyCodexManagedSkills(context);
+            // TODO(gpt-image-2-removal): Temporary compatibility cleanup. Remove this
+            // call and `legacy-gpt-image-2-cleanup.ts` once enough releases have
+            // shipped that no user still has the oo-managed `@alwaysmavs/gpt-image-2`
+            // skills materialized in an AI agent. Must run before the sync below so
+            // the canonical sources are gone before re-publishing could re-create them.
+            await removeLegacyGptImage2ManagedSkills(context);
+            await synchronizeManagedSkillsForAvailableHosts(context);
+        }
 
         exitCode = await adapter.run({
             argv: invocation.argv,

--- a/src/application/commands/check-update.cli.test.ts
+++ b/src/application/commands/check-update.cli.test.ts
@@ -407,4 +407,26 @@ describe("checkUpdateCommand CLI", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("refuses to run when OO_NO_SELF_UPDATE is set", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_NO_SELF_UPDATE = "1";
+
+        try {
+            const result = await sandbox.run(["check-update"], {
+                fetcher: () => {
+                    throw new Error("check-update must not fetch when disabled");
+                },
+                version: "1.0.0",
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("OO_NO_SELF_UPDATE");
+            expect(result.stdout).toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });

--- a/src/application/commands/check-update.ts
+++ b/src/application/commands/check-update.ts
@@ -3,6 +3,7 @@ import type { CliUpdateCheckResult } from "../update/update-notifier.ts";
 
 import { z } from "zod";
 import { CliUserError } from "../contracts/cli.ts";
+import { isSelfUpdateDisabledByEnv } from "../self-update/self-update-disabled-preference.ts";
 import {
     checkForCliUpdate,
     cliUpdateCommand,
@@ -46,6 +47,12 @@ export const checkUpdateCommand: CliCommandDefinition<CheckUpdateInput> = {
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
+        // OO_NO_SELF_UPDATE disables the update machinery, including the remote
+        // release check that hits the hardcoded static.oomol.com source.
+        if (isSelfUpdateDisabledByEnv(context.env)) {
+            throw new CliUserError("errors.selfUpdate.disabledByEnv", 1);
+        }
+
         context.telemetry?.recordProperties({
             version_kind: classifyTelemetryVersionKind(context.version),
         });

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -3489,6 +3489,88 @@ describe("connectorCommand CLI", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("runs connector search via OO_API_KEY without login and routes through OO_ENDPOINT", async () => {
+        const sandbox = await createCliSandbox();
+
+        // Drive execution purely from env: no login, no auth.toml on disk.
+        sandbox.env.OO_API_KEY = "env-api-key";
+        sandbox.env.OO_ENDPOINT = "oomol.dev";
+
+        const authFilePath = join(
+            sandbox.env.XDG_CONFIG_HOME!,
+            APP_NAME,
+            "auth.toml",
+        );
+        const requests: Request[] = [];
+
+        try {
+            const result = await sandbox.run(
+                ["connector", "search", "send mail", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        return new Response(JSON.stringify({ data: [] }));
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("[]");
+            expect(requests).toHaveLength(1);
+            // OO_ENDPOINT must drive the execution endpoint derivation.
+            expect(requests[0]!.url).toStartWith(
+                "https://search.oomol.dev/v1/connector-actions",
+            );
+            // OO_API_KEY must be used as the Authorization credential.
+            expect(requests[0]!.headers.get("Authorization")).toBe("env-api-key");
+            // The env override must never read or create auth.toml.
+            await expect(Bun.file(authFilePath).exists()).resolves.toBeFalse();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("redirects a logged-in account's execution endpoint with OO_ENDPOINT", async () => {
+        const sandbox = await createCliSandbox();
+
+        // A persisted account (endpoint oomol.com) plus a bare OO_ENDPOINT, no
+        // OO_API_KEY: the saved credential is kept but the endpoint is redirected.
+        await writeAuthFile(sandbox);
+        sandbox.env.OO_ENDPOINT = "oomol.dev";
+
+        const requests: Request[] = [];
+
+        try {
+            const result = await sandbox.run(
+                ["connector", "search", "send mail", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        return new Response(JSON.stringify({ data: [] }));
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(1);
+            expect(requests[0]!.url).toStartWith(
+                "https://search.oomol.dev/v1/connector-actions",
+            );
+            // The persisted API key is still used as the credential.
+            expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });
 
 type SeedConnectorAction = ConnectorActionDefinition & Partial<Pick<

--- a/src/application/commands/install.ts
+++ b/src/application/commands/install.ts
@@ -11,6 +11,7 @@ import {
 } from "../self-update/core.ts";
 import { resolveSelfUpdateModifyPath } from "../self-update/modify-path-preference.ts";
 import { resolveSelfUpdateShowPathShadowingWarning } from "../self-update/path-shadowing-warning-preference.ts";
+import { isSelfUpdateDisabledByEnv } from "../self-update/self-update-disabled-preference.ts";
 import { isSemver } from "../semver.ts";
 import { writeSelfUpdatePathNoteIfNeeded } from "./self-update-output.ts";
 import { SelfUpdateProgressReporter } from "./self-update-progress.ts";
@@ -54,6 +55,10 @@ export const installCommand: CliCommandDefinition<
     ],
     inputSchema: installCommandInputSchema,
     handler: async (input, context) => {
+        if (isSelfUpdateDisabledByEnv(context.env)) {
+            throw new CliUserError("errors.selfUpdate.disabledByEnv", 1);
+        }
+
         context.telemetry?.recordProperties({
             force: input.force,
             path_modified: false,

--- a/src/application/commands/llm/index.cli.test.ts
+++ b/src/application/commands/llm/index.cli.test.ts
@@ -417,6 +417,40 @@ describe("llm CLI", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("derives the LLM config from OO_API_KEY and OO_ENDPOINT without login", async () => {
+        const sandbox = await createCliSandbox();
+
+        // No writeAuthFile: drive auth and endpoint purely from env.
+        sandbox.env.OO_API_KEY = "env-key";
+        sandbox.env.OO_ENDPOINT = "oomol.dev";
+
+        try {
+            const result = await sandbox.run(["llm", "config", "--json"], {
+                fetcher: () => {
+                    throw new Error("llm config should not make network requests");
+                },
+            });
+
+            expect(result.exitCode).toBe(0);
+            const config = JSON.parse(result.stdout) as {
+                apiKey: string;
+                baseUrl: string;
+                chatCompletionsUrl: string;
+                model: string;
+            };
+
+            expect(config).toEqual({
+                apiKey: "env-key",
+                baseUrl: "https://llm.oomol.dev/v1",
+                chatCompletionsUrl: "https://llm.oomol.dev/v1/chat/completions",
+                model: "oomol-chat",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });
 
 function createChatCompletionResponse(content: string): Response {

--- a/src/application/commands/self-update.cli.test.ts
+++ b/src/application/commands/self-update.cli.test.ts
@@ -965,6 +965,50 @@ describe("self-update commands", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("update refuses to run when OO_NO_SELF_UPDATE is set", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_NO_SELF_UPDATE = "1";
+
+        try {
+            const result = await sandbox.run(["update"], {
+                fetcher: () => {
+                    throw new Error("self-update must not fetch when disabled");
+                },
+                version: "1.0.0",
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("OO_NO_SELF_UPDATE");
+            expect(result.stdout).toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("install refuses to run when OO_NO_SELF_UPDATE is set", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_NO_SELF_UPDATE = "1";
+
+        try {
+            const result = await sandbox.run(["install", "2.0.0"], {
+                fetcher: () => {
+                    throw new Error("self-update must not fetch when disabled");
+                },
+                version: "1.0.0",
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("OO_NO_SELF_UPDATE");
+            expect(result.stdout).toBe("");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
 });
 
 async function withShadowedLegacyUpdateScenario(

--- a/src/application/commands/shared/auth-env-override.test.ts
+++ b/src/application/commands/shared/auth-env-override.test.ts
@@ -1,0 +1,73 @@
+import type { AuthAccount } from "../../schemas/auth.ts";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    applyEndpointOverride,
+    buildEnvApiKeyAccount,
+    readEndpointOverride,
+} from "./auth-env-override.ts";
+
+const persistedAccount: AuthAccount = {
+    apiKey: "persisted-key",
+    endpoint: "oomol.com",
+    id: "user-1",
+    name: "Alice",
+};
+
+describe("buildEnvApiKeyAccount", () => {
+    test("returns undefined when OO_API_KEY is unset, empty, or whitespace", () => {
+        expect(buildEnvApiKeyAccount({})).toBeUndefined();
+        expect(buildEnvApiKeyAccount({ OO_API_KEY: "" })).toBeUndefined();
+        expect(buildEnvApiKeyAccount({ OO_API_KEY: "   " })).toBeUndefined();
+    });
+
+    test("builds an in-memory account using the default endpoint when OO_ENDPOINT is absent", () => {
+        const account = buildEnvApiKeyAccount({ OO_API_KEY: "  env-key  " });
+
+        expect(account).toEqual({
+            apiKey: "env-key",
+            endpoint: "oomol.com",
+            id: "oo-env-override",
+            name: "Environment (OO_API_KEY)",
+        });
+    });
+
+    test("uses OO_ENDPOINT for the in-memory account endpoint when set", () => {
+        const account = buildEnvApiKeyAccount({
+            OO_API_KEY: "env-key",
+            OO_ENDPOINT: "  oomol.dev  ",
+        });
+
+        expect(account?.endpoint).toBe("oomol.dev");
+        expect(account?.apiKey).toBe("env-key");
+    });
+});
+
+describe("readEndpointOverride", () => {
+    test("returns the trimmed OO_ENDPOINT when set", () => {
+        expect(readEndpointOverride({ OO_ENDPOINT: "  oomol.dev " })).toBe("oomol.dev");
+    });
+
+    test("returns undefined when OO_ENDPOINT is unset, empty, or whitespace", () => {
+        expect(readEndpointOverride({})).toBeUndefined();
+        expect(readEndpointOverride({ OO_ENDPOINT: "" })).toBeUndefined();
+        expect(readEndpointOverride({ OO_ENDPOINT: "  " })).toBeUndefined();
+    });
+});
+
+describe("applyEndpointOverride", () => {
+    test("overrides the persisted account endpoint when OO_ENDPOINT is set", () => {
+        const result = applyEndpointOverride(persistedAccount, {
+            OO_ENDPOINT: "oomol.dev",
+        });
+
+        expect(result.endpoint).toBe("oomol.dev");
+        expect(result.apiKey).toBe("persisted-key");
+        expect(result.id).toBe("user-1");
+    });
+
+    test("returns the account unchanged when OO_ENDPOINT is absent", () => {
+        expect(applyEndpointOverride(persistedAccount, {})).toEqual(persistedAccount);
+    });
+});

--- a/src/application/commands/shared/auth-env-override.ts
+++ b/src/application/commands/shared/auth-env-override.ts
@@ -1,0 +1,84 @@
+import type { AuthAccount } from "../../schemas/auth.ts";
+
+// Public base endpoint used when nothing else is configured. Service URLs are
+// derived by prefixing subdomains (api./llm./connector./search./...), so a
+// single base value is enough to switch between environments.
+export const defaultOomolEndpoint = "oomol.com";
+
+// Environment variables that let embedded callers drive execution commands
+// without an interactive login or a persisted auth.toml.
+const apiKeyEnvName = "OO_API_KEY";
+const endpointEnvName = "OO_ENDPOINT";
+
+// Synthetic identity for the in-memory account built from OO_API_KEY. It is
+// never written to disk; the id/name only satisfy the auth account schema and
+// surface in diagnostics. The id is stable so callers can recognize the env
+// override (it has no real account scope, so e.g. publish must not derive a
+// package name from it).
+export const envOverrideAccountId = "oo-env-override";
+const envOverrideAccountName = "Environment (OO_API_KEY)";
+
+function readTrimmedEnv(
+    env: Record<string, string | undefined>,
+    name: string,
+): string | undefined {
+    const value = env[name]?.trim();
+    return value === undefined || value === "" ? undefined : value;
+}
+
+// Returns the OO_ENDPOINT override when set to a non-empty value, otherwise
+// undefined. OO_ENDPOINT only affects the new override path; the legacy
+// OOMOL_ENDPOINT keeps its historical login/unauthenticated-read behavior.
+export function readEndpointOverride(
+    env: Record<string, string | undefined>,
+): string | undefined {
+    return readTrimmedEnv(env, endpointEnvName);
+}
+
+// Builds an in-memory account from OO_API_KEY (paired with OO_ENDPOINT, or the
+// public default). Returns undefined when OO_API_KEY is absent so callers fall
+// back to the persisted auth.toml. When defined, callers must NOT read or
+// require auth.toml.
+export function buildEnvApiKeyAccount(
+    env: Record<string, string | undefined>,
+): AuthAccount | undefined {
+    const apiKey = readTrimmedEnv(env, apiKeyEnvName);
+
+    if (apiKey === undefined) {
+        return undefined;
+    }
+
+    return {
+        apiKey,
+        endpoint: readEndpointOverride(env) ?? defaultOomolEndpoint,
+        id: envOverrideAccountId,
+        name: envOverrideAccountName,
+    };
+}
+
+// True when the account is the in-memory identity built from OO_API_KEY rather
+// than a persisted account. Such an account has no real scope/username, so
+// scope-deriving callers (e.g. skill publish) must require explicit input.
+export function isEnvOverrideAccount(
+    account: Pick<AuthAccount, "id">,
+): boolean {
+    return account.id === envOverrideAccountId;
+}
+
+// Applies the OO_ENDPOINT override to an account resolved from auth.toml so a
+// bare OO_ENDPOINT (without OO_API_KEY) still redirects execution endpoints.
+export function applyEndpointOverride(
+    account: AuthAccount,
+    env: Record<string, string | undefined>,
+): AuthAccount {
+    const endpointOverride = readEndpointOverride(env);
+
+    if (endpointOverride === undefined) {
+        return account;
+    }
+
+    return {
+        ...account,
+        endpoint: endpointOverride,
+    };
+}

--- a/src/application/commands/shared/auth-utils.test.ts
+++ b/src/application/commands/shared/auth-utils.test.ts
@@ -1,3 +1,4 @@
+import type { AuthStore } from "../../contracts/auth-store.ts";
 import type {
     CliCatalog,
     CliExecutionContext,
@@ -74,20 +75,96 @@ describe("requireCurrentAccount", () => {
 
         await expect(requireCurrentAccount(context)).resolves.toEqual(account);
     });
+
+    test("resolves the OO_API_KEY override without reading auth.toml", async () => {
+        const context = createAuthContext(
+            { auth: [], id: "" },
+            {
+                authStore: createThrowingAuthStore(),
+                env: { OO_API_KEY: "env-key", OO_ENDPOINT: "oomol.dev" },
+            },
+        );
+
+        await expect(requireCurrentAccount(context)).resolves.toEqual({
+            apiKey: "env-key",
+            endpoint: "oomol.dev",
+            id: "oo-env-override",
+            name: "Environment (OO_API_KEY)",
+        });
+    });
+
+    test("prefers OO_API_KEY over a persisted active account", async () => {
+        const context = createAuthContext(
+            {
+                auth: [{
+                    id: "user-1",
+                    name: "Test User",
+                    apiKey: "persisted-key",
+                    endpoint: "oomol.com",
+                }],
+                id: "user-1",
+            },
+            { env: { OO_API_KEY: "env-key" } },
+        );
+
+        const resolved = await requireCurrentAccount(context);
+
+        expect(resolved.apiKey).toBe("env-key");
+        expect(resolved.id).toBe("oo-env-override");
+        // OO_ENDPOINT is unset, so the override falls back to the public default.
+        expect(resolved.endpoint).toBe("oomol.com");
+    });
+
+    test("redirects a persisted account endpoint with a bare OO_ENDPOINT", async () => {
+        const account = {
+            id: "user-1",
+            name: "Test User",
+            apiKey: "persisted-key",
+            endpoint: "oomol.com",
+        };
+        const context = createAuthContext(
+            { auth: [account], id: "user-1" },
+            { env: { OO_ENDPOINT: "oomol.dev" } },
+        );
+
+        await expect(requireCurrentAccount(context)).resolves.toEqual({
+            ...account,
+            endpoint: "oomol.dev",
+        });
+    });
 });
 
-function createAuthContext(authFile: AuthFile): CliExecutionContext {
+function createThrowingAuthStore(): AuthStore {
+    const fail = (): never => {
+        throw new Error("auth.toml must not be accessed when OO_API_KEY is set");
+    };
+
+    return {
+        getFilePath: () => "/should-not-be-read/auth.toml",
+        read: async () => fail(),
+        write: async () => fail(),
+        update: async () => fail(),
+    };
+}
+
+function createAuthContext(
+    authFile: AuthFile,
+    overrides: {
+        authStore?: AuthStore;
+        env?: Record<string, string | undefined>;
+    } = {},
+): CliExecutionContext {
     const stdout = createTextBuffer();
     const stderr = createTextBuffer();
 
     return {
-        authStore: createAuthStore(authFile),
+        authStore: overrides.authStore ?? createAuthStore(authFile),
         cacheStore: createCacheStore(),
         currentLogFilePath: "",
         execPath: process.execPath,
         fetcher: async () => new Response(null),
         cwd: process.cwd(),
-        env: {},
+        env: overrides.env ?? {},
         fileDownloadSessionStore: createNoopFileDownloadSessionStore(),
         fileUploadStore: createNoopFileUploadStore(),
         stdin,

--- a/src/application/commands/shared/auth-utils.ts
+++ b/src/application/commands/shared/auth-utils.ts
@@ -3,21 +3,35 @@ import type { AuthAccount } from "../../schemas/auth.ts";
 
 import { CliUserError } from "../../contracts/cli.ts";
 import { readCurrentAuth } from "../auth/shared.ts";
+import {
+    applyEndpointOverride,
+    buildEnvApiKeyAccount,
+    defaultOomolEndpoint,
+    readEndpointOverride,
+} from "./auth-env-override.ts";
 
 const authErrorKeys = {
     activeAccountMissing: "auth.account.activeAccountMissing",
     required: "errors.auth.required",
 } as const;
 
-const defaultOomolEndpoint = "oomol.com";
-
 export async function requireCurrentAccount(
     context: CliExecutionContext,
 ): Promise<AuthAccount> {
+    // OO_API_KEY short-circuits before any auth.toml access so embedded callers
+    // can run execution commands without a login or a persisted account.
+    const envAccount = buildEnvApiKeyAccount(context.env);
+
+    if (envAccount !== undefined) {
+        return envAccount;
+    }
+
     const { authFile, currentAccount } = await readCurrentAuth(context);
 
     if (currentAccount !== undefined) {
-        return currentAccount;
+        // A bare OO_ENDPOINT (without OO_API_KEY) still redirects the execution
+        // endpoint of the persisted account.
+        return applyEndpointOverride(currentAccount, context.env);
     }
 
     const errorKey = authFile.id === ""
@@ -27,12 +41,25 @@ export async function requireCurrentAccount(
 }
 
 // Resolves the OOMOL endpoint without requiring a logged-in account. Prefers
-// the active account's endpoint (so non-default environments are honored), then
-// the OOMOL_ENDPOINT override, then the public default. Used by unauthenticated
-// reads such as the skill-recommendation registry existence check.
+// the OO_API_KEY/OO_ENDPOINT overrides, then the active account's endpoint (so
+// non-default environments are honored), then the legacy OOMOL_ENDPOINT
+// override, then the public default. Used by unauthenticated reads such as the
+// skill-recommendation registry existence check.
 export async function resolveCurrentEndpoint(
     context: CliExecutionContext,
 ): Promise<string> {
+    const envAccount = buildEnvApiKeyAccount(context.env);
+
+    if (envAccount !== undefined) {
+        return envAccount.endpoint;
+    }
+
+    const endpointOverride = readEndpointOverride(context.env);
+
+    if (endpointOverride !== undefined) {
+        return endpointOverride;
+    }
+
     const { currentAccount } = await readCurrentAuth(context);
 
     if (currentAccount !== undefined) {

--- a/src/application/commands/skills/publish.test.ts
+++ b/src/application/commands/skills/publish.test.ts
@@ -360,6 +360,43 @@ describe("skills publish command", () => {
             key: "errors.skills.publish.invalidOwnershipMetadata",
         });
     });
+
+    test("rejects publishing under the OO_API_KEY override when no scoped package name is available", async () => {
+        const configRootDirectoryPath = await createTemporaryDirectory("publish-env-api-key");
+        const settingsFilePath = join(configRootDirectoryPath, "settings.toml");
+        const context = createPublishContext(settingsFilePath);
+        const skillDirectoryPath = join(configRootDirectoryPath, "env-api-key-skill");
+
+        cleanup.track(configRootDirectoryPath);
+
+        await writeSkillFile(skillDirectoryPath, createSkillMarkdown(
+            "env-api-key-skill",
+            "Use an env api key workflow.",
+        ));
+
+        await expect(publishSkillPackage(
+            skillDirectoryPath,
+            context,
+            "private",
+            {},
+            {
+                // Simulate auth resolved from OO_API_KEY: a synthetic account
+                // with no real scope (id "oo-env-override").
+                requireCurrentAccount: async () => ({
+                    apiKey: "env-key",
+                    endpoint: "oomol.com",
+                    id: "oo-env-override",
+                    name: "Environment (OO_API_KEY)",
+                }),
+                convertSkillDirectoryToPackage: () => {
+                    throw new Error("Conversion should not run.");
+                },
+                publishConvertedSkillPackage: () => Promise.resolve(),
+            },
+        )).rejects.toMatchObject({
+            key: "errors.skills.publish.envApiKeyPackageName",
+        });
+    });
 });
 
 function createPublishContext(

--- a/src/application/commands/skills/publish.ts
+++ b/src/application/commands/skills/publish.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { resolveRequestLanguage } from "../../../i18n/locale.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { compareSemver, isSemver } from "../../semver.ts";
+import { isEnvOverrideAccount } from "../shared/auth-env-override.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { parseEnumOption } from "../shared/input-parsing.ts";
 import { writeLine } from "../shared/output.ts";
@@ -427,11 +428,23 @@ async function areSamePath(leftPath: string, rightPath: string): Promise<boolean
 }
 
 async function resolveSkillPublishPackageName(
-    account: Pick<AuthAccount, "name">,
+    account: Pick<AuthAccount, "id" | "name">,
     source: SkillPublishSource,
 ): Promise<string> {
-    return await readSkillPublishSourceScopedPackageName(source)
-        ?? resolveCanonicalSkillPackageName(account.name, source.skillId);
+    const scopedPackageName = await readSkillPublishSourceScopedPackageName(source);
+
+    if (scopedPackageName !== undefined) {
+        return scopedPackageName;
+    }
+
+    // The OO_API_KEY env override has no account scope, so deriving a canonical
+    // package name from its synthetic account name would produce an invalid
+    // identifier. Require an explicit scoped packageName instead.
+    if (isEnvOverrideAccount(account)) {
+        throw new CliUserError("errors.skills.publish.envApiKeyPackageName", 1);
+    }
+
+    return resolveCanonicalSkillPackageName(account.name, source.skillId);
 }
 
 async function readSkillPublishSourceScopedPackageName(

--- a/src/application/commands/update.ts
+++ b/src/application/commands/update.ts
@@ -3,6 +3,7 @@ import type { CliCommandDefinition } from "../contracts/cli.ts";
 import type { SelfUpdateCommandResolutionResult, SelfUpdatePathConfigurationResult } from "../contracts/self-update.ts";
 import process from "node:process";
 import { z } from "zod";
+import { CliUserError } from "../contracts/cli.ts";
 import {
     attemptManagedSkillInstall,
     isManagedVersionExecutableInstalled,
@@ -18,6 +19,7 @@ import {
 import { detectInstallationMethodFromExecPath } from "../self-update/installation.ts";
 import { resolveSelfUpdateModifyPath } from "../self-update/modify-path-preference.ts";
 import { resolveSelfUpdateShowPathShadowingWarning } from "../self-update/path-shadowing-warning-preference.ts";
+import { isSelfUpdateDisabledByEnv } from "../self-update/self-update-disabled-preference.ts";
 import { writeSelfUpdatePathNoteIfNeeded } from "./self-update-output.ts";
 import { SelfUpdateProgressReporter } from "./self-update-progress.ts";
 import {
@@ -46,6 +48,10 @@ export const updateCommand: CliCommandDefinition<
     ],
     inputSchema: updateCommandInputSchema,
     handler: async (input, context) => {
+        if (isSelfUpdateDisabledByEnv(context.env)) {
+            throw new CliUserError("errors.selfUpdate.disabledByEnv", 1);
+        }
+
         context.telemetry?.recordProperties({
             force: true,
             path_modified: false,

--- a/src/application/self-update/modify-path-preference.test.ts
+++ b/src/application/self-update/modify-path-preference.test.ts
@@ -43,4 +43,11 @@ describe("resolveSelfUpdateModifyPath", () => {
             modifyPathFlag: false,
         })).toBeFalse();
     });
+
+    test("skips PATH modification when OO_NO_SELF_UPDATE is truthy", () => {
+        expect(resolveSelfUpdateModifyPath({
+            env: { OO_NO_SELF_UPDATE: "1" },
+            modifyPathFlag: true,
+        })).toBeFalse();
+    });
 });

--- a/src/application/self-update/modify-path-preference.ts
+++ b/src/application/self-update/modify-path-preference.ts
@@ -1,4 +1,5 @@
 import { readEnvBoolean } from "../shared/env-boolean.ts";
+import { isSelfUpdateDisabledByEnv } from "./self-update-disabled-preference.ts";
 
 export const selfUpdateNoModifyPathEnvName = "OO_NO_MODIFY_PATH";
 
@@ -7,6 +8,12 @@ export function resolveSelfUpdateModifyPath(options: {
     modifyPathFlag: boolean;
 }): boolean {
     if (!options.modifyPathFlag) {
+        return false;
+    }
+
+    // OO_NO_SELF_UPDATE disables PATH modification entirely, in addition to the
+    // dedicated OO_NO_MODIFY_PATH opt-out.
+    if (isSelfUpdateDisabledByEnv(options.env)) {
         return false;
     }
 

--- a/src/application/self-update/self-update-disabled-preference.test.ts
+++ b/src/application/self-update/self-update-disabled-preference.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import {
+    isSelfUpdateDisabledByEnv,
+    selfUpdateDisabledEnvName,
+} from "./self-update-disabled-preference.ts";
+
+describe("isSelfUpdateDisabledByEnv", () => {
+    test("returns true for truthy OO_NO_SELF_UPDATE values", () => {
+        for (const value of ["1", "true", "YES", " on "]) {
+            expect(isSelfUpdateDisabledByEnv({
+                [selfUpdateDisabledEnvName]: value,
+            })).toBeTrue();
+        }
+    });
+
+    test("returns false when OO_NO_SELF_UPDATE is unset, falsy, or unrecognized", () => {
+        expect(isSelfUpdateDisabledByEnv({})).toBeFalse();
+
+        for (const value of ["0", "false", "no", "", "maybe"]) {
+            expect(isSelfUpdateDisabledByEnv({
+                [selfUpdateDisabledEnvName]: value,
+            })).toBeFalse();
+        }
+    });
+});

--- a/src/application/self-update/self-update-disabled-preference.ts
+++ b/src/application/self-update/self-update-disabled-preference.ts
@@ -1,0 +1,12 @@
+import { readEnvBoolean } from "../shared/env-boolean.ts";
+
+export const selfUpdateDisabledEnvName = "OO_NO_SELF_UPDATE";
+
+// True when OO_NO_SELF_UPDATE is set to a truthy value. Embedded callers set
+// this so the bundled binary never updates itself or rewrites PATH; the update
+// and install commands refuse to run and PATH modification is forced off.
+export function isSelfUpdateDisabledByEnv(
+    env: Record<string, string | undefined>,
+): boolean {
+    return readEnvBoolean(env[selfUpdateDisabledEnvName]) === true;
+}

--- a/src/application/telemetry/emitter.ts
+++ b/src/application/telemetry/emitter.ts
@@ -9,6 +9,7 @@ import { readFile } from "node:fs/promises";
 import { arch, release } from "node:os";
 import process from "node:process";
 import { parse as parseToml } from "smol-toml";
+import { buildEnvApiKeyAccount } from "../commands/shared/auth-env-override.ts";
 import { authTomlFileSchema, getCurrentAuthAccount } from "../schemas/auth.ts";
 import { detectInstallationMethodFromExecPath } from "../self-update/installation.ts";
 import {
@@ -86,7 +87,10 @@ export async function emitCliCommandTelemetry(
         const ci = detectCiEnvironment(options.env);
         const uuid = Bun.randomUUIDv7();
         const payload = createCliCommandTelemetryPayload({
-            accountState: await resolveTelemetryAccountState(options.authStore),
+            accountState: await resolveTelemetryAccountState(
+                options.authStore,
+                options.env,
+            ),
             arch: arch(),
             ciName: ci.name,
             cliCommit: options.buildCommit,
@@ -200,7 +204,14 @@ function spawnTelemetryFlusherIfDue(
 
 async function resolveTelemetryAccountState(
     authStore: AuthStore | undefined,
+    env: Record<string, string | undefined>,
 ): Promise<TelemetryAccountState> {
+    // OO_API_KEY is an authenticated credential; report it as such without
+    // reading auth.toml, matching the override's "never touch auth.toml" contract.
+    if (buildEnvApiKeyAccount(env) !== undefined) {
+        return "authenticated";
+    }
+
     if (authStore === undefined) {
         return "unknown";
     }

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -483,6 +483,8 @@ export const enMessages = {
         "Invalid skill publish visibility: {value}. Use private or public.",
     "errors.skills.publish.bundledSkill":
         "Bundled skill {name} cannot be published directly because it is managed by the oo CLI release. Create a local skill before publishing.",
+    "errors.skills.publish.envApiKeyPackageName":
+        "Publishing with OO_API_KEY requires an explicit scoped package name. Add a `packageName` (for example `@scope/name`) to the skill's frontmatter.",
     "errors.skills.publish.localSkillAmbiguous":
         "Local skill {name} exists in multiple local sources ({agents}). Pass --agent to choose which agent-native skill to publish.",
     "errors.skills.share.localSkillAmbiguous":
@@ -635,6 +637,8 @@ export const enMessages = {
         "Failed to read the settings file at {path}.",
     "errors.store.writeFailed":
         "Failed to write the settings file at {path}.",
+    "errors.selfUpdate.disabledByEnv":
+        "Self-update is disabled by the OO_NO_SELF_UPDATE environment variable.",
     "errors.selfUpdate.downloadError":
         "Failed to download the target CLI release: {message}",
     "errors.selfUpdate.downloadFailed":
@@ -1602,6 +1606,8 @@ export const zhMessages = {
         "无效的 skill 发布可见性：{value}。请使用 private 或 public。",
     "errors.skills.publish.bundledSkill":
         "不能直接发布内置 skill {name}，因为它由 oo CLI 版本管理。请先创建本地 skill 再发布。",
+    "errors.skills.publish.envApiKeyPackageName":
+        "使用 OO_API_KEY 发布时需要显式的带 scope 的包名。请在 skill 的 frontmatter 中添加 `packageName`（例如 `@scope/name`）。",
     "errors.skills.publish.localSkillAmbiguous":
         "本地 skill {name} 存在于多个本地来源（{agents}）。请传入 --agent 选择要发布的 Agent 本地 skill。",
     "errors.skills.share.localSkillAmbiguous":
@@ -1750,6 +1756,8 @@ export const zhMessages = {
     "errors.store.invalidSchema": "配置文件 {path} 的结构不受支持。",
     "errors.store.readFailed": "读取配置文件 {path} 失败。",
     "errors.store.writeFailed": "写入配置文件 {path} 失败。",
+    "errors.selfUpdate.disabledByEnv":
+        "self-update 已被环境变量 OO_NO_SELF_UPDATE 禁用。",
     "errors.selfUpdate.downloadError":
         "下载目标 CLI 版本失败：{message}",
     "errors.selfUpdate.downloadFailed":


### PR DESCRIPTION
## Why

The OOMOL desktop app bundles the `oo` binary and drives it as a subprocess via environment variables, so it needs to isolate state from a user's own `oo` install, run without an interactive login, and suppress side effects that don't belong in an embedded run (skills sync, self-update, PATH rewrites, telemetry).

## What

New environment variables, honored across the CLI (truthy values: `1`/`true`/`yes`/`on`):

**Directories** (`src/adapters/store/store-path.ts`)
- `OO_CONFIG_DIR` — config root override (auth/settings/telemetry), outranks `XDG_CONFIG_HOME`, used as the root directly.
- `OO_DATA_DIR` — data dir override (cache/uploads/download-sessions).
- `OO_LOG_DIR` — log dir override, outranks every platform default.

**Auth / endpoint** (`auth-env-override.ts` → `requireCurrentAccount` / `resolveCurrentEndpoint`)
- `OO_API_KEY` — builds a login-free in-memory account; execution commands run without reading/requiring/writing `auth.toml`; outranks any persisted account.
- `OO_ENDPOINT` — base domain (e.g. `oomol.com`/`oomol.dev`) driving all service-URL derivation for execution commands; also redirects a persisted account's endpoint. Outranks the legacy `OOMOL_ENDPOINT`.

**Side-effect guards**
- `OO_SKILLS_SYNC_DISABLED` — guards the startup managed-skill sync + legacy cleanup so nothing is written into other agents' homes (`~/.agents`, `~/.claude`, ...).
- `OO_NO_SELF_UPDATE` — refuses `update`/`install`/`check-update` and forces self-update PATH modification off.

## Notes

- Telemetry reports `OO_API_KEY` runs as `authenticated` without touching `auth.toml`.
- `oo skills publish` rejects the scope-less env override with a clear error instead of deriving an invalid package name.
- Docs updated in both `docs/commands.md` and `docs/commands.zh-CN.md`.

## Testing

- `bun run lint:fix`, `bun run ts-check`, `bun run knip` — clean.
- `bun run test` — 1348 pass, 0 fail. New unit + CLI integration tests cover each variable's set/unset/priority paths (incl. no-login `connector search`/`llm config` hitting `*.oomol.dev`, `auth.toml` never read under `OO_API_KEY`, zero writes to agent homes, and self-update refusal).