### PR TITLE
feat(skills): dedupe repeated recommendations per session

### DIFF
--- a/contrib/skills/shared/oo/SKILL.md
+++ b/contrib/skills/shared/oo/SKILL.md
@@ -156,16 +156,20 @@ proves its output.
    Lead with the useful result. For blockers, name the exact blocker and the
    next useful move. If you group or summarize by an attribute, make sure the
    payload or result actually used that attribute.
-   After the final useful result, run the wrap-up skill recommendation once.
-   Pass the deduplicated wrap-up list of connector services to
+   After the final useful result, run the wrap-up skill recommendation. Pass the
+   deduplicated wrap-up list of connector services to
    `oo skills recommend plan <connectorService>... --json`. That single command
    derives each `oo-<service>` package, confirms it is published, and skips
-   packages that are already installed and current, not published, dismissed, or
-   globally muted. Present its result and persist any "never remind" choice
+   packages that are already installed and current, not published, dismissed,
+   globally muted, or already suggested earlier this session. The CLI
+   de-duplicates within a session, so re-running the wrap-up will not re-surface
+   an already-shown suggestion: present only what is under `recommendations`, and
+   never re-present a suggestion absent from it. Persist any "never remind" choice
    exactly as
    [references/search-and-selection.md](references/search-and-selection.md)
    describes. If the plan reports `muted` or returns no `recommendations`, say
-   nothing about skills and finish.
+   nothing about skills and finish. Omit the optional suggestion when the user
+   explicitly asked for concise output.
 
 ## Capability contract
 

--- a/contrib/skills/shared/oo/references/search-and-selection.md
+++ b/contrib/skills/shared/oo/references/search-and-selection.md
@@ -200,8 +200,8 @@ selected connector path has produced a successful useful result.
 
 ## Wrap-up skill recommendation
 
-After the final useful result, run the recommendation exactly once over the
-deduplicated list of connector services you used:
+After the final useful result, run the recommendation once at the wrap-up over
+the deduplicated list of connector services you used:
 
 ```bash
 oo skills recommend plan <connectorService>... --json
@@ -218,7 +218,20 @@ returns:
   installed package has a newer version, and the entry also carries
   `currentVersion` and `latestVersion`.
 - `skipped`: packages excluded because they are already current, not published,
-  dismissed, or muted. Never mention skipped packages.
+  dismissed, muted, or already suggested earlier this session
+  (`recently-suggested`). Never mention skipped packages.
+
+The CLI de-duplicates suggestions across runs within a session: a suggestion it
+already surfaced recently is returned under `skipped` as `recently-suggested`,
+not under `recommendations`. So if you re-run the wrap-up in a later turn of the
+same conversation, an already-shown suggestion will not reappear. Only present
+what is in `recommendations`; never re-present a suggestion that is absent from
+it. Pass `--force` only when the user explicitly asks to see install suggestions
+again.
+
+If the user explicitly asked for concise output (for example only ids, or no
+extra text), omit the optional suggestion entirely, even when `recommendations`
+is non-empty.
 
 If `recommendations` is empty, say nothing about skills and finish. Otherwise
 present one short batched prompt that lists the install and update actions and

--- a/contrib/skills/shared/oo/references/search-and-selection.md
+++ b/contrib/skills/shared/oo/references/search-and-selection.md
@@ -226,8 +226,7 @@ already surfaced recently is returned under `skipped` as `recently-suggested`,
 not under `recommendations`. So if you re-run the wrap-up in a later turn of the
 same conversation, an already-shown suggestion will not reappear. Only present
 what is in `recommendations`; never re-present a suggestion that is absent from
-it. Pass `--force` only when the user explicitly asks to see install suggestions
-again.
+it. Pass `--force` only when the user explicitly asks to see suggestions again.
 
 If the user explicitly asked for concise output (for example only ids, or no
 extra text), omit the optional suggestion entirely, even when `recommendations`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1540,12 +1540,23 @@ suggest installing or updating and which to skip.
   preserved in the output. With no arguments the plan is empty.
 - Options: `--format=json` and `--json` switch to a structured payload.
   `--show-schema-version` (only meaningful with JSON) prepends `schemaVersion`.
+  `--force` re-surfaces suggestions that the session cooldown would otherwise
+  suppress (see below).
 - Behavior: each derived `oo-<service>` package is confirmed against the
   registry. It is suggested for `install` when it is published but not installed
   locally; for `update` when an installed package has a newer published version;
   and skipped when it is already current, not published, previously dismissed,
   or globally muted. When suggestions are globally muted, the plan returns
   `muted: true` with no recommendations.
+- Session cooldown: once a suggestion is surfaced, the same suggestion is
+  suppressed on later runs for a short window so a repeated wrap-up does not
+  re-surface it every time. A suppressed suggestion is returned under `skipped`
+  with reason `recently-suggested` instead of `recommendations`. The window is
+  per suggestion: switching to a different service, or a suggestion whose content
+  changes (for example `install` becoming `update`, or a newer latest version),
+  surfaces again, as does passing `--force`. Globally muted plans surface nothing
+  and do not start a cooldown. This suppression is best-effort: if its on-disk
+  state is unavailable the plan is returned without de-duplication.
 - Network: every non-dismissed, non-muted package is verified with a public
   registry package-info request (existence + latest version). This endpoint
   needs no login, so no account or API key is required — the active account's
@@ -1576,7 +1587,7 @@ suggest installing or updating and which to skip.
 
 - `action` values: `install` / `update`.
 - `reason` values: `up-to-date` / `not-published` / `dismissed` / `muted` /
-  `lookup-failed`.
+  `lookup-failed` / `recently-suggested`.
 - Exit code: `0` even when a lookup fails or a package is unpublished (both are
   encoded as skips). Argument errors (for example `--format xml`) exit `2`.
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -1303,10 +1303,17 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   skill 包（`github` → `oo-github`，`aliyun_oss` → `oo-aliyun-oss`）。空白项被忽略；
   推导出的包会去重，输出保留输入顺序。不传参数时计划为空。
 - 选项：`--format=json` 与 `--json` 切换到结构化 JSON 输出。`--show-schema-version`
-  （仅在 JSON 下有意义）会在顶层添加 `schemaVersion`。
+  （仅在 JSON 下有意义）会在顶层添加 `schemaVersion`。`--force` 会重新展示本应被会话冷却
+  抑制的推荐（见下文）。
 - 行为：每个推导出的 `oo-<service>` 包都会向 registry 确认。包已发布但本地未安装时推荐
   `install`；已安装且有更新的已发布版本时推荐 `update`；当包已是最新、未发布、此前被忽略
   或被全局静音时跳过。当推荐被全局静音时，计划返回 `muted: true` 且无推荐项。
+- 会话冷却：某条推荐被展示后，在一个较短的时间窗内，后续运行会抑制同一条推荐，从而避免重复的
+  wrap-up 每次都再次展示它。被抑制的推荐会以 `recently-suggested` 原因出现在 `skipped` 中，
+  而不是 `recommendations`。冷却按单条推荐计算：切换到不同的 service，或推荐内容发生变化
+  （例如 `install` 变为 `update`，或出现更新的最新版本）都会再次展示；传 `--force` 也会。
+  被全局静音的计划不展示任何内容，也不会开启冷却。该抑制是尽力而为的：当其本地状态不可用时，
+  计划会在不去重的情况下返回。
 - 网络：每个未被忽略、未被静音的包都会发一次公开的 registry package-info 请求（确认存在性
   与最新版本）。该端点无需登录，因此不需要账号或 API key——有账号时用其 endpoint，否则用默认
   endpoint；请求以较小的并发上限执行。被忽略、被静音的包不需要网络。`404` 视为"未发布"
@@ -1334,7 +1341,7 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 
 - `action` 取值：`install` / `update`。
 - `reason` 取值：`up-to-date` / `not-published` / `dismissed` / `muted` /
-  `lookup-failed`。
+  `lookup-failed` / `recently-suggested`。
 - 退出码：即使查询失败或包未发布也返回 `0`（二者都编码为跳过项）。参数错误（如
   `--format xml`）以 exit 2 退出。
 

--- a/src/application/commands/skills/recommend/plan.cli.test.ts
+++ b/src/application/commands/skills/recommend/plan.cli.test.ts
@@ -337,6 +337,221 @@ describe("skills recommend plan CLI", () => {
         }
     });
 
+    test("--json suppresses a recommendation already surfaced earlier this session", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const fetcher = async (input: string | URL | Request, init?: RequestInit) => {
+                const request = toRequest(input, init);
+
+                if (request.url.includes("package-info/oo-gmail")) {
+                    return packageInfoResponse("oo-gmail", "1.0.0", "gmail");
+                }
+                throw new Error(`Unexpected request: ${request.url}`);
+            };
+
+            const first = await sandbox.run(
+                ["skills", "recommend", "plan", "gmail", "--json"],
+                { fetcher },
+            );
+            const firstPlan = JSON.parse(first.stdout) as Record<string, unknown>;
+
+            expect(firstPlan.recommendations).toEqual([
+                { packageName: "oo-gmail", action: "install" },
+            ]);
+            expect(firstPlan.skipped).toEqual([]);
+
+            // A second wrap-up in the same session must not re-surface the same
+            // suggestion; it is demoted to a recently-suggested skip.
+            const second = await sandbox.run(
+                ["skills", "recommend", "plan", "gmail", "--json"],
+                { fetcher },
+            );
+            const secondPlan = JSON.parse(second.stdout) as Record<string, unknown>;
+
+            expect(secondPlan.recommendations).toEqual([]);
+            expect(secondPlan.skipped).toEqual([
+                { packageName: "oo-gmail", reason: "recently-suggested" },
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json still surfaces a different service after another was suggested", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const fetcher = async (input: string | URL | Request, init?: RequestInit) => {
+                const request = toRequest(input, init);
+
+                if (request.url.includes("package-info/oo-gmail")) {
+                    return packageInfoResponse("oo-gmail", "1.0.0", "gmail");
+                }
+                if (request.url.includes("package-info/oo-notion")) {
+                    return packageInfoResponse("oo-notion", "1.0.0", "notion");
+                }
+                throw new Error(`Unexpected request: ${request.url}`);
+            };
+
+            await sandbox.run(
+                ["skills", "recommend", "plan", "gmail", "--json"],
+                { fetcher },
+            );
+            const second = await sandbox.run(
+                ["skills", "recommend", "plan", "notion", "--json"],
+                { fetcher },
+            );
+            const secondPlan = JSON.parse(second.stdout) as Record<string, unknown>;
+
+            expect(secondPlan.recommendations).toEqual([
+                { packageName: "oo-notion", action: "install" },
+            ]);
+            expect(secondPlan.skipped).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--force re-surfaces a recommendation suppressed by the session cooldown", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const fetcher = async (input: string | URL | Request, init?: RequestInit) => {
+                const request = toRequest(input, init);
+
+                if (request.url.includes("package-info/oo-gmail")) {
+                    return packageInfoResponse("oo-gmail", "1.0.0", "gmail");
+                }
+                throw new Error(`Unexpected request: ${request.url}`);
+            };
+
+            await sandbox.run(
+                ["skills", "recommend", "plan", "gmail", "--json"],
+                { fetcher },
+            );
+            const forced = await sandbox.run(
+                ["skills", "recommend", "plan", "gmail", "--force", "--json"],
+                { fetcher },
+            );
+            const forcedPlan = JSON.parse(forced.stdout) as Record<string, unknown>;
+
+            expect(forcedPlan.recommendations).toEqual([
+                { packageName: "oo-gmail", action: "install" },
+            ]);
+            expect(forcedPlan.skipped).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json re-surfaces when a suggestion changes from install to update", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const fetcher = async (input: string | URL | Request, init?: RequestInit) => {
+                const request = toRequest(input, init);
+
+                if (request.url.includes("package-info/oo-notion")) {
+                    return packageInfoResponse("oo-notion", "2.0.0", "notion");
+                }
+                throw new Error(`Unexpected request: ${request.url}`);
+            };
+
+            const first = await sandbox.run(
+                ["skills", "recommend", "plan", "notion", "--json"],
+                { fetcher },
+            );
+
+            expect((JSON.parse(first.stdout) as Record<string, unknown>).recommendations)
+                .toEqual([{ packageName: "oo-notion", action: "install" }]);
+
+            // Installing an older version flips the suggestion to `update`, which
+            // is a different cooldown key, so it surfaces again.
+            await seedRegistrySkill({
+                sandbox,
+                skillName: "notion",
+                packageName: "oo-notion",
+                version: "1.0.0",
+            });
+
+            const second = await sandbox.run(
+                ["skills", "recommend", "plan", "notion", "--json"],
+                { fetcher },
+            );
+            const secondPlan = JSON.parse(second.stdout) as Record<string, unknown>;
+
+            expect(secondPlan.recommendations).toEqual([
+                {
+                    packageName: "oo-notion",
+                    action: "update",
+                    currentVersion: "1.0.0",
+                    latestVersion: "2.0.0",
+                },
+            ]);
+            expect(secondPlan.skipped).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("muted plans do not consume the session cooldown", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const gmailFetcher = async (input: string | URL | Request, init?: RequestInit) => {
+                const request = toRequest(input, init);
+
+                if (request.url.includes("package-info/oo-gmail")) {
+                    return packageInfoResponse("oo-gmail", "1.0.0", "gmail");
+                }
+                throw new Error(`Unexpected request: ${request.url}`);
+            };
+
+            const muteResult = await sandbox.run(
+                ["skills", "recommend", "mute", "--all", "--json"],
+            );
+
+            expect(muteResult.exitCode).toBe(0);
+
+            // While muted the plan surfaces nothing and must stamp nothing.
+            const mutedRun = await sandbox.run(
+                ["skills", "recommend", "plan", "gmail", "--json"],
+                { fetcher: throwingFetcher },
+            );
+
+            expect((JSON.parse(mutedRun.stdout) as Record<string, unknown>).muted).toBe(true);
+
+            const unmuteResult = await sandbox.run(
+                ["skills", "recommend", "unmute", "--all", "--json"],
+            );
+
+            expect(unmuteResult.exitCode).toBe(0);
+
+            // The earlier muted run left no cooldown stamp, so the suggestion
+            // surfaces normally now.
+            const afterUnmute = await sandbox.run(
+                ["skills", "recommend", "plan", "gmail", "--json"],
+                { fetcher: gmailFetcher },
+            );
+            const afterPlan = JSON.parse(afterUnmute.stdout) as Record<string, unknown>;
+
+            expect(afterPlan.recommendations).toEqual([
+                { packageName: "oo-gmail", action: "install" },
+            ]);
+            expect(afterPlan.skipped).toEqual([]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("--format xml exits 2 with a format error", async () => {
         const sandbox = await createCliSandbox();
 

--- a/src/application/commands/skills/recommend/plan.ts
+++ b/src/application/commands/skills/recommend/plan.ts
@@ -118,8 +118,10 @@ export const skillsRecommendPlanCommand: CliCommandDefinition<SkillsRecommendPla
             ? { plan: resolvedPlan, cooldownSuppressedCount: 0 }
             : applySessionCooldown(resolvedPlan, input.force === true, context);
 
+        // Muted plans skip the cooldown entirely, so `--force` bypasses nothing
+        // there; only report a force when the cooldown actually ran.
         recordTelemetry(context, plan, packageNames, {
-            forced: input.force === true,
+            forced: !muted && input.force === true,
             cooldownSuppressedCount,
         });
 

--- a/src/application/commands/skills/recommend/plan.ts
+++ b/src/application/commands/skills/recommend/plan.ts
@@ -1,5 +1,7 @@
+import type { Cache } from "../../../contracts/cache.ts";
 import type { CliCommandDefinition, CliExecutionContext } from "../../../contracts/cli.ts";
 import type { ManagedSkillListItem } from "../managed-skill-listings.ts";
+import type { RecommendationCooldownGate } from "./recommendation-cooldown.ts";
 import type { CandidateResolution, RecommendationPartition } from "./recommendation-plan.ts";
 
 import { z } from "zod";
@@ -17,6 +19,7 @@ import { readKnownManagedSkillInstallations } from "../installed-managed-skills.
 import { resolveAvailableManagedSkillHosts } from "../managed-skill-hosts.ts";
 import { loadRegistryPackageSkillInfoAllowingMissing } from "../registry-skill-source.ts";
 import { createPackageNamesTelemetryProperties } from "../telemetry.ts";
+import { applyRecommendationCooldown } from "./recommendation-cooldown.ts";
 import {
     dedupePreserveOrder,
     deriveSkillPackageName,
@@ -27,6 +30,14 @@ const planFormatValues = ["json"] as const;
 // The package-info endpoint has no rate limit, so a small fixed fan-out keeps
 // the wrap-up snappy without hammering the registry.
 const packageExistenceConcurrency = 3;
+// The recommendation cooldown approximates "one session": once a suggestion is
+// surfaced, it is suppressed for this window so an agent that re-runs the wrap-up
+// after every task does not re-append the identical prompt every turn. The
+// window is long enough to span a continuous working session and short enough
+// that a genuinely new session later re-surfaces the suggestion.
+const recommendationCooldownCacheId = "skills-recommend-cooldown";
+const recommendationCooldownTtlMs = 4 * 60 * 60 * 1000;
+const recommendationCooldownMaxEntries = 256;
 
 interface RecommendationPlan extends RecommendationPartition {
     muted: boolean;
@@ -39,6 +50,7 @@ type RemotePackageStatus
 
 interface SkillsRecommendPlanInput {
     connectorServices?: string[];
+    force?: boolean;
     format?: (typeof planFormatValues)[number];
     showSchemaVersion?: boolean;
 }
@@ -55,9 +67,17 @@ export const skillsRecommendPlanCommand: CliCommandDefinition<SkillsRecommendPla
             variadic: true,
         },
     ],
-    options: [...jsonOutputOptions],
+    options: [
+        {
+            name: "force",
+            longFlag: "--force",
+            descriptionKey: "options.skills.recommend.plan.force",
+        },
+        ...jsonOutputOptions,
+    ],
     inputSchema: z.object({
         connectorServices: z.array(z.string()).optional(),
+        force: z.boolean().optional(),
         format: z.enum(planFormatValues).optional(),
         showSchemaVersion: z.boolean().optional(),
     }),
@@ -74,7 +94,7 @@ export const skillsRecommendPlanCommand: CliCommandDefinition<SkillsRecommendPla
         const dismissed = new Set(getDismissedSkillRecommendations(settings));
         const muted = isSkillRecommendationsMuted(settings);
 
-        const plan: RecommendationPlan = muted
+        const resolvedPlan: RecommendationPlan = muted
             ? {
                     muted: true,
                     ...partitionRecommendations(
@@ -91,7 +111,17 @@ export const skillsRecommendPlanCommand: CliCommandDefinition<SkillsRecommendPla
                     ),
                 };
 
-        recordTelemetry(context, plan, packageNames);
+        // Muted plans surface nothing, so they neither read nor stamp the
+        // cooldown. Every other plan is de-duplicated against the per-session
+        // cooldown window before it reaches the user.
+        const { plan, cooldownSuppressedCount } = muted
+            ? { plan: resolvedPlan, cooldownSuppressedCount: 0 }
+            : applySessionCooldown(resolvedPlan, input.force === true, context);
+
+        recordTelemetry(context, plan, packageNames, {
+            forced: input.force === true,
+            cooldownSuppressedCount,
+        });
 
         if (input.format === "json") {
             writeJsonOutput(context.stdout, plan, {
@@ -103,6 +133,55 @@ export const skillsRecommendPlanCommand: CliCommandDefinition<SkillsRecommendPla
         writeText(context, plan);
     },
 };
+
+// Applies the per-session cooldown to a resolved (non-muted) plan: recommendations
+// already surfaced within the window are demoted to `recently-suggested` skips.
+// The cooldown is best-effort — if the cache is unavailable the plan passes
+// through unchanged, preserving the pre-cooldown behavior rather than failing.
+function applySessionCooldown(
+    plan: RecommendationPlan,
+    force: boolean,
+    context: CliExecutionContext,
+): { plan: RecommendationPlan; cooldownSuppressedCount: number } {
+    if (plan.recommendations.length === 0) {
+        return { plan, cooldownSuppressedCount: 0 };
+    }
+
+    try {
+        const gate = createRecommendationCooldownGate(context);
+        const gated = applyRecommendationCooldown(plan, gate, { force });
+
+        return {
+            plan: { muted: false, ...gated },
+            cooldownSuppressedCount:
+                plan.recommendations.length - gated.recommendations.length,
+        };
+    }
+    catch (error) {
+        context.logger.warn(
+            { err: error },
+            "skills recommend plan cooldown unavailable; surfacing without de-duplication.",
+        );
+        return { plan, cooldownSuppressedCount: 0 };
+    }
+}
+
+function createRecommendationCooldownGate(
+    context: Pick<CliExecutionContext, "cacheStore">,
+): RecommendationCooldownGate {
+    const cache: Cache<number> = context.cacheStore.getCache<number>({
+        defaultTtlMs: recommendationCooldownTtlMs,
+        id: recommendationCooldownCacheId,
+        maxEntries: recommendationCooldownMaxEntries,
+    });
+
+    return {
+        wasRecentlySuggested: key => cache.has(key),
+        markSuggested: (key) => {
+            cache.set(key, 1);
+        },
+    };
+}
 
 // Resolves each candidate package to install/update/skip. Dismissed packages
 // short-circuit offline; every other package is confirmed against the registry
@@ -269,6 +348,7 @@ function recordTelemetry(
     context: CliExecutionContext,
     plan: RecommendationPlan,
     packageNames: readonly string[],
+    cooldown: { forced: boolean; cooldownSuppressedCount: number },
 ): void {
     const installCount = plan.recommendations.filter(
         entry => entry.action === "install",
@@ -279,9 +359,13 @@ function recordTelemetry(
 
     context.telemetry?.recordProperties({
         muted: plan.muted,
+        forced: cooldown.forced,
         install_count_bucket: bucketTelemetryCount(installCount),
         update_count_bucket: bucketTelemetryCount(updateCount),
         skipped_count_bucket: bucketTelemetryCount(plan.skipped.length),
+        cooldown_suppressed_count_bucket: bucketTelemetryCount(
+            cooldown.cooldownSuppressedCount,
+        ),
         ...createPackageNamesTelemetryProperties(packageNames),
     });
 }

--- a/src/application/commands/skills/recommend/recommendation-cooldown.test.ts
+++ b/src/application/commands/skills/recommend/recommendation-cooldown.test.ts
@@ -1,0 +1,169 @@
+import type { RecommendationCooldownGate } from "./recommendation-cooldown.ts";
+
+import type { RecommendationEntry, RecommendationPartition } from "./recommendation-plan.ts";
+import { describe, expect, test } from "bun:test";
+import {
+    applyRecommendationCooldown,
+    buildRecommendationCooldownKey,
+} from "./recommendation-cooldown.ts";
+
+describe("buildRecommendationCooldownKey", () => {
+    test("keys an install on the package and action with an empty version target", () => {
+        const key = buildRecommendationCooldownKey({
+            packageName: "oo-monday",
+            action: "install",
+        });
+
+        expect(key).toBe("oo-monday|install|");
+    });
+
+    test("keys an update on the current and latest version so content changes re-surface", () => {
+        const key = buildRecommendationCooldownKey({
+            packageName: "oo-monday",
+            action: "update",
+            currentVersion: "1.0.0",
+            latestVersion: "2.0.0",
+        });
+
+        expect(key).toBe("oo-monday|update|1.0.0->2.0.0");
+    });
+
+    test("install and update of the same package produce distinct keys", () => {
+        const install = buildRecommendationCooldownKey({
+            packageName: "oo-monday",
+            action: "install",
+        });
+        const update = buildRecommendationCooldownKey({
+            packageName: "oo-monday",
+            action: "update",
+            currentVersion: "1.0.0",
+            latestVersion: "2.0.0",
+        });
+
+        expect(install).not.toBe(update);
+    });
+});
+
+describe("applyRecommendationCooldown", () => {
+    test("passes through and marks a first-time recommendation", () => {
+        const gate = createFakeGate();
+        const partition = partitionOf([
+            { packageName: "oo-monday", action: "install" },
+        ]);
+
+        const result = applyRecommendationCooldown(partition, gate);
+
+        expect(result.recommendations).toEqual(partition.recommendations);
+        expect(result.skipped).toEqual([]);
+        expect(gate.marked).toEqual(["oo-monday|install|"]);
+    });
+
+    test("demotes a recommendation surfaced again within the window to a recently-suggested skip", () => {
+        const gate = createFakeGate();
+        const partition = partitionOf([
+            { packageName: "oo-monday", action: "install" },
+        ]);
+
+        applyRecommendationCooldown(partition, gate);
+        const second = applyRecommendationCooldown(partition, gate);
+
+        expect(second.recommendations).toEqual([]);
+        expect(second.skipped).toEqual([
+            { packageName: "oo-monday", reason: "recently-suggested" },
+        ]);
+    });
+
+    test("force bypasses suppression but still refreshes the stamp", () => {
+        const gate = createFakeGate();
+        const partition = partitionOf([
+            { packageName: "oo-monday", action: "install" },
+        ]);
+
+        applyRecommendationCooldown(partition, gate);
+        const forced = applyRecommendationCooldown(partition, gate, { force: true });
+        const afterForce = applyRecommendationCooldown(partition, gate);
+
+        expect(forced.recommendations).toEqual(partition.recommendations);
+        expect(forced.skipped).toEqual([]);
+        // The forced run re-stamped the key, so the next un-forced run suppresses.
+        expect(afterForce.recommendations).toEqual([]);
+        expect(afterForce.skipped).toEqual([
+            { packageName: "oo-monday", reason: "recently-suggested" },
+        ]);
+    });
+
+    test("a content change re-surfaces even after the install was suggested", () => {
+        const gate = createFakeGate();
+
+        applyRecommendationCooldown(
+            partitionOf([{ packageName: "oo-monday", action: "install" }]),
+            gate,
+        );
+        const afterChange = applyRecommendationCooldown(
+            partitionOf([
+                {
+                    packageName: "oo-monday",
+                    action: "update",
+                    currentVersion: "1.0.0",
+                    latestVersion: "2.0.0",
+                },
+            ]),
+            gate,
+        );
+
+        expect(afterChange.recommendations).toEqual([
+            {
+                packageName: "oo-monday",
+                action: "update",
+                currentVersion: "1.0.0",
+                latestVersion: "2.0.0",
+            },
+        ]);
+        expect(afterChange.skipped).toEqual([]);
+    });
+
+    test("preserves resolved skips and appends cooldown demotions, keeping order", () => {
+        const gate = createFakeGate(["oo-gmail|install|"]);
+        const partition: RecommendationPartition = {
+            recommendations: [
+                { packageName: "oo-gmail", action: "install" },
+                { packageName: "oo-notion", action: "install" },
+            ],
+            skipped: [{ packageName: "oo-drive", reason: "up-to-date" }],
+        };
+
+        const result = applyRecommendationCooldown(partition, gate);
+
+        expect(result.recommendations).toEqual([
+            { packageName: "oo-notion", action: "install" },
+        ]);
+        expect(result.skipped).toEqual([
+            { packageName: "oo-drive", reason: "up-to-date" },
+            { packageName: "oo-gmail", reason: "recently-suggested" },
+        ]);
+    });
+});
+
+interface FakeGate extends RecommendationCooldownGate {
+    marked: string[];
+}
+
+function createFakeGate(initial: readonly string[] = []): FakeGate {
+    const seen = new Set<string>(initial);
+    const marked: string[] = [];
+
+    return {
+        marked,
+        wasRecentlySuggested: key => seen.has(key),
+        markSuggested: (key) => {
+            seen.add(key);
+            marked.push(key);
+        },
+    };
+}
+
+function partitionOf(
+    recommendations: readonly RecommendationEntry[],
+): RecommendationPartition {
+    return { recommendations: [...recommendations], skipped: [] };
+}

--- a/src/application/commands/skills/recommend/recommendation-cooldown.ts
+++ b/src/application/commands/skills/recommend/recommendation-cooldown.ts
@@ -1,0 +1,76 @@
+// Session-level de-duplication for the wrap-up skill recommendation. The CLI has
+// no stable cross-invocation session id (each process mints a fresh one), so a
+// "session" is approximated by a time-window cooldown: once a recommendation is
+// surfaced, the same recommendation is suppressed on later runs until the window
+// lapses. This keeps an agent that re-runs the wrap-up after every task from
+// re-appending the identical suggestion every turn.
+//
+// All persistence (the TTL store) lives in the command handler; this module is a
+// pure transform over a resolved partition so it stays testable in isolation.
+
+import type { RecommendationEntry, RecommendationPartition } from "./recommendation-plan.ts";
+
+// Gate over the cooldown store. `wasRecentlySuggested` reports whether the key is
+// still inside its window; `markSuggested` (re)stamps it so an active session
+// keeps the suggestion suppressed for the whole session.
+export interface RecommendationCooldownGate {
+    wasRecentlySuggested: (key: string) => boolean;
+    markSuggested: (key: string) => void;
+}
+
+export interface ApplyRecommendationCooldownOptions {
+    // Bypass suppression (the explicit "the user asked to see it again" path).
+    // The stamp is still refreshed so the next un-forced run suppresses again.
+    force?: boolean;
+}
+
+// Builds the cooldown key for a recommendation. Keying on the version target as
+// well as the package and action makes the legitimate re-surface triggers fall
+// out for free: a different package, or a content change (install -> update, or a
+// newer latest version), yields a different key and surfaces again.
+export function buildRecommendationCooldownKey(
+    entry: RecommendationEntry,
+): string {
+    const versionTarget = entry.action === "update"
+        ? `${entry.currentVersion ?? ""}->${entry.latestVersion ?? ""}`
+        : "";
+
+    return `${entry.packageName}|${entry.action}|${versionTarget}`;
+}
+
+// Demotes recommendations that were already surfaced within the cooldown window
+// to skips (reason `recently-suggested`), preserving input order, and stamps
+// every surfaced (or force-surfaced) entry so an active session stays quiet.
+export function applyRecommendationCooldown(
+    partition: RecommendationPartition,
+    gate: RecommendationCooldownGate,
+    options: ApplyRecommendationCooldownOptions = {},
+): RecommendationPartition {
+    const force = options.force === true;
+    const recommendations: RecommendationEntry[] = [];
+    const suppressed: RecommendationPartition["skipped"] = [];
+
+    for (const entry of partition.recommendations) {
+        const key = buildRecommendationCooldownKey(entry);
+        const recentlySuggested = gate.wasRecentlySuggested(key);
+
+        // Refresh the stamp on every active run so a long session never repeats.
+        gate.markSuggested(key);
+
+        if (!force && recentlySuggested) {
+            suppressed.push({
+                packageName: entry.packageName,
+                reason: "recently-suggested",
+            });
+            continue;
+        }
+
+        recommendations.push(entry);
+    }
+
+    return {
+        recommendations,
+        // Resolved skips keep their order; cooldown demotions follow them.
+        skipped: [...partition.skipped, ...suppressed],
+    };
+}

--- a/src/application/commands/skills/recommend/recommendation-plan.ts
+++ b/src/application/commands/skills/recommend/recommendation-plan.ts
@@ -10,7 +10,8 @@ export type RecommendationSkipReason
         | "dismissed"
         | "up-to-date"
         | "not-published"
-        | "lookup-failed";
+        | "lookup-failed"
+        | "recently-suggested";
 
 export interface RecommendationEntry {
     packageName: string;

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -395,14 +395,16 @@ const commandTelemetryDecisions = {
         kind: "properties",
         properties: [
             "muted",
+            "forced",
             "install_count_bucket",
             "update_count_bucket",
             "skipped_count_bucket",
+            "cooldown_suppressed_count_bucket",
             "package_names_count_bucket",
             "package_names_sample",
             "package_names_truncated",
         ],
-        reason: "Records the global mute flag, bucketed install/update/skip counts, and bounded package-name samples; never records versions or paths.",
+        reason: "Records the global mute flag, whether the session cooldown was force-bypassed, bucketed install/update/skip/cooldown-suppressed counts, and bounded package-name samples; never records versions or paths.",
     },
     "skills.recommend.mute": {
         kind: "properties",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -784,6 +784,8 @@ export const enMessages = {
         "Package name(s) to stop suggesting",
     "arguments.skills.recommend.unmute.packageName":
         "Package name(s) to resume suggesting",
+    "options.skills.recommend.plan.force":
+        "Surface suggestions even when they were already suggested recently this session",
     "options.skills.recommend.mute.all":
         "Mute every skill suggestion instead of specific packages",
     "options.skills.recommend.unmute.all":
@@ -1943,6 +1945,8 @@ export const zhMessages = {
         "要停止推荐的包名（可指定多个）",
     "arguments.skills.recommend.unmute.packageName":
         "要恢复推荐的包名（可指定多个）",
+    "options.skills.recommend.plan.force":
+        "即使本会话最近已推荐过，也仍然展示推荐",
     "options.skills.recommend.mute.all":
         "静音所有 skill 推荐，而非指定的包",
     "options.skills.recommend.unmute.all":


### PR DESCRIPTION
`oo skills recommend plan` is stateless: a connector that is published-but-not-installed resolves to the same `install` suggestion on every call. Agents run the wrap-up recommendation after each task and can't tell which turn is the last, so the identical "Optional: install …" prompt was re-appended on every turn of a multi-step session — even when the user explicitly asked for concise output. The skill guidance already said "run the wrap-up exactly once," but that's unenforceable mid-conversation, and there's no stable cross-invocation session id the CLI could key on.

This adds a per-session cooldown so repeated wrap-ups become idempotent. A surfaced suggestion is stamped in the data-dir cache (not the user-editable settings file), keyed by `packageName | action | versionTarget`; on later runs within the window the same suggestion is demoted from `recommendations` to a new `recently-suggested` skip, so the agent stays silent. The per-entry key makes the legitimate re-surface triggers fall out for free: switching service, a content change (`install` → `update`, or a newer latest version), or passing the new `--force` flag all re-surface it. Globally muted plans surface nothing and stamp nothing, and the cooldown is best-effort — if its on-disk state is unavailable the plan is returned without de-duplication rather than failing.

Because there is no real session identifier, "one session" is approximated by a TTL window (currently 4h) — long enough to span a continuous working session, short enough that a genuinely new session later re-surfaces the suggestion. That window is the main judgment call worth a reviewer's eye.

On the agent side, the `oo` skill guidance is softened to lean on this CLI backstop instead of the unenforceable "exactly once" rule, and to omit the optional suggestion when the user asks for concise output. Telemetry gains a `forced` flag and a bucketed cooldown-suppressed count (manifest updated); docs and tests (unit plus cross-invocation CLI) cover the new behavior.