### PR TITLE
feat(skills): add --out-dir export with --agent-format

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1137,6 +1137,25 @@ Install bundled or published skills into supported local skill directories.
   **not** bypass path containment, package validation, auth, or download
   validation; and it does **not** affect startup auto-sync, `oo skills update`,
   `oo skills sync`, `oo skills uninstall`, or `oo skills publish`.
+- Options: `--out-dir <dir>` exports the bundled skills into `<dir>` instead of
+  installing them into local agent skill directories. This is a pure export: it
+  writes only inside `<dir>` and does not modify oo's managed storage or any
+  agent home directory. Each selected bundled skill is written to
+  `<dir>/<skill-id>/`; an existing `<dir>/<skill-id>` directory is replaced,
+  while other contents of `<dir>` are left untouched. Only bundled skills are
+  exported — passing a published package name together with `--out-dir` fails.
+  The `-s, --skill` filter still narrows which bundled skills are exported, and
+  an explicit bundled skill name argument exports just that skill. `--force` has
+  no effect in export mode.
+- Options: `--agent-format <agent>` selects the render format for the exported
+  skills and only applies together with `--out-dir`; using it without
+  `--out-dir` fails. The default is `universal` (the `~/.agents` format).
+  Accepted values are `universal`, `claude`, `hermes`, `codebuddy`,
+  `workbuddy`, `trae`, `trae-cn`, `openclaw`, `qoderwork`, and `deepseek-tui`.
+- Output: with `--out-dir`, the command prints the exported skills and their
+  target directory; `--json` / `--format json` emits an export report with
+  `command: "skills.install.export"` that lists each exported skill's `path` and
+  written `files`, plus the resolved `agentFormat` and `outputDirectory`.
 - Output: successful non-interactive installs print a compact summary grouped by
   installed skills and target AI agents. When exactly one target is written, the
   summary includes that target path. With several package names, each package

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -960,6 +960,21 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   skill，并以 `warn` 日志记录此事件。`--force` **不会**绕过路径校验、
   package 校验、auth 或下载校验；**不影响**启动自动同步、`oo skills update`、
   `oo skills sync`、`oo skills uninstall`、`oo skills publish`。
+- 选项：`--out-dir <dir>` 会将内置 skill 释放到 `<dir>`，而不是安装到本地 AI Agent
+  的 skill 目录。这是一个纯导出操作：只在 `<dir>` 内写入文件，不会改动 oo 的受管
+  存储，也不会改动任何 Agent 的主目录。每个被选中的内置 skill 写入到
+  `<dir>/<skill-id>/`；已存在的 `<dir>/<skill-id>` 目录会被替换，而 `<dir>` 中的
+  其他内容保持不变。仅导出内置 skill——与 `--out-dir` 一起传入已发布的 package 名称
+  会失败。`-s, --skill` 过滤仍可缩小导出范围，显式传入内置 skill 名称则只导出该
+  skill。`--force` 在导出模式下无效。
+- 选项：`--agent-format <agent>` 选择导出 skill 的渲染格式，且仅在与 `--out-dir`
+  一起使用时生效；不带 `--out-dir` 使用它会失败。默认值为 `universal`（即
+  `~/.agents` 格式）。可选值为 `universal`、`claude`、`hermes`、`codebuddy`、
+  `workbuddy`、`trae`、`trae-cn`、`openclaw`、`qoderwork`、`deepseek-tui`。
+- 输出：使用 `--out-dir` 时，命令会输出已导出的 skill 及其目标目录；`--json` /
+  `--format json` 会输出 `command: "skills.install.export"` 的导出报告，列出每个已
+  导出 skill 的 `path` 与写入的 `files`，以及解析后的 `agentFormat` 和
+  `outputDirectory`。
 - 输出：非交互安装成功时，会按已安装 skill 和目标 AI Agent 聚合输出精简摘要；
   当实际只写入一个目标时，摘要会包含该目标路径。传入多个 package 时，每个
   package 会按顺序各自输出摘要。

--- a/src/application/commands/skills/embedded-assets.test.ts
+++ b/src/application/commands/skills/embedded-assets.test.ts
@@ -1,9 +1,14 @@
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, test } from "bun:test";
 
 import {
     availableBundledSkillAgentNames,
     availableBundledSkillNames,
     getBundledSkillFiles,
+    materializeBundledSkillToDirectory,
     readBundledSkillFileContent,
 } from "./embedded-assets.ts";
 
@@ -1120,6 +1125,133 @@ describe("embedded skill assets", () => {
         }
     });
 });
+
+describe("materializeBundledSkillToDirectory", () => {
+    test("writes every bundled skill file into the target directory", async () => {
+        const outputDirectory = await mkdtemp(join(tmpdir(), "oo-export-"));
+
+        try {
+            const targetSkillDirectoryPath = join(outputDirectory, "oo");
+            const written = await materializeBundledSkillToDirectory({
+                agentName: "universal",
+                skillName: "oo",
+                targetSkillDirectoryPath,
+            });
+
+            expect([...written]).toEqual(
+                getBundledSkillFiles("oo", "universal").map(file => file.relativePath),
+            );
+
+            for (const relativePath of written) {
+                expect(
+                    await pathExists(join(targetSkillDirectoryPath, relativePath)),
+                ).toBeTrue();
+            }
+        }
+        finally {
+            await rm(outputDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("renders the skill for the requested agent format", async () => {
+        const outputDirectory = await mkdtemp(join(tmpdir(), "oo-export-"));
+
+        try {
+            await materializeBundledSkillToDirectory({
+                agentName: "claude",
+                skillName: "oo",
+                targetSkillDirectoryPath: join(outputDirectory, "claude", "oo"),
+            });
+            await materializeBundledSkillToDirectory({
+                agentName: "universal",
+                skillName: "oo",
+                targetSkillDirectoryPath: join(outputDirectory, "universal", "oo"),
+            });
+
+            const claudeSkill = await readFile(
+                join(outputDirectory, "claude", "oo", "SKILL.md"),
+                "utf8",
+            );
+            const universalSkill = await readFile(
+                join(outputDirectory, "universal", "oo", "SKILL.md"),
+                "utf8",
+            );
+
+            // Claude renders the host-specific frontmatter; universal does not.
+            expect(claudeSkill).toContain("allowed-tools: [Bash(oo *)]");
+            expect(universalSkill).not.toContain("allowed-tools");
+            // No agentic-markdown directives survive the render in either format.
+            expect(claudeSkill).not.toContain("agentic:");
+            expect(universalSkill).not.toContain("agentic:");
+        }
+        finally {
+            await rm(outputDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("does not write an oo management metadata marker", async () => {
+        const outputDirectory = await mkdtemp(join(tmpdir(), "oo-export-"));
+
+        try {
+            const targetSkillDirectoryPath = join(outputDirectory, "oo");
+            await materializeBundledSkillToDirectory({
+                agentName: "universal",
+                skillName: "oo",
+                targetSkillDirectoryPath,
+            });
+
+            expect(
+                await pathExists(join(targetSkillDirectoryPath, ".oo-metadata.json")),
+            ).toBeFalse();
+        }
+        finally {
+            await rm(outputDirectory, { force: true, recursive: true });
+        }
+    });
+
+    test("replaces only the per-skill directory and keeps sibling content", async () => {
+        const outputDirectory = await mkdtemp(join(tmpdir(), "oo-export-"));
+
+        try {
+            const targetSkillDirectoryPath = join(outputDirectory, "oo");
+            await mkdir(targetSkillDirectoryPath, { recursive: true });
+            await writeFile(join(targetSkillDirectoryPath, "STALE.md"), "stale\n");
+            await writeFile(join(outputDirectory, "keep.txt"), "keep\n");
+
+            await materializeBundledSkillToDirectory({
+                agentName: "universal",
+                skillName: "oo",
+                targetSkillDirectoryPath,
+            });
+
+            // The stale file inside the per-skill directory is removed.
+            expect(
+                await pathExists(join(targetSkillDirectoryPath, "STALE.md")),
+            ).toBeFalse();
+            // The freshly materialized skill is present.
+            expect(
+                await pathExists(join(targetSkillDirectoryPath, "SKILL.md")),
+            ).toBeTrue();
+            // Sibling content outside the per-skill directory is untouched.
+            expect(await readFile(join(outputDirectory, "keep.txt"), "utf8")).toBe(
+                "keep\n",
+            );
+        }
+        finally {
+            await rm(outputDirectory, { force: true, recursive: true });
+        }
+    });
+});
+
+async function pathExists(path: string): Promise<boolean> {
+    try {
+        await access(path);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
 
 function normalizePathForAssertion(path: string): string {
     return path.replaceAll("\\", "/");

--- a/src/application/commands/skills/embedded-assets.ts
+++ b/src/application/commands/skills/embedded-assets.ts
@@ -1,7 +1,10 @@
 import type { BundledSkillAgentName } from "./managed-skill-agents.ts";
+import { mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { render } from "agentic-markdown";
 
 import ooCreateSkillPath from "../../../../contrib/skills/shared/oo-create-skill/SKILL.md" with { type: "file" };
+
 import ooFindSkillsCliContractPath from "../../../../contrib/skills/shared/oo-find-skills/references/oo-cli-contract.md" with { type: "file" };
 import ooFindSkillsSkillPath from "../../../../contrib/skills/shared/oo-find-skills/SKILL.md" with { type: "file" };
 import ooPublishSkillPath from "../../../../contrib/skills/shared/oo-publish-skill/SKILL.md" with { type: "file" };
@@ -11,6 +14,7 @@ import ooFileTransferReferencePath from "../../../../contrib/skills/shared/oo/re
 import ooLlmClientReferencePath from "../../../../contrib/skills/shared/oo/references/llm-client.md" with { type: "file" };
 import ooSearchAndSelectionReferencePath from "../../../../contrib/skills/shared/oo/references/search-and-selection.md" with { type: "file" };
 import ooSkillPath from "../../../../contrib/skills/shared/oo/SKILL.md" with { type: "file" };
+import { removePath } from "./bundled-skill-filesystem.ts";
 
 import {
     availableBundledSkillAgentNames,
@@ -74,6 +78,36 @@ export function getBundledSkillFiles(
         agentName,
         skillName,
     }));
+}
+
+// Materialize a bundled skill into an arbitrary directory rendered for the
+// given agent format. This is a pure export: it writes only inside
+// `targetSkillDirectoryPath`, never touches the oo app-data canonical storage
+// or any agent home directory, and writes no `.oo-metadata.json` management
+// marker. The per-skill directory is removed and recreated so stale files from
+// a previous export do not linger; sibling content in the parent directory is
+// left untouched. Returns the written file relative paths in registry order.
+export async function materializeBundledSkillToDirectory(options: {
+    agentName: BundledSkillAgentName;
+    skillName: BundledSkillName;
+    targetSkillDirectoryPath: string;
+}): Promise<readonly string[]> {
+    await removePath(options.targetSkillDirectoryPath);
+    await mkdir(options.targetSkillDirectoryPath, { recursive: true });
+
+    const files = getBundledSkillFiles(options.skillName, options.agentName);
+
+    for (const file of files) {
+        const destinationPath = join(
+            options.targetSkillDirectoryPath,
+            file.relativePath,
+        );
+
+        await mkdir(dirname(destinationPath), { recursive: true });
+        await Bun.write(destinationPath, await readBundledSkillFileContent(file));
+    }
+
+    return files.map(file => file.relativePath);
 }
 
 export async function readBundledSkillFileContent(

--- a/src/application/commands/skills/install-output.ts
+++ b/src/application/commands/skills/install-output.ts
@@ -129,6 +129,55 @@ export function writeManagedSkillInstallSummary(
     );
 }
 
+export function writeBundledSkillExportSummary(
+    context: Pick<CliExecutionContext, "stdout" | "translator">,
+    options: {
+        agentName: BundledSkillAgentName;
+        exports: readonly { path: string; skillId: string }[];
+        outputDirectoryPath: string;
+    },
+): void {
+    if (options.exports.length === 0) {
+        return;
+    }
+
+    const colors = createWriterColors(context.stdout);
+    const format = colors.cyan(
+        readManagedSkillAgentLabel(options.agentName, context.translator),
+    );
+
+    if (options.exports.length === 1) {
+        const exported = options.exports[0]!;
+
+        writeLine(
+            context.stdout,
+            context.translator.t("skills.install.export.single", {
+                format,
+                name: colors.cyan(exported.skillId),
+                path: colors.dim(exported.path),
+            }),
+        );
+        return;
+    }
+
+    writeLine(
+        context.stdout,
+        context.translator.t("skills.install.export.multiple", {
+            count: colors.bold(options.exports.length),
+            format,
+            path: colors.dim(options.outputDirectoryPath),
+        }),
+    );
+    writeDetailLine(
+        context,
+        colors.bold(context.translator.t("skills.install.summary.skillsLabel")),
+        formatSkillNames(
+            options.exports.map(exported => exported.skillId),
+            colors,
+        ),
+    );
+}
+
 function readUniqueAgentNames(
     summaries: readonly ManagedSkillInstallSummary[],
 ): BundledSkillAgentName[] {

--- a/src/application/commands/skills/install.cli.test.ts
+++ b/src/application/commands/skills/install.cli.test.ts
@@ -1,4 +1,5 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
@@ -483,3 +484,337 @@ describe("skills install --json", () => {
         }
     });
 });
+
+describe("skills install --out-dir export", () => {
+    // The export tests omit `version`, so the CLI runs as a development build and
+    // startup auto-sync is skipped. That keeps the agent homes and app-data
+    // canonical storage untouched, letting the tests assert the export's purity.
+    const allBundledSkillNames = [
+        "oo",
+        "oo-find-skills",
+        "oo-create-skill",
+        "oo-publish-skill",
+    ];
+
+    test("exports all bundled skills into the directory without touching agent homes", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            // Disable startup auto-sync so the only skill writes come from the
+            // export command itself, isolating its purity from the unrelated
+            // bundled-skill startup synchronization.
+            sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+
+            const result = await sandbox.run(["skills", "add", "--out-dir", outDir]);
+
+            expect(result.exitCode).toBe(0);
+
+            for (const skillName of allBundledSkillNames) {
+                expect(
+                    await pathExists(join(outDir, skillName, "SKILL.md")),
+                ).toBeTrue();
+            }
+
+            // The default format equals the universal `~/.agents` format, which
+            // has no host-specific frontmatter.
+            const ooSkill = await readFile(join(outDir, "oo", "SKILL.md"), "utf8");
+
+            expect(ooSkill).not.toContain("allowed-tools");
+
+            // Pure export: nothing is published to any agent home. The
+            // always-provision universal host would be written first if the
+            // export wrongly fell back to the install path.
+            const universalHome = resolveManagedSkillAgentHomeDirectory(
+                sandbox.env,
+                "universal",
+            );
+            const claudeHome = resolveManagedSkillAgentHomeDirectory(
+                sandbox.env,
+                "claude",
+            );
+
+            expect(await pathExists(join(universalHome, "skills"))).toBeFalse();
+            expect(await pathExists(join(claudeHome, "skills"))).toBeFalse();
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders the requested agent format", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "add",
+                "--out-dir",
+                outDir,
+                "--agent-format",
+                "claude",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            const ooSkill = await readFile(join(outDir, "oo", "SKILL.md"), "utf8");
+
+            expect(ooSkill).toContain("allowed-tools: [Bash(oo *)]");
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("defaults the agent format to universal when --agent-format is omitted", async () => {
+        const sandbox = await createCliSandbox();
+        const omittedDir = await mkdtemp(join(tmpdir(), "oo-out-omitted-"));
+        const universalDir = await mkdtemp(join(tmpdir(), "oo-out-universal-"));
+
+        try {
+            const omittedResult = await sandbox.run([
+                "skills",
+                "add",
+                "oo",
+                "--out-dir",
+                omittedDir,
+            ]);
+            const universalResult = await sandbox.run([
+                "skills",
+                "add",
+                "oo",
+                "--out-dir",
+                universalDir,
+                "--agent-format",
+                "universal",
+            ]);
+
+            expect(omittedResult.exitCode).toBe(0);
+            expect(universalResult.exitCode).toBe(0);
+            expect(await readFile(join(omittedDir, "oo", "SKILL.md"), "utf8")).toBe(
+                await readFile(join(universalDir, "oo", "SKILL.md"), "utf8"),
+            );
+        }
+        finally {
+            await rm(omittedDir, { force: true, recursive: true });
+            await rm(universalDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects the removed default agent-format alias", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "add",
+                "--out-dir",
+                outDir,
+                "--agent-format",
+                "default",
+            ]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("Unsupported agent format");
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("narrows the export with --skill", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "add",
+                "--out-dir",
+                outDir,
+                "--skill",
+                "oo",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(await pathExists(join(outDir, "oo", "SKILL.md"))).toBeTrue();
+            expect(await pathExists(join(outDir, "oo-find-skills"))).toBeFalse();
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("exports an explicitly named bundled skill", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "add",
+                "oo-create-skill",
+                "--out-dir",
+                outDir,
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(
+                await pathExists(join(outDir, "oo-create-skill", "SKILL.md")),
+            ).toBeTrue();
+            expect(await pathExists(join(outDir, "oo"))).toBeFalse();
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails when --skill matches no bundled skill", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "add",
+                "--out-dir",
+                outDir,
+                "--skill",
+                "nope",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("None of the requested skills exist");
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects a non-bundled package name in export mode", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "add",
+                "not-a-bundled-skill",
+                "--out-dir",
+                outDir,
+            ]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("is not a bundled skill");
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects --agent-format without --out-dir", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "add",
+                "--agent-format",
+                "claude",
+            ]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("--out-dir");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects an unsupported agent format", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "add",
+                "--out-dir",
+                outDir,
+                "--agent-format",
+                "bogus",
+            ]);
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("Unsupported agent format");
+            // The error lists the accepted agents (no `default` alias).
+            expect(result.stderr).toContain("universal");
+            expect(result.stderr).not.toContain("default");
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("emits a structured JSON export report", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "add",
+                "oo",
+                "--out-dir",
+                outDir,
+                "--json",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.command).toBe("skills.install.export");
+            expect(payload.status).toBe("completed");
+            expect(payload.agentFormat).toBe("universal");
+            expect(payload.outputDirectory).toBe(outDir);
+            expect(payload.summary).toMatchObject({
+                requestedSkills: 1,
+                exported: 1,
+                failed: 0,
+            });
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(1);
+            expect(skills[0]).toMatchObject({
+                skillId: "oo",
+                status: "exported",
+                path: join(outDir, "oo"),
+            });
+            expect(skills[0]!.files).toContain("SKILL.md");
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+});
+
+async function pathExists(path: string): Promise<boolean> {
+    try {
+        await access(path);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -2,26 +2,36 @@ import type {
     CliCommandDefinition,
     CliExecutionContext,
 } from "../../contracts/cli.ts";
-import type { BundledSkillName } from "./embedded-assets.ts";
+import type { BundledSkillAgentName, BundledSkillName } from "./embedded-assets.ts";
 
 import type { ManagedSkillInstallSummary } from "./install-output.ts";
 import type {
+    ExportReport,
     InstallReport,
     PreviousState,
+    SkillExportResult,
     SkillOperationError,
     SkillResult,
     SkillTargetResult,
 } from "./operation-result.ts";
+import { join, resolve } from "node:path";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
 import { parsePackageSpecifier } from "../shared/package-info.ts";
 import { directoryExists } from "./bundled-skill-observation.ts";
-import { availableBundledSkillNames } from "./embedded-assets.ts";
-import { writeManagedSkillInstallSummary } from "./install-output.ts";
+import {
+    availableBundledSkillNames,
+    materializeBundledSkillToDirectory,
+} from "./embedded-assets.ts";
+import {
+    writeBundledSkillExportSummary,
+    writeManagedSkillInstallSummary,
+} from "./install-output.ts";
 import { migrateLegacyCanonicalSkillLayout } from "./legacy-canonical-migration.ts";
 import { readSkillMetadataFileState } from "./local-skill-ownership.ts";
+import { parseAgentFormatOption } from "./managed-skill-agents.ts";
 import { readManagedSkillMetadata } from "./managed-skill-metadata.ts";
 import {
     resolveManagedSkillCanonicalDirectoryPath,
@@ -50,6 +60,8 @@ interface SkillsInstallInput {
     force?: boolean;
     packageNames?: string[];
     skill?: string[];
+    outDir?: string;
+    agentFormat?: string;
     format?: "json";
     showSchemaVersion?: boolean;
 }
@@ -111,17 +123,49 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
             valueName: "skills...",
             descriptionKey: "options.skills.skill",
         },
+        {
+            name: "outDir",
+            longFlag: "--out-dir",
+            valueName: "dir",
+            descriptionKey: "options.skills.install.outDir",
+        },
+        {
+            name: "agentFormat",
+            longFlag: "--agent-format",
+            valueName: "agent",
+            descriptionKey: "options.skills.install.agentFormat",
+        },
         ...skillOperationOutputOptions,
     ],
     inputSchema: z.object({
         force: z.boolean().optional(),
         packageNames: z.array(z.string()).optional(),
         skill: z.array(z.string()).optional(),
+        outDir: z.string().optional(),
+        agentFormat: z.string().optional(),
         format: z.enum(["json"]).optional(),
         showSchemaVersion: z.boolean().optional(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
+        // `--agent-format` only shapes the `--out-dir` export; on the normal
+        // install path it would be ignored, so reject the combination loudly
+        // instead of silently doing nothing.
+        if (input.agentFormat !== undefined && input.outDir === undefined) {
+            throw new CliUserError(
+                "errors.skills.install.agentFormatRequiresOutDir",
+                2,
+            );
+        }
+
+        // `--out-dir` switches to a pure bundled-skill export: it writes only
+        // inside the requested directory, with no app-data canonical storage,
+        // host detection, legacy migration, or network side effects.
+        if (input.outDir !== undefined) {
+            await runBundledSkillExport(input, context);
+            return;
+        }
+
         await migrateLegacyCanonicalSkillLayout(context);
 
         const force = input.force === true;
@@ -381,6 +425,141 @@ function selectBundledSkillNamesOrThrow(
     }
 
     return selected;
+}
+
+// Export bundled skills into an arbitrary directory rendered for one agent
+// format. Pure with respect to oo state: it never writes to the app-data
+// canonical storage or any agent home, performs no network requests, and
+// writes no `.oo-metadata.json` marker.
+async function runBundledSkillExport(
+    input: SkillsInstallInput,
+    context: CliExecutionContext,
+): Promise<void> {
+    const outputDirectoryPath = resolve(input.outDir!);
+    const agentName = parseAgentFormatOption(
+        input.agentFormat,
+        "errors.skills.install.invalidAgentFormat",
+    );
+    const skillFilterActive = normalizeSkillFilterTokens(input.skill) !== undefined;
+    const selectedBundled = selectExportBundledSkillNames(
+        input.packageNames,
+        input.skill,
+    );
+
+    context.telemetry?.recordProperties({
+        agent_format: agentName,
+        has_bundled_skill: true,
+        has_out_dir: true,
+        has_registry_skill: false,
+        has_skill_filter: skillFilterActive,
+        package_kind: "bundled",
+        skill_count_bucket: bucketTelemetryCount(selectedBundled.length),
+        ...createSkillIdsTelemetryProperties(selectedBundled),
+    });
+
+    const exports: SkillExportResult[] = [];
+
+    for (const skillName of selectedBundled) {
+        const targetSkillDirectoryPath = join(outputDirectoryPath, skillName);
+        const files = await materializeBundledSkillToDirectory({
+            agentName,
+            skillName,
+            targetSkillDirectoryPath,
+        });
+
+        context.logger.info(
+            {
+                agentName,
+                path: targetSkillDirectoryPath,
+                skillName,
+            },
+            "Bundled skill exported to directory.",
+        );
+        exports.push({
+            skillId: skillName,
+            status: "exported",
+            path: targetSkillDirectoryPath,
+            files: [...files],
+        });
+    }
+
+    if (input.format === "json") {
+        writeSkillOperationJson(
+            context.stdout,
+            buildExportReport(exports, agentName, outputDirectoryPath),
+            { showSchemaVersion: input.showSchemaVersion },
+        );
+        return;
+    }
+
+    writeBundledSkillExportSummary(context, {
+        agentName,
+        exports,
+        outputDirectoryPath,
+    });
+}
+
+// Resolve which bundled skills the export should materialize. With no positional
+// names the export covers every bundled skill, narrowed by the optional
+// `--skill` filter. Positional names must each identify a bundled skill: the
+// export is bundled-only and offline, so registry package specifiers are
+// rejected rather than downloaded.
+function selectExportBundledSkillNames(
+    packageNames: readonly string[] | undefined,
+    skillFilter: readonly string[] | undefined,
+): readonly BundledSkillName[] {
+    const names = packageNames ?? [];
+
+    if (names.length === 0) {
+        return selectBundledSkillNamesOrThrow(skillFilter);
+    }
+
+    const selected: BundledSkillName[] = [];
+    const seen = new Set<string>();
+
+    for (const rawName of names) {
+        const trimmedName = rawName.trim();
+
+        if (!isBundledSkillName(trimmedName)) {
+            throw new CliUserError("errors.skills.install.exportRequiresBundled", 2, {
+                skills: availableBundledSkillNames.join(", "),
+                value: rawName,
+            });
+        }
+
+        if (!seen.has(trimmedName)) {
+            seen.add(trimmedName);
+            selected.push(trimmedName);
+        }
+    }
+
+    return selected;
+}
+
+function buildExportReport(
+    exports: readonly SkillExportResult[],
+    agentName: BundledSkillAgentName,
+    outputDirectoryPath: string,
+): ExportReport {
+    const exported = exports.length;
+
+    return {
+        command: "skills.install.export",
+        status: computeCommandStatus({
+            succeeded: exported,
+            failed: 0,
+            commandLevelErrors: 0,
+        }),
+        agentFormat: agentName,
+        outputDirectory: outputDirectoryPath,
+        summary: {
+            requestedSkills: exported,
+            exported,
+            failed: 0,
+        },
+        skills: [...exports],
+        errors: [],
+    };
 }
 
 async function runInstallJsonReport(

--- a/src/application/commands/skills/managed-skill-agents.ts
+++ b/src/application/commands/skills/managed-skill-agents.ts
@@ -150,6 +150,30 @@ export function formatSupportedSkillAgentNames(): string {
     return availableBundledSkillAgentNames.join(", ");
 }
 
+// Resolve the `--agent-format` export option. An omitted (or blank) value
+// defaults to the universal `~/.agents` format; every provided value must name a
+// supported agent. Throws a localized `CliUserError` (exit 2) listing the
+// accepted agents when the value is unsupported.
+export function parseAgentFormatOption(
+    value: string | undefined,
+    errorKey: string,
+): BundledSkillAgentName {
+    const normalized = value === undefined ? "" : value.trim();
+
+    if (normalized === "") {
+        return "universal";
+    }
+
+    if (availableBundledSkillAgentNames.includes(normalized as BundledSkillAgentName)) {
+        return normalized as BundledSkillAgentName;
+    }
+
+    throw new CliUserError(errorKey, 2, {
+        agents: formatSupportedSkillAgentNames(),
+        value: normalized,
+    });
+}
+
 export function parseManagedSkillAgentOption(
     value: string | undefined,
     errorKey: string,

--- a/src/application/commands/skills/operation-result.ts
+++ b/src/application/commands/skills/operation-result.ts
@@ -67,6 +67,27 @@ export interface InstallReport {
     errors: SkillOperationError[];
 }
 
+export interface SkillExportResult {
+    skillId: string;
+    status: "exported";
+    path: string;
+    files: string[];
+}
+
+export interface ExportReport {
+    command: "skills.install.export";
+    status: CommandStatus;
+    agentFormat: BundledSkillAgentName;
+    outputDirectory: string;
+    summary: {
+        requestedSkills: number;
+        exported: number;
+        failed: number;
+    };
+    skills: SkillExportResult[];
+    errors: SkillOperationError[];
+}
+
 export interface UninstallReport {
     command: "skills.uninstall";
     status: CommandStatus;
@@ -121,6 +142,7 @@ export interface SyncApplyReport {
 
 export type SkillOperationReport
     = | InstallReport
+        | ExportReport
         | UninstallReport
         | UpdateReport
         | SyncUploadReport

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -270,11 +270,13 @@ const commandTelemetryDecisions = {
     "skills.install": {
         kind: "properties",
         properties: [
+            "agent_format",
             "bundled_skill",
             "failed_count_bucket",
             "format",
             "has_bundled_skill",
             "has_force",
+            "has_out_dir",
             "has_registry_skill",
             "has_skill_filter",
             "installed_count_bucket",
@@ -288,7 +290,7 @@ const commandTelemetryDecisions = {
             "skill_ids_sample",
             "skill_ids_truncated",
         ],
-        reason: "Records install source, product-domain package dimensions, bounded skill/package samples, force-flag and skill-filter usage, and JSON-output result buckets.",
+        reason: "Records install source, product-domain package dimensions, bounded skill/package samples, force-flag and skill-filter usage, JSON-output result buckets, and for the --out-dir export the directory presence flag and selected agent render format (a fixed enum).",
     },
     "skills.info": {
         kind: "properties",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -583,8 +583,14 @@ export const enMessages = {
         "{agentName} is not installed. Expected the {agentName} home directory at {path}.",
     "errors.skills.noSupportedBundledSkillHosts":
         "No supported skill host is installed. Expected one of: {paths}.",
+    "errors.skills.install.agentFormatRequiresOutDir":
+        "--agent-format can only be used together with --out-dir.",
     "errors.skills.install.confirmationRequired":
         "Skill {name} already exists and requires interactive confirmation.",
+    "errors.skills.install.exportRequiresBundled":
+        "{value} is not a bundled skill. --out-dir exports bundled skills only. Available bundled skills: {skills}.",
+    "errors.skills.install.invalidAgentFormat":
+        "Unsupported agent format: {value}. Use {agents}.",
     "errors.skills.install.invalidArchive":
         "Downloaded package archive does not contain a valid skill directory for {name}.",
     "errors.skills.install.invalidPackageInfo":
@@ -896,6 +902,10 @@ export const enMessages = {
         "Force install even when a same-name skill directory exists and is not managed by oo",
     "options.skills.skill":
         "Skill name(s) to limit the operation to (case-insensitive; non-matching names are ignored)",
+    "options.skills.install.outDir":
+        "Export bundled skills into this directory instead of installing them into local agent homes; writes only inside this directory",
+    "options.skills.install.agentFormat":
+        "Agent render format for exported skills; only applies with --out-dir (default: universal)",
     "options.lang": "Specify the display language",
     "options.version": "Show the current version",
     "selfUpdate.install.success": "Installed oo {version}.",
@@ -1033,6 +1043,10 @@ export const enMessages = {
     "warnings.skills.localUninstallAmbiguous":
         "Warning: Local skill {name} exists in multiple local sources ({agents}). Nothing was removed; pass --agent to choose one.",
     "skills.install.success": "Installed skill {name} to {path}.",
+    "skills.install.export.single":
+        "Exported skill {name} ({format}) to {path}.",
+    "skills.install.export.multiple":
+        "Exported {count} skills ({format}) to {path}.",
     "skills.install.summary.agentsLabel": "Agents",
     "skills.install.summary.detailLine": "{label}: {values}",
     "skills.install.summary.installed": "Installed",
@@ -1710,8 +1724,14 @@ export const zhMessages = {
         "未检测到 {agentName} 安装。期望的 {agentName} 根目录为 {path}。",
     "errors.skills.noSupportedBundledSkillHosts":
         "未检测到已安装的受支持 Agent。期望其中之一位于：{paths}。",
+    "errors.skills.install.agentFormatRequiresOutDir":
+        "--agent-format 只能与 --out-dir 一起使用。",
     "errors.skills.install.confirmationRequired":
         "Skill {name} 已存在，且需要在交互终端中确认覆盖。",
+    "errors.skills.install.exportRequiresBundled":
+        "{value} 不是内置 skill。--out-dir 只能导出内置 skill。可用的内置 skill：{skills}。",
+    "errors.skills.install.invalidAgentFormat":
+        "不受支持的 agent 格式：{value}。请使用 {agents}。",
     "errors.skills.install.invalidArchive":
         "下载的包归档中不包含 {name} 对应的有效 skill 目录。",
     "errors.skills.install.invalidPackageInfo":
@@ -2015,6 +2035,10 @@ export const zhMessages = {
         "强制安装，即使同名 skill 目录已存在且不受 oo 管理",
     "options.skills.skill":
         "限定操作的 skill 名称（可指定多个；大小写不敏感；不匹配的名称会被忽略）",
+    "options.skills.install.outDir":
+        "将内置 skill 释放到该目录，而不是安装到本地 Agent 主目录；仅在该目录内写入文件",
+    "options.skills.install.agentFormat":
+        "导出 skill 时使用的 Agent 渲染格式；仅在指定 --out-dir 时生效（默认：universal）",
     "options.lang": "指定显示语言",
     "options.version": "显示当前版本",
     "selfUpdate.install.success": "已安装 oo {version}。",
@@ -2152,6 +2176,10 @@ export const zhMessages = {
     "warnings.skills.localUninstallAmbiguous":
         "警告：本地 skill {name} 存在于多个本地来源（{agents}）。未删除任何内容；请传入 --agent 选择一个。",
     "skills.install.success": "已将 skill {name} 安装到 {path}。",
+    "skills.install.export.single":
+        "已将 skill {name}（{format}）导出到 {path}。",
+    "skills.install.export.multiple":
+        "已将 {count} 个 skills（{format}）导出到 {path}。",
     "skills.install.summary.agentsLabel": "Agents",
     "skills.install.summary.detailLine": "{label}：{values}",
     "skills.install.summary.installed": "已安装",


### PR DESCRIPTION
`oo skills add/install --out-dir <dir>` releases the bundled skills into an arbitrary directory as a pure operation: it renders and writes only inside <dir>, never touching oo's app-data canonical storage or any agent home, and writes no .oo-metadata.json marker. This lets callers materialize the built-in skills wherever they need them without performing a managed install.

`--agent-format <agent>` selects the render format and only applies with --out-dir; it defaults to `universal` (the ~/.agents format) and accepts the supported agent names. The --skill filter and explicit bundled skill name arguments still narrow what is exported, registry package names are rejected, and `--json` emits a skills.install.export report. Telemetry records has_out_dir and the resolved agent_format.