### PR TITLE
refactor(connector): rename --alias option to --connection-name

### DIFF
--- a/contrib/skills/shared/oo/references/connector-execution.md
+++ b/contrib/skills/shared/oo/references/connector-execution.md
@@ -91,7 +91,8 @@ Facts:
 - If `--data` is omitted, the CLI uses `{}`.
 - If a service has multiple connected apps or execution fails with
   `connection_ambiguous`, run `oo connector apps "<serviceName>" --json`, pick
-  the intended `alias`, then pass `--alias "<alias>"` to `oo connector run`.
+  the intended `connectionName`, then pass `--connection-name "<connectionName>"`
+  to `oo connector run`.
 - Do not use app ids as CLI selectors for connector actions.
 - `--json` returns a stable JSON object for execution output.
 - In execution responses, the execution id is nested under

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -601,8 +601,9 @@ Validate input data and run one connector action.
 - Options: `-d, --data <data>` accepts inline JSON or `@path` to a JSON file.
   `--input <data>` is an alias for `--data <data>`.
 - Options: `--dry-run` validates the payload without executing the action.
-- Options: `--alias <alias>` runs the action with the connector app alias.
-  Use `oo connector apps <serviceName>` to list available aliases.
+- Options: `--connection-name <connection-name>` runs the action with the
+  connector app connection name. Use `oo connector apps <serviceName>` to list
+  available connection names.
 - Options: `--wait` polls the selected action until it reaches a terminal state.
   This option is only valid when the selected action schema declares an async
   result lifecycle.
@@ -644,15 +645,15 @@ List connected connector apps for one service. This command is read-only.
 
 - Arguments: `<serviceName>` is the service name.
 - Options: `--format=json` and `--json` print a JSON array.
-- Output: JSON entries include the stable CLI fields `service`, `alias`,
-  `displayName`, `accountLabel`, `status`, `authType`, `isDefault`, and
-  `scopes`. App id fields are not included.
-- Output: when an app has no alias, JSON output uses `null` and text output
-  prints `-`.
-- Output: text output prints one tab-separated row per app with alias, name,
-  status, auth type, and default marker.
-- Notes: use the listed `alias` value with
-  `oo connector run <serviceName> --alias <alias>`.
+- Output: JSON entries include the stable CLI fields `service`,
+  `connectionName`, `displayName`, `accountLabel`, `status`, `authType`,
+  `isDefault`, and `scopes`. App id fields are not included.
+- Output: when an app has no connection name, JSON output uses `null` and text
+  output prints `-`.
+- Output: text output prints one tab-separated row per app with connection
+  name, name, status, auth type, and default marker.
+- Notes: use the listed `connectionName` value with
+  `oo connector run <serviceName> --connection-name <connection-name>`.
 
 ### `oo connector proxy <serviceName>`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -520,8 +520,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 选项：`-d, --data <data>` 支持直接传入 JSON，或使用 `@路径` 读取 JSON 文件。
   `--input <data>` 是 `--data <data>` 的 alias。
 - 选项：`--dry-run` 只做 payload 校验，不真正执行 action。
-- 选项：`--alias <alias>` 使用指定 connector app alias 运行该 action。
-  可用 `oo connector apps <serviceName>` 查看可用 alias。
+- 选项：`--connection-name <connection-name>` 使用指定 connector app 连接名称
+  运行该 action。可用 `oo connector apps <serviceName>` 查看可用连接名称。
 - 选项：`--wait` 会轮询选中的 action，直到进入终态。只有选中 action 的
   schema 声明了异步结果 lifecycle 时，这个选项才有效。
 - 选项：`--wait-result` 会提交异步 submit action，然后轮询它配置的结果
@@ -554,13 +554,13 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 
 - 参数：`<serviceName>` 为服务名。
 - 选项：`--format=json` 和 `--json` 会输出 JSON 数组。
-- 输出：JSON 条目包含稳定 CLI 字段 `service`、`alias`、`displayName`、
+- 输出：JSON 条目包含稳定 CLI 字段 `service`、`connectionName`、`displayName`、
   `accountLabel`、`status`、`authType`、`isDefault` 和 `scopes`。不会包含
   app id 字段。
-- 输出：当 app 没有 alias 时，JSON 输出使用 `null`，文本输出显示 `-`。
-- 输出：文本输出每个 app 一行，以 tab 分隔 alias、名称、状态、认证类型和默认标记。
-- 说明：可将列出的 `alias` 值传给
-  `oo connector run <serviceName> --alias <alias>`。
+- 输出：当 app 没有连接名称时，JSON 输出使用 `null`，文本输出显示 `-`。
+- 输出：文本输出每个 app 一行，以 tab 分隔连接名称、名称、状态、认证类型和默认标记。
+- 说明：可将列出的 `connectionName` 值传给
+  `oo connector run <serviceName> --connection-name <connection-name>`。
 
 ### `oo connector proxy <serviceName>`
 

--- a/src/application/commands/connector/apps.ts
+++ b/src/application/commands/connector/apps.ts
@@ -19,8 +19,8 @@ interface ConnectorAppsInput {
 
 interface ConnectorAppListItem {
     accountLabel: string;
-    alias: string | null;
     authType: string | null;
+    connectionName: string | null;
     displayName: string;
     isDefault: boolean;
     scopes: string[];
@@ -79,8 +79,8 @@ export const connectorAppsCommand: CliCommandDefinition<ConnectorAppsInput> = {
 function createConnectorAppListItem(app: ConnectorAppView): ConnectorAppListItem {
     return {
         accountLabel: app.accountLabel,
-        alias: app.alias,
         authType: app.authType,
+        connectionName: app.connectionName,
         displayName: app.displayName,
         isDefault: app.isDefault,
         scopes: app.scopes,
@@ -101,14 +101,14 @@ function formatConnectorAppsAsText(
 
     return [
         [
-            context.translator.t("connector.apps.text.alias"),
+            context.translator.t("connector.apps.text.connectionName"),
             context.translator.t("connector.apps.text.name"),
             context.translator.t("connector.apps.text.status"),
             context.translator.t("connector.apps.text.auth"),
             context.translator.t("connector.apps.text.default"),
         ].join("\t"),
         ...apps.map(app => [
-            app.alias ?? "-",
+            app.connectionName ?? "-",
             app.displayName,
             app.status,
             app.authType ?? "-",

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -492,12 +492,12 @@ describe("connectorCommand CLI", () => {
             expect(result.stdout).toContain("--organization");
             expect(result.stdout).toContain("--org ");
             expect(result.stdout).toContain("--personal");
-            expect(result.stdout).toContain("--alias");
+            expect(result.stdout).toContain("--connection-name");
             expect(help).toContain(
                 "Run the action under the given organization identity",
             );
             expect(help).toContain(
-                "Run the action with the connector app alias",
+                "Run the action with the connector app connection name",
             );
         }
         finally {
@@ -972,8 +972,8 @@ describe("connectorCommand CLI", () => {
             expect(output).toEqual([
                 {
                     accountLabel: "user@example.com",
-                    alias: "work",
                     authType: "oauth2",
+                    connectionName: "work",
                     displayName: "Work Gmail",
                     isDefault: true,
                     scopes: ["gmail.send"],
@@ -989,7 +989,7 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("lists connector apps as text with aliases and default status", async () => {
+    test("lists connector apps as text with connection names and default status", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -1016,7 +1016,7 @@ describe("connectorCommand CLI", () => {
             );
 
             expect(result.exitCode).toBe(0);
-            expect(result.stdout).toContain("Alias\tName\tStatus\tAuth\tDefault");
+            expect(result.stdout).toContain("Connection Name\tName\tStatus\tAuth\tDefault");
             expect(result.stdout).toContain("work\tWork Gmail\tactive\toauth2\tyes");
         }
         finally {
@@ -1058,7 +1058,7 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("renders missing connector app aliases as null in json and dash in text", async () => {
+    test("renders missing connector app connection names as null in json and dash in text", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -1091,7 +1091,7 @@ describe("connectorCommand CLI", () => {
             );
 
             expect(JSON.parse(jsonResult.stdout)[0]).toMatchObject({
-                alias: null,
+                connectionName: null,
             });
             expect(textResult.stdout).toContain("-\tPersonal Gmail\tactive\t-\tno");
         }
@@ -1352,7 +1352,7 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("runs a connector action with an alias selector header", async () => {
+    test("runs a connector action with a connection-name selector header", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -1367,7 +1367,7 @@ describe("connectorCommand CLI", () => {
                     "gmail",
                     "-a",
                     "send_mail",
-                    "--alias",
+                    "--connection-name",
                     " work ",
                     "-d",
                     "{\"to\":\"foo@bar.com\"}",
@@ -1404,7 +1404,7 @@ describe("connectorCommand CLI", () => {
             expect(telemetryPayload).toMatchObject({
                 properties: {
                     command_full: "connector.run",
-                    connection_selector: "alias",
+                    connection_selector: "connectionName",
                 },
             });
             expect(JSON.stringify(telemetryPayload?.properties)).not.toContain("work");
@@ -1414,7 +1414,7 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("rejects an empty --alias value before login and schema lookup", async () => {
+    test("rejects an empty --connection-name value before login and schema lookup", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -1426,7 +1426,7 @@ describe("connectorCommand CLI", () => {
                     "gmail",
                     "-a",
                     "send_mail",
-                    "--alias",
+                    "--connection-name",
                     "   ",
                     "-d",
                     "{\"to\":\"foo@bar.com\"}",
@@ -1448,7 +1448,7 @@ describe("connectorCommand CLI", () => {
 
             expect(result.exitCode).toBe(2);
             expect(result.stdout).toBe("");
-            expect(result.stderr).toContain("The --alias value cannot be empty.");
+            expect(result.stderr).toContain("The --connection-name value cannot be empty.");
             expect(requestCount).toBe(0);
         }
         finally {
@@ -1456,7 +1456,7 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("keeps schema metadata requests alias-free", async () => {
+    test("keeps schema metadata requests connection-name-free", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -1470,7 +1470,7 @@ describe("connectorCommand CLI", () => {
                     "gmail",
                     "-a",
                     "send_mail",
-                    "--alias",
+                    "--connection-name",
                     "work",
                     "-d",
                     "{\"to\":\"foo@bar.com\"}",
@@ -1697,7 +1697,7 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("sends the alias selector on every async wait poll request", async () => {
+    test("sends the connection-name selector on every async wait poll request", async () => {
         const sandbox = await createCliSandbox();
         const sleepMock = createBunSleepMock();
 
@@ -1736,7 +1736,7 @@ describe("connectorCommand CLI", () => {
                     "openai_image_async_result",
                     "-d",
                     "{\"sessionID\":\"session-1\"}",
-                    "--alias",
+                    "--connection-name",
                     "work",
                     "--wait",
                     "--json",
@@ -1882,7 +1882,7 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("sends the alias selector on async submit and result requests", async () => {
+    test("sends the connection-name selector on async submit and result requests", async () => {
         const sandbox = await createCliSandbox();
         const sleepMock = createBunSleepMock();
 
@@ -1930,7 +1930,7 @@ describe("connectorCommand CLI", () => {
                     "openai_image_async_submit",
                     "-d",
                     "{\"prompt\":\"a cat\"}",
-                    "--alias",
+                    "--connection-name",
                     "work",
                     "--wait-result",
                     "--json",
@@ -3092,8 +3092,8 @@ describe("connectorCommand CLI", () => {
                     "gmail",
                     "-a",
                     "get_message",
-                    "--alias",
-                    "secret-work-alias",
+                    "--connection-name",
+                    "secret-work-connection",
                     "-d",
                     "{\"messageId\":\"invalid-id\"}",
                 ],
@@ -3138,7 +3138,7 @@ describe("connectorCommand CLI", () => {
                 properties: {
                     action: "get_message",
                     command_full: "connector.run",
-                    connection_selector: "alias",
+                    connection_selector: "connectionName",
                     data_size_bucket: "<1KB",
                     dry_run: false,
                     error_code: "invalid_input",
@@ -3148,7 +3148,7 @@ describe("connectorCommand CLI", () => {
                 },
             });
             expect(JSON.stringify(telemetryPayload?.properties)).not.toContain(
-                "secret-work-alias",
+                "secret-work-connection",
             );
             expect(JSON.stringify(telemetryPayload?.properties)).not.toContain(
                 "Invalid id value",

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -57,7 +57,7 @@ const connectorAsyncLifecycleDefaultTimeoutMs = 6 * 3_600_000;
 
 interface ConnectorRunInput {
     action?: string;
-    alias?: string;
+    connectionName?: string;
     data?: string;
     dryRun?: boolean;
     format?: (typeof connectorFormatValues)[number];
@@ -98,10 +98,10 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             descriptionKey: "options.data",
         },
         {
-            name: "alias",
-            longFlag: "--alias",
-            valueName: "alias",
-            descriptionKey: "options.connectorRunAlias",
+            name: "connectionName",
+            longFlag: "--connection-name",
+            valueName: "connection-name",
+            descriptionKey: "options.connectorRunConnectionName",
         },
         {
             name: "dryRun",
@@ -134,7 +134,7 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
     ],
     inputSchema: z.object({
         action: z.string().optional(),
-        alias: z.string().optional(),
+        connectionName: z.string().optional(),
         data: z.string().optional(),
         dryRun: z.boolean().optional(),
         format: z.enum(connectorFormatValues).optional(),
@@ -157,12 +157,15 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             throw new CliUserError("errors.connectorRun.identityConflict", 2);
         }
 
-        const alias = input.alias?.trim();
-        if (input.alias !== undefined && alias === "") {
-            throw new CliUserError("errors.connectorRun.aliasEmpty", 2);
+        const connectionName = input.connectionName?.trim();
+        if (input.connectionName !== undefined && connectionName === "") {
+            throw new CliUserError("errors.connectorRun.connectionNameEmpty", 2);
         }
 
-        const connectionSelector = alias === undefined ? undefined : { alias };
+        // The request layer sends this connection name on the wire as the
+        // legacy `x-oo-connector-alias` header.
+        const connectionSelector
+            = connectionName === undefined ? undefined : { connectionName };
         const organizationFlag = input.organization?.trim();
         if (input.organization !== undefined && organizationFlag === "") {
             throw new CliUserError("errors.connectorRun.organizationEmpty", 2);
@@ -184,7 +187,7 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
 
         context.telemetry?.recordProperties({
             action: actionName,
-            connection_selector: connectionSelector === undefined ? "none" : "alias",
+            connection_selector: connectionSelector === undefined ? "none" : "connectionName",
             data_size_bucket: bucketTelemetryBytes(
                 Buffer.byteLength(JSON.stringify(inputData)),
             ),

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -142,12 +142,12 @@ describe("connector shared requests", () => {
         expect(requests[0]?.headers.get("Authorization")).toBe("secret-1");
         expect(apps).toHaveLength(1);
         expect(apps[0]).toMatchObject({
-            alias: "work",
+            connectionName: "work",
             displayName: "Work Gmail",
         });
     });
 
-    test("listConnectorAppsByService maps missing aliases to null", async () => {
+    test("listConnectorAppsByService maps missing connection names to null", async () => {
         const apps = await listConnectorAppsByService(
             {
                 apiKey: "secret-1",
@@ -170,7 +170,7 @@ describe("connector shared requests", () => {
             }),
         );
 
-        expect(apps[0]?.alias).toBeNull();
+        expect(apps[0]?.connectionName).toBeNull();
     });
 
     test("listConnectorAppsByService rejects unsupported response envelopes", async () => {
@@ -318,14 +318,14 @@ describe("connector shared requests", () => {
         expect(requests[0]?.headers.get("x-oo-organization-name")).toBe("acme");
     });
 
-    test("runConnectorAction sends the alias selector as a header without query params", async () => {
+    test("runConnectorAction sends the connection-name selector as a header without query params", async () => {
         const requests: Request[] = [];
         await runConnectorAction(
             {
                 actionName: "send_mail",
                 apiKey: "secret-1",
                 connectionSelector: {
-                    alias: "work",
+                    connectionName: "work",
                 },
                 endpoint: "oomol.com",
                 inputData: {

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -100,18 +100,24 @@ const connectorProxyResponseSchema = z.object({
     ...response
 }) => response);
 
-const connectorAppAliasSchema = z.string().nullable().optional().transform(value => value ?? null);
+const connectorAppConnectionNameSchema = z.string().nullable().optional().transform(value => value ?? null);
 
 const connectorAppViewSchema = z.object({
     accountLabel: z.string(),
-    alias: connectorAppAliasSchema,
+    // The backend response names this field `alias`; it is the only wire
+    // boundary that keeps the legacy name. Everything downstream reads it as
+    // `connectionName` via the transform below.
+    alias: connectorAppConnectionNameSchema,
     authType: z.string().nullable(),
     displayName: z.string(),
     isDefault: z.boolean(),
     scopes: z.array(z.string()).default([]),
     service: z.string().min(1),
     status: z.string().min(1),
-}).passthrough();
+}).passthrough().transform(({ alias, ...rest }) => ({
+    ...rest,
+    connectionName: alias,
+}));
 
 const connectorAppsByServiceResponseSchema = z.object({
     data: z.array(connectorAppViewSchema),
@@ -136,7 +142,7 @@ const connectorActionFailureResponseSchema = z.object({
 export const connectorFormatValues = ["json"] as const;
 
 export interface ConnectorConnectionSelector {
-    alias?: string;
+    connectionName?: string;
 }
 
 export function requireConnectorActionName(rawAction: string | undefined): string {
@@ -659,8 +665,10 @@ function connectorConnectionSelectorHeaders(
 ): Record<string, string> {
     const headers: Record<string, string> = {};
 
-    if (selector?.alias !== undefined) {
-        headers["x-oo-connector-alias"] = selector.alias;
+    // The connection name is sent on the wire as the legacy `x-oo-connector-alias`
+    // header; this is the only place the `alias` name survives.
+    if (selector?.connectionName !== undefined) {
+        headers["x-oo-connector-alias"] = selector.connectionName;
     }
 
     return headers;

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -134,7 +134,7 @@ const commandTelemetryDecisions = {
     "connector.apps": {
         kind: "properties",
         properties: ["result_count_bucket"],
-        reason: "Records bounded connector app list size without app ids, aliases, or account labels.",
+        reason: "Records bounded connector app list size without app ids, connection names, or account labels.",
     },
     "connector.run": {
         kind: "properties",
@@ -150,7 +150,7 @@ const commandTelemetryDecisions = {
             "wait",
             "wait_result",
         ],
-        reason: "Records connector product dimensions, bucketed payload size, async wait modes, stable error code, identity source (personal/flag/config), and none/alias selector mode without the organization name or alias value.",
+        reason: "Records connector product dimensions, bucketed payload size, async wait modes, stable error code, identity source (personal/flag/config), and none/connectionName selector mode without the organization name or connection name value.",
     },
     "connector.proxy": {
         kind: "properties",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -298,8 +298,8 @@ export const enMessages = {
         "The connector action metadata request returned HTTP {status}.",
     "errors.connectorRun.actionRequired":
         "The --action option is required.",
-    "errors.connectorRun.aliasEmpty":
-        "The --alias value cannot be empty.",
+    "errors.connectorRun.connectionNameEmpty":
+        "The --connection-name value cannot be empty.",
     "errors.connectorRun.dataFilePathRequired":
         "The @data file path cannot be empty.",
     "errors.connectorRun.dataReadFailed":
@@ -835,8 +835,8 @@ export const enMessages = {
         "Poll until an async result action reaches a terminal state",
     "options.connectorRunWaitResult":
         "Submit an async action and wait for its result action",
-    "options.connectorRunAlias":
-        "Run the action with the connector app alias",
+    "options.connectorRunConnectionName":
+        "Run the action with the connector app connection name",
     "options.connectorRunOrganization":
         "Run the action under the given organization identity (alias: --org)",
     "options.connectorRunPersonal":
@@ -1122,8 +1122,8 @@ export const enMessages = {
     "connector.search.text.authenticated.yes": "yes",
     "connector.search.text.noResults":
         "No matching connector actions were found.",
-    "connector.apps.text.alias": "Alias",
     "connector.apps.text.auth": "Auth",
+    "connector.apps.text.connectionName": "Connection Name",
     "connector.apps.text.default": "Default",
     "connector.apps.text.default.no": "no",
     "connector.apps.text.default.yes": "yes",
@@ -1462,8 +1462,8 @@ export const zhMessages = {
         "获取 connector action 元数据返回了 HTTP {status}。",
     "errors.connectorRun.actionRequired":
         "--action 选项为必填。",
-    "errors.connectorRun.aliasEmpty":
-        "--alias 的值不能为空。",
+    "errors.connectorRun.connectionNameEmpty":
+        "--connection-name 的值不能为空。",
     "errors.connectorRun.dataFilePathRequired":
         "@data 文件路径不能为空。",
     "errors.connectorRun.dataReadFailed":
@@ -1994,8 +1994,8 @@ export const zhMessages = {
         "轮询异步结果 action，直到进入终态",
     "options.connectorRunWaitResult":
         "提交异步 action，并等待它的结果 action",
-    "options.connectorRunAlias":
-        "使用指定 connector app alias 运行该 action",
+    "options.connectorRunConnectionName":
+        "使用指定 connector app 连接名称运行该 action",
     "options.connectorRunOrganization":
         "以指定组织身份运行该 action（别名：--org）",
     "options.connectorRunPersonal":
@@ -2277,8 +2277,8 @@ export const zhMessages = {
     "connector.search.text.authenticated.no": "否",
     "connector.search.text.authenticated.yes": "是",
     "connector.search.text.noResults": "未找到匹配的 connector action。",
-    "connector.apps.text.alias": "Alias",
     "connector.apps.text.auth": "认证",
+    "connector.apps.text.connectionName": "连接名称",
     "connector.apps.text.default": "默认",
     "connector.apps.text.default.no": "否",
     "connector.apps.text.default.yes": "是",


### PR DESCRIPTION
The connector connection selector was introduced in #283 as `--alias`, but the name was unclear. Rename the user-facing surface to `--connection-name` (and `connectionName` in JSON output, help text, and the telemetry selector value) so the connection concept reads consistently across the CLI.

The wire protocol is left untouched: requests still send the `x-oo-connector-alias` header, and the backend `alias` response field is mapped to `connectionName` at the schema boundary. That header string is the only place the legacy name survives.