### PR TITLE
refactor(connector): move action search to /v1/actions/search

### DIFF
--- a/contrib/skills/shared/oo-create-skill/SKILL.md
+++ b/contrib/skills/shared/oo-create-skill/SKILL.md
@@ -124,7 +124,7 @@ permission and name the blocked command. Common commands are:
 
 ```bash
 oo skills init <name> --agent <!-- agentic:var agent --> --description "..."
-oo search "<query>" --keywords "<keywords>" --json
+oo search "<query>" --json
 oo connector schema "<service>" --action "<action>"
 ```
 
@@ -175,20 +175,20 @@ not provided a complete connector action contract, use discovery before
 authoring:
 
 ```bash
-oo search "<goal>" --keywords "<comma-separated keywords>" --json
+oo search "<goal>" --json
 ```
 
 Do this even when the user mentions a model, product, provider name, or managed
 API capability, unless the user already provided a complete current connector
 contract. Shape `<goal>` as one short English outcome sentence for the current
 external step, preserving the user's decisive constraints such as target
-service, language pair, file type, and output format. Always pass `1` to `3`
-keywords. Keywords may use the user's original language and must keep product,
-brand, and proper names untranslated, for example keep `滴答清单` and do not
-turn it into `TickTick`; the backend tokenizes keywords, while the free-text
-query alone runs an untokenized semantic search. If those decisive business
-constraints are missing and would change the reusable skill contract, ask the
-user before discovery. Inspect the first result set before narrowing the query.
+service, language pair, file type, and output format. Name the target service
+when known, and keep product, brand, and proper names exactly as the user wrote
+them, for example keep `滴答清单` and do not turn it into `TickTick`, since the
+free-text query is the only discovery signal and a translated name can map onto
+a different global product. If those decisive business constraints are missing
+and would change the reusable skill contract, ask the user before discovery.
+Inspect the first result set before narrowing the query.
 
 Use only connector entries as authoring candidates. Treat non-connector entries
 as non-authoring catalog noise during this workflow: do not inspect them, do not

--- a/contrib/skills/shared/oo/SKILL.md
+++ b/contrib/skills/shared/oo/SKILL.md
@@ -112,16 +112,14 @@ proves its output.
    prechecks; let the first substantive `oo` command surface availability or
    account problems.
 2. Search goal
-   For a single-step task, write one concise English goal sentence plus `1` to
-   `3` keywords. Keywords may use the user's original language and must keep
-   product, brand, and proper names untranslated. For a short multi-step task,
-   write 2 to 4 ordered subgoals and activate only the current unresolved
-   external step.
+   For a single-step task, write one concise English goal sentence that names
+   the target service when known and keeps product, brand, and proper names
+   untranslated. For a short multi-step task, write 2 to 4 ordered subgoals and
+   activate only the current unresolved external step.
 3. Discover
    Read [references/search-and-selection.md](references/search-and-selection.md)
-   before the first search. Run
-   `oo search "<goal>" --keywords "<keywords>" --json` with `1` to `3` keywords
-   unless a complete capability contract is already known from current evidence.
+   before the first search. Run `oo search "<goal>" --json` unless a complete
+   capability contract is already known from current evidence.
    A complete contract means connector schema already proves the callable id,
    required inputs, and output semantics; a user-named service is not enough.
    Record the `service` of each connector capability you actually use, building

--- a/contrib/skills/shared/oo/references/connector-execution.md
+++ b/contrib/skills/shared/oo/references/connector-execution.md
@@ -281,8 +281,8 @@ State model:
    Discover or choose an action whose description identifies it as download or
    export and whose `outputSchema` exposes a download URL field, such as
    `transitUrl` on `googledrive.download_file`.
-   Prefer refining within the same connector service first, using the selected
-   service as a keyword or constraint.
+   Prefer refining within the same connector service first, naming the selected
+   service in the query sentence as a constraint.
 4. Save
    Feed that documented download URL to `oo file download`. Do not feed
    `webViewLink`, edit URLs, folder URLs, or console URLs to file download.

--- a/contrib/skills/shared/oo/references/search-and-selection.md
+++ b/contrib/skills/shared/oo/references/search-and-selection.md
@@ -47,6 +47,10 @@ Guidance:
   phrasing.
 - Preserve decisive constraints: language pair, file type, output format,
   target service, destination, time range, or attachment.
+- Keep product, brand, and proper names exactly as the user wrote them and do
+  not translate them (for example keep `滴答清单`; do not turn it into
+  `TickTick`). The free-form query is the only discovery signal, so a translated
+  name can map onto a different global product.
 - Avoid meta words such as `oo`, `CLI`, `search`, or `skill` unless the user
   actually asked about them.
 - For a short multi-step workflow, search only the current unresolved external
@@ -60,25 +64,6 @@ Examples:
 - `find a Google Drive file by name and download it`
 - `collect Gmail messages from yesterday`
 - `create a Notion page from prepared content`
-
-## Search keywords
-
-Always pass `1` to `3` keywords through `--keywords` on every `oo search` call.
-Never search without keywords.
-
-- Make the target service or provider name one of the keywords whenever it is
-  known or implied (for example `Gmail`, `Google Calendar`, `Stripe`), so the
-  service reaches the catalog even when the sentence phrasing buries it.
-- Keywords may use the user's original language; the English sentence stays in
-  English.
-- Keep product names, brand names, and proper nouns exactly as the user wrote
-  them and do not translate them. For example, keep `滴答清单`; do not turn it
-  into `TickTick`.
-- The backend tokenizes `--keywords`, so original-language and product-name
-  keywords reach the catalog entry the user actually wants. The free-text query
-  alone runs an untokenized semantic search that can map a localized product
-  onto a different global product.
-- Pass keywords only through `--keywords`, never as extra positional arguments.
 
 ## Repair weak first queries
 
@@ -111,20 +96,18 @@ Examples:
 Canonical form:
 
 ```bash
-oo search "<text>" --keywords "<comma-separated keywords>" --json
+oo search "<text>" --json
 ```
 
 Facts:
 
 - `oo search` performs one discovery pass over connector action search.
-- `<text>` is one free-form query string, not multiple positional keywords.
+- `<text>` is one free-form query string, not multiple positional arguments.
 - `--json` returns a raw array, not an object wrapper.
 - The array contains `connector` entries.
 - Connector entries include stable fields such as `service`, `name`,
   `description`, and `authenticated`. Record the `service` of every connector
   you actually use; the wrap-up recommendation is keyed on it.
-- `--keywords` is required on every call: always pass `1` to `3` keywords. The
-  backend tokenizes them while keeping the same free-form text query.
 
 Representative JSON example:
 
@@ -316,11 +299,10 @@ complete.
 ## Refinement policy
 
 - Refine only after inspecting the first result set.
-- The first search already carries `1` to `3` keywords. When it captured the
-  general task but missed an important connector service, format, language, or
-  destination constraint, adjust or add keywords (still `1` to `3`) and search
-  again.
-- Do not pass keywords as extra positional arguments.
+- When the first search captured the general task but missed an important
+  connector service, format, language, or destination constraint, add that
+  constraint to the query sentence and search again.
+- Pass one free-form query string, not multiple positional arguments.
 - If the task looks like a managed API capability but the result set has
   no suitable connector candidate, run one connector refinement before reporting
   that no executable capability is available.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -558,11 +558,9 @@ agents.
 Search connector actions with free-form text.
 
 - Arguments: `<text>` is the semantic search text.
-- Options: `--keywords <keywords>` sends a comma-separated keyword list after
-  trimming empty and duplicate entries.
 - Options: `--format=json` and `--json` print a JSON array of matching action
   entries.
-- Output: every match is enriched with `authenticated`.
+- Output: every match includes `authenticated`.
 - Output: JSON entries include the stable CLI fields `service`, `name`,
   `description`, and `authenticated`.
 - Output: text output prints one block per action with the service/action
@@ -706,11 +704,9 @@ Proxy a provider API request through a connected connector app.
 Search connector actions with one free-form query.
 
 - Arguments: `<text>` is the semantic search text.
-- Options: `--keywords <keywords>` sends a comma-separated keyword list after
-  trimming empty and duplicate entries.
 - Options: `--format=json` and `--json` print a JSON array of matching action
   entries.
-- Output: every match is enriched with `authenticated`.
+- Output: every match includes `authenticated`.
 - Output: JSON entries include the stable CLI fields `service`, `name`,
   `description`, and `authenticated`.
 - Output: text output prints one block per action with the service/action

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -478,10 +478,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 使用自由文本搜索 connector action。
 
 - 参数：`<text>` 为语义搜索文本。
-- 选项：`--keywords <keywords>` 接收逗号分隔的关键词列表，去掉空项和重复项
-  后发送。
 - 选项：`--format=json` 和 `--json` 会输出匹配 action 条目的 JSON 数组。
-- 输出：每条结果都会附加 `authenticated`。
+- 输出：每条结果都会包含 `authenticated`。
 - 输出：JSON 条目只包含稳定的 CLI 字段：`service`、`name`、`description`、
   `authenticated`。
 - 输出：文本输出会为每个 action 打印一个块，包含 service/action 标识、可选
@@ -606,10 +604,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 使用一个自由文本查询搜索 connector action。
 
 - 参数：`<text>` 为语义搜索文本。
-- 选项：`--keywords <keywords>` 接收逗号分隔的关键词列表，去掉空项和重复项
-  后发送。
 - 选项：`--format=json` 和 `--json` 会输出匹配 action 条目的 JSON 数组。
-- 输出：每条结果都会附加 `authenticated`。
+- 输出：每条结果都会包含 `authenticated`。
 - 输出：JSON 条目只包含稳定的 CLI 字段：`service`、`name`、`description`、
   `authenticated`。
 - 输出：文本输出会为每个 action 打印一个块，包含 service/action 标识、可选

--- a/src/application/commands/__snapshots__/search.cli.test.ts.snap
+++ b/src/application/commands/__snapshots__/search.cli.test.ts.snap
@@ -51,8 +51,6 @@ Options:
   --json                 Alias for --format=json
   --show-schema-version  Include schemaVersion in JSON output (no effect without
                          --json)
-  --keywords <keywords>  Specify comma-separated keywords to refine the
-                         connector action search
   -h, --help             Show help for command
 
 Global Options:
@@ -76,8 +74,6 @@ Options:
   --json                 Alias for --format=json
   --show-schema-version  Include schemaVersion in JSON output (no effect without
                          --json)
-  --keywords <keywords>  Specify comma-separated keywords to refine the
-                         connector action search
   -h, --help             Show help for command
 
 Global Options:

--- a/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
@@ -64,8 +64,6 @@ Options:
   --json                 Alias for --format=json
   --show-schema-version  Include schemaVersion in JSON output (no effect without
                          --json)
-  --keywords <keywords>  Specify comma-separated keywords to refine the
-                         connector action search
   -h, --help             Show help for command
 
 Global Options:
@@ -89,8 +87,6 @@ Options:
   --json                 Alias for --format=json
   --show-schema-version  Include schemaVersion in JSON output (no effect without
                          --json)
-  --keywords <keywords>  Specify comma-separated keywords to refine the
-                         connector action search
   -h, --help             Show help for command
 
 Global Options:

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -39,46 +39,24 @@ describe("connectorCommand CLI", () => {
 
             const requests: Request[] = [];
             const result = await sandbox.run(
-                ["connector", "search", "send mail", "--keywords=gmail,email,gmail"],
+                ["connector", "search", "send mail"],
                 {
                     fetcher: async (input, init) => {
                         const request = toRequest(input, init);
 
                         requests.push(request);
 
-                        if (request.url.startsWith("https://search.")) {
-                            return new Response(JSON.stringify({
-                                data: [
-                                    {
-                                        description: "Send a Gmail message.",
-                                        inputSchema: {
-                                            properties: {
-                                                to: {
-                                                    format: "email",
-                                                    type: "string",
-                                                },
-                                            },
-                                            required: ["to"],
-                                            type: "object",
-                                        },
-                                        name: "send_mail",
-                                        outputSchema: {
-                                            properties: {
-                                                messageId: {
-                                                    type: "string",
-                                                },
-                                            },
-                                            required: ["messageId"],
-                                            type: "object",
-                                        },
-                                        service: "gmail",
-                                    },
-                                ],
-                            }));
-                        }
-
                         return new Response(JSON.stringify({
-                            data: ["gmail"],
+                            success: true,
+                            message: "ok",
+                            data: [
+                                {
+                                    authenticated: true,
+                                    description: "Send a Gmail message.",
+                                    name: "send_mail",
+                                    service: "gmail",
+                                },
+                            ],
                         }));
                     },
                 },
@@ -140,14 +118,11 @@ describe("connectorCommand CLI", () => {
                 },
                 service: "gmail",
             });
-            expect(requests).toHaveLength(3);
+            expect(requests).toHaveLength(2);
             expect(requests[0]?.url).toBe(
-                "https://search.oomol.com/v1/connector-actions?q=send+mail&keywords=gmail%2Cemail",
+                "https://connector.oomol.com/v1/actions/search?q=send+mail",
             );
             expect(requests[1]?.url).toBe(
-                "https://connector.oomol.com/v1/apps/authenticated?service=gmail",
-            );
-            expect(requests[2]?.url).toBe(
                 "https://connector.oomol.com/v1/actions/gmail.send_mail",
             );
         }
@@ -168,24 +143,15 @@ describe("connectorCommand CLI", () => {
                     fetcher: async (input, init) => {
                         const request = toRequest(input, init);
 
-                        if (request.url.startsWith("https://search.")) {
+                        if (request.url.includes("/v1/actions/search")) {
                             return new Response(JSON.stringify({
+                                success: true,
+                                message: "ok",
                                 data: [
                                     {
+                                        authenticated: false,
                                         description: "Submit OpenAI image generation.",
-                                        inputSchema: {
-                                            type: "object",
-                                        },
                                         name: "openai_image_async_submit",
-                                        outputSchema: {
-                                            properties: {
-                                                sessionId: {
-                                                    type: "string",
-                                                },
-                                            },
-                                            required: ["sessionId"],
-                                            type: "object",
-                                        },
                                         service: "fusion-api",
                                     },
                                 ],
@@ -310,18 +276,15 @@ describe("connectorCommand CLI", () => {
                     fetcher: async (input, init) => {
                         const request = toRequest(input, init);
 
-                        if (request.url.startsWith("https://search.")) {
+                        if (request.url.includes("/v1/actions/search")) {
                             return new Response(JSON.stringify({
+                                success: true,
+                                message: "ok",
                                 data: [
                                     {
+                                        authenticated: false,
                                         description: "Send a Gmail message.",
-                                        inputSchema: {
-                                            type: "object",
-                                        },
                                         name: "send_mail",
-                                        outputSchema: {
-                                            type: "object",
-                                        },
                                         service: "gmail",
                                     },
                                 ],
@@ -365,18 +328,15 @@ describe("connectorCommand CLI", () => {
                     fetcher: async (input, init) => {
                         const request = toRequest(input, init);
 
-                        if (request.url.startsWith("https://search.")) {
+                        if (request.url.includes("/v1/actions/search")) {
                             return new Response(JSON.stringify({
+                                success: true,
+                                message: "ok",
                                 data: [
                                     {
+                                        authenticated: true,
                                         description: "Send a Gmail message.",
-                                        inputSchema: {
-                                            type: "object",
-                                        },
                                         name: "send_mail",
-                                        outputSchema: {
-                                            type: "object",
-                                        },
                                         service: "gmail",
                                     },
                                 ],
@@ -4174,7 +4134,7 @@ describe("connectorCommand CLI", () => {
             expect(requests).toHaveLength(1);
             // OO_ENDPOINT must drive the execution endpoint derivation.
             expect(requests[0]!.url).toStartWith(
-                "https://search.oomol.dev/v1/connector-actions",
+                "https://connector.oomol.dev/v1/actions/search",
             );
             // OO_API_KEY must be used as the Authorization credential.
             expect(requests[0]!.headers.get("Authorization")).toBe("env-api-key");
@@ -4213,7 +4173,7 @@ describe("connectorCommand CLI", () => {
             expect(result.exitCode).toBe(0);
             expect(requests).toHaveLength(1);
             expect(requests[0]!.url).toStartWith(
-                "https://search.oomol.dev/v1/connector-actions",
+                "https://connector.oomol.dev/v1/actions/search",
             );
             // The persisted API key is still used as the credential.
             expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -46,18 +46,14 @@ describe("connectorCommand CLI", () => {
 
                         requests.push(request);
 
-                        return new Response(JSON.stringify({
-                            success: true,
-                            message: "ok",
-                            data: [
-                                {
-                                    authenticated: true,
-                                    description: "Send a Gmail message.",
-                                    name: "send_mail",
-                                    service: "gmail",
-                                },
-                            ],
-                        }));
+                        return createConnectorSearchResponse([
+                            {
+                                authenticated: true,
+                                description: "Send a Gmail message.",
+                                name: "send_mail",
+                                service: "gmail",
+                            },
+                        ]);
                     },
                 },
             );
@@ -144,18 +140,14 @@ describe("connectorCommand CLI", () => {
                         const request = toRequest(input, init);
 
                         if (request.url.includes("/v1/actions/search")) {
-                            return new Response(JSON.stringify({
-                                success: true,
-                                message: "ok",
-                                data: [
-                                    {
-                                        authenticated: false,
-                                        description: "Submit OpenAI image generation.",
-                                        name: "openai_image_async_submit",
-                                        service: "fusion-api",
-                                    },
-                                ],
-                            }));
+                            return createConnectorSearchResponse([
+                                {
+                                    authenticated: false,
+                                    description: "Submit OpenAI image generation.",
+                                    name: "openai_image_async_submit",
+                                    service: "fusion-api",
+                                },
+                            ]);
                         }
 
                         return new Response(JSON.stringify({
@@ -277,18 +269,14 @@ describe("connectorCommand CLI", () => {
                         const request = toRequest(input, init);
 
                         if (request.url.includes("/v1/actions/search")) {
-                            return new Response(JSON.stringify({
-                                success: true,
-                                message: "ok",
-                                data: [
-                                    {
-                                        authenticated: false,
-                                        description: "Send a Gmail message.",
-                                        name: "send_mail",
-                                        service: "gmail",
-                                    },
-                                ],
-                            }));
+                            return createConnectorSearchResponse([
+                                {
+                                    authenticated: false,
+                                    description: "Send a Gmail message.",
+                                    name: "send_mail",
+                                    service: "gmail",
+                                },
+                            ]);
                         }
 
                         return new Response(JSON.stringify({
@@ -329,18 +317,14 @@ describe("connectorCommand CLI", () => {
                         const request = toRequest(input, init);
 
                         if (request.url.includes("/v1/actions/search")) {
-                            return new Response(JSON.stringify({
-                                success: true,
-                                message: "ok",
-                                data: [
-                                    {
-                                        authenticated: true,
-                                        description: "Send a Gmail message.",
-                                        name: "send_mail",
-                                        service: "gmail",
-                                    },
-                                ],
-                            }));
+                            return createConnectorSearchResponse([
+                                {
+                                    authenticated: true,
+                                    description: "Send a Gmail message.",
+                                    name: "send_mail",
+                                    service: "gmail",
+                                },
+                            ]);
                         }
 
                         return new Response(JSON.stringify({
@@ -4260,6 +4244,21 @@ function createAsyncResultActionSchema(
         service: "fusion-api",
         ...overrides,
     };
+}
+
+function createConnectorSearchResponse(
+    actions: Array<{
+        authenticated: boolean;
+        description: string;
+        name: string;
+        service: string;
+    }>,
+): Response {
+    return new Response(JSON.stringify({
+        success: true,
+        message: "ok",
+        data: actions,
+    }));
 }
 
 function createBunSleepMock(onSleep?: (durationMs: number) => void) {

--- a/src/application/commands/connector/search-provider.test.ts
+++ b/src/application/commands/connector/search-provider.test.ts
@@ -15,9 +15,7 @@ describe("connector search provider", () => {
                 account: {
                     apiKey: "secret-1",
                     endpoint: "oomol.com",
-                    id: "user-1",
                 },
-                keywords: [],
                 text: "send mail",
             },
             {
@@ -26,27 +24,18 @@ describe("connector search provider", () => {
 
                     requests.push(request);
 
-                    if (request.url.startsWith("https://search.")) {
+                    if (request.url.includes("/v1/actions/search")) {
                         return new Response(JSON.stringify({
+                            success: true,
+                            message: "ok",
                             data: [
                                 {
+                                    authenticated: true,
                                     description: "Send a Gmail message.",
-                                    inputSchema: {
-                                        type: "object",
-                                    },
                                     name: "send_mail",
-                                    outputSchema: {
-                                        type: "object",
-                                    },
                                     service: "gmail",
                                 },
                             ],
-                        }));
-                    }
-
-                    if (request.url.startsWith("https://connector.")) {
-                        return new Response(JSON.stringify({
-                            data: ["gmail"],
                         }));
                     }
 
@@ -68,8 +57,7 @@ describe("connector search provider", () => {
             },
         ]);
         expect(requests.map(request => request.url)).toEqual([
-            "https://search.oomol.com/v1/connector-actions?q=send+mail",
-            "https://connector.oomol.com/v1/apps/authenticated?service=gmail",
+            "https://connector.oomol.com/v1/actions/search?q=send+mail",
         ]);
     });
 });

--- a/src/application/commands/connector/search-provider.ts
+++ b/src/application/commands/connector/search-provider.ts
@@ -4,10 +4,7 @@ import type { TerminalColors } from "../../terminal-colors.ts";
 
 import { createWriterColors } from "../../terminal-colors.ts";
 
-import {
-    listAuthenticatedConnectorServices,
-    searchConnectorActions,
-} from "./shared.ts";
+import { searchConnectorActions } from "./shared.ts";
 
 export const connectorSearchActionColor = "#59F78D";
 export const connectorSearchServiceColor = "#CAA8FA";
@@ -23,8 +20,7 @@ type ConnectorSearchTextContext = Pick<CliExecutionContext, "stdout" | "translat
 
 export async function loadConnectorSearchResults(
     options: {
-        account: Pick<AuthAccount, "apiKey" | "endpoint" | "id">;
-        keywords: readonly string[];
+        account: Pick<AuthAccount, "apiKey" | "endpoint">;
         text: string;
     },
     context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
@@ -32,25 +28,11 @@ export async function loadConnectorSearchResults(
     const actions = await searchConnectorActions({
         apiKey: options.account.apiKey,
         endpoint: options.account.endpoint,
-        keywords: options.keywords,
         text: options.text,
     }, context);
 
-    if (actions.length === 0) {
-        return [];
-    }
-
-    const authenticatedServices = await listAuthenticatedConnectorServices(
-        {
-            apiKey: options.account.apiKey,
-            endpoint: options.account.endpoint,
-            services: Array.from(new Set(actions.map(action => action.service))),
-        },
-        context,
-    );
-
     return actions.map(action => ({
-        authenticated: authenticatedServices.has(action.service),
+        authenticated: action.authenticated,
         description: action.description,
         name: action.name,
         service: action.service,

--- a/src/application/commands/connector/search.ts
+++ b/src/application/commands/connector/search.ts
@@ -8,7 +8,6 @@ import {
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
-import { parseCommaSeparatedKeywords } from "../shared/keywords.ts";
 import {
     formatConnectorSearchResultsAsText,
     loadConnectorSearchResults,
@@ -17,7 +16,6 @@ import { connectorFormatValues } from "./shared.ts";
 
 interface ConnectorSearchInput {
     format?: (typeof connectorFormatValues)[number];
-    keywords?: string;
     showSchemaVersion?: boolean;
     text: string;
 }
@@ -36,25 +34,15 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
     ],
     options: [
         ...jsonOutputOptions,
-        {
-            name: "keywords",
-            longFlag: "--keywords",
-            valueName: "keywords",
-            descriptionKey: "options.connectorKeywords",
-        },
     ],
     inputSchema: z.object({
         format: z.enum(connectorFormatValues).optional(),
-        keywords: z.string().optional(),
         showSchemaVersion: z.boolean().optional(),
         text: z.string(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        const keywords = parseCommaSeparatedKeywords(input.keywords);
-
         context.telemetry?.recordProperties({
-            keyword_count_bucket: bucketTelemetryCount(keywords.length),
             query_length_bucket: bucketTelemetryStringLength(input.text),
         });
 
@@ -62,7 +50,6 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
         const results = await loadConnectorSearchResults(
             {
                 account,
-                keywords,
                 text: input.text,
             },
             context,

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -15,7 +15,6 @@ import {
 } from "../shared/billing.ts";
 import {
     getConnectorActionMetadata,
-    listAuthenticatedConnectorServices,
     listConnectorAppsByService,
     runConnectorAction,
     runConnectorProxy,
@@ -29,7 +28,6 @@ describe("connector shared requests", () => {
             {
                 apiKey: "secret-1",
                 endpoint: "oomol.com",
-                keywords: ["gmail", "email"],
                 text: "send mail",
             },
             createRequestContext({
@@ -37,19 +35,13 @@ describe("connector shared requests", () => {
                     requests.push(toRequest(input, init));
 
                     return new Response(JSON.stringify({
+                        success: true,
+                        message: "ok",
                         data: [
                             {
+                                authenticated: true,
                                 description: "Send a Gmail message.",
-                                followUpActions: [],
-                                inputSchema: {
-                                    type: "object",
-                                },
                                 name: "send_mail",
-                                outputSchema: {
-                                    type: "object",
-                                },
-                                providerPermissions: ["gmail.send"],
-                                requiredScopes: ["gmail.send"],
                                 service: "gmail",
                             },
                         ],
@@ -60,43 +52,17 @@ describe("connector shared requests", () => {
 
         expect(actions).toEqual([
             {
+                authenticated: true,
                 description: "Send a Gmail message.",
-                inputSchema: {
-                    type: "object",
-                },
                 name: "send_mail",
-                outputSchema: {
-                    type: "object",
-                },
                 service: "gmail",
             },
         ]);
         expect(requests).toHaveLength(1);
         expect(requests[0]?.url).toBe(
-            "https://search.oomol.com/v1/connector-actions?q=send+mail&keywords=gmail%2Cemail",
+            "https://connector.oomol.com/v1/actions/search?q=send+mail",
         );
         expect(requests[0]?.headers.get("Authorization")).toBe("secret-1");
-    });
-
-    test("listAuthenticatedConnectorServices avoids a request when no services are provided", async () => {
-        let fetchCount = 0;
-        const services = await listAuthenticatedConnectorServices(
-            {
-                apiKey: "secret-1",
-                endpoint: "oomol.com",
-                services: [],
-            },
-            createRequestContext({
-                fetcher: async () => {
-                    fetchCount += 1;
-
-                    return new Response("[]");
-                },
-            }),
-        );
-
-        expect([...services]).toEqual([]);
-        expect(fetchCount).toBe(0);
     });
 
     test("listConnectorAppsByService requests apps for one service", async () => {

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -56,16 +56,15 @@ export const connectorActionMetadataSchema = connectorActionDefinitionSchema.ext
     requiredScopes: z.array(z.string()).optional().default([]),
 }).passthrough();
 
-const connectorActionSearchResultSchema = connectorActionDefinitionSchema.extend({
-    asyncLifecycle: connectorActionAsyncLifecycleSchema.optional(),
+const connectorActionSearchResultSchema = z.object({
+    authenticated: z.boolean().optional().default(false),
+    description: z.string().optional().default(""),
+    name: z.string().min(1),
+    service: z.string().min(1),
 });
 
 const connectorActionSearchResponseSchema = z.object({
     data: z.array(connectorActionSearchResultSchema).optional().default([]),
-});
-
-const authenticatedConnectorServicesResponseSchema = z.object({
-    data: z.array(z.string()).optional().default([]),
 });
 
 const connectorActionMetadataResponseSchema = z.object({
@@ -156,6 +155,7 @@ export function requireConnectorActionName(rawAction: string | undefined): strin
 }
 
 export type ConnectorActionDefinition = z.output<typeof connectorActionDefinitionSchema>;
+export type ConnectorActionSearchResult = z.output<typeof connectorActionSearchResultSchema>;
 export type ConnectorActionAsyncLifecycle = z.output<typeof connectorActionAsyncLifecycleSchema>;
 export type ConnectorActionMetadata = z.output<typeof connectorActionMetadataSchema>;
 export type ConnectorActionRunResponse = z.output<typeof connectorActionRunResponseSchema>;
@@ -167,20 +167,15 @@ export async function searchConnectorActions(
     options: {
         apiKey: string;
         endpoint: string;
-        keywords: readonly string[];
         text: string;
     },
     context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
-): Promise<ConnectorActionDefinition[]> {
+): Promise<ConnectorActionSearchResult[]> {
     const requestUrl = new URL(
-        `https://search.${options.endpoint}/v1/connector-actions`,
+        `https://connector.${options.endpoint}/v1/actions/search`,
     );
 
     requestUrl.searchParams.set("q", options.text);
-
-    if (options.keywords.length > 0) {
-        requestUrl.searchParams.set("keywords", options.keywords.join(","));
-    }
 
     const rawResponse = await requestText({
         context,
@@ -200,7 +195,6 @@ export async function searchConnectorActions(
         ),
         fields: {
             start: {
-                keywordCount: options.keywords.length,
                 textLength: options.text.length,
             },
         },
@@ -220,68 +214,6 @@ export async function searchConnectorActions(
     }
     catch {
         throw new CliUserError("errors.connectorSearch.invalidResponse", 1);
-    }
-}
-
-export async function listAuthenticatedConnectorServices(
-    options: {
-        apiKey: string;
-        endpoint: string;
-        services: readonly string[];
-    },
-    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
-): Promise<Set<string>> {
-    if (options.services.length === 0) {
-        return new Set<string>();
-    }
-
-    const requestUrl = new URL(
-        `https://connector.${options.endpoint}/v1/apps/authenticated`,
-    );
-
-    for (const service of options.services) {
-        requestUrl.searchParams.append("service", service);
-    }
-
-    const rawResponse = await requestText({
-        context,
-        createRequestFailedError: status => new CliUserError(
-            "errors.connectorAuthenticated.requestFailed",
-            1,
-            {
-                status,
-            },
-        ),
-        createUnexpectedError: error => new CliUserError(
-            "errors.connectorAuthenticated.requestError",
-            1,
-            {
-                message: error instanceof Error ? error.message : String(error),
-            },
-        ),
-        fields: {
-            start: {
-                serviceCount: options.services.length,
-            },
-        },
-        init: {
-            headers: {
-                Authorization: options.apiKey,
-            },
-        },
-        requestLabel: "Authenticated connector services",
-        requestUrl,
-    });
-
-    try {
-        return new Set(
-            authenticatedConnectorServicesResponseSchema.parse(
-                JSON.parse(rawResponse) as unknown,
-            ).data,
-        );
-    }
-    catch {
-        throw new CliUserError("errors.connectorAuthenticated.invalidResponse", 1);
     }
 }
 

--- a/src/application/commands/search.cli.test.ts
+++ b/src/application/commands/search.cli.test.ts
@@ -24,33 +24,24 @@ describe("searchCommand CLI", () => {
 
             const requests: Request[] = [];
             const result = await sandbox.run(
-                ["search", "send mail", "--keywords=gmail,email,gmail"],
+                ["search", "send mail"],
                 {
                     fetcher: async (input, init) => {
                         const request = toRequest(input, init);
 
                         requests.push(request);
 
-                        if (request.url.includes("/v1/connector-actions")) {
-                            return new Response(JSON.stringify({
-                                data: [
-                                    {
-                                        description: "Send a Gmail message.",
-                                        inputSchema: {
-                                            type: "object",
-                                        },
-                                        name: "send_mail",
-                                        outputSchema: {
-                                            type: "object",
-                                        },
-                                        service: "gmail",
-                                    },
-                                ],
-                            }));
-                        }
-
                         return new Response(JSON.stringify({
-                            data: ["gmail"],
+                            success: true,
+                            message: "ok",
+                            data: [
+                                {
+                                    authenticated: true,
+                                    description: "Send a Gmail message.",
+                                    name: "send_mail",
+                                    service: "gmail",
+                                },
+                            ],
                         }));
                     },
                 },
@@ -64,18 +55,17 @@ describe("searchCommand CLI", () => {
 
             expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
             expect(requests.map(request => request.url).sort()).toEqual([
-                "https://connector.oomol.com/v1/apps/authenticated?service=gmail",
-                "https://search.oomol.com/v1/connector-actions?q=send+mail&keywords=gmail%2Cemail",
+                "https://connector.oomol.com/v1/actions/search?q=send+mail",
             ]);
             expect(logContent).not.toContain("/v1/packages/-/intent-search");
             expect(telemetryPayload).toMatchObject({
                 properties: {
                     command_full: "search",
-                    keyword_count_bucket: "1-5",
                     query_length_bucket: "6-20",
                     result_count_bucket: "1-5",
                 },
             });
+            expect(telemetryPayload?.properties).not.toHaveProperty("keyword_count_bucket");
             expect(telemetryPayload?.properties).not.toHaveProperty("query");
             expect(telemetryPayload?.properties).not.toHaveProperty("text");
         }
@@ -96,18 +86,15 @@ describe("searchCommand CLI", () => {
                     fetcher: async (input, init) => {
                         const request = toRequest(input, init);
 
-                        if (request.url.includes("/v1/connector-actions")) {
+                        if (request.url.includes("/v1/actions/search")) {
                             return new Response(JSON.stringify({
+                                success: true,
+                                message: "ok",
                                 data: [
                                     {
+                                        authenticated: false,
                                         description: "Send a Gmail message.",
-                                        inputSchema: {
-                                            type: "object",
-                                        },
                                         name: "send_mail",
-                                        outputSchema: {
-                                            type: "object",
-                                        },
                                         service: "gmail",
                                     },
                                 ],

--- a/src/application/commands/search.ts
+++ b/src/application/commands/search.ts
@@ -13,13 +13,11 @@ import {
 import { jsonOutputOptions, writeJsonOutput } from "./json-output.ts";
 import { requireCurrentAccount } from "./shared/auth-utils.ts";
 import { createFormatInputError } from "./shared/input-parsing.ts";
-import { parseCommaSeparatedKeywords } from "./shared/keywords.ts";
 
 const searchFormatValues = ["json"] as const;
 
 interface SearchInput {
     format?: (typeof searchFormatValues)[number];
-    keywords?: string;
     showSchemaVersion?: boolean;
     text: string;
 }
@@ -38,25 +36,15 @@ export const searchCommand: CliCommandDefinition<SearchInput> = {
     ],
     options: [
         ...jsonOutputOptions,
-        {
-            name: "keywords",
-            longFlag: "--keywords",
-            valueName: "keywords",
-            descriptionKey: "options.connectorKeywords",
-        },
     ],
     inputSchema: z.object({
         format: z.enum(searchFormatValues).optional(),
-        keywords: z.string().optional(),
         showSchemaVersion: z.boolean().optional(),
         text: z.string(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        const keywords = parseCommaSeparatedKeywords(input.keywords);
-
         context.telemetry?.recordProperties({
-            keyword_count_bucket: bucketTelemetryCount(keywords.length),
             query_length_bucket: bucketTelemetryStringLength(input.text),
         });
 
@@ -64,7 +52,6 @@ export const searchCommand: CliCommandDefinition<SearchInput> = {
         const results = await loadConnectorSearchResults(
             {
                 account,
-                keywords,
                 text: input.text,
             },
             context,

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -167,7 +167,6 @@ const commandTelemetryDecisions = {
     "connector.search": {
         kind: "properties",
         properties: [
-            "keyword_count_bucket",
             "query_length_bucket",
             "result_count_bucket",
         ],
@@ -255,7 +254,6 @@ const commandTelemetryDecisions = {
     "search": {
         kind: "properties",
         properties: [
-            "keyword_count_bucket",
             "query_length_bucket",
             "result_count_bucket",
         ],

--- a/src/i18n/catalog.test.ts
+++ b/src/i18n/catalog.test.ts
@@ -48,6 +48,10 @@ describe("message catalog", () => {
 
     test("does not keep removed duplicate keys", () => {
         const removedKeys = [
+            "options.connectorKeywords",
+            "errors.connectorAuthenticated.invalidResponse",
+            "errors.connectorAuthenticated.requestError",
+            "errors.connectorAuthenticated.requestFailed",
             "options.skill",
             "options.all",
             "errors.skills.install.nonInteractiveSelection",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -278,12 +278,6 @@ export const enMessages = {
         "Invalid value for {option}: {value}. Use an integer greater than or equal to 1.",
     "errors.shared.networkRestrictedSandboxHint":
         "Current environment may be running in a network-restricted sandbox. Try requesting elevated permissions.",
-    "errors.connectorAuthenticated.invalidResponse":
-        "The authenticated connector services response body is unsupported.",
-    "errors.connectorAuthenticated.requestError":
-        "The authenticated connector services request failed: {message}",
-    "errors.connectorAuthenticated.requestFailed":
-        "The authenticated connector services request returned HTTP {status}.",
     "errors.connectorApps.invalidResponse":
         "The connector apps response body is unsupported.",
     "errors.connectorApps.requestError":
@@ -829,8 +823,6 @@ export const enMessages = {
     "options.blockId": "Specify the target block id",
     "options.action": "Specify the target action name",
     "options.blockName": "Alias for --block-id",
-    "options.connectorKeywords":
-        "Specify comma-separated keywords to refine the connector action search",
     "options.data": "Provide JSON input values or @path to a JSON file",
     "options.dryRun": "Validate the request without creating a task",
     "options.connectorRunWait":
@@ -1444,12 +1436,6 @@ export const zhMessages = {
         "{option} 的值无效：{value}。请使用大于等于 1 的整数。",
     "errors.shared.networkRestrictedSandboxHint":
         "当前环境可能在网络受限的沙箱中，请尝试提权。",
-    "errors.connectorAuthenticated.invalidResponse":
-        "已认证 connector 服务列表返回了不受支持的响应内容。",
-    "errors.connectorAuthenticated.requestError":
-        "获取已认证 connector 服务列表失败：{message}",
-    "errors.connectorAuthenticated.requestFailed":
-        "获取已认证 connector 服务列表返回了 HTTP {status}。",
     "errors.connectorApps.invalidResponse":
         "connector app 列表返回了不受支持的响应内容。",
     "errors.connectorApps.requestError":
@@ -1990,8 +1976,6 @@ export const zhMessages = {
     "options.blockId": "指定目标 block id",
     "options.action": "指定目标 action 名称",
     "options.blockName": "--block-id 的别名",
-    "options.connectorKeywords":
-        "指定用于细化 connector action 搜索的逗号分隔关键词",
     "options.data": "提供 JSON 输入值，或使用 @路径 读取 JSON 文件",
     "options.dryRun": "仅校验请求，不真正创建任务",
     "options.connectorRunWait":


### PR DESCRIPTION
The connector action search moved to a new backend contract: `oo search` and `oo connector search` now call `https://connector.${endpoint}/v1/actions/search` instead of the old `https://search.${endpoint}/v1/connector-actions`, keeping the existing `Authorization` header. The response envelope becomes `{ success, message, data: [{ service, name, description, authenticated }] }`.

Because the new response carries per-action `authenticated` inline, the separate `/v1/apps/authenticated` round-trip is no longer needed — `listAuthenticatedConnectorServices`, its schema, and its error strings are gone, and `loadConnectorSearchResults` maps the search response directly.

The new endpoint accepts only `q`, so `--keywords` is removed from both `oo search` and `oo connector search`, along with its `keyword_count_bucket` telemetry and the `options.connectorKeywords` string. Note that `oo skills search` keeps its own `--keywords` — that targets the unrelated skill catalog and is untouched.

- Docs (`docs/commands.md`, `docs/commands.zh-CN.md`) drop the `--keywords` option.
- The `oo` skill guidance stops passing `--keywords` and folds the "keep original-language product names untranslated" advice into the query sentence, since the free-text query is now the only discovery signal.
- Tests and `--help` snapshots are updated; `catalog.test.ts` guards the removed i18n keys.