### PR TITLE
feat(connector): warm action schema cache from search results

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -836,6 +836,20 @@ export function createSettingsStore(settings: AppSettings): SettingsStore {
     };
 }
 
+export function createMemoryCache(): Cache<unknown> {
+    const entries = new Map<string, unknown>();
+
+    return {
+        clear: () => entries.clear(),
+        delete: key => entries.delete(key),
+        get: key => entries.get(key) ?? null,
+        has: key => entries.has(key),
+        set: (key, value) => {
+            entries.set(key, value);
+        },
+    };
+}
+
 export function createCacheStore<Value>(
     cache?: Cache<Value>,
     cacheOptions?: CacheOptions[],

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -567,6 +567,9 @@ Search connector actions with free-form text.
   label, optional description, and authenticated state.
 - Notes: use `oo connector schema "<service>" --action "<action>"` to inspect
   the selected action contract.
+- Notes: search results also update the local action schema cache, so a
+  following `oo connector schema` for a returned action is usually answered
+  locally without a fresh metadata request.
 
 ### `oo connector schema <serviceName>`
 
@@ -579,6 +582,9 @@ Show the stable schema contract for one connector action.
 - Output: the command always prints a JSON object with the stable CLI fields
   `service`, `name`, `description`, `inputSchema`, and `outputSchema`.
 - Notes: `--refresh` forces a fresh schema fetch for the selected action.
+- Notes: schemas cached by an earlier lookup or connector search are reused
+  until they expire; use `--refresh` when the latest remote contract is
+  required.
 
 ### `oo connector schema refresh`
 
@@ -713,6 +719,9 @@ Search connector actions with one free-form query.
   label, optional description, and authenticated state.
 - Notes: use `oo connector schema "<service>" --action "<action>"` to inspect
   the full connector action contract.
+- Notes: search results also update the local action schema cache, so a
+  following `oo connector schema` for a returned action is usually answered
+  locally without a fresh metadata request.
 
 ## AI Agent Skills
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -567,9 +567,9 @@ Search connector actions with free-form text.
   label, optional description, and authenticated state.
 - Notes: use `oo connector schema "<service>" --action "<action>"` to inspect
   the selected action contract.
-- Notes: search results also update the local action schema cache, so a
-  following `oo connector schema` for a returned action is usually answered
-  locally without a fresh metadata request.
+- Notes: search results also warm the local action schema cache when schema
+  data is available, so a following `oo connector schema` for a returned
+  action is usually answered locally without a fresh metadata request.
 
 ### `oo connector schema <serviceName>`
 
@@ -719,9 +719,9 @@ Search connector actions with one free-form query.
   label, optional description, and authenticated state.
 - Notes: use `oo connector schema "<service>" --action "<action>"` to inspect
   the full connector action contract.
-- Notes: search results also update the local action schema cache, so a
-  following `oo connector schema` for a returned action is usually answered
-  locally without a fresh metadata request.
+- Notes: search results also warm the local action schema cache when schema
+  data is available, so a following `oo connector schema` for a returned
+  action is usually answered locally without a fresh metadata request.
 
 ## AI Agent Skills
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -486,8 +486,9 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   描述和认证状态。
 - 说明：使用 `oo connector schema "<service>" --action "<action>"` 查看选中
   action 的 contract。
-- 说明：搜索结果还会更新本地 action schema 缓存，因此随后对返回 action 执行
-  `oo connector schema` 通常直接由本地缓存应答，无需重新请求 metadata。
+- 说明：搜索结果附带 schema 数据时还会更新本地 action schema 缓存，因此随后
+  对返回 action 执行 `oo connector schema` 通常直接由本地缓存应答，无需重新
+  请求 metadata。
 
 ### `oo connector schema <serviceName>`
 
@@ -616,8 +617,9 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   描述和认证状态。
 - 说明：使用 `oo connector schema "<service>" --action "<action>"` 获取完整
   connector action contract。
-- 说明：搜索结果还会更新本地 action schema 缓存，因此随后对返回 action 执行
-  `oo connector schema` 通常直接由本地缓存应答，无需重新请求 metadata。
+- 说明：搜索结果附带 schema 数据时还会更新本地 action schema 缓存，因此随后
+  对返回 action 执行 `oo connector schema` 通常直接由本地缓存应答，无需重新
+  请求 metadata。
 
 ## AI Agent Skill
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -486,6 +486,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   描述和认证状态。
 - 说明：使用 `oo connector schema "<service>" --action "<action>"` 查看选中
   action 的 contract。
+- 说明：搜索结果还会更新本地 action schema 缓存，因此随后对返回 action 执行
+  `oo connector schema` 通常直接由本地缓存应答，无需重新请求 metadata。
 
 ### `oo connector schema <serviceName>`
 
@@ -498,6 +500,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 输出：命令默认输出 JSON 对象，包含稳定 CLI 字段 `service`、`name`、
   `description`、`inputSchema` 和 `outputSchema`。
 - 说明：`--refresh` 会强制为选中的 action 重新获取 schema。
+- 说明：此前查询或 connector 搜索缓存的 schema 会在过期前被复用；需要
+  最新远端 contract 时请使用 `--refresh`。
 
 ### `oo connector schema refresh`
 
@@ -612,6 +616,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   描述和认证状态。
 - 说明：使用 `oo connector schema "<service>" --action "<action>"` 获取完整
   connector action contract。
+- 说明：搜索结果还会更新本地 action schema 缓存，因此随后对返回 action 执行
+  `oo connector schema` 通常直接由本地缓存应答，无需重新请求 metadata。
 
 ## AI Agent Skill
 

--- a/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
@@ -1,18 +1,5 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`connectorCommand CLI supports connector search with text output without caching partial schemas 1`] = `
-{
-  "exitCode": 0,
-  "stderr": "",
-  "stdout": 
-"gmail.send_mail
-Send a Gmail message.
-Authenticated: yes
-"
-,
-}
-`;
-
 exports[`connectorCommand CLI supports connector search with json output and omits schemas 1`] = `
 {
   "exitCode": 0,
@@ -197,6 +184,19 @@ exports[`connectorCommand CLI supports connector schema refresh subcommand by cl
   "stderr": "",
   "stdout": 
 "Cleared locally cached connector action schemas.
+"
+,
+}
+`;
+
+exports[`connectorCommand CLI supports connector search with text output without caching schema-less results 1`] = `
+{
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": 
+"gmail.send_mail
+Send a Gmail message.
+Authenticated: yes
 "
 ,
 }

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -31,7 +31,7 @@ import {
 } from "./search-provider.ts";
 
 describe("connectorCommand CLI", () => {
-    test("supports connector search with text output without caching partial schemas", async () => {
+    test("supports connector search with text output without caching schema-less results", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -121,6 +121,79 @@ describe("connectorCommand CLI", () => {
             expect(requests[1]?.url).toBe(
                 "https://connector.oomol.com/v1/actions/gmail.send_mail",
             );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("warms the schema cache from search results so connector schema needs no fresh request", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const searchResult = await sandbox.run(
+                ["connector", "search", "send mail"],
+                {
+                    fetcher: async () => createConnectorSearchResponse([
+                        {
+                            authenticated: true,
+                            description: "Send a Gmail message.",
+                            inputSchema: {
+                                properties: {
+                                    to: {
+                                        type: "string",
+                                    },
+                                },
+                                required: ["to"],
+                                type: "object",
+                            },
+                            name: "send_mail",
+                            outputSchema: {
+                                type: "object",
+                            },
+                            service: "gmail",
+                        },
+                    ]),
+                },
+            );
+
+            const schemaRequests: Request[] = [];
+            const schemaResult = await sandbox.run(
+                ["connector", "schema", "gmail", "--action", "send_mail"],
+                {
+                    fetcher: async (input, init) => {
+                        schemaRequests.push(toRequest(input, init));
+
+                        return new Response("unexpected", {
+                            status: 500,
+                        });
+                    },
+                },
+            );
+
+            expect(searchResult.exitCode).toBe(0);
+            expect(searchResult.stdout).toContain("gmail.send_mail");
+            expect(schemaResult.exitCode).toBe(0);
+            expect(schemaRequests).toHaveLength(0);
+            expect(JSON.parse(schemaResult.stdout)).toEqual({
+                description: "Send a Gmail message.",
+                inputSchema: {
+                    properties: {
+                        to: {
+                            type: "string",
+                        },
+                    },
+                    required: ["to"],
+                    type: "object",
+                },
+                name: "send_mail",
+                outputSchema: {
+                    type: "object",
+                },
+                service: "gmail",
+            });
         }
         finally {
             await sandbox.cleanup();
@@ -273,7 +346,13 @@ describe("connectorCommand CLI", () => {
                                 {
                                     authenticated: false,
                                     description: "Send a Gmail message.",
+                                    inputSchema: {
+                                        type: "object",
+                                    },
                                     name: "send_mail",
+                                    outputSchema: {
+                                        type: "object",
+                                    },
                                     service: "gmail",
                                 },
                             ]);
@@ -2522,14 +2601,17 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("rejects --wait on regular connector actions", async () => {
+    test("rejects --wait on regular connector actions after confirming with the metadata API", async () => {
         const sandbox = await createCliSandbox();
 
         try {
             await writeAuthFile(sandbox);
+            // A lifecycle-less cache entry (like the ones seeded from search
+            // results) is not trusted for wait modes; the run consults the
+            // metadata API once before rejecting the wait request.
             await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
 
-            let requestCount = 0;
+            const requests: Request[] = [];
             const result = await sandbox.run(
                 [
                     "connector",
@@ -2543,8 +2625,16 @@ describe("connectorCommand CLI", () => {
                     "--json",
                 ],
                 {
-                    fetcher: async () => {
-                        requestCount += 1;
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.method === "GET") {
+                            return new Response(JSON.stringify({
+                                data: createConnectorActionFixture(),
+                            }));
+                        }
 
                         return new Response(JSON.stringify({
                             data: {
@@ -2563,7 +2653,10 @@ describe("connectorCommand CLI", () => {
             expect(result.stderr).toContain(
                 "The --wait option is only supported for connector actions with an async result lifecycle.",
             );
-            expect(requestCount).toBe(0);
+            expect(requests.map(request => request.method)).toEqual(["GET"]);
+            expect(requests[0]?.url).toBe(
+                "https://connector.oomol.com/v1/actions/gmail.send_mail",
+            );
         }
         finally {
             await sandbox.cleanup();
@@ -2618,14 +2711,17 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("rejects --wait-result on regular connector actions before sending requests", async () => {
+    test("rejects --wait-result on regular connector actions after confirming with the metadata API", async () => {
         const sandbox = await createCliSandbox();
 
         try {
             await writeAuthFile(sandbox);
+            // A lifecycle-less cache entry (like the ones seeded from search
+            // results) is not trusted for wait modes; the run consults the
+            // metadata API once before rejecting the wait request.
             await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
 
-            let requestCount = 0;
+            const requests: Request[] = [];
             const result = await sandbox.run(
                 [
                     "connector",
@@ -2639,8 +2735,16 @@ describe("connectorCommand CLI", () => {
                     "--json",
                 ],
                 {
-                    fetcher: async () => {
-                        requestCount += 1;
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.method === "GET") {
+                            return new Response(JSON.stringify({
+                                data: createConnectorActionFixture(),
+                            }));
+                        }
 
                         return new Response(JSON.stringify({
                             data: {
@@ -2659,7 +2763,7 @@ describe("connectorCommand CLI", () => {
             expect(result.stderr).toContain(
                 "The --wait-result option is only supported for connector actions with an async submit lifecycle.",
             );
-            expect(requestCount).toBe(0);
+            expect(requests.map(request => request.method)).toEqual(["GET"]);
         }
         finally {
             await sandbox.cleanup();
@@ -4250,7 +4354,9 @@ function createConnectorSearchResponse(
     actions: Array<{
         authenticated: boolean;
         description: string;
+        inputSchema?: Record<string, unknown>;
         name: string;
+        outputSchema?: Record<string, unknown>;
         service: string;
     }>,
 ): Response {

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -202,6 +202,7 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             {
                 actionName,
                 account,
+                requireAsyncLifecycle: input.wait === true || input.waitResult === true,
                 serviceName: input.serviceName,
             },
             context,
@@ -254,6 +255,7 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
                 {
                     actionName: submitLifecycle.resultAction,
                     account,
+                    requireAsyncLifecycle: true,
                     serviceName: input.serviceName,
                 },
                 context,

--- a/src/application/commands/connector/schema-cache.test.ts
+++ b/src/application/commands/connector/schema-cache.test.ts
@@ -11,6 +11,7 @@ import pino from "pino";
 import {
     createCacheStore,
     createConnectorActionFixture,
+    createMemoryCache,
     createTemporaryDirectory,
 } from "../../../../__tests__/helpers.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
@@ -139,6 +140,106 @@ describe("connector schema cache", () => {
             providerPermissions: [],
             requiredScopes: [],
             service: "gmail",
+        });
+        expect(fetchCount).toBe(0);
+    });
+
+    test("loadConnectorActionSchema refetches lifecycle-less cache entries when the async lifecycle is required", async () => {
+        const cache = createMemoryCache();
+        const cacheKey = createConnectorActionSchemaCacheKey({
+            accountId: "user-1",
+            actionName: "send_mail",
+            endpoint: "oomol.com",
+            serviceName: "gmail",
+        });
+
+        cache.set(cacheKey, createConnectorActionFixture({
+            description: "Search-seeded schema.",
+        }));
+
+        const schema = await loadConnectorActionSchema(
+            {
+                account: createAccount(),
+                actionName: "send_mail",
+                requireAsyncLifecycle: true,
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+                fetcher: async () => createMetadataResponse({
+                    asyncLifecycle: {
+                        role: "submit",
+                        resultAction: "get_send_result",
+                        handle: {
+                            inputField: "sessionID",
+                            outputField: "sessionId",
+                        },
+                    },
+                    description: "Fresh schema.",
+                }),
+            }),
+        );
+
+        expect(schema).toMatchObject({
+            asyncLifecycle: {
+                role: "submit",
+            },
+            description: "Fresh schema.",
+        });
+        expect(cache.get(cacheKey)).toMatchObject({
+            description: "Fresh schema.",
+        });
+    });
+
+    test("loadConnectorActionSchema reuses cached entries with an async lifecycle when it is required", async () => {
+        const cache = createMemoryCache();
+
+        cache.set(
+            createConnectorActionSchemaCacheKey({
+                accountId: "user-1",
+                actionName: "openai_image_async_submit",
+                endpoint: "oomol.com",
+                serviceName: "fusion-api",
+            }),
+            {
+                ...createConnectorActionFixture({
+                    name: "openai_image_async_submit",
+                    service: "fusion-api",
+                }),
+                asyncLifecycle: {
+                    role: "submit",
+                    resultAction: "openai_image_async_result",
+                    handle: {
+                        inputField: "sessionID",
+                        outputField: "sessionId",
+                    },
+                },
+            },
+        );
+
+        let fetchCount = 0;
+        const schema = await loadConnectorActionSchema(
+            {
+                account: createAccount(),
+                actionName: "openai_image_async_submit",
+                requireAsyncLifecycle: true,
+                serviceName: "fusion-api",
+            },
+            createCacheContext({
+                cache,
+                fetcher: async () => {
+                    fetchCount += 1;
+
+                    return new Response("unexpected");
+                },
+            }),
+        );
+
+        expect(schema).toMatchObject({
+            asyncLifecycle: {
+                role: "submit",
+            },
+            name: "openai_image_async_submit",
         });
         expect(fetchCount).toBe(0);
     });
@@ -634,19 +735,5 @@ function createCacheContext(options: {
             write: async (value: AppSettings) => value,
         },
         translator: createTranslator("en"),
-    };
-}
-
-function createMemoryCache(): Cache<unknown> {
-    const entries = new Map<string, unknown>();
-
-    return {
-        clear: () => entries.clear(),
-        delete: key => entries.delete(key),
-        get: key => entries.get(key) ?? null,
-        has: key => entries.has(key),
-        set: (key, value) => {
-            entries.set(key, value);
-        },
     };
 }

--- a/src/application/commands/connector/schema-cache.ts
+++ b/src/application/commands/connector/schema-cache.ts
@@ -50,6 +50,14 @@ export async function loadConnectorActionSchema(
         account: Pick<AuthAccount, "apiKey" | "endpoint" | "id">;
         actionName: string;
         refresh?: boolean;
+        /**
+         * Treat cached entries without an `asyncLifecycle` as cache misses so
+         * the loader falls back to the metadata API. Search-seeded cache
+         * entries never carry the async lifecycle, so callers that depend on
+         * it (the `--wait` / `--wait-result` run modes) must not trust a
+         * cached entry that lacks one.
+         */
+        requireAsyncLifecycle?: boolean;
         serviceName: string;
     },
     context: ConnectorActionSchemaLoaderContext,
@@ -68,7 +76,20 @@ export async function loadConnectorActionSchema(
         const cached = tryReadConnectorActionSchemaCache(cache, cacheKey, context);
 
         if (cached !== undefined) {
-            return cached;
+            if (options.requireAsyncLifecycle !== true
+                || cached.asyncLifecycle !== undefined) {
+                return cached;
+            }
+
+            context.logger.debug(
+                {
+                    accountId: options.account.id,
+                    actionName: options.actionName,
+                    endpoint: options.account.endpoint,
+                    serviceName: options.serviceName,
+                },
+                "Connector action schema cache entry lacks an async lifecycle; fetching metadata.",
+            );
         }
     }
     else {
@@ -117,11 +138,10 @@ export async function loadConnectorActionSchema(
 }
 
 /**
- * Test-only bulk cache populator. Production fills the connector action schema
- * cache lazily through `loadConnectorActionSchema`; this helper is only used by
- * tests to seed cache state up front.
- *
- * @public
+ * Bulk cache populator used to warm the connector action schema cache from
+ * connector search responses (which carry `inputSchema` / `outputSchema` but
+ * never an `asyncLifecycle`). `loadConnectorActionSchema` still fills the
+ * cache lazily from the metadata API for anything search did not cover.
  */
 export async function cacheConnectorActionSchemas(
     actions: readonly ConnectorActionDefinition[],

--- a/src/application/commands/connector/search-provider.test.ts
+++ b/src/application/commands/connector/search-provider.test.ts
@@ -1,24 +1,31 @@
+import type { AppSettings } from "../../schemas/settings.ts";
+
 import { describe, expect, test } from "bun:test";
 import pino from "pino";
 
-import { toRequest } from "../../../../__tests__/helpers.ts";
+import {
+    createCacheStore,
+    createMemoryCache,
+    createSettingsStore,
+    toRequest,
+} from "../../../../__tests__/helpers.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
 
+import { createConnectorActionSchemaCacheKey } from "./schema-cache.ts";
 import { loadConnectorSearchResults } from "./search-provider.ts";
 
 describe("connector search provider", () => {
-    test("returns search results without using the schema cache", async () => {
+    test("returns search results and warms the schema cache from schema payloads", async () => {
+        const cache = createMemoryCache();
         const requests: Request[] = [];
 
         const results = await loadConnectorSearchResults(
             {
-                account: {
-                    apiKey: "secret-1",
-                    endpoint: "oomol.com",
-                },
+                account: createAccount(),
                 text: "send mail",
             },
-            {
+            createSearchContext({
+                cache,
                 fetcher: async (input, init) => {
                     const request = toRequest(input, init);
 
@@ -32,7 +39,13 @@ describe("connector search provider", () => {
                                 {
                                     authenticated: true,
                                     description: "Send a Gmail message.",
+                                    inputSchema: {
+                                        type: "object",
+                                    },
                                     name: "send_mail",
+                                    outputSchema: {
+                                        type: "object",
+                                    },
                                     service: "gmail",
                                 },
                             ],
@@ -41,11 +54,7 @@ describe("connector search provider", () => {
 
                     throw new Error(`Unexpected request: ${request.url}`);
                 },
-                logger: pino({
-                    enabled: false,
-                }),
-                translator: createTranslator("en"),
-            },
+            }),
         );
 
         expect(results).toEqual([
@@ -59,5 +68,123 @@ describe("connector search provider", () => {
         expect(requests.map(request => request.url)).toEqual([
             "https://connector.oomol.com/v1/actions/search?q=send+mail",
         ]);
+        expect(cache.get(createConnectorActionSchemaCacheKey({
+            accountId: "user-1",
+            actionName: "send_mail",
+            endpoint: "oomol.com",
+            serviceName: "gmail",
+        }))).toMatchObject({
+            description: "Send a Gmail message.",
+            inputSchema: {
+                type: "object",
+            },
+            name: "send_mail",
+            outputSchema: {
+                type: "object",
+            },
+            service: "gmail",
+        });
+    });
+
+    test("skips schema cache warming for results without schema payloads", async () => {
+        const cache = createMemoryCache();
+
+        const results = await loadConnectorSearchResults(
+            {
+                account: createAccount(),
+                text: "send mail",
+            },
+            createSearchContext({
+                cache,
+                fetcher: async () => new Response(JSON.stringify({
+                    success: true,
+                    message: "ok",
+                    data: [
+                        {
+                            authenticated: true,
+                            description: "Send a Gmail message.",
+                            name: "send_mail",
+                            service: "gmail",
+                        },
+                    ],
+                })),
+            }),
+        );
+
+        expect(results).toHaveLength(1);
+        expect(cache.get(createConnectorActionSchemaCacheKey({
+            accountId: "user-1",
+            actionName: "send_mail",
+            endpoint: "oomol.com",
+            serviceName: "gmail",
+        }))).toBeNull();
+    });
+
+    test("returns search results when schema cache warming fails", async () => {
+        const cache = createMemoryCache();
+
+        cache.set = () => {
+            throw new Error("cache write failed");
+        };
+
+        const results = await loadConnectorSearchResults(
+            {
+                account: createAccount(),
+                text: "send mail",
+            },
+            createSearchContext({
+                cache,
+                fetcher: async () => new Response(JSON.stringify({
+                    success: true,
+                    message: "ok",
+                    data: [
+                        {
+                            authenticated: true,
+                            description: "Send a Gmail message.",
+                            inputSchema: {
+                                type: "object",
+                            },
+                            name: "send_mail",
+                            outputSchema: {
+                                type: "object",
+                            },
+                            service: "gmail",
+                        },
+                    ],
+                })),
+            }),
+        );
+
+        expect(results).toEqual([
+            {
+                authenticated: true,
+                description: "Send a Gmail message.",
+                name: "send_mail",
+                service: "gmail",
+            },
+        ]);
     });
 });
+
+function createAccount() {
+    return {
+        apiKey: "secret-1",
+        endpoint: "oomol.com",
+        id: "user-1",
+    };
+}
+
+function createSearchContext(options: {
+    cache: ReturnType<typeof createMemoryCache>;
+    fetcher: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+}) {
+    return {
+        cacheStore: createCacheStore(options.cache),
+        fetcher: options.fetcher,
+        logger: pino({
+            enabled: false,
+        }),
+        settingsStore: createSettingsStore({} as AppSettings),
+        translator: createTranslator("en"),
+    };
+}

--- a/src/application/commands/connector/search-provider.ts
+++ b/src/application/commands/connector/search-provider.ts
@@ -2,7 +2,9 @@ import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
 import type { TerminalColors } from "../../terminal-colors.ts";
 
+import type { ConnectorActionSearchResult } from "./shared.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
+import { cacheConnectorActionSchemas } from "./schema-cache.ts";
 
 import { searchConnectorActions } from "./shared.ts";
 
@@ -20,10 +22,13 @@ type ConnectorSearchTextContext = Pick<CliExecutionContext, "stdout" | "translat
 
 export async function loadConnectorSearchResults(
     options: {
-        account: Pick<AuthAccount, "apiKey" | "endpoint">;
+        account: Pick<AuthAccount, "apiKey" | "endpoint" | "id">;
         text: string;
     },
-    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
+    context: Pick<
+        CliExecutionContext,
+        "cacheStore" | "fetcher" | "logger" | "settingsStore" | "translator"
+    >,
 ): Promise<ConnectorSearchResult[]> {
     const actions = await searchConnectorActions({
         apiKey: options.account.apiKey,
@@ -31,12 +36,41 @@ export async function loadConnectorSearchResults(
         text: options.text,
     }, context);
 
+    await warmConnectorActionSchemaCache(actions, options.account, context);
+
     return actions.map(action => ({
         authenticated: action.authenticated,
         description: action.description,
         name: action.name,
         service: action.service,
     }));
+}
+
+async function warmConnectorActionSchemaCache(
+    actions: readonly ConnectorActionSearchResult[],
+    account: Pick<AuthAccount, "endpoint" | "id">,
+    context: Pick<CliExecutionContext, "cacheStore" | "logger" | "settingsStore">,
+): Promise<void> {
+    const cacheableActions = actions.filter(action =>
+        action.inputSchema !== undefined && action.outputSchema !== undefined);
+
+    if (cacheableActions.length === 0) {
+        return;
+    }
+
+    try {
+        await cacheConnectorActionSchemas(cacheableActions, account, context);
+    }
+    catch (error) {
+        // Cache warming is a best-effort optimization; search results must
+        // still be returned when the local cache cannot be written.
+        context.logger.warn(
+            {
+                err: error,
+            },
+            "Failed to warm connector action schemas during search.",
+        );
+    }
 }
 
 export function formatConnectorSearchResultsAsText(

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -41,7 +41,13 @@ describe("connector shared requests", () => {
                             {
                                 authenticated: true,
                                 description: "Send a Gmail message.",
+                                inputSchema: {
+                                    type: "object",
+                                },
                                 name: "send_mail",
+                                outputSchema: {
+                                    type: "object",
+                                },
                                 service: "gmail",
                             },
                         ],
@@ -54,7 +60,13 @@ describe("connector shared requests", () => {
             {
                 authenticated: true,
                 description: "Send a Gmail message.",
+                inputSchema: {
+                    type: "object",
+                },
                 name: "send_mail",
+                outputSchema: {
+                    type: "object",
+                },
                 service: "gmail",
             },
         ]);
@@ -63,6 +75,39 @@ describe("connector shared requests", () => {
             "https://connector.oomol.com/v1/actions/search?q=send+mail",
         );
         expect(requests[0]?.headers.get("Authorization")).toBe("secret-1");
+    });
+
+    test("searchConnectorActions accepts results without schema payloads", async () => {
+        const actions = await searchConnectorActions(
+            {
+                apiKey: "secret-1",
+                endpoint: "oomol.com",
+                text: "send mail",
+            },
+            createRequestContext({
+                fetcher: async () => new Response(JSON.stringify({
+                    success: true,
+                    message: "ok",
+                    data: [
+                        {
+                            name: "send_mail",
+                            service: "gmail",
+                        },
+                    ],
+                })),
+            }),
+        );
+
+        expect(actions).toEqual([
+            {
+                authenticated: false,
+                description: "",
+                inputSchema: undefined,
+                name: "send_mail",
+                outputSchema: undefined,
+                service: "gmail",
+            },
+        ]);
     });
 
     test("listConnectorAppsByService requests apps for one service", async () => {

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -59,7 +59,9 @@ export const connectorActionMetadataSchema = connectorActionDefinitionSchema.ext
 const connectorActionSearchResultSchema = z.object({
     authenticated: z.boolean().optional().default(false),
     description: z.string().optional().default(""),
+    inputSchema: z.unknown(),
     name: z.string().min(1),
+    outputSchema: z.unknown(),
     service: z.string().min(1),
 });
 

--- a/src/application/commands/search.cli.test.ts
+++ b/src/application/commands/search.cli.test.ts
@@ -94,7 +94,13 @@ describe("searchCommand CLI", () => {
                                     {
                                         authenticated: false,
                                         description: "Send a Gmail message.",
+                                        inputSchema: {
+                                            type: "object",
+                                        },
                                         name: "send_mail",
+                                        outputSchema: {
+                                            type: "object",
+                                        },
                                         service: "gmail",
                                     },
                                 ],
@@ -109,6 +115,8 @@ describe("searchCommand CLI", () => {
             );
 
             expect(createCliSnapshot(result, { sandbox })).toMatchSnapshot();
+            // Schema payloads warm the local action schema cache but stay out
+            // of the search output contract.
             expect(JSON.parse(result.stdout)).toEqual([
                 {
                     authenticated: false,


### PR DESCRIPTION
Since `/v1/actions/search` (#288) returns `inputSchema` and `outputSchema` for every match, connector search now seeds the local action schema cache with those payloads. A follow-up `oo connector schema` (or the input validation in `oo connector run`) for a returned action is then answered locally instead of issuing a fresh metadata request. Warming is best-effort: results without schema payloads are skipped, cache write failures only log a warning, and the search output contract is unchanged. This effectively restores the search-time warming removed in #193 — safe again now that search is served by the connector service itself rather than a separate index that could return stale schemas.

One correctness guard comes with it: search payloads never carry an `asyncLifecycle`, so the `--wait` / `--wait-result` run modes must not trust a search-seeded cache entry — they would misreport async actions as unsupported. `loadConnectorActionSchema` gains a `requireAsyncLifecycle` option that treats lifecycle-less cache entries as misses and falls back to the metadata API once, re-caching the full metadata. The observable side effect is that rejecting `--wait` on a genuinely non-async action now performs one metadata request before erroring.

Docs for `oo search`, `oo connector search`, and `oo connector schema` note the new caching behavior (en + zh-CN).