### PR TITLE
refactor(connector): rename org header to x-oo-organization-name

### DIFF
--- a/src/application/commands/connector/identity.test.ts
+++ b/src/application/commands/connector/identity.test.ts
@@ -65,7 +65,7 @@ describe("resolveConnectorIdentity", () => {
 describe("connectorIdentityHeaders", () => {
     test("returns the organization header for an organization identity", () => {
         expect(connectorIdentityHeaders({ organization: "acme" })).toEqual({
-            "x-oo-organization": "acme",
+            "x-oo-organization-name": "acme",
         });
     });
 

--- a/src/application/commands/connector/identity.ts
+++ b/src/application/commands/connector/identity.ts
@@ -53,15 +53,15 @@ export function resolveConnectorIdentity(input: {
     return { identity: {}, source: "personal" };
 }
 
-// Builds the identity request headers (`x-oo-organization`). Returns an empty
-// object for the personal identity so callers can spread it unconditionally.
+// Builds the identity request headers (`x-oo-organization-name`). Returns an
+// empty object for the personal identity so callers can spread it unconditionally.
 export function connectorIdentityHeaders(
     identity: ConnectorIdentity | undefined,
 ): Record<string, string> {
     const headers: Record<string, string> = {};
 
     if (identity?.organization !== undefined) {
-        headers["x-oo-organization"] = identity.organization;
+        headers["x-oo-organization-name"] = identity.organization;
     }
 
     return headers;

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -602,7 +602,7 @@ describe("connectorCommand CLI", () => {
             expect(requests).toHaveLength(1);
             expect(requests[0]?.method).toBe("POST");
             expect(requests[0]?.url).toBe("https://connector.oomol.com/v1/proxy/tavily");
-            expect(requests[0]?.headers.get("x-oo-organization")).toBe("acme");
+            expect(requests[0]?.headers.get("x-oo-organization-name")).toBe("acme");
             await expect(requests[0]?.json()).resolves.toEqual({
                 body: {
                     query: "hello",
@@ -3187,7 +3187,7 @@ describe("connectorCommand CLI", () => {
             expect(requests[0]?.url).toBe(
                 "https://connector.oomol.com/v1/actions/gmail.send_mail",
             );
-            expect(requests[0]?.headers.get("x-oo-organization")).toBe("acme");
+            expect(requests[0]?.headers.get("x-oo-organization-name")).toBe("acme");
             expect(telemetryPayload).toMatchObject({
                 properties: {
                     command_full: "connector.run",
@@ -3271,13 +3271,13 @@ describe("connectorCommand CLI", () => {
             expect(requests[0]?.url).toBe(
                 "https://connector.oomol.com/v1/actions/gmail.send_mail",
             );
-            expect(requests[0]?.headers.get("x-oo-organization")).toBeNull();
+            expect(requests[0]?.headers.get("x-oo-organization-name")).toBeNull();
             // The run POST carries the organization identity.
             expect(requests[1]?.method).toBe("POST");
             expect(requests[1]?.url).toBe(
                 "https://connector.oomol.com/v1/actions/gmail.send_mail",
             );
-            expect(requests[1]?.headers.get("x-oo-organization")).toBe("acme");
+            expect(requests[1]?.headers.get("x-oo-organization-name")).toBe("acme");
         }
         finally {
             await sandbox.cleanup();
@@ -3330,7 +3330,7 @@ describe("connectorCommand CLI", () => {
             expect(requests[0]?.url).toBe(
                 "https://connector.oomol.com/v1/actions/gmail.send_mail",
             );
-            expect(requests[0]?.headers.get("x-oo-organization")).toBe("acme");
+            expect(requests[0]?.headers.get("x-oo-organization-name")).toBe("acme");
             expect(runTelemetryPayload).toMatchObject({
                 properties: {
                     identity_source: "config",
@@ -3389,7 +3389,7 @@ describe("connectorCommand CLI", () => {
             expect(requests[0]?.url).toBe(
                 "https://connector.oomol.com/v1/actions/gmail.send_mail",
             );
-            expect(requests[0]?.headers.get("x-oo-organization")).toBeNull();
+            expect(requests[0]?.headers.get("x-oo-organization-name")).toBeNull();
             expect(runTelemetryPayload).toMatchObject({
                 properties: {
                     identity_source: "personal",

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -223,7 +223,7 @@ describe("connector shared requests", () => {
         expect(requests[0]?.url).toBe(
             "https://connector.oomol.com/v1/actions/gmail.send_mail",
         );
-        expect(requests[0]?.headers.get("x-oo-organization")).toBe("acme");
+        expect(requests[0]?.headers.get("x-oo-organization-name")).toBe("acme");
     });
 
     test("runConnectorAction omits the organization query and header for the personal identity", async () => {
@@ -257,7 +257,7 @@ describe("connector shared requests", () => {
         expect(requests[0]?.url).toBe(
             "https://connector.oomol.com/v1/actions/gmail.send_mail",
         );
-        expect(requests[0]?.headers.get("x-oo-organization")).toBeNull();
+        expect(requests[0]?.headers.get("x-oo-organization-name")).toBeNull();
     });
 
     test("getConnectorActionMetadata never sends an organization query or header", async () => {
@@ -293,7 +293,7 @@ describe("connector shared requests", () => {
         expect(requests[0]?.url).toBe(
             "https://connector.oomol.com/v1/actions/gmail.get_message",
         );
-        expect(requests[0]?.headers.get("x-oo-organization")).toBeNull();
+        expect(requests[0]?.headers.get("x-oo-organization-name")).toBeNull();
     });
 
     test("runConnectorProxy sends proxy requests with identity headers", async () => {
@@ -357,7 +357,7 @@ describe("connector shared requests", () => {
         expect(requests).toHaveLength(1);
         expect(requests[0]?.url).toBe("https://connector.oomol.com/v1/proxy/tavily");
         expect(requests[0]?.headers.get("Authorization")).toBe("secret-1");
-        expect(requests[0]?.headers.get("x-oo-organization")).toBe("acme");
+        expect(requests[0]?.headers.get("x-oo-organization-name")).toBe("acme");
         await expect(requests[0]?.json()).resolves.toEqual({
             endpoint: "/search",
             method: "GET",


### PR DESCRIPTION
The organization identity request header was renamed from
x-oo-organization to x-oo-organization-name to match the server-side
contract. This is a header-name-only change; identity resolution,
telemetry, and the user-facing CLI contract are unaffected.

Signed-off-by: Kevin Cui <bh@bugs.cc>
