### PR TITLE
feat(connector): surface error detail on failed requests

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -628,7 +628,9 @@ Validate input data and run one connector action.
   includes `meta.pollCount`.
 - Output: dry-run JSON output returns `{ dryRun, ok }`.
 - Errors: stderr prints the HTTP status and includes the server `message`
-  and `errorCode` when the failure response provides them.
+  and `errorCode` when the failure response provides them. When the response
+  carries neither, the raw response body is included (trimmed and length
+  bounded) so the failure detail is not lost.
 - Notes: the command validates the input against the selected action contract
   before executing.
 - Notes: while waiting for an async result action in text mode, interactive
@@ -671,7 +673,9 @@ Proxy a provider API request through a connected connector app.
 - Output: JSON output keeps the stable shape
   `{ data: { status, headers, data }, meta: { executionId, service } }`.
 - Errors: stderr prints the connector proxy HTTP status and includes the server
-  `message` and `errorCode` when the failure response provides them.
+  `message` and `errorCode` when the failure response provides them. When the
+  response carries neither, the raw response body is included (trimmed and
+  length bounded) so the failure detail is not lost.
 - Notes: `oo connector proxy` does not use connector action schemas or schema
   cache. Use it when the selected connector supports proxy execution and no
   purpose-built connector action is available.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -540,7 +540,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   `--wait` 时，JSON 输出的 `data` 是完成后的结果，并包含 `meta.pollCount`。
 - 输出：dry-run 的 JSON 输出返回 `{ dryRun, ok }`。
 - 错误：stderr 会打印 HTTP 状态；如果失败响应包含服务端 `message` 或
-  `errorCode`，也会一并输出。
+  `errorCode`，也会一并输出；两者都缺失时，会输出原始响应体（已去除首尾空白
+  并限制长度），以免丢失失败详情。
 - 说明：命令会在执行前根据选中 action 的 contract 校验输入。
 - 说明：text 模式下等待 async result action 时，交互式终端会在 stderr
   显示进度。JSON 输出不会混入进度文本。
@@ -577,7 +578,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 输出：JSON 输出保持稳定结构
   `{ data: { status, headers, data }, meta: { executionId, service } }`。
 - 错误：stderr 会打印 connector proxy HTTP 状态；如果失败响应提供了
-  `message` 和 `errorCode`，也会一并包含。
+  `message` 和 `errorCode`，也会一并包含；两者都缺失时，会输出原始响应体
+  （已去除首尾空白并限制长度），以免丢失失败详情。
 - 说明：`oo connector proxy` 不使用 connector action schema 或 schema cache。
   当选中的 connector 支持 proxy execution 且没有专用 connector action 时使用。
 

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -2557,8 +2557,10 @@ describe("connectorCommand CLI", () => {
             const content = await readLatestLogContent(sandbox);
 
             expect(result.exitCode).toBe(1);
+            // The raw body is surfaced to stderr when no structured failure
+            // fields are present, so the operator sees the detail directly.
             expect(result.stderr).toContain(
-                "Connector action openai_image_async_result returned HTTP 500.",
+                "Connector action openai_image_async_result returned HTTP 500: <html><body>Internal Server Error</body></html>",
             );
             expect(content).toContain("\"actionName\":\"openai_image_async_result\"");
             // Safe bounded diagnostics:
@@ -2684,9 +2686,13 @@ describe("connectorCommand CLI", () => {
             const content = await readLatestLogContent(sandbox);
 
             expect(result.exitCode).toBe(1);
+            // The raw body is surfaced to stderr, but bounded so the oversized
+            // detail is truncated rather than dumped in full.
             expect(result.stderr).toContain(
-                "Connector action send_mail returned HTTP 500.",
+                "Connector action send_mail returned HTTP 500: {\"detail\":\"xxx",
             );
+            expect(result.stderr).not.toContain(oversizedDetail);
+            expect(result.stderr).toContain("...");
             expect(content).toContain("\"responseBodyLength\":");
             expect(content).toContain("\"responseContentType\":\"application/json\"");
             expect(content).toContain("\"rawResponsePreview\":");
@@ -2747,8 +2753,9 @@ describe("connectorCommand CLI", () => {
             const content = await readLatestLogContent(sandbox);
 
             expect(result.exitCode).toBe(1);
+            // No useful structured fields → the raw body is surfaced to stderr.
             expect(result.stderr).toContain(
-                "Connector action send_mail returned HTTP 500.",
+                "Connector action send_mail returned HTTP 500: {}",
             );
             // Schema parsed successfully but no useful fields → still include preview.
             expect(content).toContain("\"rawResponsePreview\":\"{}\"");

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -618,6 +618,35 @@ describe("connector shared requests", () => {
         });
     });
 
+    test("runConnectorAction keeps the canonical message when an alias field is not a string", async () => {
+        const error = await expectCliUserError(runConnectorAction(
+            {
+                actionName: "assume_role",
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                inputData: {},
+                serviceName: "aws_sts",
+            },
+            createRequestContext({
+                fetcher: async () => new Response(JSON.stringify({
+                    error: {
+                        nested: true,
+                    },
+                    message: "access denied by policy",
+                }), {
+                    status: 403,
+                }),
+            }),
+        ));
+
+        expect(error.key).toBe("errors.connectorRun.requestFailedWithMessage");
+        expect(error.params).toEqual({
+            action: "assume_role",
+            message: "access denied by policy",
+            status: 403,
+        });
+    });
+
     test("runConnectorAction surfaces the raw body when the failure response is not a recognized envelope", async () => {
         const error = await expectCliUserError(runConnectorAction(
             {

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -476,7 +476,7 @@ describe("connector shared requests", () => {
         });
     });
 
-    test("runConnectorProxy surfaces status when the failure response has no message or errorCode", async () => {
+    test("runConnectorProxy surfaces the raw body when the failure response has no message or errorCode", async () => {
         const error = await expectCliUserError(runConnectorProxy(
             createProxyRunInput(),
             createProxyRequestContext(async () => new Response(JSON.stringify({
@@ -486,10 +486,46 @@ describe("connector shared requests", () => {
             })),
         ));
 
+        expect(error.key).toBe("errors.connectorProxy.requestFailedWithBody");
+        expect(error.params).toEqual({
+            body: "{\"success\":false}",
+            service: "tavily",
+            status: 500,
+        });
+    });
+
+    test("runConnectorProxy maps the code and error aliases to errorCode and message", async () => {
+        const error = await expectCliUserError(runConnectorProxy(
+            createProxyRunInput(),
+            createProxyRequestContext(async () => new Response(JSON.stringify({
+                code: "POLICY_DENIED",
+                error: "access denied by policy",
+            }), {
+                status: 403,
+            })),
+        ));
+
+        expect(error.key).toBe("errors.connectorProxy.requestFailedWithMessageAndCode");
+        expect(error.params).toEqual({
+            errorCode: "POLICY_DENIED",
+            message: "access denied by policy",
+            service: "tavily",
+            status: 403,
+        });
+    });
+
+    test("runConnectorProxy surfaces status when the failure response body is empty", async () => {
+        const error = await expectCliUserError(runConnectorProxy(
+            createProxyRunInput(),
+            createProxyRequestContext(async () => new Response("", {
+                status: 502,
+            })),
+        ));
+
         expect(error.key).toBe("errors.connectorProxy.requestFailed");
         expect(error.params).toEqual({
             service: "tavily",
-            status: 500,
+            status: 502,
         });
     });
 
@@ -551,6 +587,81 @@ describe("connector shared requests", () => {
             action: "send_mail",
             errorCode: "invalid_input",
             status: 400,
+        });
+    });
+
+    test("runConnectorAction maps the code and error aliases to errorCode and message", async () => {
+        const error = await expectCliUserError(runConnectorAction(
+            {
+                actionName: "assume_role",
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                inputData: {},
+                serviceName: "aws_sts",
+            },
+            createRequestContext({
+                fetcher: async () => new Response(JSON.stringify({
+                    code: "POLICY_DENIED",
+                    error: "access denied by policy",
+                }), {
+                    status: 403,
+                }),
+            }),
+        ));
+
+        expect(error.key).toBe("errors.connectorRun.requestFailedWithMessageAndCode");
+        expect(error.params).toEqual({
+            action: "assume_role",
+            errorCode: "POLICY_DENIED",
+            message: "access denied by policy",
+            status: 403,
+        });
+    });
+
+    test("runConnectorAction surfaces the raw body when the failure response is not a recognized envelope", async () => {
+        const error = await expectCliUserError(runConnectorAction(
+            {
+                actionName: "assume_role",
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                inputData: {},
+                serviceName: "aws_sts",
+            },
+            createRequestContext({
+                fetcher: async () => new Response("Forbidden by gateway", {
+                    status: 403,
+                }),
+            }),
+        ));
+
+        expect(error.key).toBe("errors.connectorRun.requestFailedWithBody");
+        expect(error.params).toEqual({
+            action: "assume_role",
+            body: "Forbidden by gateway",
+            status: 403,
+        });
+    });
+
+    test("runConnectorAction surfaces status when the failure response body is empty", async () => {
+        const error = await expectCliUserError(runConnectorAction(
+            {
+                actionName: "assume_role",
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                inputData: {},
+                serviceName: "aws_sts",
+            },
+            createRequestContext({
+                fetcher: async () => new Response("", {
+                    status: 403,
+                }),
+            }),
+        ));
+
+        expect(error.key).toBe("errors.connectorRun.requestFailed");
+        expect(error.params).toEqual({
+            action: "assume_role",
+            status: 403,
         });
     });
 

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -103,8 +103,11 @@ const connectorProxyResponseSchema = z.object({
 const connectorActionFailureResponseSchema = z.object({
     // `code` / `error` are accepted as aliases for `errorCode` / `message`
     // because some upstream connector responses use the shorter field names.
-    code: z.string().optional(),
-    error: z.string().optional(),
+    // They are typed as `unknown` so a non-string alias value (e.g. a nested
+    // `error` object) does not fail validation and discard the canonical
+    // fields; `firstNonEmptyString` filters them down to usable strings.
+    code: z.unknown().optional(),
+    error: z.unknown().optional(),
     errorCode: z.string().optional(),
     message: z.string().optional(),
     meta: z.object({
@@ -725,7 +728,7 @@ function createConnectorFailureBodyPreview(
 }
 
 function firstNonEmptyString(
-    ...values: (string | undefined)[]
+    ...values: unknown[]
 ): string | undefined {
     for (const value of values) {
         if (isNonEmptyString(value)) {

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -101,6 +101,10 @@ const connectorProxyResponseSchema = z.object({
 }) => response);
 
 const connectorActionFailureResponseSchema = z.object({
+    // `code` / `error` are accepted as aliases for `errorCode` / `message`
+    // because some upstream connector responses use the shorter field names.
+    code: z.string().optional(),
+    error: z.string().optional(),
     errorCode: z.string().optional(),
     message: z.string().optional(),
     meta: z.object({
@@ -382,6 +386,7 @@ export async function runConnectorAction(
             throw createConnectorRunRequestFailedError({
                 actionName: options.actionName,
                 failureResponse,
+                rawResponse,
                 status: response.status,
             });
         }
@@ -500,6 +505,7 @@ export async function runConnectorProxy(
 
             throw createConnectorProxyRequestFailedError({
                 failureResponse,
+                rawResponse,
                 serviceName: options.serviceName,
                 status: response.status,
             });
@@ -572,14 +578,24 @@ function createConnectorProxyRequestUrl(
 function parseConnectorFailureResponse(
     rawResponse: string,
 ): ConnectorActionFailureResponse | undefined {
+    let parsed: ConnectorActionFailureResponse;
+
     try {
-        return connectorActionFailureResponseSchema.parse(
+        parsed = connectorActionFailureResponseSchema.parse(
             JSON.parse(rawResponse) as unknown,
         );
     }
     catch {
         return undefined;
     }
+
+    // Normalize the alias fields so downstream readers only deal with the
+    // canonical `message` / `errorCode` shape.
+    return {
+        ...parsed,
+        errorCode: firstNonEmptyString(parsed.errorCode, parsed.code),
+        message: firstNonEmptyString(parsed.message, parsed.error),
+    };
 }
 
 const safeResponseHeaderNames = [
@@ -663,15 +679,61 @@ function collectSafeConnectorFailureDiagnostics(
     return diagnostics;
 }
 
+function sanitizeConnectorResponseText(rawResponse: string): string {
+    return rawResponse
+        .replaceAll(responsePreviewWhitespacePattern, " ")
+        .replaceAll(responsePreviewControlCharsPattern, "");
+}
+
 function createBoundedResponsePreview(rawResponse: string): string {
-    const flattened = rawResponse.replaceAll(responsePreviewWhitespacePattern, " ");
-    const stripped = flattened.replaceAll(responsePreviewControlCharsPattern, "");
+    const stripped = sanitizeConnectorResponseText(rawResponse);
 
     if (stripped.length <= rawResponsePreviewMaxLength) {
         return stripped;
     }
 
     return `${stripped.slice(0, rawResponsePreviewMaxLength)}...`;
+}
+
+const connectorFailureBodyPreviewMaxLength = 500;
+
+/**
+ * Builds a user-facing preview of a non-success connector response body.
+ *
+ * Used as a fallback so the operator who ran the action still sees the raw
+ * error detail when the response could not be reduced to a structured
+ * `message` / `errorCode`. Control characters are stripped and whitespace is
+ * folded to keep the error message single-line; the result is bounded to
+ * {@link connectorFailureBodyPreviewMaxLength} characters. Returns `undefined`
+ * when the body is empty (or only whitespace) so callers can fall back to a
+ * status-only message.
+ */
+function createConnectorFailureBodyPreview(
+    rawResponse: string,
+): string | undefined {
+    const preview = sanitizeConnectorResponseText(rawResponse).trim();
+
+    if (preview === "") {
+        return undefined;
+    }
+
+    if (preview.length <= connectorFailureBodyPreviewMaxLength) {
+        return preview;
+    }
+
+    return `${preview.slice(0, connectorFailureBodyPreviewMaxLength)}...`;
+}
+
+function firstNonEmptyString(
+    ...values: (string | undefined)[]
+): string | undefined {
+    for (const value of values) {
+        if (isNonEmptyString(value)) {
+            return value;
+        }
+    }
+
+    return undefined;
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -697,6 +759,7 @@ function sanitizeConnectorFailureMessage(
 
 function createConnectorProxyRequestFailedError(input: {
     failureResponse: ConnectorActionFailureResponse | undefined;
+    rawResponse: string;
     serviceName: string;
     status: number;
 }): CliUserError {
@@ -736,6 +799,15 @@ function createConnectorProxyRequestFailedError(input: {
         });
     }
 
+    const responseBody = createConnectorFailureBodyPreview(input.rawResponse);
+    if (responseBody !== undefined) {
+        return new CliUserError("errors.connectorProxy.requestFailedWithBody", 1, {
+            body: responseBody,
+            service: input.serviceName,
+            status: input.status,
+        });
+    }
+
     return new CliUserError("errors.connectorProxy.requestFailed", 1, {
         service: input.serviceName,
         status: input.status,
@@ -745,6 +817,7 @@ function createConnectorProxyRequestFailedError(input: {
 function createConnectorRunRequestFailedError(options: {
     actionName: string;
     failureResponse: ConnectorActionFailureResponse | undefined;
+    rawResponse: string;
     status: number;
 }): CliUserError {
     const responseMessage = options.failureResponse?.message;
@@ -790,6 +863,19 @@ function createConnectorRunRequestFailedError(options: {
             {
                 action: options.actionName,
                 errorCode,
+                status: options.status,
+            },
+        );
+    }
+
+    const responseBody = createConnectorFailureBodyPreview(options.rawResponse);
+    if (responseBody !== undefined) {
+        return new CliUserError(
+            "errors.connectorRun.requestFailedWithBody",
+            1,
+            {
+                action: options.actionName,
+                body: responseBody,
                 status: options.status,
             },
         );

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -317,6 +317,8 @@ export const enMessages = {
         "The connector action run request failed: {message}",
     "errors.connectorRun.requestFailed":
         "Connector action {action} returned HTTP {status}.",
+    "errors.connectorRun.requestFailedWithBody":
+        "Connector action {action} returned HTTP {status}: {body}",
     "errors.connectorRun.requestFailedWithCode":
         "Connector action {action} returned HTTP {status} (errorCode: {errorCode}).",
     "errors.connectorRun.requestFailedWithMessage":
@@ -361,6 +363,8 @@ export const enMessages = {
         "The connector proxy request failed: {message}",
     "errors.connectorProxy.requestFailed":
         "Connector proxy service {service} returned HTTP {status}.",
+    "errors.connectorProxy.requestFailedWithBody":
+        "Connector proxy service {service} returned HTTP {status}: {body}",
     "errors.connectorProxy.requestFailedWithCode":
         "Connector proxy service {service} returned HTTP {status} (errorCode: {errorCode}).",
     "errors.connectorProxy.requestFailedWithMessage":
@@ -1440,6 +1444,8 @@ export const zhMessages = {
         "运行 connector action 失败：{message}",
     "errors.connectorRun.requestFailed":
         "Connector action {action} 返回了 HTTP {status}。",
+    "errors.connectorRun.requestFailedWithBody":
+        "Connector action {action} 返回了 HTTP {status}：{body}",
     "errors.connectorRun.requestFailedWithCode":
         "Connector action {action} 返回了 HTTP {status}（errorCode: {errorCode}）。",
     "errors.connectorRun.requestFailedWithMessage":
@@ -1484,6 +1490,8 @@ export const zhMessages = {
         "Connector proxy 请求失败：{message}",
     "errors.connectorProxy.requestFailed":
         "Connector proxy service {service} 返回了 HTTP {status}。",
+    "errors.connectorProxy.requestFailedWithBody":
+        "Connector proxy service {service} 返回了 HTTP {status}：{body}",
     "errors.connectorProxy.requestFailedWithCode":
         "Connector proxy service {service} 返回了 HTTP {status}（errorCode: {errorCode}）。",
     "errors.connectorProxy.requestFailedWithMessage":


### PR DESCRIPTION
Previously a non-success connector response only surfaced the HTTP status to stderr unless the body matched the structured message / errorCode shape, so real failure causes were only visible in debug logs. Accept the common `error` / `code` field aliases and, when no structured fields are present, fall back to a trimmed, length-bounded preview of the raw response body. The body preview is never recorded to telemetry, preserving the existing privacy guarantees.