### PR TITLE
refactor(connector): drop self-hosted authenticated lookup

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -607,8 +607,6 @@ Search connector actions with free-form text.
 - Notes: search results also warm the local action schema cache when schema
   data is available, so a following `oo connector schema` for a returned
   action is usually answered locally without a fresh metadata request.
-- Notes: against a self-hosted connector server, `authenticated` is derived
-  from the server's connected-apps state.
 
 ### `oo connector schema <actionId...>`
 
@@ -819,8 +817,6 @@ Search connector actions with one free-form query.
 - Notes: search results also warm the local action schema cache when schema
   data is available, so a following `oo connector schema` for a returned
   action is usually answered locally without a fresh metadata request.
-- Notes: against a self-hosted connector server, `authenticated` is derived
-  from the server's connected-apps state.
 
 ## AI Agent Skills
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -521,8 +521,6 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 说明：搜索结果附带 schema 数据时还会更新本地 action schema 缓存，因此随后
   对返回 action 执行 `oo connector schema` 通常直接由本地缓存应答，无需重新
   请求 metadata。
-- 说明：面向自部署 Connector 服务时，`authenticated` 由该服务已连接 app 的
-  状态推导得出。
 
 ### `oo connector schema <actionId...>`
 
@@ -698,8 +696,6 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 说明：搜索结果附带 schema 数据时还会更新本地 action schema 缓存，因此随后
   对返回 action 执行 `oo connector schema` 通常直接由本地缓存应答，无需重新
   请求 metadata。
-- 说明：面向自部署 Connector 服务时，`authenticated` 由该服务已连接 app 的
-  状态推导得出。
 
 ## AI Agent Skill
 

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -4811,7 +4811,7 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("enriches top-level search results with the self-hosted authenticated-services lookup", async () => {
+    test("uses the wire authenticated field for self-hosted top-level search results", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -4829,23 +4829,14 @@ describe("connectorCommand CLI", () => {
 
                         requests.push(request);
 
-                        if (request.url.includes("/v1/actions/search")) {
-                            // The self-hosted runtime omits the per-result
-                            // `authenticated` field; the schema defaults it to
-                            // false before the follow-up lookup fills it in.
-                            return createConnectorSearchResponse([
-                                {
-                                    authenticated: false,
-                                    description: "Send a Gmail message.",
-                                    name: "send_mail",
-                                    service: "gmail",
-                                },
-                            ]);
-                        }
-
-                        return new Response(JSON.stringify({
-                            data: ["gmail"],
-                        }));
+                        return createConnectorSearchResponse([
+                            {
+                                authenticated: true,
+                                description: "Send a Gmail message.",
+                                name: "send_mail",
+                                service: "gmail",
+                            },
+                        ]);
                     },
                 },
             );
@@ -4854,9 +4845,8 @@ describe("connectorCommand CLI", () => {
             expect(result.stderr).toBe("");
             expect(requests.map(request => request.url)).toEqual([
                 "http://localhost:3000/v1/actions/search?q=send+mail",
-                "http://localhost:3000/v1/apps/authenticated?service=gmail",
             ]);
-            expect(requests[1]?.headers.get("Authorization")).toBe("Bearer oct_test");
+            expect(requests[0]?.headers.get("Authorization")).toBe("Bearer oct_test");
             expect(JSON.parse(result.stdout)).toEqual([
                 {
                     authenticated: true,

--- a/src/application/commands/connector/search-provider.test.ts
+++ b/src/application/commands/connector/search-provider.test.ts
@@ -167,7 +167,7 @@ describe("connector search provider", () => {
         ]);
     });
 
-    test("enriches self-hosted results from the authenticated services endpoint with deduplicated service params", async () => {
+    test("uses the wire authenticated field for self-hosted results without a follow-up request", async () => {
         const requests: Request[] = [];
 
         const results = await loadConnectorSearchResults(
@@ -187,27 +187,18 @@ describe("connector search provider", () => {
                             success: true,
                             data: [
                                 {
+                                    authenticated: true,
                                     description: "Send a Gmail message.",
                                     name: "send_mail",
                                     service: "gmail",
                                 },
                                 {
-                                    description: "Draft a Gmail message.",
-                                    name: "draft_mail",
-                                    service: "gmail",
-                                },
-                                {
+                                    authenticated: false,
                                     description: "Send a Slack message.",
                                     name: "post_message",
                                     service: "slack",
                                 },
                             ],
-                        }));
-                    }
-
-                    if (request.url.includes("/v1/apps/authenticated")) {
-                        return new Response(JSON.stringify({
-                            data: ["gmail"],
                         }));
                     }
 
@@ -218,19 +209,12 @@ describe("connector search provider", () => {
 
         expect(requests.map(request => request.url)).toEqual([
             "http://localhost:3000/v1/actions/search?q=send+mail",
-            "http://localhost:3000/v1/apps/authenticated?service=gmail&service=slack",
         ]);
         expect(results).toEqual([
             {
                 authenticated: true,
                 description: "Send a Gmail message.",
                 name: "send_mail",
-                service: "gmail",
-            },
-            {
-                authenticated: true,
-                description: "Draft a Gmail message.",
-                name: "draft_mail",
                 service: "gmail",
             },
             {
@@ -238,55 +222,6 @@ describe("connector search provider", () => {
                 description: "Send a Slack message.",
                 name: "post_message",
                 service: "slack",
-            },
-        ]);
-    });
-
-    test("returns self-hosted results as unauthenticated when the authenticated services request fails", async () => {
-        const requests: Request[] = [];
-
-        const results = await loadConnectorSearchResults(
-            {
-                target: createSelfHostedConnectorTargetFixture(),
-                text: "send mail",
-            },
-            createSearchContext({
-                cache: createMemoryCache(),
-                fetcher: async (input, init) => {
-                    const request = toRequest(input, init);
-
-                    requests.push(request);
-
-                    if (request.url.includes("/v1/actions/search")) {
-                        return new Response(JSON.stringify({
-                            success: true,
-                            data: [
-                                {
-                                    description: "Send a Gmail message.",
-                                    name: "send_mail",
-                                    service: "gmail",
-                                },
-                            ],
-                        }));
-                    }
-
-                    return new Response("", {
-                        status: 500,
-                    });
-                },
-            }),
-        );
-
-        expect(requests.map(request => request.url)).toEqual([
-            "http://localhost:3000/v1/actions/search?q=send+mail",
-            "http://localhost:3000/v1/apps/authenticated?service=gmail",
-        ]);
-        expect(results).toEqual([
-            {
-                authenticated: false,
-                description: "Send a Gmail message.",
-                name: "send_mail",
-                service: "gmail",
             },
         ]);
     });

--- a/src/application/commands/connector/search-provider.ts
+++ b/src/application/commands/connector/search-provider.ts
@@ -6,10 +6,7 @@ import type { ConnectorTarget } from "./target.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { cacheConnectorActionSchemas } from "./schema-cache.ts";
 
-import {
-    listAuthenticatedConnectorServices,
-    searchConnectorActions,
-} from "./shared.ts";
+import { searchConnectorActions } from "./shared.ts";
 
 export const connectorSearchActionColor = "#59F78D";
 export const connectorSearchServiceColor = "#CAA8FA";
@@ -43,16 +40,8 @@ export async function loadConnectorSearchResults(
 
     await warmConnectorActionSchemaCache(actions, options.target, context);
 
-    const authenticatedServices = await loadAuthenticatedConnectorServices(
-        actions,
-        options.target,
-        context,
-    );
-
     return actions.map(action => ({
-        authenticated: authenticatedServices === undefined
-            ? action.authenticated
-            : authenticatedServices.has(action.service),
+        authenticated: action.authenticated,
         description: action.description,
         name: action.name,
         service: action.service,
@@ -83,44 +72,6 @@ async function warmConnectorActionSchemaCache(
             },
             "Failed to warm connector action schemas during search.",
         );
-    }
-}
-
-/**
- * The self-hosted runtime omits the per-result `authenticated` field from
- * search responses, so the connected-service set is reconstructed from its
- * `/v1/apps/authenticated` endpoint. Best-effort: on failure the results keep
- * their default (`false`) and search output is still returned.
- */
-async function loadAuthenticatedConnectorServices(
-    actions: readonly ConnectorActionSearchResult[],
-    target: Pick<ConnectorTarget, "authorization" | "baseUrl" | "kind">,
-    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
-): Promise<Set<string> | undefined> {
-    if (target.kind !== "self_hosted" || actions.length === 0) {
-        return undefined;
-    }
-
-    const serviceNames = [...new Set(actions.map(action => action.service))];
-
-    try {
-        return new Set(await listAuthenticatedConnectorServices(
-            {
-                serviceNames,
-                target,
-            },
-            context,
-        ));
-    }
-    catch (error) {
-        context.logger.warn(
-            {
-                err: error,
-            },
-            "Failed to load authenticated services for self-hosted connector search results.",
-        );
-
-        return undefined;
     }
 }
 

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -18,7 +18,6 @@ import {
 } from "../shared/billing.ts";
 import {
     getConnectorActionMetadata,
-    listAuthenticatedConnectorServices,
     listConnectorAppsByService,
     runConnectorAction,
     runConnectorProxy,
@@ -92,6 +91,7 @@ describe("connector shared requests", () => {
                     message: "ok",
                     data: [
                         {
+                            authenticated: false,
                             name: "send_mail",
                             service: "gmail",
                         },
@@ -886,6 +886,7 @@ describe("connector shared requests", () => {
                         success: true,
                         data: [
                             {
+                                authenticated: false,
                                 description: "Send a Gmail message.",
                                 name: "send_mail",
                                 service: "gmail",
@@ -1077,32 +1078,6 @@ describe("connector shared requests", () => {
 
             expect(action.asyncLifecycle).toEqual(asyncLifecycle);
         }
-    });
-
-    test("listAuthenticatedConnectorServices sends repeated service params and parses the service list", async () => {
-        const requests: Request[] = [];
-        const services = await listAuthenticatedConnectorServices(
-            {
-                serviceNames: ["gmail", "slack"],
-                target: createSelfHostedConnectorTargetFixture(),
-            },
-            createRequestContext({
-                fetcher: async (input, init) => {
-                    requests.push(toRequest(input, init));
-
-                    return new Response(JSON.stringify({
-                        data: ["gmail"],
-                    }));
-                },
-            }),
-        );
-
-        expect(services).toEqual(["gmail"]);
-        expect(requests).toHaveLength(1);
-        expect(requests[0]?.url).toBe(
-            "http://localhost:3000/v1/apps/authenticated?service=gmail&service=slack",
-        );
-        expect(requests[0]?.headers.get("Authorization")).toBe("Bearer oct_x");
     });
 
     test("runConnectorAction reports the self-hosted URL without the sandbox hint when the server is unreachable", async () => {

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -82,7 +82,7 @@ export const connectorActionMetadataSchema = connectorActionDefinitionSchema.ext
 }).passthrough();
 
 const connectorActionSearchResultSchema = z.object({
-    authenticated: z.boolean().optional().default(false),
+    authenticated: z.boolean(),
     description: z.string().optional().default(""),
     inputSchema: z.unknown(),
     name: z.string().min(1),
@@ -242,73 +242,6 @@ export async function searchConnectorActions(
     }
     catch {
         throw new CliUserError("errors.connectorSearch.invalidResponse", 1);
-    }
-}
-
-const connectorAuthenticatedServicesResponseSchema = z.object({
-    data: z.array(z.string()).optional().default([]),
-});
-
-/**
- * Lists which of the given services have an authenticated connection on the
- * connector server (`GET /v1/apps/authenticated`). The self-hosted runtime
- * omits the per-result `authenticated` field from search responses, so search
- * uses this endpoint to reconstruct that signal.
- */
-export async function listAuthenticatedConnectorServices(
-    options: {
-        serviceNames: readonly string[];
-        target: ConnectorRequestTarget;
-    },
-    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
-): Promise<string[]> {
-    const requestUrl = new URL(
-        `${options.target.baseUrl}/v1/apps/authenticated`,
-    );
-
-    for (const serviceName of options.serviceNames) {
-        requestUrl.searchParams.append("service", serviceName);
-    }
-
-    const rawResponse = await requestText({
-        context,
-        createRequestFailedError: status => new CliUserError(
-            "errors.connectorApps.requestFailed",
-            1,
-            {
-                status,
-            },
-        ),
-        createUnexpectedError: error => new CliUserError(
-            "errors.connectorApps.requestError",
-            1,
-            {
-                message: createConnectorUnexpectedErrorMessage(
-                    error,
-                    options.target,
-                    context.translator,
-                ),
-            },
-        ),
-        fields: {
-            start: {
-                serviceCount: options.serviceNames.length,
-            },
-        },
-        init: {
-            headers: connectorAuthorizationHeaders(options.target),
-        },
-        requestLabel: "Connector authenticated services",
-        requestUrl,
-    });
-
-    try {
-        return connectorAuthenticatedServicesResponseSchema.parse(
-            JSON.parse(rawResponse) as unknown,
-        ).data;
-    }
-    catch {
-        throw new CliUserError("errors.connectorApps.invalidResponse", 1);
     }
 }
 


### PR DESCRIPTION
The self-hosted connector runtime now returns the per-result `authenticated` field in its search responses, so the compatibility path that reconstructed it from a second `/v1/apps/authenticated` request is no longer needed.

Search now uses the wire `authenticated` field for every target kind — OOMOL-hosted and self-hosted alike — and the search-result schema requires the field instead of defaulting it to `false`. oo-cli is still unreleased, so no backward-compatibility shim is kept.

**What changed**
- `search-provider.ts`: remove `loadAuthenticatedConnectorServices`; the result map reads `action.authenticated` directly for all targets
- `shared.ts`: remove `listAuthenticatedConnectorServices` and its response schema; tighten the search-result schema's `authenticated` to a required `z.boolean()`
- tests: the self-hosted search cases now assert a single `/v1/actions/search` request with the wire `authenticated` field (no follow-up lookup); the `listAuthenticatedConnectorServices` unit test is removed
- docs: drop the now-inaccurate note in `commands.md` / `commands.zh-CN.md` about `authenticated` being derived on self-hosted servers

Net −224 lines. `lint` / `ts-check` / `knip` clean; full suite 1500 pass / 0 fail.