### PR TITLE
feat(org): add commands to discover and manage organizations

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -214,6 +214,61 @@ and `--api-key <api-key>` options.
 
 Alias for `oo auth logout`.
 
+## Organizations
+
+Organization identity lets connector commands (`oo connector run`, `oo connector
+proxy`, `oo connector apps`) act as an organization instead of your personal
+account, selected per run with `--organization <name>` or as a default with the
+`identity.organization` config key. These commands help discover which
+organizations your account can use and manage that default. They apply to OOMOL
+accounts only and are not available when only a self-hosted connector is
+configured.
+
+### `oo org list`
+
+List the organizations the active account can authenticate as. This command is
+read-only.
+
+- Options: `--format=json` and `--json` print a JSON array.
+- Output: JSON entries include the stable CLI fields `name`, `id`, `role`, and
+  `current`. `role` is `creator` or `member`. `current` is `true` for the
+  organization that matches the `identity.organization` default.
+- Output: pass the `name` value to `--organization <name>` (or `oo org use
+  <name>`).
+- Output: text output prints one column-aligned row per organization and marks
+  the current default. When the account has no organizations, it reports that
+  connector commands run under your personal identity.
+
+### `oo org current`
+
+Show the default organization identity (`identity.organization`) used by
+connector commands when no `--organization` / `--personal` flag is given. This
+command is offline and does not make a network request.
+
+- Options: `--format=json` and `--json` print a JSON object.
+- Output: JSON is `{ "organization": "<name>" }`, or `{ "organization": null }`
+  when no default is configured.
+
+### `oo org use <name>`
+
+Set the default organization identity to `<name>` after checking the active
+account can access it.
+
+- Arguments: `<name>` is the organization name, as shown by `oo org list`.
+- Behavior: the name is validated against the organizations the account can
+  access; an inaccessible name is rejected with exit `1` and the default is left
+  unchanged. On success it is persisted to the `identity.organization` config
+  key.
+
+### `oo org clear`
+
+Clear the default organization identity so connector commands run under your
+personal identity. This command is offline.
+
+- Behavior: removes the `identity.organization` config key. When no default is
+  configured it reports that connector commands already run under your personal
+  identity.
+
 ## LLM
 
 ### `oo llm config`

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -188,6 +188,49 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
 
 `oo auth logout` 的别名。
 
+## 组织
+
+组织身份让 connector 命令（`oo connector run`、`oo connector proxy`、`oo connector
+apps`）以某个组织身份运行，而非个人账号：既可用每次运行的 `--organization <name>`
+指定，也可用配置项 `identity.organization` 设为默认。下列命令用于发现当前账号可用的
+组织并管理该默认值。它们仅适用于 OOMOL 账号；当仅配置了自部署 Connector 时不可用。
+
+### `oo org list`
+
+列出当前活动账号可认证的组织。该命令是只读的。
+
+- 选项：`--format=json` 与 `--json` 输出 JSON 数组。
+- 输出：JSON 条目包含稳定的 CLI 字段 `name`、`id`、`role`、`current`。`role` 为
+  `creator` 或 `member`。`current` 对与 `identity.organization` 默认值匹配的组织为
+  `true`。
+- 输出：将 `name` 的值传给 `--organization <name>`（或 `oo org use <name>`）。
+- 输出：文本输出为每个组织打印一行列对齐的记录，并标出当前默认组织。当账号没有任何
+  组织时，会提示 connector 命令以个人身份运行。
+
+### `oo org current`
+
+显示未传 `--organization` / `--personal` 时 connector 命令使用的默认组织身份
+（`identity.organization`）。该命令离线运行，不发起网络请求。
+
+- 选项：`--format=json` 与 `--json` 输出 JSON 对象。
+- 输出：JSON 为 `{ "organization": "<name>" }`；未配置默认值时为
+  `{ "organization": null }`。
+
+### `oo org use <name>`
+
+在确认当前活动账号可访问后，将默认组织身份设置为 `<name>`。
+
+- 参数：`<name>` 为组织名称，取值见 `oo org list`。
+- 行为：会用账号可访问的组织校验该名称；无法访问的名称以退出码 `1` 拒绝，且默认值保持
+  不变。成功时持久化到配置项 `identity.organization`。
+
+### `oo org clear`
+
+清除默认组织身份，让 connector 命令以个人身份运行。该命令离线运行。
+
+- 行为：移除配置项 `identity.organization`。当未配置默认值时，会提示 connector 命令
+  本就以个人身份运行。
+
 ## LLM
 
 ### `oo llm config`

--- a/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
+++ b/src/application/bootstrap/__snapshots__/run-cli.test.ts.snap
@@ -51,6 +51,7 @@ Commands:
                                login)
   logout                       Log out the current account (alias for auth
                                logout)
+  org                          Manage organization identity
   completion <shell>           Generate shell completion scripts
   config                       Manage persisted configuration
   skills                       Manage AI agent skills
@@ -92,6 +93,7 @@ Commands:
                                login)
   logout                       Log out the current account (alias for auth
                                logout)
+  org                          Manage organization identity
   completion <shell>           Generate shell completion scripts
   config                       Manage persisted configuration
   skills                       Manage AI agent skills
@@ -136,6 +138,7 @@ Commands:
                                login)
   logout                       Log out the current account (alias for auth
                                logout)
+  org                          Manage organization identity
   completion <shell>           Generate shell completion scripts
   config                       Manage persisted configuration
   skills                       Manage AI agent skills
@@ -175,6 +178,7 @@ exports[`runCli bootstrap renders help in English and Chinese 1`] = `
   llm                          管理 LLM client 配置
   login [options]              登录 OOMOL 账号（auth login 的别名）
   logout                       登出当前账号（auth logout 的别名）
+  org                          管理组织身份
   completion <shell>           生成 shell 补全脚本
   config                       管理持久化配置
   skills                       管理 AI Agent skill
@@ -213,6 +217,7 @@ Commands:
                                login)
   logout                       Log out the current account (alias for auth
                                logout)
+  org                          Manage organization identity
   completion <shell>           Generate shell completion scripts
   config                       Manage persisted configuration
   skills                       Manage AI agent skills
@@ -255,6 +260,7 @@ Commands:
                                login)
   logout                       Log out the current account (alias for auth
                                logout)
+  org                          Manage organization identity
   completion <shell>           Generate shell completion scripts
   config                       Manage persisted configuration
   skills                       Manage AI agent skills

--- a/src/application/commands/catalog.ts
+++ b/src/application/commands/catalog.ts
@@ -13,6 +13,7 @@ import { llmCommand } from "./llm/index.ts";
 import { logCommand } from "./log/index.ts";
 import { loginCommand } from "./login.ts";
 import { logoutCommand } from "./logout.ts";
+import { orgCommand } from "./org/index.ts";
 import { searchCommand } from "./search.ts";
 import { skillsCommand } from "./skills/index.ts";
 import { telemetryCommand } from "./telemetry/index.ts";
@@ -52,6 +53,7 @@ export function createCliCatalog(): CliCatalog {
             llmCommand,
             loginCommand,
             logoutCommand,
+            orgCommand,
             completionCommand,
             configCommand,
             skillsCommand,

--- a/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/config/__snapshots__/index.cli.test.ts.snap
@@ -37,6 +37,7 @@ Commands:
                                login)
   logout                       Log out the current account (alias for auth
                                logout)
+  org                          Manage organization identity
   completion <shell>           Generate shell completion scripts
   config                       Manage persisted configuration
   skills                       Manage AI agent skills
@@ -72,6 +73,7 @@ Commands:
   llm                          管理 LLM client 配置
   login [options]              登录 OOMOL 账号（auth login 的别名）
   logout                       登出当前账号（auth logout 的别名）
+  org                          管理组织身份
   completion <shell>           生成 shell 补全脚本
   config                       管理持久化配置
   skills                       管理 AI Agent skill
@@ -193,6 +195,48 @@ exports[`config CLI supports the file download output directory config key 1`] =
     "stderr": "",
     "stdout": 
 "Removed file.download.out_dir.
+"
+,
+  },
+}
+`;
+
+exports[`config CLI supports the identity organization config key 1`] = `
+{
+  "get": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"acme
+"
+,
+  },
+  "getAfterUnset": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": "",
+  },
+  "list": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"identity.organization=acme
+"
+,
+  },
+  "set": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Set identity.organization to acme.
+"
+,
+  },
+  "unset": {
+    "exitCode": 0,
+    "stderr": "",
+    "stdout": 
+"Removed identity.organization.
 "
 ,
   },
@@ -343,47 +387,5 @@ exports[`config CLI ignores unknown persisted settings keys and logs a warning 1
 "zh
 "
 ,
-}
-`;
-
-exports[`config CLI supports the identity organization config key 1`] = `
-{
-  "get": {
-    "exitCode": 0,
-    "stderr": "",
-    "stdout": 
-"acme
-"
-,
-  },
-  "getAfterUnset": {
-    "exitCode": 0,
-    "stderr": "",
-    "stdout": "",
-  },
-  "list": {
-    "exitCode": 0,
-    "stderr": "",
-    "stdout": 
-"identity.organization=acme
-"
-,
-  },
-  "set": {
-    "exitCode": 0,
-    "stderr": "",
-    "stdout": 
-"Set identity.organization to acme.
-"
-,
-  },
-  "unset": {
-    "exitCode": 0,
-    "stderr": "",
-    "stdout": 
-"Removed identity.organization.
-"
-,
-  },
 }
 `;

--- a/src/application/commands/org/clear.ts
+++ b/src/application/commands/org/clear.ts
@@ -1,0 +1,39 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import {
+    getConfiguredIdentityOrganization,
+    unsetIdentityOrganization,
+} from "../../schemas/settings.ts";
+import { writeLine } from "../shared/output.ts";
+
+// Clears the default organization identity (config `identity.organization`),
+// returning connector commands to the personal identity. Offline: it only
+// rewrites local settings.
+export const orgClearCommand: CliCommandDefinition = {
+    name: "clear",
+    summaryKey: "commands.org.clear.summary",
+    descriptionKey: "commands.org.clear.description",
+    inputSchema: z.object({}),
+    handler: async (_input, context) => {
+        const settings = await context.settingsStore.read();
+        const hadConfiguredOrganization
+            = getConfiguredIdentityOrganization(settings) !== undefined;
+
+        if (!hadConfiguredOrganization) {
+            writeLine(
+                context.stdout,
+                context.translator.t("org.clear.alreadyPersonal"),
+            );
+            return;
+        }
+
+        await context.settingsStore.update(unsetIdentityOrganization);
+
+        context.logger.info(
+            { organizationConfigured: false },
+            "Default organization identity cleared.",
+        );
+        writeLine(context.stdout, context.translator.t("org.clear.success"));
+    },
+};

--- a/src/application/commands/org/current.ts
+++ b/src/application/commands/org/current.ts
@@ -1,0 +1,61 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import { getConfiguredIdentityOrganization } from "../../schemas/settings.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { createFormatInputError } from "../shared/input-parsing.ts";
+import { writeLine } from "../shared/output.ts";
+import { orgFormatValues } from "./shared.ts";
+
+interface OrgCurrentInput {
+    format?: (typeof orgFormatValues)[number];
+    showSchemaVersion?: boolean;
+}
+
+interface OrgCurrentJsonPayload {
+    organization: string | null;
+}
+
+// Reports the default organization identity (config `identity.organization`)
+// that connector commands use when no `--org` / `--personal` flag is given.
+// Offline by design: it only reads local settings, so agents can cheaply learn
+// "which identity do I run as by default" without a network round-trip.
+export const orgCurrentCommand: CliCommandDefinition<OrgCurrentInput> = {
+    name: "current",
+    summaryKey: "commands.org.current.summary",
+    descriptionKey: "commands.org.current.description",
+    options: [...jsonOutputOptions],
+    inputSchema: z.object({
+        format: z.enum(orgFormatValues).optional(),
+        showSchemaVersion: z.boolean().optional(),
+    }),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+    handler: async (input, context) => {
+        const settings = await context.settingsStore.read();
+        const configuredOrganization = getConfiguredIdentityOrganization(settings);
+
+        context.telemetry?.recordProperties({
+            has_configured_org: configuredOrganization !== undefined,
+        });
+
+        if (input.format === "json") {
+            const payload: OrgCurrentJsonPayload = {
+                organization: configuredOrganization ?? null,
+            };
+
+            writeJsonOutput(context.stdout, payload, {
+                showSchemaVersion: input.showSchemaVersion,
+            });
+            return;
+        }
+
+        writeLine(
+            context.stdout,
+            configuredOrganization === undefined
+                ? context.translator.t("org.current.text.personal")
+                : context.translator.t("org.current.text.configured", {
+                        organization: configuredOrganization,
+                    }),
+        );
+    },
+};

--- a/src/application/commands/org/index.cli.test.ts
+++ b/src/application/commands/org/index.cli.test.ts
@@ -1,0 +1,253 @@
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+    createCliSandbox,
+    toRequest,
+    writeAuthFile,
+} from "../../../../__tests__/helpers.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../../telemetry/outbox.ts";
+
+const organizationsResponse = {
+    organizations: [
+        {
+            id: "org-1",
+            name: "acme",
+            avatar: "",
+            creator_user_id: "user-1",
+            role: "creator",
+        },
+        {
+            id: "org-2",
+            name: "beta",
+            role: "member",
+        },
+    ],
+};
+
+describe("orgCommand CLI", () => {
+    test("lists accessible organizations as JSON and marks the configured default", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await sandbox.run(["config", "set", "identity.organization", "acme"]);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(["org", "list", "--json"], {
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+
+                    return new Response(JSON.stringify(organizationsResponse));
+                },
+            });
+            const telemetryPayload = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            )
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "org.list");
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.url).toBe(
+                "https://org-control.oomol.com/v1/me/organizations",
+            );
+            expect(requests[0]?.headers.get("authorization")).toBe("secret-1");
+            expect(JSON.parse(result.stdout)).toEqual([
+                { name: "acme", id: "org-1", role: "creator", current: true },
+                { name: "beta", id: "org-2", role: "member", current: false },
+            ]);
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    command_full: "org.list",
+                    result_count_bucket: "1-5",
+                },
+            });
+            expect(telemetryPayload?.properties).not.toHaveProperty("organization");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("renders accessible organizations as an aligned text table", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["org", "list"], {
+                fetcher: async () => new Response(JSON.stringify(organizationsResponse)),
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("acme");
+            expect(result.stdout).toContain("beta");
+            expect(result.stdout).toContain("creator");
+            expect(result.stdout).toContain("member");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports personal identity when the account has no organizations", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["org", "list"], {
+                fetcher: async () => new Response(JSON.stringify({ organizations: [] })),
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("personal identity");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails to list organizations without an account", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            let requested = false;
+            const result = await sandbox.run(["org", "list"], {
+                fetcher: async () => {
+                    requested = true;
+
+                    return new Response(JSON.stringify({ organizations: [] }));
+                },
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(requested).toBe(false);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("shows the default organization identity via current", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await sandbox.run(["config", "set", "identity.organization", "acme"]);
+
+            const jsonResult = await sandbox.run(["org", "current", "--json"]);
+            const textResult = await sandbox.run(["org", "current"]);
+
+            expect(jsonResult.exitCode).toBe(0);
+            expect(JSON.parse(jsonResult.stdout)).toEqual({ organization: "acme" });
+            expect(textResult.stdout).toContain("acme");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports personal identity via current when no default is configured", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const jsonResult = await sandbox.run(["org", "current", "--json"]);
+            const textResult = await sandbox.run(["org", "current"]);
+
+            expect(jsonResult.exitCode).toBe(0);
+            expect(JSON.parse(jsonResult.stdout)).toEqual({ organization: null });
+            expect(textResult.stdout).toContain("personal identity");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("sets the default organization with use after checking membership", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const requests: Request[] = [];
+            const useResult = await sandbox.run(["org", "use", "beta"], {
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+
+                    return new Response(JSON.stringify(organizationsResponse));
+                },
+            });
+            const currentResult = await sandbox.run(["org", "current", "--json"]);
+
+            expect(useResult.exitCode).toBe(0);
+            expect(requests).toHaveLength(1);
+            expect(JSON.parse(currentResult.stdout)).toEqual({ organization: "beta" });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects use for an organization the account cannot access", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["org", "use", "ghost"], {
+                fetcher: async () => new Response(JSON.stringify(organizationsResponse)),
+            });
+            const currentResult = await sandbox.run(["org", "current", "--json"]);
+
+            expect(result.exitCode).toBe(1);
+            expect(JSON.parse(currentResult.stdout)).toEqual({ organization: null });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("clears the default organization identity", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await sandbox.run(["config", "set", "identity.organization", "acme"]);
+
+            const clearResult = await sandbox.run(["org", "clear"]);
+            const currentResult = await sandbox.run(["org", "current", "--json"]);
+
+            expect(clearResult.exitCode).toBe(0);
+            expect(JSON.parse(currentResult.stdout)).toEqual({ organization: null });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports already-personal when clearing with no configured organization", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["org", "clear"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("personal identity");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/org/index.ts
+++ b/src/application/commands/org/index.ts
@@ -1,0 +1,18 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { orgClearCommand } from "./clear.ts";
+import { orgCurrentCommand } from "./current.ts";
+import { orgListCommand } from "./list.ts";
+import { orgUseCommand } from "./use.ts";
+
+export const orgCommand: CliCommandDefinition = {
+    name: "org",
+    summaryKey: "commands.org.summary",
+    descriptionKey: "commands.org.description",
+    children: [
+        orgListCommand,
+        orgCurrentCommand,
+        orgUseCommand,
+        orgClearCommand,
+    ],
+};

--- a/src/application/commands/org/list.test.ts
+++ b/src/application/commands/org/list.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+
+import { createTerminalColors } from "../../terminal-colors.ts";
+import { formatOrganizationsAsText } from "./list.ts";
+
+type OrgListRow = Parameters<typeof formatOrganizationsAsText>[0][number];
+
+const greenOpenCode = "[32m";
+
+describe("formatOrganizationsAsText", () => {
+    test("marks the current default organization with a green check", () => {
+        const output = formatOrganizationsAsText(
+            [sampleOrg({ current: true, name: "acme", role: "creator" })],
+            createTranslatorStub(),
+            createTerminalColors(true),
+        );
+
+        expect(output).toContain(greenOpenCode);
+        expect(output).toContain("✓");
+        expect(output).toContain("acme");
+        expect(output).toContain("creator");
+    });
+
+    test("aligns columns as plain text without escape sequences when colors are disabled", () => {
+        const output = formatOrganizationsAsText(
+            [
+                sampleOrg({ current: true, name: "acme", role: "creator" }),
+                sampleOrg({ current: false, name: "beta", role: "member" }),
+            ],
+            createTranslatorStub(),
+            createTerminalColors(false),
+        );
+        const lines = output.split("\n");
+
+        expect(output).not.toContain("[");
+        // The non-current organization renders a dash in the default column.
+        expect(output).toContain("-");
+        // The role column lines up across rows because the organization column
+        // is padded to a shared width.
+        expect(lines[1]!.indexOf("creator")).toBe(lines[2]!.indexOf("member"));
+    });
+
+    test("pads wide CJK organization names by display width so later columns stay aligned", () => {
+        const output = formatOrganizationsAsText(
+            [
+                sampleOrg({ name: "钉钉", role: "creator" }),
+                sampleOrg({ name: "AB", role: "member" }),
+            ],
+            createTranslatorStub(),
+            createTerminalColors(false),
+        );
+        const lines = output.split("\n");
+        const displayWidthBeforeRole = (line: string, role: string): number =>
+            Bun.stringWidth(line.slice(0, line.indexOf(role)));
+
+        expect(displayWidthBeforeRole(lines[1]!, "creator")).toBe(
+            displayWidthBeforeRole(lines[2]!, "member"),
+        );
+    });
+
+    test("returns the empty-listing message when there are no organizations", () => {
+        const output = formatOrganizationsAsText(
+            [],
+            createTranslatorStub(),
+            createTerminalColors(false),
+        );
+
+        expect(output).toBe("org.list.text.noOrganizations");
+    });
+});
+
+function sampleOrg(overrides: Partial<OrgListRow> = {}): OrgListRow {
+    return {
+        current: false,
+        id: "org-1",
+        name: "acme",
+        role: "member",
+        ...overrides,
+    };
+}
+
+function createTranslatorStub(): { t: (key: string) => string } {
+    return { t: key => key };
+}

--- a/src/application/commands/org/list.ts
+++ b/src/application/commands/org/list.ts
@@ -1,0 +1,156 @@
+import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
+import type { TerminalColors } from "../../terminal-colors.ts";
+
+import type { OrganizationRole, OrganizationView } from "./shared.ts";
+
+import { z } from "zod";
+import { getConfiguredIdentityOrganization } from "../../schemas/settings.ts";
+import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
+import { createWriterColors } from "../../terminal-colors.ts";
+import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
+import { createFormatInputError } from "../shared/input-parsing.ts";
+import { listMemberOrganizations, orgFormatValues } from "./shared.ts";
+
+interface OrgListInput {
+    format?: (typeof orgFormatValues)[number];
+    showSchemaVersion?: boolean;
+}
+
+interface OrgListItem {
+    current: boolean;
+    id: string;
+    name: string;
+    role: OrganizationRole;
+}
+
+export const orgListCommand: CliCommandDefinition<OrgListInput> = {
+    name: "list",
+    summaryKey: "commands.org.list.summary",
+    descriptionKey: "commands.org.list.description",
+    options: [...jsonOutputOptions],
+    inputSchema: z.object({
+        format: z.enum(orgFormatValues).optional(),
+        showSchemaVersion: z.boolean().optional(),
+    }),
+    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
+    handler: async (input, context) => {
+        const account = await requireCurrentAccount(context);
+        const settings = await context.settingsStore.read();
+        const configuredOrganization = getConfiguredIdentityOrganization(settings);
+
+        const organizations = await listMemberOrganizations(account, context);
+        const output = organizations.map(organization =>
+            createOrgListItem(organization, configuredOrganization),
+        );
+
+        context.telemetry?.recordProperties({
+            result_count_bucket: bucketTelemetryCount(output.length),
+        });
+
+        if (input.format === "json") {
+            writeJsonOutput(context.stdout, output, {
+                showSchemaVersion: input.showSchemaVersion,
+            });
+            return;
+        }
+
+        context.stdout.write(
+            `${formatOrganizationsAsText(
+                output,
+                context.translator,
+                createWriterColors(context.stdout),
+            )}\n`,
+        );
+    },
+};
+
+function createOrgListItem(
+    organization: OrganizationView,
+    configuredOrganization: string | undefined,
+): OrgListItem {
+    return {
+        current: organization.name === configuredOrganization,
+        id: organization.id,
+        name: organization.name,
+        role: organization.role,
+    };
+}
+
+type OrgListTranslator = Pick<CliExecutionContext["translator"], "t">;
+
+interface OrgListColumn {
+    header: string;
+    render: (organization: OrgListItem) => string;
+}
+
+// Renders the organization listing as a color-coded, column-aligned table. The
+// current default (matching `identity.organization`) is marked so callers can
+// see at a glance which value `oo connector run` uses without `--org`.
+export function formatOrganizationsAsText(
+    organizations: readonly OrgListItem[],
+    translator: OrgListTranslator,
+    colors: TerminalColors,
+): string {
+    if (organizations.length === 0) {
+        return translator.t("org.list.text.noOrganizations");
+    }
+
+    const columns = createOrgListColumns(translator, colors);
+    const headerCells = columns.map(column => colors.dim(column.header));
+    const rows = organizations.map(
+        organization => columns.map(column => column.render(organization)),
+    );
+    // Column widths use the terminal display width, which ignores ANSI color
+    // escapes and counts wide CJK/emoji glyphs as two columns, so neither color
+    // codes nor multi-cell characters skew the alignment.
+    const widths = columns.map((_, index) => Math.max(
+        visibleWidth(headerCells[index]!),
+        ...rows.map(row => visibleWidth(row[index]!)),
+    ));
+
+    return [headerCells, ...rows]
+        .map(cells => joinOrgListRow(cells, widths))
+        .join("\n");
+}
+
+function createOrgListColumns(
+    translator: OrgListTranslator,
+    colors: TerminalColors,
+): OrgListColumn[] {
+    return [
+        {
+            header: translator.t("org.list.text.organization"),
+            render: organization => colors.bold(organization.name),
+        },
+        {
+            header: translator.t("org.list.text.role"),
+            render: organization => colors.dim(organization.role),
+        },
+        {
+            header: translator.t("org.list.text.default"),
+            render: organization => organization.current
+                ? colors.green("✓")
+                : colors.dim("-"),
+        },
+    ];
+}
+
+// Pads every cell except the last to its column width (measured in display
+// columns) and joins the row with a two-space gutter.
+function joinOrgListRow(
+    cells: readonly string[],
+    widths: readonly number[],
+): string {
+    return cells
+        .map((cell, index) => index === cells.length - 1
+            ? cell
+            : cell + " ".repeat(widths[index]! - visibleWidth(cell)))
+        .join("  ");
+}
+
+// Terminal display width of the cell: ANSI color escapes count as zero and wide
+// CJK/emoji glyphs count as two columns, unlike `String.length` (UTF-16 units).
+function visibleWidth(cell: string): number {
+    return Bun.stringWidth(cell);
+}

--- a/src/application/commands/org/shared.test.ts
+++ b/src/application/commands/org/shared.test.ts
@@ -1,0 +1,120 @@
+import type { Fetcher } from "../../contracts/cli.ts";
+
+import { describe, expect, test } from "bun:test";
+import pino from "pino";
+
+import { expectCliUserError, toRequest } from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
+import { listMemberOrganizations } from "./shared.ts";
+
+const testAccount = {
+    apiKey: "api-secret-1",
+    endpoint: "oomol.com",
+};
+
+describe("listMemberOrganizations", () => {
+    test("requests the membership endpoint with the account api key and maps roles", async () => {
+        const requests: Request[] = [];
+        const organizations = await listMemberOrganizations(
+            testAccount,
+            createRequestContext({
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+
+                    return new Response(JSON.stringify({
+                        organizations: [
+                            {
+                                id: "org-1",
+                                name: "acme",
+                                avatar: "",
+                                creator_user_id: "user-1",
+                                role: "creator",
+                            },
+                            {
+                                id: "org-2",
+                                name: "beta",
+                                role: "member",
+                            },
+                        ],
+                    }));
+                },
+            }),
+        );
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0]?.url).toBe(
+            "https://org-control.oomol.com/v1/me/organizations",
+        );
+        expect(requests[0]?.headers.get("authorization")).toBe("api-secret-1");
+        expect(organizations).toEqual([
+            { id: "org-1", name: "acme", role: "creator" },
+            { id: "org-2", name: "beta", role: "member" },
+        ]);
+    });
+
+    test("treats an unknown or missing role as a plain membership", async () => {
+        const organizations = await listMemberOrganizations(
+            testAccount,
+            createRequestContext({
+                fetcher: async () => new Response(JSON.stringify({
+                    organizations: [
+                        { id: "org-1", name: "acme", role: "owner" },
+                        { id: "org-2", name: "beta" },
+                    ],
+                })),
+            }),
+        );
+
+        expect(organizations).toEqual([
+            { id: "org-1", name: "acme", role: "member" },
+            { id: "org-2", name: "beta", role: "member" },
+        ]);
+    });
+
+    test("returns an empty list when the account has no organizations", async () => {
+        const organizations = await listMemberOrganizations(
+            testAccount,
+            createRequestContext({
+                fetcher: async () => new Response(JSON.stringify({})),
+            }),
+        );
+
+        expect(organizations).toEqual([]);
+    });
+
+    test("rejects an unsupported response body", async () => {
+        const error = await expectCliUserError(listMemberOrganizations(
+            testAccount,
+            createRequestContext({
+                fetcher: async () => new Response(JSON.stringify({
+                    organizations: [{ name: "acme" }],
+                })),
+            }),
+        ));
+
+        expect(error.key).toBe("errors.org.invalidResponse");
+    });
+
+    test("surfaces a non-success status as a request-failed error", async () => {
+        const error = await expectCliUserError(listMemberOrganizations(
+            testAccount,
+            createRequestContext({
+                fetcher: async () => new Response("nope", { status: 500 }),
+            }),
+        ));
+
+        expect(error.key).toBe("errors.org.requestFailed");
+    });
+});
+
+function createRequestContext(options: {
+    fetcher: Fetcher;
+}) {
+    return {
+        fetcher: options.fetcher,
+        logger: pino({
+            enabled: false,
+        }),
+        translator: createTranslator("en"),
+    };
+}

--- a/src/application/commands/org/shared.ts
+++ b/src/application/commands/org/shared.ts
@@ -1,0 +1,91 @@
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+import type { AuthAccount } from "../../schemas/auth.ts";
+
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import {
+    getUnexpectedRequestErrorMessage,
+    requestText,
+} from "../shared/request.ts";
+
+export const orgFormatValues = ["json"] as const;
+
+// One organization the current account belongs to. The backend membership
+// listing carries a role of exactly `creator` or `member`; anything else is
+// treated as a plain membership.
+const organizationResponseItemSchema = z.object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    role: z.string().optional(),
+});
+
+// `GET /v1/me/organizations` wraps the memberships in an `organizations` array.
+// The array is optional/defaulted so an empty account (personal identity only)
+// parses cleanly instead of failing validation.
+const organizationsResponseSchema = z.object({
+    organizations: z.array(organizationResponseItemSchema).optional().default([]),
+});
+
+export type OrganizationRole = "creator" | "member";
+
+export interface OrganizationView {
+    id: string;
+    name: string;
+    role: OrganizationRole;
+}
+
+// Lists every organization the account can authenticate as. Backed by
+// `GET https://org-control.{endpoint}/v1/me/organizations`, which returns the
+// full membership set (organizations the account created appear here too, with
+// `role: "creator"`), so a single request answers "which values are valid for
+// `--org`". The account API key authenticates through the gateway; no
+// organization identity header is involved.
+export async function listMemberOrganizations(
+    account: Pick<AuthAccount, "apiKey" | "endpoint">,
+    context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
+): Promise<OrganizationView[]> {
+    const requestUrl = new URL(
+        `https://org-control.${account.endpoint}/v1/me/organizations`,
+    );
+
+    const rawResponse = await requestText({
+        context,
+        createRequestFailedError: status => new CliUserError(
+            "errors.org.requestFailed",
+            1,
+            { status },
+        ),
+        createUnexpectedError: error => new CliUserError(
+            "errors.org.requestError",
+            1,
+            { message: getUnexpectedRequestErrorMessage(error, context.translator) },
+        ),
+        init: {
+            headers: {
+                Authorization: account.apiKey,
+            },
+        },
+        requestLabel: "Organization list",
+        requestUrl,
+    });
+
+    try {
+        return organizationsResponseSchema
+            .parse(JSON.parse(rawResponse) as unknown)
+            .organizations
+            .map(toOrganizationView);
+    }
+    catch {
+        throw new CliUserError("errors.org.invalidResponse", 1);
+    }
+}
+
+function toOrganizationView(
+    item: z.output<typeof organizationResponseItemSchema>,
+): OrganizationView {
+    return {
+        id: item.id,
+        name: item.name,
+        role: item.role === "creator" ? "creator" : "member",
+    };
+}

--- a/src/application/commands/org/use.ts
+++ b/src/application/commands/org/use.ts
@@ -1,0 +1,61 @@
+import type { CliCommandDefinition } from "../../contracts/cli.ts";
+
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { setIdentityOrganization } from "../../schemas/settings.ts";
+import { requireCurrentAccount } from "../shared/auth-utils.ts";
+import { writeLine } from "../shared/output.ts";
+import { listMemberOrganizations } from "./shared.ts";
+
+interface OrgUseInput {
+    name: string;
+}
+
+// Sets the default organization identity (config `identity.organization`) after
+// confirming the account is actually a member of it. The membership check is
+// the value over a bare `oo config set identity.organization`: it rejects typos
+// and stale names up front instead of surfacing them later on a connector run.
+export const orgUseCommand: CliCommandDefinition<OrgUseInput> = {
+    name: "use",
+    summaryKey: "commands.org.use.summary",
+    descriptionKey: "commands.org.use.description",
+    arguments: [
+        {
+            name: "name",
+            descriptionKey: "arguments.orgUseName",
+            required: true,
+        },
+    ],
+    inputSchema: z.object({
+        name: z.string(),
+    }),
+    handler: async (input, context) => {
+        const name = input.name.trim();
+
+        if (name === "") {
+            throw new CliUserError("errors.org.nameEmpty", 2);
+        }
+
+        const account = await requireCurrentAccount(context);
+        const organizations = await listMemberOrganizations(account, context);
+
+        if (!organizations.some(organization => organization.name === name)) {
+            throw new CliUserError("errors.org.notAccessible", 1, {
+                organization: name,
+            });
+        }
+
+        await context.settingsStore.update(settings =>
+            setIdentityOrganization(settings, name),
+        );
+
+        context.logger.info(
+            { organizationConfigured: true },
+            "Default organization identity persisted.",
+        );
+        writeLine(
+            context.stdout,
+            context.translator.t("org.use.success", { organization: name }),
+        );
+    },
+};

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -268,6 +268,28 @@ const commandTelemetryDecisions = {
         properties: ["account_count_bucket"],
         reason: "Top-level auth alias records the same safe auth dimensions as auth.logout.",
     },
+    "org": {
+        kind: "generic",
+        reason: "Command group; child commands record organization dimensions where safe.",
+    },
+    "org.list": {
+        kind: "properties",
+        properties: ["result_count_bucket"],
+        reason: "Records the bounded accessible-organization count without organization names or ids.",
+    },
+    "org.current": {
+        kind: "properties",
+        properties: ["has_configured_org"],
+        reason: "Records whether a default organization identity is configured, without the organization name.",
+    },
+    "org.use": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; the organization name is never recorded.",
+    },
+    "org.clear": {
+        kind: "generic",
+        reason: "Generic command telemetry is enough; no organization details are recorded.",
+    },
     "search": {
         kind: "properties",
         properties: [

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -144,6 +144,21 @@ export const enMessages = {
         "Remove the current account from persisted auth data. Alias for auth logout.",
     "commands.logout.summary":
         "Log out the current account (alias for auth logout)",
+    "commands.org.description":
+        "List the organizations your account can access and manage the default organization identity used by connector commands.",
+    "commands.org.summary": "Manage organization identity",
+    "commands.org.list.description":
+        "List the organizations the active account can authenticate as, marking the current default.",
+    "commands.org.list.summary": "List accessible organizations",
+    "commands.org.current.description":
+        "Show the default organization identity used by connector commands when no --organization / --personal flag is given.",
+    "commands.org.current.summary": "Show the default organization identity",
+    "commands.org.use.description":
+        "Set the default organization identity used by connector commands, after checking the account can access it.",
+    "commands.org.use.summary": "Set the default organization identity",
+    "commands.org.clear.description":
+        "Clear the default organization identity so connector commands run under your personal identity.",
+    "commands.org.clear.summary": "Clear the default organization identity",
     "commands.search.description":
         "Search connector actions with one free-form query.",
     "commands.search.summary": "Search connector actions",
@@ -325,6 +340,14 @@ export const enMessages = {
         "The connector apps request failed: {message}",
     "errors.connectorApps.requestFailed":
         "The connector apps request returned HTTP {status}.",
+    "errors.org.invalidResponse":
+        "The organization list response body is unsupported.",
+    "errors.org.nameEmpty": "The organization name must not be empty.",
+    "errors.org.notAccessible":
+        "The active account cannot access the organization \"{organization}\". Run `oo org list` to see the organizations you can use.",
+    "errors.org.requestError": "The organization list request failed: {message}",
+    "errors.org.requestFailed":
+        "The organization list request returned HTTP {status}.",
     "errors.connectorMetadata.invalidResponse":
         "The connector action metadata response body is unsupported.",
     "errors.connectorMetadata.requestError":
@@ -1159,6 +1182,7 @@ export const enMessages = {
     "arguments.skills.uninstall.name": "Skill or package name(s) to remove; a package name removes every installed skill that belongs to it",
     "arguments.serviceName": "Service name",
     "arguments.connectorAppsServiceName": "Optional service name; omit to list every connected app",
+    "arguments.orgUseName": "Organization name to use as the default identity",
     "arguments.connectorUrl": "Self-hosted connector server URL, for example http://localhost:3000",
     "arguments.actionId": "Action id(s) in the form <service>.<action>, for example cal.create_schedule",
     "arguments.shell": "Target shell",
@@ -1182,6 +1206,19 @@ export const enMessages = {
         "No connector apps were found for this service.",
     "connector.apps.text.service": "Service",
     "connector.apps.text.status": "Status",
+    "org.list.text.organization": "Organization",
+    "org.list.text.role": "Role",
+    "org.list.text.default": "Default",
+    "org.list.text.noOrganizations":
+        "The active account has no organizations; connector commands run under your personal identity.",
+    "org.current.text.configured": "Default organization identity: {organization}",
+    "org.current.text.personal":
+        "No default organization; connector commands run under your personal identity.",
+    "org.use.success": "Set the default organization identity to {organization}.",
+    "org.clear.success":
+        "Cleared the default organization identity; connector commands now run under your personal identity.",
+    "org.clear.alreadyPersonal":
+        "No default organization was set; connector commands already run under your personal identity.",
     "connector.run.text.dryRunPassed": "Validation passed.",
     "connector.login.manageTokens": "Manage runtime tokens at {accessUrl}",
     "connector.login.noToken":
@@ -1388,6 +1425,21 @@ export const zhMessages = {
     "commands.login.summary": "登录 OOMOL 账号（auth login 的别名）",
     "commands.logout.description": "从持久化认证数据中移除当前账号。是 auth logout 的别名。",
     "commands.logout.summary": "登出当前账号（auth logout 的别名）",
+    "commands.org.description":
+        "列出当前账号可访问的组织，并管理 connector 命令使用的默认组织身份。",
+    "commands.org.summary": "管理组织身份",
+    "commands.org.list.description":
+        "列出当前活动账号可认证的组织，并标出当前默认组织。",
+    "commands.org.list.summary": "列出可访问的组织",
+    "commands.org.current.description":
+        "显示未传 --organization / --personal 时 connector 命令使用的默认组织身份。",
+    "commands.org.current.summary": "显示默认组织身份",
+    "commands.org.use.description":
+        "在确认账号可访问后，设置 connector 命令使用的默认组织身份。",
+    "commands.org.use.summary": "设置默认组织身份",
+    "commands.org.clear.description":
+        "清除默认组织身份，让 connector 命令以个人身份运行。",
+    "commands.org.clear.summary": "清除默认组织身份",
     "commands.search.description":
         "使用一个自由文本查询搜索 connector action。",
     "commands.search.summary": "搜索 connector action",
@@ -1549,6 +1601,14 @@ export const zhMessages = {
         "获取 connector app 列表失败：{message}",
     "errors.connectorApps.requestFailed":
         "获取 connector app 列表返回了 HTTP {status}。",
+    "errors.org.invalidResponse":
+        "组织列表返回了不受支持的响应内容。",
+    "errors.org.nameEmpty": "组织名称不能为空。",
+    "errors.org.notAccessible":
+        "当前活动账号无法访问组织 “{organization}”。运行 `oo org list` 查看可用的组织。",
+    "errors.org.requestError": "获取组织列表失败：{message}",
+    "errors.org.requestFailed":
+        "获取组织列表返回了 HTTP {status}。",
     "errors.connectorMetadata.invalidResponse":
         "connector action 元数据返回了不受支持的响应内容。",
     "errors.connectorMetadata.requestError":
@@ -2375,6 +2435,7 @@ export const zhMessages = {
     "arguments.skills.uninstall.name": "要移除的 skill 或包名（可指定多个）；传入包名会移除该包已安装的全部 skill",
     "arguments.serviceName": "服务名",
     "arguments.connectorAppsServiceName": "可选的服务名；省略时列出全部已连接的 app",
+    "arguments.orgUseName": "用作默认身份的组织名称",
     "arguments.connectorUrl": "自部署 Connector 服务地址，例如 http://localhost:3000",
     "arguments.actionId": "<service>.<action> 形式的 action id（可多个），例如 cal.create_schedule",
     "arguments.shell": "目标 shell",
@@ -2397,6 +2458,19 @@ export const zhMessages = {
         "该服务下未找到 connector app。",
     "connector.apps.text.service": "服务",
     "connector.apps.text.status": "状态",
+    "org.list.text.organization": "组织",
+    "org.list.text.role": "角色",
+    "org.list.text.default": "默认",
+    "org.list.text.noOrganizations":
+        "当前活动账号没有任何组织；connector 命令以个人身份运行。",
+    "org.current.text.configured": "默认组织身份：{organization}",
+    "org.current.text.personal":
+        "未设置默认组织；connector 命令以个人身份运行。",
+    "org.use.success": "已将默认组织身份设置为 {organization}。",
+    "org.clear.success":
+        "已清除默认组织身份；connector 命令现在以个人身份运行。",
+    "org.clear.alreadyPersonal":
+        "未设置默认组织；connector 命令本就以个人身份运行。",
     "connector.run.text.dryRunPassed": "校验通过。",
     "connector.login.manageTokens": "可在 {accessUrl} 管理 Runtime Token。",
     "connector.login.noToken":


### PR DESCRIPTION
Connector commands (`oo connector run`, `oo connector proxy`, `oo connector apps`) accept `--organization <name>` and read an `identity.organization` default, but nothing let you discover which organizations the active account can actually use — agents saw the flag yet had to already know the valid names, and `oo auth status` never listed organizations (#296).

This adds an `oo org` command group backed by the existing org-control service. `oo org list` calls `GET /v1/me/organizations`, which already returns the account's full membership set — organizations you created come back with `role: "creator"` — so a single request answers "what can I pass to `--organization`", with no backend change required. The listing marks the entry matching the configured default, so you can see which identity connector commands use by default.

- `oo org list [--json]` — list accessible organizations (`name`, `id`, `role`, `current`); text output is a color-coded aligned table.
- `oo org current [--json]` — show the default organization identity, offline.
- `oo org use <name>` — validate the name against the account's memberships, then persist `identity.organization`.
- `oo org clear` — return connector commands to the personal identity, offline.

The group resolves an OOMOL account only (honoring the `OO_API_KEY` override) and is rejected when just a self-hosted connector is configured, consistent with other non-connector commands. Telemetry records bucketed counts and a configured-default flag, never organization names. Covered by unit tests for the request and formatting layers plus CLI tests for each subcommand, including the no-account and inaccessible-name paths.

Closes #296