### PR TITLE
feat(connector): accept multiple <service>.<action> ids in schema command

### DIFF
--- a/contrib/skills/shared/oo-create-skill/SKILL.md
+++ b/contrib/skills/shared/oo-create-skill/SKILL.md
@@ -46,7 +46,7 @@ reusable user intent, compact runtime runbook, then convenience.
 3. Evidence outranks memory. For existing local workflows, inspect current files
    and use safe local command output or tests when they are proportionate. For
    connector workflows, a callable contract exists only when current command
-   output and `oo connector schema "<service>" --action "<action>"` prove the
+   output and `oo connector schema "<service>.<action>"` prove the
    selected service/action, required inputs, and output semantics. Do not invent
    connector facts from prior knowledge, examples, old runs, or catalog guesses.
 4. Resolve before designing. Do not predesign the whole execution process and
@@ -125,7 +125,7 @@ permission and name the blocked command. Common commands are:
 ```bash
 oo skills init <name> --agent <!-- agentic:var agent --> --description "..."
 oo search "<query>" --json
-oo connector schema "<service>" --action "<action>"
+oo connector schema "<service>.<action>"
 ```
 
 If <!-- agentic:var agentTitle --> cannot request the needed permission, or the
@@ -237,8 +237,13 @@ description, authentication state, and schema-derived input/output concepts.
 Use the schema command before authoring the runbook:
 
 ```bash
-oo connector schema "<service>" --action "<action>"
+oo connector schema "<service>.<action>"
 ```
+
+When the runbook depends on more than one action contract, such as an async
+submit/result pair, pass every `<service>.<action>` id to one schema command
+instead of running one command per action; with two or more ids the output is
+a JSON array in request order.
 
 When result shape, status transitions, file return format, or envelope structure
 will affect the runbook, run a minimal representative invocation or status/result

--- a/contrib/skills/shared/oo/references/connector-execution.md
+++ b/contrib/skills/shared/oo/references/connector-execution.md
@@ -14,8 +14,11 @@ smallest sufficient JSON payload that matches the user's real intent.
 ## Confirm the action contract
 
 - Use the chosen search result's `service` and `name` as the starting point.
-- Run `oo connector schema "<service>" --action "<name>"` before
-  building any payload.
+- Run `oo connector schema "<service>.<action>"` before building any payload.
+- To inspect several actions, pass multiple `<service>.<action>` ids to one
+  command instead of running one command per action. With two or more ids the
+  output is a JSON array in request order; with one id it stays a single JSON
+  object.
 - Use the returned exact `service`, `name`, `description`, `inputSchema`, and
   `outputSchema` to confirm the action fit.
 - Prefer the action whose description most directly matches the user's desired
@@ -28,7 +31,15 @@ smallest sufficient JSON payload that matches the user's real intent.
 Representative schema command:
 
 ```bash
-oo connector schema "gmail" --action "send_mail"
+oo connector schema "gmail.send_mail"
+```
+
+Batch form for several actions at once (returns a JSON array in request
+order), useful when a workflow needs more than one contract, such as an async
+submit/result pair or a read step feeding a write step:
+
+```bash
+oo connector schema "cal.create_schedule" "callingly.get_agent_schedule"
 ```
 
 Representative schema JSON shape:
@@ -234,6 +245,10 @@ synchronous action. Treat that pattern as a resumable task lifecycle.
 
 Rules:
 
+- Fetch the whole lifecycle contract up front with one batch schema call, for
+  example
+  `oo connector schema "<service>.<submit_action>" "<service>.<result_action>"`,
+  instead of one schema command per lifecycle action.
 - Submit exactly once for the same logical work item.
 - Immediately save the submit response and extracted task id in a checkpoint
   file before polling.

--- a/contrib/skills/shared/oo/references/search-and-selection.md
+++ b/contrib/skills/shared/oo/references/search-and-selection.md
@@ -151,7 +151,7 @@ decide. Rank results in this order:
 Tie-breakers:
 
 - `fusion-api` actions are connector actions in `oo`. Prove them with
-  `oo connector schema "fusion-api" --action "<name>"` before execution, but
+  `oo connector schema "fusion-api.<name>"` before execution, but
   classify them as OOMOL-hosted Fusion API for selection.
 - For generic managed transforms such as OCR, translation, transcription, TTS,
   image generation, background removal, subtitling, document conversion, and
@@ -289,7 +289,10 @@ blindly or inventing a result.
 After selecting a candidate, do not execute yet.
 
 Read [connector-execution.md](connector-execution.md), then run
-`oo connector schema "<service>" --action "<name>"`.
+`oo connector schema "<service>.<name>"`. When the workflow already needs more
+than one action contract, pass all the `<service>.<action>` ids to one command
+(the output becomes a JSON array in request order) instead of running one
+schema command per action.
 
 Use the inspected metadata or schema to complete the minimum viable contract:
 exact callable id, required input names, payload shape, output meaning, and

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -565,23 +565,29 @@ Search connector actions with free-form text.
   `description`, and `authenticated`.
 - Output: text output prints one block per action with the service/action
   label, optional description, and authenticated state.
-- Notes: use `oo connector schema "<service>" --action "<action>"` to inspect
-  the selected action contract.
+- Notes: use `oo connector schema "<service>.<action>"` to inspect the selected
+  action contract.
 - Notes: search results also warm the local action schema cache when schema
   data is available, so a following `oo connector schema` for a returned
   action is usually answered locally without a fresh metadata request.
 
-### `oo connector schema <serviceName>`
+### `oo connector schema <actionId...>`
 
-Show the stable schema contract for one connector action.
+Show the stable schema contract for one or more connector actions.
 
-- Arguments: `<serviceName>` is the service name.
-- Options: `-a, --action <action>` selects the action name and is required.
+- Arguments: `<actionId...>` is one or more action identifiers in the form
+  `<service>.<action>`, for example `cal.create_schedule`.
+- Options: `-a, --action <action>` selects the action name and treats the single
+  positional argument as a bare service name. This legacy form is retained for
+  backwards compatibility; it accepts exactly one bare service name and rejects
+  both additional positional arguments and the `<service>.<action>` form.
 - Options: `--refresh` fetches fresh metadata from the connector metadata API.
 - Options: `--json` is accepted for compatibility and does not change output.
-- Output: the command always prints a JSON object with the stable CLI fields
-  `service`, `name`, `description`, `inputSchema`, and `outputSchema`.
-- Notes: `--refresh` forces a fresh schema fetch for the selected action.
+- Output: for a single requested action, the command prints a JSON object with
+  the stable CLI fields `service`, `name`, `description`, `inputSchema`, and
+  `outputSchema`. For two or more requested actions, it prints a JSON array of
+  those objects in request order.
+- Notes: `--refresh` forces a fresh schema fetch for every selected action.
 - Notes: schemas cached by an earlier lookup or connector search are reused
   until they expire; use `--refresh` when the latest remote contract is
   required.
@@ -717,8 +723,8 @@ Search connector actions with one free-form query.
   `description`, and `authenticated`.
 - Output: text output prints one block per action with the service/action
   label, optional description, and authenticated state.
-- Notes: use `oo connector schema "<service>" --action "<action>"` to inspect
-  the full connector action contract.
+- Notes: use `oo connector schema "<service>.<action>"` to inspect the full
+  connector action contract.
 - Notes: search results also warm the local action schema cache when schema
   data is available, so a following `oo connector schema` for a returned
   action is usually answered locally without a fresh metadata request.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -484,23 +484,27 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   `authenticated`。
 - 输出：文本输出会为每个 action 打印一个块，包含 service/action 标识、可选
   描述和认证状态。
-- 说明：使用 `oo connector schema "<service>" --action "<action>"` 查看选中
-  action 的 contract。
+- 说明：使用 `oo connector schema "<service>.<action>"` 查看选中 action 的
+  contract。
 - 说明：搜索结果附带 schema 数据时还会更新本地 action schema 缓存，因此随后
   对返回 action 执行 `oo connector schema` 通常直接由本地缓存应答，无需重新
   请求 metadata。
 
-### `oo connector schema <serviceName>`
+### `oo connector schema <actionId...>`
 
-显示一个 connector action 的稳定 schema contract。
+显示一个或多个 connector action 的稳定 schema contract。
 
-- 参数：`<serviceName>` 为服务名。
-- 选项：`-a, --action <action>` 用于指定 action 名称，且为必填。
+- 参数：`<actionId...>` 为一个或多个 `<service>.<action>` 形式的 action 标识，
+  例如 `cal.create_schedule`。
+- 选项：`-a, --action <action>` 用于指定 action 名称，并将唯一的位置参数视为
+  纯服务名。该旧写法为向后兼容而保留：只接受一个纯服务名，并会拒绝额外的
+  位置参数以及 `<service>.<action>` 形式。
 - 选项：`--refresh` 会直接从 connector metadata API 获取最新 schema。
 - 选项：`--json` 作为兼容性选项被接受，不会改变输出。
-- 输出：命令默认输出 JSON 对象，包含稳定 CLI 字段 `service`、`name`、
-  `description`、`inputSchema` 和 `outputSchema`。
-- 说明：`--refresh` 会强制为选中的 action 重新获取 schema。
+- 输出：当只请求一个 action 时，命令输出 JSON 对象，包含稳定 CLI 字段
+  `service`、`name`、`description`、`inputSchema` 和 `outputSchema`；当请求两个
+  或更多 action 时，则按请求顺序输出这些对象组成的 JSON 数组。
+- 说明：`--refresh` 会强制为每个选中的 action 重新获取 schema。
 - 说明：此前查询或 connector 搜索缓存的 schema 会在过期前被复用；需要
   最新远端 contract 时请使用 `--refresh`。
 
@@ -615,8 +619,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   `authenticated`。
 - 输出：文本输出会为每个 action 打印一个块，包含 service/action 标识、可选
   描述和认证状态。
-- 说明：使用 `oo connector schema "<service>" --action "<action>"` 获取完整
-  connector action contract。
+- 说明：使用 `oo connector schema "<service>.<action>"` 获取完整 connector
+  action contract。
 - 说明：搜索结果附带 schema 数据时还会更新本地 action schema 缓存，因此随后
   对返回 action 执行 `oo connector schema` 通常直接由本地缓存应答，无需重新
   请求 metadata。

--- a/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
@@ -91,10 +91,11 @@ exports[`connectorCommand CLI renders connector schema help with the json compat
   "exitCode": 0,
   "stderr": "",
   "stdout": 
-"Show the schema contract for one connector action.
+"Show the schema contract for one or more connector actions.
 
 Arguments:
-  serviceName            Service name
+  actionId               Action id(s) in the form <service>.<action>, for
+                         example cal.create_schedule
 
 Options:
   -a, --action <action>  Specify the target action name

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -3636,6 +3636,331 @@ describe("connectorCommand CLI", () => {
         }
     });
 
+    test("returns a JSON object for a single qualified action id", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["connector", "schema", "gmail.send_mail"],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                description: "Send a Gmail message.",
+                                id: "gmail.send_mail",
+                                inputSchema: {
+                                    type: "object",
+                                },
+                                name: "send_mail",
+                                outputSchema: {
+                                    type: "object",
+                                },
+                                providerPermissions: [],
+                                requiredScopes: [],
+                                service: "gmail",
+                            },
+                        }));
+                    },
+                },
+            );
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(Array.isArray(JSON.parse(result.stdout))).toBe(false);
+            expect(JSON.parse(result.stdout)).toEqual({
+                description: "Send a Gmail message.",
+                inputSchema: {
+                    type: "object",
+                },
+                name: "send_mail",
+                outputSchema: {
+                    type: "object",
+                },
+                service: "gmail",
+            });
+            expect(requests.map(request => request.url)).toEqual([
+                "https://connector.oomol.com/v1/actions/gmail.send_mail",
+            ]);
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    action_count_bucket: "1-5",
+                    command_full: "connector.schema",
+                    qualified: true,
+                    refresh: false,
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports connector schema for multiple qualified action ids with array output", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "schema",
+                    "cal.create_schedule",
+                    "callingly.get_agent_schedule",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.url.endsWith("cal.create_schedule")) {
+                            return new Response(JSON.stringify({
+                                data: {
+                                    description: "Create a schedule.",
+                                    id: "cal.create_schedule",
+                                    inputSchema: {
+                                        type: "object",
+                                    },
+                                    name: "create_schedule",
+                                    outputSchema: {
+                                        type: "object",
+                                    },
+                                    providerPermissions: [],
+                                    requiredScopes: [],
+                                    service: "cal",
+                                },
+                            }));
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                description: "Get an agent schedule.",
+                                id: "callingly.get_agent_schedule",
+                                inputSchema: {
+                                    type: "object",
+                                },
+                                name: "get_agent_schedule",
+                                outputSchema: {
+                                    type: "object",
+                                },
+                                providerPermissions: [],
+                                requiredScopes: [],
+                                service: "callingly",
+                            },
+                        }));
+                    },
+                },
+            );
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            // Two action ids widen the output to an array in request order.
+            expect(JSON.parse(result.stdout)).toEqual([
+                {
+                    description: "Create a schedule.",
+                    inputSchema: {
+                        type: "object",
+                    },
+                    name: "create_schedule",
+                    outputSchema: {
+                        type: "object",
+                    },
+                    service: "cal",
+                },
+                {
+                    description: "Get an agent schedule.",
+                    inputSchema: {
+                        type: "object",
+                    },
+                    name: "get_agent_schedule",
+                    outputSchema: {
+                        type: "object",
+                    },
+                    service: "callingly",
+                },
+            ]);
+            expect(result.stdout).not.toContain("providerPermissions");
+            expect(requests.map(request => request.url)).toEqual([
+                "https://connector.oomol.com/v1/actions/cal.create_schedule",
+                "https://connector.oomol.com/v1/actions/callingly.get_agent_schedule",
+            ]);
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    action_count_bucket: "1-5",
+                    command_full: "connector.schema",
+                    qualified: true,
+                    refresh: false,
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects a malformed action id that is missing the service separator", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            let metadataRequestCount = 0;
+            const result = await sandbox.run(
+                ["connector", "schema", "send_mail"],
+                {
+                    fetcher: async () => {
+                        metadataRequestCount += 1;
+
+                        throw new Error("Unexpected schema metadata request");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("Invalid action id");
+            expect(result.stderr).toContain("send_mail");
+            // The identifier is parsed before any account lookup or request.
+            expect(metadataRequestCount).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects the legacy --action option combined with multiple service names", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            let metadataRequestCount = 0;
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "schema",
+                    "gmail",
+                    "calendar",
+                    "--action",
+                    "send_mail",
+                ],
+                {
+                    fetcher: async () => {
+                        metadataRequestCount += 1;
+
+                        throw new Error("Unexpected schema metadata request");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("--action");
+            expect(metadataRequestCount).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects the legacy --action option combined with a qualified action id", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            let metadataRequestCount = 0;
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "schema",
+                    "cal.create_schedule",
+                    "--action",
+                    "send_mail",
+                ],
+                {
+                    fetcher: async () => {
+                        metadataRequestCount += 1;
+
+                        throw new Error("Unexpected schema metadata request");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("--action");
+            // Mixing syntaxes is rejected before any doomed metadata request.
+            expect(metadataRequestCount).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("records legacy telemetry when --action selects the action name", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["connector", "schema", "gmail", "--action", "send_mail"],
+                {
+                    fetcher: async () => new Response(JSON.stringify({
+                        data: {
+                            description: "Send a Gmail message.",
+                            id: "gmail.send_mail",
+                            inputSchema: {
+                                type: "object",
+                            },
+                            name: "send_mail",
+                            outputSchema: {
+                                type: "object",
+                            },
+                            providerPermissions: [],
+                            requiredScopes: [],
+                            service: "gmail",
+                        },
+                    })),
+                },
+            );
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(Array.isArray(JSON.parse(result.stdout))).toBe(false);
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    action_count_bucket: "1-5",
+                    command_full: "connector.schema",
+                    qualified: false,
+                    refresh: false,
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("supports connector schema refresh by bypassing cached metadata", async () => {
         const sandbox = await createCliSandbox();
 

--- a/src/application/commands/connector/schema.ts
+++ b/src/application/commands/connector/schema.ts
@@ -1,6 +1,9 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
+import type { ConnectorActionSchemaOutput } from "./schema-cache.ts";
 import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
@@ -13,7 +16,12 @@ import { requireConnectorActionName } from "./shared.ts";
 
 interface ConnectorSchemaInput {
     action?: string;
+    actionId?: string[];
     refresh?: boolean;
+}
+
+interface QualifiedActionTarget {
+    actionName: string;
     serviceName: string;
 }
 
@@ -27,9 +35,10 @@ export const connectorSchemaCommand: CliCommandDefinition<ConnectorSchemaInput> 
     ],
     arguments: [
         {
-            name: "serviceName",
-            descriptionKey: "arguments.serviceName",
+            name: "actionId",
+            descriptionKey: "arguments.actionId",
             required: true,
+            variadic: true,
         },
     ],
     options: [
@@ -53,28 +62,104 @@ export const connectorSchemaCommand: CliCommandDefinition<ConnectorSchemaInput> 
     ],
     inputSchema: z.object({
         action: z.string().optional(),
+        actionId: z.array(z.string()).optional(),
         refresh: z.boolean().optional(),
-        serviceName: z.string(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        const actionName = requireConnectorActionName(input.action);
+        const actionIds = input.actionId ?? [];
+        const targets = input.action === undefined
+            // New form: every positional is a `service.action` identifier.
+            ? parseQualifiedActionIds(actionIds)
+            // Legacy form: `--action` selects the action name and the single
+            // positional is treated verbatim as the service name.
+            : [createLegacyActionTarget(actionIds, input.action)];
 
         context.telemetry?.recordProperties({
+            action_count_bucket: bucketTelemetryCount(targets.length),
+            qualified: input.action === undefined,
             refresh: input.refresh === true,
         });
 
         const account = await requireCurrentAccount(context);
-        const actionSchema = await loadConnectorActionSchema(
-            {
-                account,
-                actionName,
-                refresh: input.refresh,
-                serviceName: input.serviceName,
-            },
-            context,
-        );
+        const outputs: ConnectorActionSchemaOutput[] = [];
 
-        writeJsonOutput(context.stdout, createConnectorActionSchemaOutput(actionSchema));
+        for (const target of targets) {
+            const actionSchema = await loadConnectorActionSchema(
+                {
+                    account,
+                    actionName: target.actionName,
+                    refresh: input.refresh,
+                    serviceName: target.serviceName,
+                },
+                context,
+            );
+
+            outputs.push(createConnectorActionSchemaOutput(actionSchema));
+        }
+
+        // A single requested action keeps the historical object shape; two or
+        // more actions widen the output to an array in request order.
+        writeJsonOutput(
+            context.stdout,
+            outputs.length === 1 ? outputs[0]! : outputs,
+        );
     },
 };
+
+function parseQualifiedActionIds(
+    actionIds: readonly string[],
+): QualifiedActionTarget[] {
+    if (actionIds.length === 0) {
+        throw new CliUserError("errors.connectorSchema.actionIdRequired", 2);
+    }
+
+    return actionIds.map(parseQualifiedActionId);
+}
+
+function parseQualifiedActionId(rawActionId: string): QualifiedActionTarget {
+    const trimmed = rawActionId.trim();
+    const separatorIndex = trimmed.indexOf(".");
+
+    // Require a non-empty service segment before the first dot and a non-empty
+    // action segment after it, e.g. `cal.create_schedule`.
+    if (separatorIndex <= 0 || separatorIndex >= trimmed.length - 1) {
+        throw new CliUserError("errors.connectorSchema.invalidActionId", 2, {
+            actionId: rawActionId,
+        });
+    }
+
+    return {
+        actionName: trimmed.slice(separatorIndex + 1),
+        serviceName: trimmed.slice(0, separatorIndex),
+    };
+}
+
+function createLegacyActionTarget(
+    actionIds: readonly string[],
+    rawAction: string,
+): QualifiedActionTarget {
+    if (actionIds.length !== 1) {
+        throw new CliUserError(
+            "errors.connectorSchema.legacyActionSingleService",
+            2,
+        );
+    }
+
+    const serviceName = actionIds[0]!.trim();
+
+    // With `--action` present the positional is a bare service name, so an
+    // empty value or a dotted `<service>.<action>` value means the two syntaxes
+    // were mixed; reject it instead of issuing a doomed metadata request.
+    if (serviceName === "" || serviceName.includes(".")) {
+        throw new CliUserError(
+            "errors.connectorSchema.legacyActionSingleService",
+            2,
+        );
+    }
+
+    return {
+        actionName: requireConnectorActionName(rawAction),
+        serviceName,
+    };
+}

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -174,8 +174,8 @@ const commandTelemetryDecisions = {
     },
     "connector.schema": {
         kind: "properties",
-        properties: ["refresh"],
-        reason: "Records whether the user requested a fresh schema lookup without service or action identity.",
+        properties: ["action_count_bucket", "qualified", "refresh"],
+        reason: "Records how many actions were requested (bucketed), whether the qualified <service>.<action> form was used, and whether a fresh lookup was requested, without service or action identity.",
     },
     "connector.schema.refresh": {
         kind: "generic",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -42,7 +42,7 @@ export const enMessages = {
         "Search connector actions.",
     "commands.connector.search.summary": "Search connector actions",
     "commands.connector.schema.description":
-        "Show the schema contract for one connector action.",
+        "Show the schema contract for one or more connector actions.",
     "commands.connector.schema.refresh.description":
         "Clear all locally cached connector action schemas.",
     "commands.connector.schema.refresh.summary":
@@ -376,6 +376,12 @@ export const enMessages = {
         "Connector proxy service {service} returned HTTP {status}: {message}",
     "errors.connectorProxy.requestFailedWithMessageAndCode":
         "Connector proxy service {service} returned HTTP {status} (errorCode: {errorCode}): {message}",
+    "errors.connectorSchema.actionIdRequired":
+        "Provide at least one action id in the form <service>.<action>.",
+    "errors.connectorSchema.invalidActionId":
+        "Invalid action id \"{actionId}\". Use the form <service>.<action>, for example cal.create_schedule.",
+    "errors.connectorSchema.legacyActionSingleService":
+        "The --action option accepts exactly one bare service name. To look up one or more actions by identifier, omit --action and pass <service>.<action> arguments instead.",
     "errors.connectorSchema.readFailed":
         "Failed to read the connector action schema cache at {path}: {message}",
     "errors.connectorSchema.writeFailed":
@@ -1105,6 +1111,7 @@ export const enMessages = {
     "arguments.skills.checkUpdate.packageName": "Package name(s) to check; checks every installed skill of each package",
     "arguments.skills.uninstall.name": "Skill or package name(s) to remove; a package name removes every installed skill that belongs to it",
     "arguments.serviceName": "Service name",
+    "arguments.actionId": "Action id(s) in the form <service>.<action>, for example cal.create_schedule",
     "arguments.shell": "Target shell",
     "arguments.skill": "Skill name",
     "arguments.taskId": "Task id",
@@ -1223,7 +1230,7 @@ export const zhMessages = {
     "commands.connector.search.summary":
         "搜索 connector action",
     "commands.connector.schema.description":
-        "显示一个 connector action 的 schema contract。",
+        "显示一个或多个 connector action 的 schema contract。",
     "commands.connector.schema.refresh.description":
         "清除所有本地缓存的 connector action schema。",
     "commands.connector.schema.refresh.summary":
@@ -1534,6 +1541,12 @@ export const zhMessages = {
         "Connector proxy service {service} 返回了 HTTP {status}：{message}",
     "errors.connectorProxy.requestFailedWithMessageAndCode":
         "Connector proxy service {service} 返回了 HTTP {status}（errorCode: {errorCode}）：{message}",
+    "errors.connectorSchema.actionIdRequired":
+        "请至少提供一个 <service>.<action> 形式的 action id。",
+    "errors.connectorSchema.invalidActionId":
+        "无效的 action id “{actionId}”。请使用 <service>.<action> 形式，例如 cal.create_schedule。",
+    "errors.connectorSchema.legacyActionSingleService":
+        "--action 选项只接受一个纯服务名（不含点号）。若要按标识查询一个或多个 action，请省略 --action 并改用 <service>.<action> 形式的参数。",
     "errors.connectorSchema.readFailed":
         "读取 {path} 的 connector action schema cache 失败：{message}",
     "errors.connectorSchema.writeFailed":
@@ -2255,6 +2268,7 @@ export const zhMessages = {
     "arguments.skills.checkUpdate.packageName": "要检查的包名（可指定多个）；会检查每个包已安装的全部 skill",
     "arguments.skills.uninstall.name": "要移除的 skill 或包名（可指定多个）；传入包名会移除该包已安装的全部 skill",
     "arguments.serviceName": "服务名",
+    "arguments.actionId": "<service>.<action> 形式的 action id（可多个），例如 cal.create_schedule",
     "arguments.shell": "目标 shell",
     "arguments.skill": "skill 名称",
     "arguments.taskId": "任务 ID",


### PR DESCRIPTION
`oo connector schema` used to take exactly one bare service name plus a required `--action` option, so inspecting more than one action contract — an async submit/result pair, or a read step feeding a write step — meant running the command once per action. This changes the command to accept one or more `<service>.<action>` qualified ids directly as positional arguments: a single id keeps the existing JSON object output, and two or more widen it to a JSON array in request order.

The old `--action` form is kept for backwards compatibility but is now restricted to exactly one bare, undotted service name; mixing it with the qualified form is rejected before any metadata request goes out. Telemetry for `connector.schema` gains `action_count_bucket` and `qualified` alongside the existing `refresh` property, without recording service or action identity.

Bundled `oo` / `oo-create-skill` skill references and `docs/commands*.md` are updated to the `<service>.<action>` syntax, including guidance to batch lifecycle-style workflows (e.g. submit + result) into one schema call instead of two.