### PR TITLE
feat(skills): export registry skills with --out-dir

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1137,25 +1137,35 @@ Install bundled or published skills into supported local skill directories.
   **not** bypass path containment, package validation, auth, or download
   validation; and it does **not** affect startup auto-sync, `oo skills update`,
   `oo skills sync`, `oo skills uninstall`, or `oo skills publish`.
-- Options: `--out-dir <dir>` exports the bundled skills into `<dir>` instead of
-  installing them into local agent skill directories. This is a pure export: it
-  writes only inside `<dir>` and does not modify oo's managed storage or any
-  agent home directory. Each selected bundled skill is written to
-  `<dir>/<skill-id>/`; an existing `<dir>/<skill-id>` directory is replaced,
-  while other contents of `<dir>` are left untouched. Only bundled skills are
-  exported — passing a published package name together with `--out-dir` fails.
-  The `-s, --skill` filter still narrows which bundled skills are exported, and
-  an explicit bundled skill name argument exports just that skill. `--force` has
-  no effect in export mode.
-- Options: `--agent-format <agent>` selects the render format for the exported
-  skills and only applies together with `--out-dir`; using it without
-  `--out-dir` fails. The default is `universal` (the `~/.agents` format).
-  Accepted values are `universal`, `claude`, `hermes`, `codebuddy`,
-  `workbuddy`, `trae`, `trae-cn`, `openclaw`, `qoderwork`, and `deepseek-tui`.
+- Options: `--out-dir <dir>` exports skills into `<dir>` instead of installing
+  them into local agent skill directories. This is a pure export: it writes only
+  inside `<dir>` and does not modify oo's managed storage or any agent home
+  directory. Each selected skill is written to `<dir>/<skill-id>/`; an existing
+  `<dir>/<skill-id>` directory is replaced, while other contents of `<dir>` are
+  left untouched. Exported skills are keyed only by skill id, so when more than
+  one selected skill resolves to the same id (across packages, or a registry
+  skill that shares a bundled skill name) the last one written wins. Both bundled
+  skills and published registry packages can be exported: a bundled skill name
+  (or the no-argument form) is materialized offline, while a published package
+  name is downloaded, extracted, and written in its published form. Registry exports send the active account's
+  `Authorization` header. The `-s, --skill` filter narrows which skills are
+  exported from each registry package and, in the no-argument form, which
+  bundled skills are exported; an explicit bundled skill name argument exports
+  just that skill. `--force` has no effect in export mode.
+- Options: `--agent-format <agent>` selects the render format for exported
+  bundled skills and only applies together with `--out-dir`; using it without
+  `--out-dir` fails. It does not reshape exported registry skills, which are
+  always written in their published form. The default is `universal` (the
+  `~/.agents` format). Accepted values are `universal`, `claude`, `hermes`,
+  `codebuddy`, `workbuddy`, `trae`, `trae-cn`, `openclaw`, `qoderwork`, and
+  `deepseek-tui`.
 - Output: with `--out-dir`, the command prints the exported skills and their
   target directory; `--json` / `--format json` emits an export report with
-  `command: "skills.install.export"` that lists each exported skill's `path` and
-  written `files`, plus the resolved `agentFormat` and `outputDirectory`.
+  `command: "skills.install.export"` that lists each exported skill's `kind`
+  (`bundled` or `registry`), source `packageName` (`null` for bundled skills),
+  `path`, and written `files`, plus the resolved `agentFormat` and
+  `outputDirectory`. When a requested registry package cannot be exported, the
+  failure is reported in the report's `errors[]` and the command exits `1`.
 - Output: successful non-interactive installs print a compact summary grouped by
   installed skills and target AI agents. When exactly one target is written, the
   summary includes that target path. With several package names, each package

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1166,6 +1166,12 @@ Install bundled or published skills into supported local skill directories.
   `path`, and written `files`, plus the resolved `agentFormat` and
   `outputDirectory`. When a requested registry package cannot be exported, the
   failure is reported in the report's `errors[]` and the command exits `1`.
+  Skills exported before a later failure within the same package are still
+  listed in the report's exported skills, yielding a `partial-failure` status.
+- Path rule: under `--out-dir`, a registry skill name is accepted only when it
+  is a single safe path segment that stays inside the output directory;
+  otherwise the export is rejected with `invalid_path` before anything is
+  downloaded or written.
 - Output: successful non-interactive installs print a compact summary grouped by
   installed skills and target AI agents. When exactly one target is written, the
   summary includes that target path. With several package names, each package

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -981,7 +981,11 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   导出 skill 的 `kind`（`bundled` 或 `registry`）、来源 `packageName`（内置 skill
   为 `null`）、`path` 与写入的 `files`，以及解析后的 `agentFormat` 和
   `outputDirectory`。当请求的 registry package 无法导出时，失败会记录在报告的
-  `errors[]` 中，命令以退出码 `1` 结束。
+  `errors[]` 中，命令以退出码 `1` 结束。同一 package 中在后续 skill 失败之前已
+  导出的 skill 仍会列入报告的已导出 skill 列表，此时状态为 `partial-failure`。
+- 路径规则：使用 `--out-dir` 时，registry skill 名仅在其为单个安全路径段、且保持
+  在输出目录内时才被接受；否则导出会在下载或写入任何内容之前以 `invalid_path`
+  拒绝。
 - 输出：非交互安装成功时，会按已安装 skill 和目标 AI Agent 聚合输出精简摘要；
   当实际只写入一个目标时，摘要会包含该目标路径。传入多个 package 时，每个
   package 会按顺序各自输出摘要。

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -960,21 +960,28 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   skill，并以 `warn` 日志记录此事件。`--force` **不会**绕过路径校验、
   package 校验、auth 或下载校验；**不影响**启动自动同步、`oo skills update`、
   `oo skills sync`、`oo skills uninstall`、`oo skills publish`。
-- 选项：`--out-dir <dir>` 会将内置 skill 释放到 `<dir>`，而不是安装到本地 AI Agent
+- 选项：`--out-dir <dir>` 会将 skill 释放到 `<dir>`，而不是安装到本地 AI Agent
   的 skill 目录。这是一个纯导出操作：只在 `<dir>` 内写入文件，不会改动 oo 的受管
-  存储，也不会改动任何 Agent 的主目录。每个被选中的内置 skill 写入到
+  存储，也不会改动任何 Agent 的主目录。每个被选中的 skill 写入到
   `<dir>/<skill-id>/`；已存在的 `<dir>/<skill-id>` 目录会被替换，而 `<dir>` 中的
-  其他内容保持不变。仅导出内置 skill——与 `--out-dir` 一起传入已发布的 package 名称
-  会失败。`-s, --skill` 过滤仍可缩小导出范围，显式传入内置 skill 名称则只导出该
-  skill。`--force` 在导出模式下无效。
-- 选项：`--agent-format <agent>` 选择导出 skill 的渲染格式，且仅在与 `--out-dir`
-  一起使用时生效；不带 `--out-dir` 使用它会失败。默认值为 `universal`（即
+  其他内容保持不变。导出的 skill 仅以 skill id 作为目录名，因此当多个被选中的
+  skill 解析到同一个 id（跨多个 package，或 registry skill 与内置 skill 同名）时，
+  后写入者会覆盖先前的导出。内置 skill 与已发布的 registry package 都可以导出：
+  内置 skill 名称（或无参形式）会离线生成，已发布的 package 名称则会被下载、解压
+  并以其发布形态写入。registry 导出会携带当前账号的 `Authorization` 头。`-s, --skill` 过滤
+  会缩小每个 registry package 导出的 skill，以及无参形式下导出的内置 skill；显式
+  传入内置 skill 名称则只导出该 skill。`--force` 在导出模式下无效。
+- 选项：`--agent-format <agent>` 选择导出内置 skill 的渲染格式，且仅在与
+  `--out-dir` 一起使用时生效；不带 `--out-dir` 使用它会失败。它不会改变导出的
+  registry skill，后者始终以发布形态写入。默认值为 `universal`（即
   `~/.agents` 格式）。可选值为 `universal`、`claude`、`hermes`、`codebuddy`、
   `workbuddy`、`trae`、`trae-cn`、`openclaw`、`qoderwork`、`deepseek-tui`。
 - 输出：使用 `--out-dir` 时，命令会输出已导出的 skill 及其目标目录；`--json` /
   `--format json` 会输出 `command: "skills.install.export"` 的导出报告，列出每个已
-  导出 skill 的 `path` 与写入的 `files`，以及解析后的 `agentFormat` 和
-  `outputDirectory`。
+  导出 skill 的 `kind`（`bundled` 或 `registry`）、来源 `packageName`（内置 skill
+  为 `null`）、`path` 与写入的 `files`，以及解析后的 `agentFormat` 和
+  `outputDirectory`。当请求的 registry package 无法导出时，失败会记录在报告的
+  `errors[]` 中，命令以退出码 `1` 结束。
 - 输出：非交互安装成功时，会按已安装 skill 和目标 AI Agent 聚合输出精简摘要；
   当实际只写入一个目标时，摘要会包含该目标路径。传入多个 package 时，每个
   package 会按顺序各自输出摘要。

--- a/src/application/commands/skills/install-output.ts
+++ b/src/application/commands/skills/install-output.ts
@@ -129,7 +129,7 @@ export function writeManagedSkillInstallSummary(
     );
 }
 
-export function writeBundledSkillExportSummary(
+export function writeSkillExportSummary(
     context: Pick<CliExecutionContext, "stdout" | "translator">,
     options: {
         agentName: BundledSkillAgentName;

--- a/src/application/commands/skills/install.cli.test.ts
+++ b/src/application/commands/skills/install.cli.test.ts
@@ -708,15 +708,27 @@ describe("skills install --out-dir export", () => {
             // With registry export support, an unknown positional name is no
             // longer rejected as "not a bundled skill"; it is treated as a
             // registry package, so the export now requires authentication.
-            const result = await sandbox.run([
-                "skills",
-                "add",
-                "@alice/demo",
-                "--out-dir",
-                outDir,
-            ]);
+            let fetchCalled = false;
+            const result = await sandbox.run(
+                [
+                    "skills",
+                    "add",
+                    "@alice/demo",
+                    "--out-dir",
+                    outDir,
+                ],
+                {
+                    fetcher: async () => {
+                        fetchCalled = true;
+                        throw new Error("fetch must not run before auth");
+                    },
+                },
+            );
 
+            // The auth gate must trip before any registry request, so the
+            // failure proves the auth requirement rather than an unrelated error.
             expect(result.exitCode).toBe(1);
+            expect(fetchCalled).toBeFalse();
             expect(await pathExists(join(outDir, "demo"))).toBeFalse();
         }
         finally {
@@ -1201,6 +1213,107 @@ describe("skills install --out-dir export", () => {
             expect(result.exitCode).toBe(0);
             expect(await pathExists(join(outDir, "demo", "stale.txt"))).toBeFalse();
             expect(await pathExists(join(outDir, "demo", "SKILL.md"))).toBeTrue();
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("preserves an earlier skill when a later skill in the same package fails", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+
+            const result = await sandbox.run(
+                ["skills", "add", "@alice/demo", "--out-dir", outDir, "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return twoSkillPackageInfoResponse();
+                        }
+                        if (request.url.includes("/download-count")) {
+                            return new Response(null, { status: 204 });
+                        }
+                        if (request.url.endsWith("/demo-0.1.0.tgz")) {
+                            // The archive ships the first skill but omits the
+                            // second skill's SKILL.md, so the later export fails.
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/demo/SKILL.md":
+                                    "---\nname: demo\ndescription: Demo skill\n---\n\n# Demo\n",
+                            }));
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            // The skill exported before the failure is preserved in the report
+            // and on disk instead of being discarded by the later failure.
+            expect(payload.status).toBe("partial-failure");
+            expect(skills.map(skill => skill.skillId)).toEqual(["demo"]);
+            expect(await pathExists(join(outDir, "demo", "SKILL.md"))).toBeTrue();
+            expect(errors[0]).toMatchObject({ code: "invalid_package_archive" });
+            expect(await pathExists(join(outDir, "extra"))).toBeFalse();
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects a registry skill whose name escapes the output directory", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+
+            let tarballRequested = false;
+            const result = await sandbox.run(
+                ["skills", "add", "@alice/demo", "--out-dir", outDir, "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            // A malicious registry advertises a traversal name.
+                            return new Response(JSON.stringify({
+                                packageName: "@alice/demo",
+                                version: "0.1.0",
+                                skills: [
+                                    { description: "evil", name: "../evil", title: "evil" },
+                                ],
+                            }));
+                        }
+                        if (request.url.endsWith("/demo-0.1.0.tgz")) {
+                            tarballRequested = true;
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            // The unsafe name is rejected before any download or filesystem
+            // write, and nothing is created outside the output directory.
+            expect(errors[0]).toMatchObject({ code: "invalid_path" });
+            expect(tarballRequested).toBeFalse();
+            expect(await pathExists(join(outDir, "..", "evil"))).toBeFalse();
         }
         finally {
             await rm(outDir, { force: true, recursive: true });

--- a/src/application/commands/skills/install.cli.test.ts
+++ b/src/application/commands/skills/install.cli.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
     createCliSandbox,
+    createRegistrySkillArchiveBytes,
     toRequest,
     writeAuthFile,
 } from "../../../../__tests__/helpers.ts";
@@ -699,21 +700,24 @@ describe("skills install --out-dir export", () => {
         }
     });
 
-    test("rejects a non-bundled package name in export mode", async () => {
+    test("treats a non-bundled package name as a registry package that needs auth", async () => {
         const sandbox = await createCliSandbox();
         const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
 
         try {
+            // With registry export support, an unknown positional name is no
+            // longer rejected as "not a bundled skill"; it is treated as a
+            // registry package, so the export now requires authentication.
             const result = await sandbox.run([
                 "skills",
                 "add",
-                "not-a-bundled-skill",
+                "@alice/demo",
                 "--out-dir",
                 outDir,
             ]);
 
-            expect(result.exitCode).toBe(2);
-            expect(result.stderr).toContain("is not a bundled skill");
+            expect(result.exitCode).toBe(1);
+            expect(await pathExists(join(outDir, "demo"))).toBeFalse();
         }
         finally {
             await rm(outDir, { force: true, recursive: true });
@@ -797,6 +801,8 @@ describe("skills install --out-dir export", () => {
             expect(skills).toHaveLength(1);
             expect(skills[0]).toMatchObject({
                 skillId: "oo",
+                kind: "bundled",
+                packageName: null,
                 status: "exported",
                 path: join(outDir, "oo"),
             });
@@ -807,7 +813,433 @@ describe("skills install --out-dir export", () => {
             await sandbox.cleanup();
         }
     });
+
+    test("exports a registry package into the directory without managed side effects", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+            // Pre-existing sibling content must survive the export.
+            await writeFile(join(outDir, "keep.txt"), "keep\n");
+
+            const result = await sandbox.run(
+                ["skills", "add", "@alice/demo", "--out-dir", outDir],
+                { fetcher: createRegistryDemoFetcher() },
+            );
+
+            expect(result.exitCode).toBe(0);
+
+            const skillMarkdown = await readFile(
+                join(outDir, "demo", "SKILL.md"),
+                "utf8",
+            );
+
+            expect(skillMarkdown).toContain("name: demo");
+            // Registry exports normalize the SKILL.md exactly like installs do.
+            expect(skillMarkdown).toContain("Requires the oo CLI.");
+            expect(
+                await pathExists(join(outDir, "demo", "references", "guide.md")),
+            ).toBeTrue();
+            // Pure export: no oo management marker is written.
+            expect(
+                await pathExists(join(outDir, "demo", ".oo-metadata.json")),
+            ).toBeFalse();
+            // Sibling content is untouched.
+            expect(await readFile(join(outDir, "keep.txt"), "utf8")).toBe("keep\n");
+
+            // Nothing is published to any agent home.
+            const universalHome = resolveManagedSkillAgentHomeDirectory(
+                sandbox.env,
+                "universal",
+            );
+
+            expect(await pathExists(join(universalHome, "skills"))).toBeFalse();
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("narrows a registry export with --skill", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+
+            const result = await sandbox.run(
+                ["skills", "add", "@alice/demo", "--out-dir", outDir, "--skill", "demo"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        if (request.url.includes("/package-info/")) {
+                            return twoSkillPackageInfoResponse();
+                        }
+                        if (request.url.includes("/download-count")) {
+                            return new Response(null, { status: 204 });
+                        }
+                        if (request.url.endsWith("/demo-0.1.0.tgz")) {
+                            return new Response(await createRegistrySkillArchiveBytes({
+                                "package/package/skills/demo/SKILL.md":
+                                    "---\nname: demo\ndescription: Demo skill\n---\n\n# Demo\n",
+                                "package/package/skills/extra/SKILL.md":
+                                    "---\nname: extra\ndescription: Extra skill\n---\n\n# Extra\n",
+                            }));
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(await pathExists(join(outDir, "demo", "SKILL.md"))).toBeTrue();
+            expect(await pathExists(join(outDir, "extra"))).toBeFalse();
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("emits registry kind and packageName in the JSON export report", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+
+            const result = await sandbox.run(
+                ["skills", "add", "@alice/demo", "--out-dir", outDir, "--json"],
+                { fetcher: createRegistryDemoFetcher() },
+            );
+
+            expect(result.exitCode).toBe(0);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(payload.command).toBe("skills.install.export");
+            expect(payload.status).toBe("completed");
+            const skills = payload.skills as Array<Record<string, unknown>>;
+
+            expect(skills).toHaveLength(1);
+            expect(skills[0]).toMatchObject({
+                skillId: "demo",
+                kind: "registry",
+                packageName: "@alice/demo",
+                status: "exported",
+                path: join(outDir, "demo"),
+            });
+            expect(skills[0]!.files).toContain("SKILL.md");
+            expect(skills[0]!.files).toContain("references/guide.md");
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports a registry lookup failure in the JSON export report errors", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+
+            const result = await sandbox.run(
+                ["skills", "add", "@alice/demo", "--out-dir", outDir, "--json"],
+                { fetcher: async () => new Response("err", { status: 500 }) },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(payload.status).toBe("failed");
+            expect(skills).toHaveLength(0);
+            expect(errors[0]).toMatchObject({ code: "package_lookup_failed" });
+            expect(await pathExists(join(outDir, "demo"))).toBeFalse();
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("exports bundled and registry skills together", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+
+            const result = await sandbox.run(
+                ["skills", "add", "oo", "@alice/demo", "--out-dir", outDir],
+                { fetcher: createRegistryDemoFetcher() },
+            );
+
+            expect(result.exitCode).toBe(0);
+            // Bundled skill is materialized offline.
+            expect(await pathExists(join(outDir, "oo", "SKILL.md"))).toBeTrue();
+            // Registry skill is downloaded and written alongside it.
+            expect(await pathExists(join(outDir, "demo", "SKILL.md"))).toBeTrue();
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects a blank --out-dir without deleting a same-named cwd directory", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            // A blank --out-dir would resolve to the working directory; guard
+            // against the per-skill removePath wiping a same-named directory.
+            const collidingDirectory = join(sandbox.cwd, "oo");
+
+            await mkdir(collidingDirectory, { recursive: true });
+            await writeFile(join(collidingDirectory, "keep.txt"), "keep\n");
+
+            const result = await sandbox.run(["skills", "add", "oo", "--out-dir", ""]);
+
+            expect(result.exitCode).toBe(2);
+            // The pre-existing directory in the working directory is untouched.
+            expect(await readFile(join(collidingDirectory, "keep.txt"), "utf8")).toBe(
+                "keep\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects a whitespace-only --out-dir", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(["skills", "add", "--out-dir", "   "]);
+
+            expect(result.exitCode).toBe(2);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("resolves a relative --out-dir against the invocation cwd", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "add",
+                "oo",
+                "--out-dir",
+                "exported",
+            ]);
+
+            expect(result.exitCode).toBe(0);
+            expect(
+                await pathExists(join(sandbox.cwd, "exported", "oo", "SKILL.md")),
+            ).toBeTrue();
+        }
+        finally {
+            await rm(join(sandbox.cwd, "exported"), { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports a no-package --skill miss as JSON instead of throwing", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            const result = await sandbox.run([
+                "skills",
+                "add",
+                "--out-dir",
+                outDir,
+                "--skill",
+                "nope",
+                "--json",
+            ]);
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(payload.command).toBe("skills.install.export");
+            expect(payload.status).toBe("failed");
+            expect(skills).toHaveLength(0);
+            expect(errors[0]).toMatchObject({ code: "skill_filter_no_match" });
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports a registry --skill miss in the JSON export report", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+
+            const result = await sandbox.run(
+                ["skills", "add", "@alice/demo", "--out-dir", outDir, "--skill", "nope", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        // The filter excludes every published skill after
+                        // package-info loads but before any tarball fetch.
+                        if (request.url.includes("/package-info/")) {
+                            return packageInfoResponse("@alice/demo", "0.1.0", "demo");
+                        }
+                        throw new Error(`Unexpected request: ${request.url}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(payload.command).toBe("skills.install.export");
+            expect(payload.status).toBe("failed");
+            expect(skills).toHaveLength(0);
+            expect(errors[0]).toMatchObject({ code: "skill_filter_no_match" });
+            expect(await pathExists(join(outDir, "demo"))).toBeFalse();
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("keeps earlier exports when a later registry package fails in text mode", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+
+            const result = await sandbox.run(
+                ["skills", "add", "oo", "@alice/demo", "--out-dir", outDir],
+                { fetcher: async () => new Response("err", { status: 500 }) },
+            );
+
+            expect(result.exitCode).toBe(1);
+            // The bundled skill exported before the registry failure survives.
+            expect(await pathExists(join(outDir, "oo", "SKILL.md"))).toBeTrue();
+            expect(await pathExists(join(outDir, "demo"))).toBeFalse();
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("emits a partial-failure JSON report when one package fails", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+
+            const result = await sandbox.run(
+                ["skills", "add", "oo", "@alice/demo", "--out-dir", outDir, "--json"],
+                { fetcher: async () => new Response("err", { status: 500 }) },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const skills = payload.skills as Array<Record<string, unknown>>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            expect(payload.status).toBe("partial-failure");
+            expect(skills.map(skill => skill.skillId)).toEqual(["oo"]);
+            expect(skills[0]).toMatchObject({ kind: "bundled" });
+            expect(errors[0]).toMatchObject({ code: "package_lookup_failed" });
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
+
+    test("replaces an existing per-skill directory and removes stale files", async () => {
+        const sandbox = await createCliSandbox();
+        const outDir = await mkdtemp(join(tmpdir(), "oo-out-"));
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_SKILLS_SYNC_DISABLED = "1";
+            // A stale file from a previous export must not linger.
+            await mkdir(join(outDir, "demo"), { recursive: true });
+            await writeFile(join(outDir, "demo", "stale.txt"), "stale\n");
+
+            const result = await sandbox.run(
+                ["skills", "add", "@alice/demo", "--out-dir", outDir],
+                { fetcher: createRegistryDemoFetcher() },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(await pathExists(join(outDir, "demo", "stale.txt"))).toBeFalse();
+            expect(await pathExists(join(outDir, "demo", "SKILL.md"))).toBeTrue();
+        }
+        finally {
+            await rm(outDir, { force: true, recursive: true });
+            await sandbox.cleanup();
+        }
+    });
 });
+
+function twoSkillPackageInfoResponse() {
+    return new Response(JSON.stringify({
+        packageName: "@alice/demo",
+        version: "0.1.0",
+        skills: [
+            { description: "demo", name: "demo", title: "demo" },
+            { description: "extra", name: "extra", title: "extra" },
+        ],
+    }));
+}
+
+function createRegistryDemoFetcher() {
+    return async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const request = toRequest(input, init);
+
+        if (request.url.includes("/package-info/")) {
+            return packageInfoResponse("@alice/demo", "0.1.0", "demo");
+        }
+        if (request.url.includes("/download-count")) {
+            return new Response(null, { status: 204 });
+        }
+        if (request.url.endsWith("/demo-0.1.0.tgz")) {
+            return new Response(await createRegistrySkillArchiveBytes({
+                "package/package/skills/demo/SKILL.md":
+                    "---\nname: demo\ndescription: Demo skill\n---\n\n# Demo\n",
+                "package/package/skills/demo/references/guide.md": "# Guide\n",
+            }));
+        }
+        throw new Error(`Unexpected request: ${request.url}`);
+    };
+}
 
 async function pathExists(path: string): Promise<boolean> {
     try {

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -622,7 +622,8 @@ async function exportBundledSkill(
 }
 
 // Download and export one registry package's selected skills, appending each
-// written skill to `exports`. Throws on download/lookup failure; the caller's
+// written skill to `exports`. Throws on download/lookup failure, or after a
+// per-skill failure once the skills that did succeed are recorded; the caller's
 // guard decides whether to propagate (text mode) or collect into `errors[]`.
 async function exportRegistryPackageSkills(
     specifier: SkillsInstallPackageSpecifier,
@@ -634,7 +635,7 @@ async function exportRegistryPackageSkills(
     },
     context: CliExecutionContext,
 ): Promise<void> {
-    const results = await exportRegistrySkills(
+    const { exported, failures } = await exportRegistrySkills(
         {
             outputDirectoryPath: state.outputDirectoryPath,
             packageName: specifier.packageName,
@@ -647,11 +648,14 @@ async function exportRegistryPackageSkills(
         context,
     );
 
-    if (results.length > 0) {
+    // A package that produced any export attempt matched the `--skill` filter,
+    // even if some of its skills then failed; record the match so a per-package
+    // failure is not misreported as a global filter miss.
+    if (exported.length + failures.length > 0) {
         state.registryFilterMatch.recordMatch();
     }
 
-    for (const result of results) {
+    for (const result of exported) {
         state.exports.push({
             skillId: result.skillName,
             kind: "registry",
@@ -660,6 +664,13 @@ async function exportRegistryPackageSkills(
             path: result.targetSkillDirectoryPath,
             files: result.files,
         });
+    }
+
+    // Surface the first per-skill failure only after the successful exports are
+    // recorded, so the package-level error still drives the exit code while the
+    // skills written before it remain in the report and on disk.
+    if (failures.length > 0) {
+        throw failures[0]!.error;
     }
 }
 

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -26,8 +26,8 @@ import {
     materializeBundledSkillToDirectory,
 } from "./embedded-assets.ts";
 import {
-    writeBundledSkillExportSummary,
     writeManagedSkillInstallSummary,
+    writeSkillExportSummary,
 } from "./install-output.ts";
 import { migrateLegacyCanonicalSkillLayout } from "./legacy-canonical-migration.ts";
 import { readSkillMetadataFileState } from "./local-skill-ownership.ts";
@@ -41,6 +41,7 @@ import {
     skillOperationOutputOptions,
     writeSkillOperationJson,
 } from "./operation-result.ts";
+import { exportRegistrySkills } from "./registry-skill-export.ts";
 import { installRegistrySkills } from "./registry-skill-install.ts";
 import {
     installBundledSkill,
@@ -158,11 +159,13 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
             );
         }
 
-        // `--out-dir` switches to a pure bundled-skill export: it writes only
-        // inside the requested directory, with no app-data canonical storage,
-        // host detection, legacy migration, or network side effects.
+        // `--out-dir` switches to a pure export: it writes only inside the
+        // requested directory, with no app-data canonical storage, host
+        // detection, or legacy migration. Bundled skills are materialized
+        // offline; registry packages are downloaded and extracted into the same
+        // directory without any oo-managed marker.
         if (input.outDir !== undefined) {
-            await runBundledSkillExport(input, context);
+            await runSkillExport(input, context);
             return;
         }
 
@@ -408,157 +411,374 @@ function resolveInstallPackageKindLabel(
 function selectBundledSkillNamesOrThrow(
     skillFilter: readonly string[] | undefined,
 ): readonly BundledSkillName[] {
-    const tokens = normalizeSkillFilterTokens(skillFilter);
+    const selection = resolveBundledSkillSelection(skillFilter);
 
-    if (tokens === undefined) {
-        return availableBundledSkillNames;
-    }
-
-    const selected = availableBundledSkillNames.filter(name =>
-        skillMatchesFilterTokens({ name }, tokens),
-    );
-
-    if (selected.length === 0) {
+    if (selection.filterMissed) {
         throw new CliUserError("errors.skills.skillFilterNoMatch", 1, {
             skills: availableBundledSkillNames.join(", "),
         });
     }
 
-    return selected;
+    return selection.skills;
 }
 
-// Export bundled skills into an arbitrary directory rendered for one agent
-// format. Pure with respect to oo state: it never writes to the app-data
-// canonical storage or any agent home, performs no network requests, and
-// writes no `.oo-metadata.json` marker.
-async function runBundledSkillExport(
+// Resolve the bundled skills selected by the optional `--skill` filter without
+// throwing. `filterMissed` is true only when a filter was active yet matched no
+// bundled skill, letting callers either throw (text mode) or report a structured
+// error (JSON mode).
+function resolveBundledSkillSelection(
+    skillFilter: readonly string[] | undefined,
+): { filterMissed: boolean; skills: readonly BundledSkillName[] } {
+    const tokens = normalizeSkillFilterTokens(skillFilter);
+
+    if (tokens === undefined) {
+        return { filterMissed: false, skills: availableBundledSkillNames };
+    }
+
+    const skills = availableBundledSkillNames.filter(name =>
+        skillMatchesFilterTokens({ name }, tokens),
+    );
+
+    return { filterMissed: skills.length === 0, skills };
+}
+
+// Export bundled and registry skills into an arbitrary directory. Pure with
+// respect to oo state: it never writes to the app-data canonical storage or any
+// agent home, and writes no `.oo-metadata.json` marker. Bundled skills are
+// materialized offline and rendered for the requested `--agent-format`; registry
+// packages are downloaded, extracted, and written in their published form.
+async function runSkillExport(
     input: SkillsInstallInput,
     context: CliExecutionContext,
 ): Promise<void> {
-    const outputDirectoryPath = resolve(input.outDir!);
+    // Reject a blank `--out-dir` before resolving: `resolve("")` would silently
+    // fall back to the working directory and the per-skill removePath/cp would
+    // then clobber a same-named directory there.
+    if (input.outDir!.trim() === "") {
+        throw new CliUserError("errors.skills.install.invalidOutDir", 2);
+    }
+
+    // Resolve a relative `--out-dir` against the invocation cwd (not the process
+    // cwd) so embedded hosts that override the working directory behave like the
+    // file download command.
+    const outputDirectoryPath = resolve(context.cwd, input.outDir!);
     const agentName = parseAgentFormatOption(
         input.agentFormat,
         "errors.skills.install.invalidAgentFormat",
     );
     const skillFilterActive = normalizeSkillFilterTokens(input.skill) !== undefined;
-    const selectedBundled = selectExportBundledSkillNames(
-        input.packageNames,
-        input.skill,
-    );
+    const wantJson = input.format === "json";
+    const packageNames = input.packageNames ?? [];
 
-    context.telemetry?.recordProperties({
-        agent_format: agentName,
-        has_bundled_skill: true,
-        has_out_dir: true,
-        has_registry_skill: false,
-        has_skill_filter: skillFilterActive,
-        package_kind: "bundled",
-        skill_count_bucket: bucketTelemetryCount(selectedBundled.length),
-        ...createSkillIdsTelemetryProperties(selectedBundled),
+    // Parse every specifier up front so a malformed package name fails the whole
+    // command before any export side effects are written.
+    const targets = packageNames.map(classifySkillsInstallTarget);
+
+    recordExportBaseTelemetry(context, {
+        agentName,
+        skillFilterActive,
+        targets,
     });
 
     const exports: SkillExportResult[] = [];
+    const errors: SkillOperationError[] = [];
+    const registryFilterMatch = new RegistrySkillFilterMatchTracker();
 
-    for (const skillName of selectedBundled) {
-        const targetSkillDirectoryPath = join(outputDirectoryPath, skillName);
-        const files = await materializeBundledSkillToDirectory({
-            agentName,
-            skillName,
-            targetSkillDirectoryPath,
-        });
+    if (packageNames.length === 0) {
+        // No package argument exports the bundled skills, narrowed by the
+        // optional `--skill` filter.
+        const selection = resolveBundledSkillSelection(input.skill);
 
-        context.logger.info(
-            {
-                agentName,
-                path: targetSkillDirectoryPath,
-                skillName,
-            },
-            "Bundled skill exported to directory.",
-        );
-        exports.push({
-            skillId: skillName,
-            status: "exported",
-            path: targetSkillDirectoryPath,
-            files: [...files],
-        });
+        if (selection.filterMissed) {
+            reportExportSkillFilterMiss(
+                wantJson,
+                errors,
+                availableBundledSkillNames.join(", "),
+            );
+        }
+        else {
+            for (const skillName of selection.skills) {
+                await runGuardedExportStep(wantJson, errors, context, undefined, async () => {
+                    exports.push(await exportBundledSkill(
+                        skillName,
+                        agentName,
+                        outputDirectoryPath,
+                        context,
+                    ));
+                });
+            }
+        }
+    }
+    else {
+        for (const target of targets) {
+            if (target.kind === "bundled") {
+                // An explicitly named bundled skill is already a single-skill
+                // selection, so `--skill` does not further narrow it.
+                await runGuardedExportStep(wantJson, errors, context, undefined, async () => {
+                    exports.push(await exportBundledSkill(
+                        target.specifier.packageName as BundledSkillName,
+                        agentName,
+                        outputDirectoryPath,
+                        context,
+                    ));
+                });
+                continue;
+            }
+
+            await runGuardedExportStep(
+                wantJson,
+                errors,
+                context,
+                target.specifier.packageName,
+                () => exportRegistryPackageSkills(
+                    target.specifier,
+                    { exports, input, outputDirectoryPath, registryFilterMatch },
+                    context,
+                ),
+            );
+        }
+
+        // With a `--skill` filter, fail only when nothing was exported at all:
+        // per-package registry misses are silently skipped, and an explicitly
+        // named bundled skill (which `--skill` never narrows) keeps the command
+        // successful even when no registry package matched.
+        if (
+            skillFilterActive
+            && registryFilterMatch.isGlobalMiss()
+            && exports.length === 0
+        ) {
+            reportExportSkillFilterMiss(
+                wantJson,
+                errors,
+                registryFilterMatch.availableSkillsList(),
+            );
+        }
     }
 
-    if (input.format === "json") {
-        writeSkillOperationJson(
-            context.stdout,
-            buildExportReport(exports, agentName, outputDirectoryPath),
-            { showSchemaVersion: input.showSchemaVersion },
+    context.telemetry?.recordProperties({
+        skill_count_bucket: bucketTelemetryCount(exports.length),
+        ...createSkillIdsTelemetryProperties(exports.map(result => result.skillId)),
+    });
+
+    if (wantJson) {
+        const report = buildExportReport(
+            exports,
+            errors,
+            agentName,
+            outputDirectoryPath,
         );
+
+        writeSkillOperationJson(context.stdout, report, {
+            showSchemaVersion: input.showSchemaVersion,
+        });
+
+        if (report.status === "partial-failure" || report.status === "failed") {
+            throw new CliUserError("errors.skills.install.partialFailure", 1, {
+                count: errors.length,
+            });
+        }
         return;
     }
 
-    writeBundledSkillExportSummary(context, {
+    writeSkillExportSummary(context, {
         agentName,
         exports,
         outputDirectoryPath,
     });
 }
 
-// Resolve which bundled skills the export should materialize. With no positional
-// names the export covers every bundled skill, narrowed by the optional
-// `--skill` filter. Positional names must each identify a bundled skill: the
-// export is bundled-only and offline, so registry package specifiers are
-// rejected rather than downloaded.
-function selectExportBundledSkillNames(
-    packageNames: readonly string[] | undefined,
-    skillFilter: readonly string[] | undefined,
-): readonly BundledSkillName[] {
-    const names = packageNames ?? [];
+// Materialize one bundled skill into `<outputDirectoryPath>/<skillName>` and
+// return the structured export result.
+async function exportBundledSkill(
+    skillName: BundledSkillName,
+    agentName: BundledSkillAgentName,
+    outputDirectoryPath: string,
+    context: CliExecutionContext,
+): Promise<SkillExportResult> {
+    const targetSkillDirectoryPath = join(outputDirectoryPath, skillName);
+    const files = await materializeBundledSkillToDirectory({
+        agentName,
+        skillName,
+        targetSkillDirectoryPath,
+    });
 
-    if (names.length === 0) {
-        return selectBundledSkillNamesOrThrow(skillFilter);
+    context.logger.info(
+        {
+            agentName,
+            path: targetSkillDirectoryPath,
+            skillName,
+        },
+        "Bundled skill exported to directory.",
+    );
+
+    return {
+        skillId: skillName,
+        kind: "bundled",
+        packageName: null,
+        status: "exported",
+        path: targetSkillDirectoryPath,
+        files: [...files],
+    };
+}
+
+// Download and export one registry package's selected skills, appending each
+// written skill to `exports`. Throws on download/lookup failure; the caller's
+// guard decides whether to propagate (text mode) or collect into `errors[]`.
+async function exportRegistryPackageSkills(
+    specifier: SkillsInstallPackageSpecifier,
+    state: {
+        exports: SkillExportResult[];
+        input: SkillsInstallInput;
+        outputDirectoryPath: string;
+        registryFilterMatch: RegistrySkillFilterMatchTracker;
+    },
+    context: CliExecutionContext,
+): Promise<void> {
+    const results = await exportRegistrySkills(
+        {
+            outputDirectoryPath: state.outputDirectoryPath,
+            packageName: specifier.packageName,
+            packageShareId: specifier.packageShareId,
+            packageVersion: specifier.packageVersion,
+            reportSkillFilterMiss: names =>
+                state.registryFilterMatch.recordMiss(names),
+            skillFilter: state.input.skill,
+        },
+        context,
+    );
+
+    if (results.length > 0) {
+        state.registryFilterMatch.recordMatch();
     }
 
-    const selected: BundledSkillName[] = [];
-    const seen = new Set<string>();
+    for (const result of results) {
+        state.exports.push({
+            skillId: result.skillName,
+            kind: "registry",
+            packageName: result.packageName,
+            status: "exported",
+            path: result.targetSkillDirectoryPath,
+            files: result.files,
+        });
+    }
+}
 
-    for (const rawName of names) {
-        const trimmedName = rawName.trim();
-
-        if (!isBundledSkillName(trimmedName)) {
-            throw new CliUserError("errors.skills.install.exportRequiresBundled", 2, {
-                skills: availableBundledSkillNames.join(", "),
-                value: rawName,
-            });
-        }
-
-        if (!seen.has(trimmedName)) {
-            seen.add(trimmedName);
-            selected.push(trimmedName);
-        }
+// Run one export step (bundled or registry). In JSON mode a failure is captured
+// into `errors` so the structured report still drives the exit code (mirroring
+// the install JSON path); in text mode it propagates so the CLI renders it,
+// keeping earlier exports on disk.
+async function runGuardedExportStep(
+    wantJson: boolean,
+    errors: SkillOperationError[],
+    context: CliExecutionContext,
+    packageName: string | undefined,
+    run: () => Promise<void>,
+): Promise<void> {
+    if (!wantJson) {
+        await run();
+        return;
     }
 
-    return selected;
+    try {
+        await run();
+    }
+    catch (error) {
+        const code = mapInstallErrorCode(error);
+
+        errors.push({
+            code,
+            message: installErrorMessages[code] ?? installErrorMessages.unknown!,
+        });
+        context.logger.warn(
+            { err: error, ...(packageName === undefined ? {} : { packageName }) },
+            "Skills export step failed.",
+        );
+    }
+}
+
+// Surface a `--skill` filter miss: throw in text mode, or record a structured
+// `skill_filter_no_match` error in JSON mode so the export report still emits.
+function reportExportSkillFilterMiss(
+    wantJson: boolean,
+    errors: SkillOperationError[],
+    availableSkills: string,
+): void {
+    if (!wantJson) {
+        throw new CliUserError("errors.skills.skillFilterNoMatch", 1, {
+            skills: availableSkills,
+        });
+    }
+
+    errors.push({
+        code: "skill_filter_no_match",
+        message: installErrorMessages.skill_filter_no_match!,
+    });
+}
+
+function recordExportBaseTelemetry(
+    context: CliExecutionContext,
+    options: {
+        agentName: BundledSkillAgentName;
+        skillFilterActive: boolean;
+        targets: readonly ClassifiedSkillsInstallTarget[];
+    },
+): void {
+    const registryPackageNames = [
+        ...new Set(
+            options.targets
+                .filter(target => target.kind === "registry")
+                .map(target => target.specifier.packageName),
+        ),
+    ];
+    const hasRegistry = registryPackageNames.length > 0;
+    // The no-argument export covers every bundled skill, so it always has a
+    // bundled component even though no positional bundled target is present.
+    const hasBundled = options.targets.length === 0
+        || options.targets.some(target => target.kind === "bundled");
+
+    context.telemetry?.recordProperties({
+        agent_format: options.agentName,
+        has_bundled_skill: hasBundled,
+        has_out_dir: true,
+        has_registry_skill: hasRegistry,
+        has_skill_filter: options.skillFilterActive,
+        package_kind: resolveInstallPackageKindLabel(hasBundled, hasRegistry),
+        ...createPackageNamesTelemetryProperties(registryPackageNames),
+    });
+
+    if (registryPackageNames.length === 1) {
+        context.telemetry?.recordProperties({
+            package_name: registryPackageNames[0]!,
+        });
+    }
 }
 
 function buildExportReport(
     exports: readonly SkillExportResult[],
+    errors: readonly SkillOperationError[],
     agentName: BundledSkillAgentName,
     outputDirectoryPath: string,
 ): ExportReport {
     const exported = exports.length;
+    const failed = errors.length;
 
     return {
         command: "skills.install.export",
         status: computeCommandStatus({
             succeeded: exported,
             failed: 0,
-            commandLevelErrors: 0,
+            commandLevelErrors: failed,
+            noopWhenEmpty: exported === 0 && failed === 0,
         }),
         agentFormat: agentName,
         outputDirectory: outputDirectoryPath,
         summary: {
-            requestedSkills: exported,
+            requestedSkills: exported + failed,
             exported,
-            failed: 0,
+            failed,
         },
         skills: [...exports],
-        errors: [],
+        errors: [...errors],
     };
 }
 
@@ -573,14 +793,9 @@ async function runInstallJsonReport(
     const packageNames = input.packageNames ?? [];
 
     if (packageNames.length === 0) {
-        const skillFilterTokens = normalizeSkillFilterTokens(input.skill);
-        const selectedBundled = skillFilterTokens === undefined
-            ? availableBundledSkillNames
-            : availableBundledSkillNames.filter(name =>
-                    skillMatchesFilterTokens({ name }, skillFilterTokens),
-                );
+        const selection = resolveBundledSkillSelection(input.skill);
 
-        if (skillFilterTokens !== undefined && selectedBundled.length === 0) {
+        if (selection.filterMissed) {
             errors.push({
                 code: "skill_filter_no_match",
                 message: installErrorMessages.skill_filter_no_match!,
@@ -589,7 +804,7 @@ async function runInstallJsonReport(
             return buildReport(skills, errors, 0);
         }
 
-        for (const bundledName of selectedBundled) {
+        for (const bundledName of selection.skills) {
             const result = await installBundledSkillForJson(
                 bundledName,
                 context,

--- a/src/application/commands/skills/operation-result.ts
+++ b/src/application/commands/skills/operation-result.ts
@@ -69,6 +69,8 @@ export interface InstallReport {
 
 export interface SkillExportResult {
     skillId: string;
+    kind: "bundled" | "registry";
+    packageName: string | null;
     status: "exported";
     path: string;
     files: string[];

--- a/src/application/commands/skills/registry-skill-export.ts
+++ b/src/application/commands/skills/registry-skill-export.ts
@@ -21,6 +21,7 @@ import {
     normalizeSkillFilterTokens,
     selectSkillsByFilter,
 } from "./skill-filter.ts";
+import { isSkillIdReference } from "./skill-id.ts";
 
 export interface RegistrySkillExportRequest {
     outputDirectoryPath: string;
@@ -43,6 +44,16 @@ export interface RegistrySkillExportResult {
     targetSkillDirectoryPath: string;
 }
 
+export interface RegistrySkillExportFailure {
+    error: unknown;
+    skillName: string;
+}
+
+export interface RegistrySkillExportOutcome {
+    exported: RegistrySkillExportResult[];
+    failures: RegistrySkillExportFailure[];
+}
+
 // Export published registry skills into an arbitrary directory. This mirrors the
 // registry install download/extract pipeline but is pure with respect to oo
 // state: it writes only inside `outputDirectoryPath`, never touches the oo
@@ -53,7 +64,7 @@ export interface RegistrySkillExportResult {
 export async function exportRegistrySkills(
     request: RegistrySkillExportRequest,
     context: CliExecutionContext,
-): Promise<RegistrySkillExportResult[]> {
+): Promise<RegistrySkillExportOutcome> {
     const account = await requireCurrentAccount(context);
     const packageInfo = await loadRegistryPackageSkillInfo(
         request.packageName,
@@ -75,7 +86,19 @@ export async function exportRegistrySkills(
     );
 
     if (selectedSkills.length === 0) {
-        return [];
+        return { exported: [], failures: [] };
+    }
+
+    // Registry skill names are server-provided and are used directly in
+    // filesystem joins and a destructive removePath. Reject any name that is not
+    // a single safe path segment before downloading or touching the output
+    // directory, mirroring the registry install path's containment check.
+    for (const skill of selectedSkills) {
+        if (!isSkillIdReference(skill.name)) {
+            throw new CliUserError("errors.skills.invalidPath", 1, {
+                name: skill.name,
+            });
+        }
     }
 
     await tryReportRegistryPackageDownload(
@@ -94,19 +117,27 @@ export async function exportRegistrySkills(
     const extractedPackage = await extractRegistryPackageArchive(packageBytes);
 
     try {
-        const results: RegistrySkillExportResult[] = [];
+        const exported: RegistrySkillExportResult[] = [];
+        const failures: RegistrySkillExportFailure[] = [];
 
         for (const skill of selectedSkills) {
-            results.push(await exportRegistrySkill({
-                context,
-                extractedPackage,
-                outputDirectoryPath: request.outputDirectoryPath,
-                packageInfo,
-                skill,
-            }));
+            try {
+                exported.push(await exportRegistrySkill({
+                    context,
+                    extractedPackage,
+                    outputDirectoryPath: request.outputDirectoryPath,
+                    packageInfo,
+                    skill,
+                }));
+            }
+            catch (error) {
+                // Preserve skills already written to disk: a later skill's
+                // failure must not discard earlier successful exports.
+                failures.push({ error, skillName: skill.name });
+            }
         }
 
-        return results;
+        return { exported, failures };
     }
     finally {
         await extractedPackage.cleanup();

--- a/src/application/commands/skills/registry-skill-export.ts
+++ b/src/application/commands/skills/registry-skill-export.ts
@@ -1,0 +1,226 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+import type { RegistryPackageSkillInfo, RegistrySkillSummary } from "./registry-skill-source.ts";
+
+import { cp, mkdir, readdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { CliUserError } from "../../contracts/cli.ts";
+import { withPackageIdentity } from "../../logging/log-fields.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
+import { removePath } from "./bundled-skill-filesystem.ts";
+import {
+    extractRegistryPackageArchive,
+    requireExtractedRegistrySkillDirectory,
+} from "./registry-skill-archive.ts";
+import { rewriteInstalledRegistrySkillMarkdown } from "./registry-skill-markdown.ts";
+import {
+    downloadRegistryPackageTarball,
+    loadRegistryPackageSkillInfo,
+    tryReportRegistryPackageDownload,
+} from "./registry-skill-source.ts";
+import {
+    normalizeSkillFilterTokens,
+    selectSkillsByFilter,
+} from "./skill-filter.ts";
+
+export interface RegistrySkillExportRequest {
+    outputDirectoryPath: string;
+    packageName: string;
+    packageShareId?: string;
+    packageVersion?: string;
+    // The `--skill` narrowing for the export. When provided, only the package's
+    // published skills whose name matches one of these values are exported.
+    skillFilter?: readonly string[];
+    // Invoked with this package's published skill names when `skillFilter`
+    // matched none of them. A no-match exports nothing for the package; whether
+    // an empty result across all packages is an error is decided by the caller.
+    reportSkillFilterMiss?: (availableSkillNames: readonly string[]) => void;
+}
+
+export interface RegistrySkillExportResult {
+    files: string[];
+    packageName: string;
+    skillName: string;
+    targetSkillDirectoryPath: string;
+}
+
+// Export published registry skills into an arbitrary directory. This mirrors the
+// registry install download/extract pipeline but is pure with respect to oo
+// state: it writes only inside `outputDirectoryPath`, never touches the oo
+// app-data canonical storage or any agent home, and writes no `.oo-metadata.json`
+// management marker. The per-skill directory is removed and recreated so stale
+// files from a previous export do not linger; sibling content in the parent
+// directory is left untouched.
+export async function exportRegistrySkills(
+    request: RegistrySkillExportRequest,
+    context: CliExecutionContext,
+): Promise<RegistrySkillExportResult[]> {
+    const account = await requireCurrentAccount(context);
+    const packageInfo = await loadRegistryPackageSkillInfo(
+        request.packageName,
+        account,
+        context,
+        request.packageVersion,
+    );
+
+    if (packageInfo.skills.length === 0) {
+        throw new CliUserError("errors.skills.install.noPublishedSkills", 1, {
+            packageName: packageInfo.packageName,
+        });
+    }
+
+    const selectedSkills = selectExportSkills(
+        packageInfo,
+        request.skillFilter,
+        request.reportSkillFilterMiss,
+    );
+
+    if (selectedSkills.length === 0) {
+        return [];
+    }
+
+    await tryReportRegistryPackageDownload(
+        packageInfo.packageName,
+        packageInfo.packageVersion,
+        account,
+        context,
+    );
+    const packageBytes = await downloadRegistryPackageTarball(
+        packageInfo.packageName,
+        packageInfo.packageVersion,
+        account,
+        context,
+        request.packageShareId,
+    );
+    const extractedPackage = await extractRegistryPackageArchive(packageBytes);
+
+    try {
+        const results: RegistrySkillExportResult[] = [];
+
+        for (const skill of selectedSkills) {
+            results.push(await exportRegistrySkill({
+                context,
+                extractedPackage,
+                outputDirectoryPath: request.outputDirectoryPath,
+                packageInfo,
+                skill,
+            }));
+        }
+
+        return results;
+    }
+    finally {
+        await extractedPackage.cleanup();
+    }
+}
+
+async function exportRegistrySkill(options: {
+    context: Pick<CliExecutionContext, "logger">;
+    extractedPackage: Awaited<ReturnType<typeof extractRegistryPackageArchive>>;
+    outputDirectoryPath: string;
+    packageInfo: RegistryPackageSkillInfo;
+    skill: RegistrySkillSummary;
+}): Promise<RegistrySkillExportResult> {
+    const sourceSkillDirectoryPath = await requireExtractedRegistrySkillDirectory(
+        options.extractedPackage,
+        options.skill.name,
+    );
+    const targetSkillDirectoryPath = join(
+        options.outputDirectoryPath,
+        options.skill.name,
+    );
+
+    await removePath(targetSkillDirectoryPath);
+    await mkdir(dirname(targetSkillDirectoryPath), { recursive: true });
+    await cp(sourceSkillDirectoryPath, targetSkillDirectoryPath, {
+        force: true,
+        recursive: true,
+    });
+    await rewriteInstalledRegistrySkillMarkdown(
+        targetSkillDirectoryPath,
+        options.skill,
+        options.packageInfo.packageName,
+    );
+
+    const files = await listExportedSkillFiles(targetSkillDirectoryPath);
+
+    options.context.logger.info(
+        {
+            ...withPackageIdentity(
+                options.packageInfo.packageName,
+                options.packageInfo.packageVersion,
+            ),
+            path: targetSkillDirectoryPath,
+            skillName: options.skill.name,
+        },
+        "Registry skill exported to directory.",
+    );
+
+    return {
+        files,
+        packageName: options.packageInfo.packageName,
+        skillName: options.skill.name,
+        targetSkillDirectoryPath,
+    };
+}
+
+// Narrow the package's published skills by the `--skill` filter. Returns every
+// skill when no filter is active. When the filter matches nothing, exports
+// nothing and reports the package's published skill names through `reportMiss`.
+function selectExportSkills(
+    packageInfo: RegistryPackageSkillInfo,
+    skillFilter: readonly string[] | undefined,
+    reportMiss: ((availableSkillNames: readonly string[]) => void) | undefined,
+): RegistrySkillSummary[] {
+    const tokens = normalizeSkillFilterTokens(skillFilter);
+
+    if (tokens === undefined) {
+        return packageInfo.skills;
+    }
+
+    const selected = selectSkillsByFilter(packageInfo.skills, tokens);
+
+    if (selected.length === 0) {
+        reportMiss?.(packageInfo.skills.map(skill => skill.name));
+
+        return [];
+    }
+
+    return selected;
+}
+
+// List the files written for an exported skill as forward-slash relative paths,
+// sorted for deterministic reporting. Directories are walked recursively so
+// reference files alongside SKILL.md are included.
+async function listExportedSkillFiles(
+    skillDirectoryPath: string,
+): Promise<string[]> {
+    const files: string[] = [];
+
+    const walk = async (
+        currentDirectoryPath: string,
+        relativePrefix: string,
+    ): Promise<void> => {
+        const entries = await readdir(currentDirectoryPath, {
+            withFileTypes: true,
+        });
+
+        for (const entry of entries) {
+            const entryRelativePath = relativePrefix === ""
+                ? entry.name
+                : `${relativePrefix}/${entry.name}`;
+
+            if (entry.isDirectory()) {
+                await walk(join(currentDirectoryPath, entry.name), entryRelativePath);
+                continue;
+            }
+
+            if (entry.isFile()) {
+                files.push(entryRelativePath);
+            }
+        }
+    };
+
+    await walk(skillDirectoryPath, "");
+
+    return files.sort();
+}

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -290,7 +290,7 @@ const commandTelemetryDecisions = {
             "skill_ids_sample",
             "skill_ids_truncated",
         ],
-        reason: "Records install source, product-domain package dimensions, bounded skill/package samples, force-flag and skill-filter usage, JSON-output result buckets, and for the --out-dir export the directory presence flag and selected agent render format (a fixed enum).",
+        reason: "Records install source, product-domain package dimensions, bounded skill/package samples, force-flag and skill-filter usage, JSON-output result buckets, and for the --out-dir export (bundled or registry) the directory presence flag, the selected agent render format (a fixed enum), and the same package/skill dimensions.",
     },
     "skills.info": {
         kind: "properties",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -587,8 +587,8 @@ export const enMessages = {
         "--agent-format can only be used together with --out-dir.",
     "errors.skills.install.confirmationRequired":
         "Skill {name} already exists and requires interactive confirmation.",
-    "errors.skills.install.exportRequiresBundled":
-        "{value} is not a bundled skill. --out-dir exports bundled skills only. Available bundled skills: {skills}.",
+    "errors.skills.install.invalidOutDir":
+        "--out-dir requires a non-empty directory path.",
     "errors.skills.install.invalidAgentFormat":
         "Unsupported agent format: {value}. Use {agents}.",
     "errors.skills.install.invalidArchive":
@@ -903,9 +903,9 @@ export const enMessages = {
     "options.skills.skill":
         "Skill name(s) to limit the operation to (case-insensitive; non-matching names are ignored)",
     "options.skills.install.outDir":
-        "Export bundled skills into this directory instead of installing them into local agent homes; writes only inside this directory",
+        "Export bundled or registry skills into this directory instead of installing them into local agent homes; writes only inside this directory",
     "options.skills.install.agentFormat":
-        "Agent render format for exported skills; only applies with --out-dir (default: universal)",
+        "Agent render format for exported bundled skills; only applies with --out-dir (default: universal)",
     "options.lang": "Specify the display language",
     "options.version": "Show the current version",
     "selfUpdate.install.success": "Installed oo {version}.",
@@ -1728,8 +1728,8 @@ export const zhMessages = {
         "--agent-format 只能与 --out-dir 一起使用。",
     "errors.skills.install.confirmationRequired":
         "Skill {name} 已存在，且需要在交互终端中确认覆盖。",
-    "errors.skills.install.exportRequiresBundled":
-        "{value} 不是内置 skill。--out-dir 只能导出内置 skill。可用的内置 skill：{skills}。",
+    "errors.skills.install.invalidOutDir":
+        "--out-dir 需要一个非空的目录路径。",
     "errors.skills.install.invalidAgentFormat":
         "不受支持的 agent 格式：{value}。请使用 {agents}。",
     "errors.skills.install.invalidArchive":
@@ -2036,9 +2036,9 @@ export const zhMessages = {
     "options.skills.skill":
         "限定操作的 skill 名称（可指定多个；大小写不敏感；不匹配的名称会被忽略）",
     "options.skills.install.outDir":
-        "将内置 skill 释放到该目录，而不是安装到本地 Agent 主目录；仅在该目录内写入文件",
+        "将内置或 Registry skill 释放到该目录，而不是安装到本地 Agent 主目录；仅在该目录内写入文件",
     "options.skills.install.agentFormat":
-        "导出 skill 时使用的 Agent 渲染格式；仅在指定 --out-dir 时生效（默认：universal）",
+        "导出内置 skill 时使用的 Agent 渲染格式；仅在指定 --out-dir 时生效（默认：universal）",
     "options.lang": "指定显示语言",
     "options.version": "显示当前版本",
     "selfUpdate.install.success": "已安装 oo {version}。",


### PR DESCRIPTION
Extend the `oo skills add --out-dir` export beyond bundled skills: a published package name is now downloaded, extracted, and written to the output directory in its published form, and bundled and registry skills can be exported together. The export stays pure — no managed storage, agent-home publication, or `.oo-metadata.json` marker — and reuses the install pipeline's archive extraction and SKILL.md normalization. `-s, --skill` narrows registry packages, auth is required only when a registry package is present, and the JSON report gains per-skill `kind` and `packageName` with per-package failures collected into `errors[]`.

Also harden the export path:
- Reject a blank/whitespace `--out-dir` (exit 2) before resolving, so it can no longer fall back to the working directory and let the per-skill removePath clobber a same-named directory there.
- Resolve a relative `--out-dir` against the invocation cwd so embedded hosts behave like the file download command.
- Route bundled and registry export failures and `--skill` misses through the same JSON-aware path so `--json` always emits a structured report instead of throwing plain text, matching the install path.