### PR TITLE
fix(auth): honor OO_API_KEY precedence in auth commands

### DIFF
--- a/contrib/skills/shared/oo/references/auth-and-billing.md
+++ b/contrib/skills/shared/oo/references/auth-and-billing.md
@@ -48,11 +48,10 @@ instead of an OOMOL account. Detect this mode when either signal appears:
 - `oo auth status --json` shows a top-level `connector` object while `status`
   is not `logged-in`.
 
-Exception: when the `OO_API_KEY` environment variable is set, OOMOL-backed
-capabilities work even if `oo auth status` reports `logged-out`, so do not
-treat that combination as self-hosted-only mode. In practice this rarely
-matters because you should only check auth status after a command has already
-failed with an auth error.
+When the `OO_API_KEY` environment variable supplies the credential,
+`oo auth status` reports `logged-in` with a top-level `envOverride` object and
+no active entry in `accounts[]`. That is an authenticated OOMOL account, not
+self-hosted-only mode.
 
 In this mode, connector commands keep working against the self-hosted server:
 `oo search`, `oo connector search`, `oo connector schema`, `oo connector run`,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,9 +28,14 @@ use. Truthy values are `1`, `true`, `yes`, or `on` (case-insensitive).
 - `OO_API_KEY`: Run execution commands with this API key without an interactive
   login. When set, the CLI builds an in-memory account and does not read,
   require, or write `auth.toml`, and it takes precedence over any saved account.
+  Because no saved account can be in effect while it is set, `oo auth logout`
+  and `oo auth switch` become no-ops that leave `auth.toml` untouched, and
+  `oo auth login` still saves the account but reports that this variable
+  outranks it. `oo auth status` reports the identity this variable provides.
 - `OO_ENDPOINT`: Base endpoint domain (for example `oomol.com` or `oomol.dev`)
   used to derive every service URL for execution commands. It pairs with
-  `OO_API_KEY` and also overrides the endpoint of a saved account. Takes
+  `OO_API_KEY` and also overrides the endpoint of a saved account, including
+  the endpoint `oo auth status` reports and validates against. Takes
   precedence over the legacy `OOMOL_ENDPOINT`.
 - `OO_CONNECTOR_URL`: Self-hosted connector server URL. It overrides the
   configuration saved by `oo connector login`. Only connector commands
@@ -105,16 +110,30 @@ with an existing API key, then save the authenticated account.
 - Notes: when a self-hosted connector is configured (`oo connector login`), it
   keeps handling connector commands after login; the success output prints a
   hint that `oo connector logout` switches them back to OOMOL.
+- When `OO_API_KEY` is set, login still validates and saves the account, but
+  that variable keeps outranking it. The success output prints a hint that the
+  saved account takes effect only once `OO_API_KEY` is unset.
 
 ### `oo auth logout`
 
 Remove the current account from persisted auth data.
+
+- When `OO_API_KEY` is set it supplies the credential instead of a saved
+  account, so there is nothing for this command to log out of. It exits `0`
+  without modifying `auth.toml` and reports that nothing was logged out.
 
 ### `oo auth status`
 
 Show every saved auth account and validate the API key of the active one.
 
 - Aliases: `oo auth info`.
+- Reports the identity that commands actually run as, which is not always the
+  active saved account: `OO_API_KEY` outranks `auth.toml` entirely, and
+  `OO_ENDPOINT` redirects the endpoint of a saved account. The reported
+  endpoint is the one the API key is validated against.
+- When `OO_API_KEY` is set, the status is always `logged-in` (a stale active id
+  in `auth.toml` is irrelevant), no saved account is marked `[active]`, and
+  text output notes that saved accounts are not in use.
 - Text output lists all saved accounts under an `Accounts:` block. The active
   account is annotated with `[active]`; the active account additionally shows
   `API key status` resolved from a single profile request to its endpoint.
@@ -164,6 +183,20 @@ Show every saved auth account and validate the API key of the active one.
   }
   ```
 
+- When `OO_API_KEY` supplies the credential, the payload is `logged-in` and
+  carries an optional top-level `envOverride` field:
+
+  ```json
+  {
+    "status": "logged-in",
+    "activeAccountId": "oo-env-override",
+    "envOverride": { "endpoint": "oomol.dev", "apiKeyStatus": "valid" },
+    "accounts": [
+      { "id": "user-1", "name": "Alice", "endpoint": "oomol.com", "active": false }
+    ]
+  }
+  ```
+
 - Notes (JSON):
   - The `apiKey` field is **never** emitted, and the JSON payload never
     contains the actual API key string under any field name.
@@ -171,9 +204,20 @@ Show every saved auth account and validate the API key of the active one.
     original order; each entry is `{ id, name, endpoint, active, apiKeyStatus? }`.
   - `activeAccountId` is the active account id, or `null` when no active
     account can be resolved (including the `active-account-missing` state).
-  - `accounts[].active` is `true` only for the active account.
+    Under `OO_API_KEY` it is the stable synthetic id `oo-env-override`, which
+    is deliberately absent from `accounts[]` because it is not a saved account.
+  - `accounts[].active` is `true` only for the active account, and is `false`
+    for every entry while `OO_API_KEY` is set.
   - `accounts[].apiKeyStatus` is present only on the active entry and uses
     the enum `valid` / `invalid` / `request_failed` / `request_failed_sandbox`.
+  - `envOverride` is present only when `OO_API_KEY` is set, in which case the
+    status is always `logged-in`. It reports the `endpoint` in effect (from
+    `OO_ENDPOINT`, otherwise the public default) and the `apiKeyStatus` of the
+    environment credential, using the same enum as `accounts[].apiKeyStatus`.
+    The API key value itself is never emitted.
+  - `accounts[].endpoint` is the endpoint saved in `auth.toml`. A bare
+    `OO_ENDPOINT` (without `OO_API_KEY`) redirects the endpoint used for text
+    output and API key validation, but does not rewrite this field.
   - `missingAccountId` appears only when the auth file records an active id
     that is no longer present in `accounts[]`.
   - `connector` is present only when a self-hosted connector is configured
@@ -203,6 +247,11 @@ Switch the active auth account.
   them.
 - When the requested account is already the active one, the switch is
   idempotent (exit `0`, no rewrite mode change).
+- When `OO_API_KEY` is set, no saved account can be in effect, so switching
+  would change nothing that a later command honors. The command exits `0`
+  without reading or rewriting `auth.toml` and reports that nothing was
+  switched. This applies with and without `--user`, and takes precedence over
+  the no-saved-accounts error.
 - API key values are never written to stdout or stderr in any output path.
 
 ### `oo login`

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -24,9 +24,13 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
 - `OO_LOG_DIR`：覆盖 debug 日志目录。优先级高于所有平台默认值。
 - `OO_API_KEY`：使用该 API key 执行命令，无需交互式登录。设置后 CLI 会构造一个
   内存账号，不读取、不要求、也不写入 `auth.toml`，且优先级高于任何已保存的账号。
+  由于设置它之后任何已保存账号都不会生效，`oo auth logout` 与 `oo auth switch`
+  会成为空操作并保持 `auth.toml` 不变；`oo auth login` 仍会保存账号，但会说明该
+  变量的优先级高于它。`oo auth status` 会展示该变量提供的身份。
 - `OO_ENDPOINT`：基础域名（例如 `oomol.com` 或 `oomol.dev`），用于派生执行命令的
-  所有服务 URL。它与 `OO_API_KEY` 搭配使用，也会覆盖已保存账号的 endpoint。优先级
-  高于历史遗留的 `OOMOL_ENDPOINT`。
+  所有服务 URL。它与 `OO_API_KEY` 搭配使用，也会覆盖已保存账号的 endpoint，
+  包括 `oo auth status` 展示与校验所用的 endpoint。优先级高于历史遗留的
+  `OOMOL_ENDPOINT`。
 - `OO_CONNECTOR_URL`：自部署 Connector 服务地址。它会覆盖 `oo connector login`
   保存的配置。只有 connector 相关命令（`oo connector
   search/schema/run/proxy/apps` 及顶层 `oo search`）会将请求路由到该地址；
@@ -88,16 +92,27 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
 - 说明：如果已配置自部署 Connector（`oo connector login`），登录后 connector
   相关命令仍会继续使用它；成功输出会打印一行提示，说明可运行
   `oo connector logout` 切回 OOMOL。
+- 设置了 `OO_API_KEY` 时，登录仍会校验并保存账号，但该变量的优先级依然高于它。
+  成功输出会打印一行提示，说明取消 `OO_API_KEY` 后刚保存的账号才会生效。
 
 ### `oo auth logout`
 
 从持久化认证数据中移除当前账号。
+
+- 设置了 `OO_API_KEY` 时，提供凭证的是该变量而非已保存账号，因此没有任何可登出的
+  对象。命令以 `0` 退出，不修改 `auth.toml`，并说明没有登出任何账号。
 
 ### `oo auth status`
 
 显示已保存的全部认证账号，并校验当前激活账号的 API key 状态。
 
 - 别名：`oo auth info`。
+- 展示的是命令实际生效的身份，它未必是当前激活的已保存账号：`OO_API_KEY`
+  的优先级完全高于 `auth.toml`，`OO_ENDPOINT` 则会重定向已保存账号的 endpoint。
+  展示的 endpoint 就是校验 API key 所使用的 endpoint。
+- 设置了 `OO_API_KEY` 时，状态恒为 `logged-in`（`auth.toml` 中过期的 active id
+  不再有影响），不会有任何已保存账号被标注 `[active]`，文本输出会说明已保存账号
+  不会被使用。
 - 文本输出会在 `Accounts:` 区块下列出所有已保存账号。当前激活账号会标注
   `[active]`，并额外显示其 `API key status`——通过一次 profile 请求向该账号
   对应的 endpoint 校验得到。其它账号不参与校验，所以无论有多少账号，
@@ -145,15 +160,38 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   }
   ```
 
+- 当由 `OO_API_KEY` 提供凭证时，payload 恒为 `logged-in`，并携带一个可选的顶层
+  `envOverride` 字段：
+
+  ```json
+  {
+    "status": "logged-in",
+    "activeAccountId": "oo-env-override",
+    "envOverride": { "endpoint": "oomol.dev", "apiKeyStatus": "valid" },
+    "accounts": [
+      { "id": "user-1", "name": "Alice", "endpoint": "oomol.com", "active": false }
+    ]
+  }
+  ```
+
 - 说明（JSON）：
   - **绝不**输出 `apiKey` 字段；JSON payload 在任何字段下都不包含实际 API key 字符串。
   - `accounts[]` 按原顺序列出本地 auth file 中保存的全部账号，每条 entry 为
     `{ id, name, endpoint, active, apiKeyStatus? }`。
   - `activeAccountId` 是当前激活账号 ID；无可用激活账号时（包括
-    `active-account-missing` 状态）为 `null`。
-  - `accounts[].active` 仅在激活账号上为 `true`。
+    `active-account-missing` 状态）为 `null`。设置了 `OO_API_KEY` 时为稳定的
+    合成 ID `oo-env-override`，它并非已保存账号，因此不会出现在 `accounts[]` 中。
+  - `accounts[].active` 仅在激活账号上为 `true`；设置了 `OO_API_KEY` 时，
+    所有 entry 均为 `false`。
   - `accounts[].apiKeyStatus` 只在激活账号 entry 出现，枚举为
     `valid` / `invalid` / `request_failed` / `request_failed_sandbox`。
+  - `envOverride` 仅在设置了 `OO_API_KEY` 时出现，此时状态恒为 `logged-in`。
+    它报告生效的 `endpoint`（来自 `OO_ENDPOINT`，否则为公有默认值）以及该环境
+    凭证的 `apiKeyStatus`，枚举与 `accounts[].apiKeyStatus` 相同。API key
+    实际内容永远不会被输出。
+  - `accounts[].endpoint` 是 `auth.toml` 中保存的 endpoint。单独设置
+    `OO_ENDPOINT`（不设 `OO_API_KEY`）会重定向文本输出与 API key 校验所用的
+    endpoint，但不会改写该字段。
   - `missingAccountId` 仅在 auth file 记录的 active id 已不存在于
     `accounts[]` 时出现。
   - `connector` 仅在配置了自部署 Connector 时出现，报告已配置的自部署
@@ -177,6 +215,9 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   并提示需要传 account id 进行消歧。account id 是稳定字符串，可通过
   `oo auth status --json` 获取。
 - 当指定的账号已是激活账号时，切换为幂等操作（exit `0`，不改变激活状态）。
+- 设置了 `OO_API_KEY` 时，任何已保存账号都不可能生效，因此切换不会改变后续命令
+  的任何行为。命令以 `0` 退出，不读取也不重写 `auth.toml`，并说明没有切换任何
+  账号。该行为在传与不传 `--user` 时一致，且优先于「没有已保存账号」的报错。
 - 任何输出路径都不会将 API key 写入 stdout/stderr。
 
 ### `oo login`

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -1573,6 +1573,348 @@ describe("authCommand CLI self-hosted connector login hint", () => {
     });
 });
 
+describe("auth CLI OO_API_KEY override", () => {
+    test("status text reports the env identity and marks no saved account active", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_API_KEY = "env-key-1";
+        sandbox.env.OO_ENDPOINT = "oomol.dev";
+
+        try {
+            await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                    { id: "user-2", name: "Bob", apiKey: "secret-2", endpoint: defaultAuthEndpoint },
+                ],
+            });
+
+            const result = await sandbox.run(
+                ["auth", "status"],
+                { fetcher: async () => new Response(null, { status: 200 }) },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                "Logged in to oomol.dev with the API key from OO_API_KEY",
+            );
+            expect(result.stdout).toContain("API key status: Valid");
+            expect(result.stdout).toContain(
+                "Saved accounts are not in use while OO_API_KEY is set.",
+            );
+            // The saved active id must not win over the env credential.
+            expect(result.stdout).not.toContain("[active]");
+            expect(result.stdout).not.toContain("Not logged in");
+            expect(result.stdout).toContain("Alice");
+            expect(result.stdout).toContain("Bob");
+            expectNoAuthSecrets(result.stdout);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("status text stays compact under OO_API_KEY without saved accounts", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_API_KEY = "env-key-1";
+
+        try {
+            const result = await sandbox.run(
+                ["auth", "status"],
+                { fetcher: async () => new Response(null, { status: 200 }) },
+            );
+
+            expect(result.exitCode).toBe(0);
+            // The public default applies when OO_ENDPOINT is absent.
+            expect(result.stdout).toContain(
+                "Logged in to oomol.com with the API key from OO_API_KEY",
+            );
+            expect(result.stdout).not.toContain("Accounts:");
+            expect(result.stdout).not.toContain(
+                "Saved accounts are not in use",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("status validates the env credential against the OO_ENDPOINT host", async () => {
+        const sandbox = await createCliSandbox();
+        const requests: Request[] = [];
+
+        sandbox.env.OO_API_KEY = "env-key-1";
+        sandbox.env.OO_ENDPOINT = "oomol.dev";
+
+        try {
+            await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                ],
+            });
+
+            const result = await sandbox.run(
+                ["auth", "status"],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+                        return new Response(null, { status: 200 });
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(1);
+            // The saved account's key and host must not be used for validation.
+            expect(requests[0]!.url).toBe("https://api.oomol.dev/v1/users/profile");
+            expect(requests[0]!.headers.get("Authorization")).toBe("env-key-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json exposes the envOverride block and keeps saved accounts inactive", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_API_KEY = "env-key-1";
+        sandbox.env.OO_ENDPOINT = "oomol.dev";
+
+        try {
+            await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                ],
+            });
+
+            const result = await sandbox.run(
+                ["auth", "status", "--json"],
+                { fetcher: async () => new Response(null, { status: 200 }) },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(JSON.parse(result.stdout)).toEqual({
+                status: "logged-in",
+                activeAccountId: "oo-env-override",
+                accounts: [
+                    {
+                        id: "user-1",
+                        name: "Alice",
+                        endpoint: defaultAuthEndpoint,
+                        active: false,
+                    },
+                ],
+                envOverride: {
+                    endpoint: "oomol.dev",
+                    apiKeyStatus: "valid",
+                },
+            });
+            expectNoAuthSecrets(result.stdout);
+            expect(result.stdout).not.toContain("env-key-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--json reports logged-in under OO_API_KEY even when the saved active id is stale", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_API_KEY = "env-key-1";
+
+        try {
+            await writeAuthFile(sandbox, {
+                activeId: "user-missing",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                ],
+            });
+
+            const result = await sandbox.run(
+                ["auth", "status", "--json"],
+                { fetcher: async () => new Response(null, { status: 200 }) },
+            );
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+
+            expect(result.exitCode).toBe(0);
+            // A stale auth.toml id is irrelevant while the env credential wins.
+            expect(payload.status).toBe("logged-in");
+            expect(payload).not.toHaveProperty("missingAccountId");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("logout does nothing and leaves auth.toml untouched under OO_API_KEY", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_API_KEY = "env-key-1";
+
+        try {
+            const authFilePath = await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                ],
+            });
+            const before = await readFile(authFilePath, "utf8");
+
+            const result = await sandbox.run(["auth", "logout"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                "Nothing was logged out: the active credential comes from OO_API_KEY, not from a saved account.",
+            );
+            expect(result.stdout).toContain(
+                "Unset OO_API_KEY to manage saved accounts.",
+            );
+            expect(result.stdout).not.toContain("Logged out the current account.");
+            // The saved account must survive a logout that could not log out.
+            expect(await readFile(authFilePath, "utf8")).toBe(before);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("switch does nothing and leaves auth.toml untouched under OO_API_KEY", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_API_KEY = "env-key-1";
+
+        try {
+            const authFilePath = await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                    { id: "user-2", name: "Bob", apiKey: "secret-2", endpoint: defaultAuthEndpoint },
+                ],
+            });
+            const before = await readFile(authFilePath, "utf8");
+
+            const result = await sandbox.run(["auth", "switch", "--user", "Bob"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                "Nothing was switched: the active credential comes from OO_API_KEY, not from a saved account.",
+            );
+            expect(result.stdout).toContain(
+                "Unset OO_API_KEY to manage saved accounts.",
+            );
+            expect(result.stdout).not.toContain("Switched active account");
+            expect(await readFile(authFilePath, "utf8")).toBe(before);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("switch reports the no-op instead of failing when no account is saved", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_API_KEY = "env-key-1";
+
+        try {
+            const result = await sandbox.run(["auth", "switch"]);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("Nothing was switched");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("login saves the account and warns that OO_API_KEY outranks it", async () => {
+        const sandbox = await createCliSandbox();
+        const apiKey = "secret-api-1";
+
+        sandbox.env.OO_API_KEY = "env-key-1";
+
+        try {
+            const authFilePath = join(
+                sandbox.env.XDG_CONFIG_HOME!,
+                APP_NAME,
+                "auth.toml",
+            );
+            const result = await sandbox.run(
+                ["auth", "login", "--api-key", apiKey],
+                {
+                    fetcher: async () =>
+                        new Response(JSON.stringify({
+                            displayname: "Kevin Cui",
+                            email: "bh@bugs.cc",
+                            nickname: "Kevin Cui",
+                            uid: "019343c2-c43d-710f-81b2-dfa68d3079de",
+                            username: "BlackHole1",
+                        })),
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            // Login still persists the account; only its effect is deferred.
+            expect(await readFile(authFilePath, "utf8")).toContain(
+                "name = \"BlackHole1\"",
+            );
+            expect(result.stdout).toContain(
+                "Commands keep using the API key from OO_API_KEY, not this account. Unset OO_API_KEY to use the account you just saved.",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});
+
+describe("auth CLI OO_ENDPOINT override", () => {
+    test("status reports and validates the redirected endpoint of a saved account", async () => {
+        const sandbox = await createCliSandbox();
+        const requests: Request[] = [];
+
+        sandbox.env.OO_ENDPOINT = "oomol.dev";
+
+        try {
+            await writeAuthFile(sandbox, {
+                activeId: "user-1",
+                accounts: [
+                    { id: "user-1", name: "Alice", apiKey: "secret-1", endpoint: defaultAuthEndpoint },
+                ],
+            });
+
+            const result = await sandbox.run(
+                ["auth", "status"],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+                        return new Response(null, { status: 200 });
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            // A bare OO_ENDPOINT redirects every other command, so status must
+            // not keep reporting (and validating against) the saved endpoint.
+            expect(result.stdout).toContain("Logged in to oomol.dev account Alice");
+            expect(requests).toHaveLength(1);
+            expect(requests[0]!.url).toBe("https://api.oomol.dev/v1/users/profile");
+            expect(requests[0]!.headers.get("Authorization")).toBe("secret-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});
+
+function expectNoAuthSecrets(output: string): void {
+    for (const secret of ["secret-1", "secret-2", "apiKey\"", "api_key"]) {
+        expect(output).not.toContain(secret);
+    }
+}
+
 async function writeCorruptConnectorFile(
     sandbox: { env: Record<string, string | undefined> },
 ): Promise<string> {

--- a/src/application/commands/auth/login.ts
+++ b/src/application/commands/auth/login.ts
@@ -14,6 +14,7 @@ import { CliUserError } from "../../contracts/cli.ts";
 import { upsertAuthAccount } from "../../schemas/auth.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
+import { buildEnvApiKeyAccount } from "../shared/auth-env-override.ts";
 import { writeLine } from "../shared/output.ts";
 import { resolveSelfHostedConnectorTolerantly } from "../shared/self-hosted-connector.ts";
 import {
@@ -78,8 +79,11 @@ export const authLoginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
         const nextAuthFile = await context.authStore.update(authFile =>
             upsertAuthAccount(authFile, account),
         );
+        const hasEnvOverride = buildEnvApiKeyAccount(context.env) !== undefined;
+
         context.telemetry?.recordProperties({
             account_count_bucket: bucketTelemetryCount(nextAuthFile.auth.length),
+            credential_source: hasEnvOverride ? "env" : "file",
         });
         context.logger.info(
             {
@@ -104,6 +108,16 @@ export const authLoginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
                 },
             ],
         });
+
+        // The account is saved, but OO_API_KEY still outranks it everywhere, so
+        // the login block above would otherwise imply an identity that no
+        // command actually uses.
+        if (hasEnvOverride) {
+            writeLine(
+                context.stdout,
+                context.translator.t("auth.login.envOverrideHint"),
+            );
+        }
 
         // Connector routing does not change with this login: a configured
         // self-hosted connector keeps handling connector commands, which is

--- a/src/application/commands/auth/logout.ts
+++ b/src/application/commands/auth/logout.ts
@@ -2,8 +2,9 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { removeCurrentAuthAccount } from "../../schemas/auth.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
+import { buildEnvApiKeyAccount } from "../shared/auth-env-override.ts";
 import { writeLine } from "../shared/output.ts";
-import { emptyAuthCommandInputSchema } from "./shared.ts";
+import { emptyAuthCommandInputSchema, writeAuthBlock } from "./shared.ts";
 
 export const authLogoutCommand: CliCommandDefinition = {
     name: "logout",
@@ -11,6 +12,28 @@ export const authLogoutCommand: CliCommandDefinition = {
     descriptionKey: "commands.auth.logout.description",
     inputSchema: emptyAuthCommandInputSchema,
     handler: async (_, context) => {
+        // OO_API_KEY, not auth.toml, is what authenticates every command here,
+        // and this command cannot unset an environment variable. Removing the
+        // saved account would leave the caller just as authenticated as before
+        // while destroying state they never asked to lose, so do nothing and
+        // say so.
+        if (buildEnvApiKeyAccount(context.env) !== undefined) {
+            context.telemetry?.recordProperties({ credential_source: "env" });
+            context.logger.info(
+                {},
+                "Auth logout did nothing: OO_API_KEY provides the active credential.",
+            );
+            writeAuthBlock(context, {
+                tone: "warning",
+                summary: context.translator.t("auth.logout.envOverrideNoop"),
+            });
+            writeLine(
+                context.stdout,
+                context.translator.t("auth.envOverride.unsetHint"),
+            );
+            return;
+        }
+
         let previousCurrentAuthId = "";
         let remainingSavedAccounts = 0;
 
@@ -31,6 +54,7 @@ export const authLogoutCommand: CliCommandDefinition = {
         );
         context.telemetry?.recordProperties({
             account_count_bucket: bucketTelemetryCount(remainingSavedAccounts),
+            credential_source: "file",
         });
 
         writeLine(

--- a/src/application/commands/auth/status.ts
+++ b/src/application/commands/auth/status.ts
@@ -7,7 +7,12 @@ import { z } from "zod";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import {
+    applyEndpointOverride,
+    buildEnvApiKeyAccount,
+} from "../shared/auth-env-override.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
+import { writeLine } from "../shared/output.ts";
 import { isNetworkRestrictedSandboxError } from "../shared/request.ts";
 import { resolveSelfHostedConnectorTolerantly } from "../shared/self-hosted-connector.ts";
 import {
@@ -28,9 +33,21 @@ const apiKeyStatusConfig = {
 
 type ApiKeyStatus = keyof typeof apiKeyStatusConfig;
 
+/**
+ * Where the credential that commands actually use comes from. `env` means
+ * OO_API_KEY short-circuited auth.toml, so no saved account is in effect.
+ */
+type CredentialSource = "env" | "file";
+
 interface ActiveAccountStatus {
     account: AuthAccount;
     apiKeyStatus: ApiKeyStatus;
+    source: CredentialSource;
+}
+
+interface ResolvedStatusIdentity {
+    account: AuthAccount;
+    source: CredentialSource;
 }
 
 const authStatusFormatValues = ["json"] as const;
@@ -55,11 +72,20 @@ interface AuthStatusJsonConnector {
     source: "env" | "file";
 }
 
+// Present only when OO_API_KEY supplies the credential. The key itself is
+// never emitted; the endpoint and the validation result are enough to explain
+// which identity commands actually run as.
+interface AuthStatusJsonEnvOverride {
+    endpoint: string;
+    apiKeyStatus: ApiKeyStatus;
+}
+
 type AuthStatusJsonPayload
     = | {
         status: "logged-in";
         activeAccountId: string;
         accounts: AuthStatusJsonAccount[];
+        envOverride?: AuthStatusJsonEnvOverride;
         connector?: AuthStatusJsonConnector;
     }
     | {
@@ -92,17 +118,24 @@ export const authStatusCommand: CliCommandDefinition<AuthStatusInput> = {
         // Tolerant lookup: a broken connector.toml must not take down the
         // whole status report; the block is simply omitted.
         const selfHostedConnector = await resolveSelfHostedConnectorTolerantly(context);
+        // Status must describe the identity commands actually run as, which is
+        // what requireCurrentAccount() resolves — not the raw auth.toml
+        // contents. Reporting the file while OO_API_KEY/OO_ENDPOINT redirect
+        // every other command is how status ends up naming the wrong account,
+        // the wrong endpoint, and validating the wrong key.
+        const identity = resolveStatusIdentity(currentAccount, context.env);
 
         context.telemetry?.recordProperties({
             account_count_bucket: bucketTelemetryCount(authFile.auth.length),
+            credential_source: identity?.source ?? "none",
         });
 
         const activeStatus: ActiveAccountStatus | undefined
-            = currentAccount === undefined
+            = identity === undefined
                 ? undefined
                 : {
-                        account: currentAccount,
-                        apiKeyStatus: await readApiKeyStatus(currentAccount, context),
+                        ...identity,
+                        apiKeyStatus: await readApiKeyStatus(identity.account, context),
                     };
 
         if (input.format === "json") {
@@ -119,6 +152,30 @@ export const authStatusCommand: CliCommandDefinition<AuthStatusInput> = {
     },
 };
 
+/**
+ * Mirrors requireCurrentAccount()'s precedence: OO_API_KEY wins outright, then
+ * the active saved account with a bare OO_ENDPOINT applied on top.
+ */
+function resolveStatusIdentity(
+    currentAccount: AuthAccount | undefined,
+    env: CliExecutionContext["env"],
+): ResolvedStatusIdentity | undefined {
+    const envAccount = buildEnvApiKeyAccount(env);
+
+    if (envAccount !== undefined) {
+        return { account: envAccount, source: "env" };
+    }
+
+    if (currentAccount === undefined) {
+        return undefined;
+    }
+
+    return {
+        account: applyEndpointOverride(currentAccount, env),
+        source: "file",
+    };
+}
+
 function buildAuthStatusJsonPayload(
     authFile: AuthFile,
     activeStatus: ActiveAccountStatus | undefined,
@@ -134,7 +191,11 @@ function buildAuthStatusJsonPayload(
                         source: selfHostedConnector.source,
                     },
                 };
-    const activeId = activeStatus?.account.id;
+    // Only a file-sourced identity can mark a saved account active; the
+    // OO_API_KEY account is synthetic and never appears in accounts[].
+    const activeId = activeStatus?.source === "file"
+        ? activeStatus.account.id
+        : undefined;
     const accounts: AuthStatusJsonAccount[] = authFile.auth.map((account) => {
         const isActive = account.id === activeId;
         return {
@@ -153,6 +214,14 @@ function buildAuthStatusJsonPayload(
             status: "logged-in",
             activeAccountId: activeStatus.account.id,
             accounts,
+            ...(activeStatus.source === "env"
+                ? {
+                        envOverride: {
+                            endpoint: activeStatus.account.endpoint,
+                            apiKeyStatus: activeStatus.apiKeyStatus,
+                        },
+                    }
+                : {}),
             ...connector,
         };
     }
@@ -232,8 +301,34 @@ function writeAuthStatusText(
         return;
     }
 
-    const { account, apiKeyStatus } = activeStatus;
+    const { account, apiKeyStatus, source } = activeStatus;
     const statusConfig = apiKeyStatusConfig[apiKeyStatus];
+    const apiKeyStatusDetail = {
+        label: context.translator.t("auth.status.apiKeyStatus"),
+        value: context.translator.t(statusConfig.translationKey),
+    };
+
+    if (source === "env") {
+        writeAuthBlock(context, {
+            tone: statusConfig.tone,
+            summary: context.translator.t("auth.status.envOverride", {
+                endpoint: formatAuthStrong(context, account.endpoint),
+            }),
+            details: [apiKeyStatusDetail],
+        });
+
+        // Without this the accounts list below reads as a bug: every saved
+        // account is unmarked because none of them is in effect.
+        if (authFile.auth.length > 0) {
+            writeLine(
+                context.stdout,
+                context.translator.t("auth.status.savedAccountsIgnored"),
+            );
+        }
+
+        writeAuthAccountsList(context, authFile, undefined);
+        return;
+    }
 
     writeAuthBlock(context, {
         tone: statusConfig.tone,
@@ -246,10 +341,7 @@ function writeAuthStatusText(
                 label: context.translator.t("auth.status.activeAccount"),
                 value: "true",
             },
-            {
-                label: context.translator.t("auth.status.apiKeyStatus"),
-                value: context.translator.t(statusConfig.translationKey),
-            },
+            apiKeyStatusDetail,
         ],
     });
     writeAuthAccountsList(context, authFile, account.id);

--- a/src/application/commands/auth/switch.ts
+++ b/src/application/commands/auth/switch.ts
@@ -5,6 +5,8 @@ import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { getNextAuthAccount, setCurrentAuthId } from "../../schemas/auth.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
+import { buildEnvApiKeyAccount } from "../shared/auth-env-override.ts";
+import { writeLine } from "../shared/output.ts";
 import {
     formatAuthStrong,
     writeAuthBlock,
@@ -33,10 +35,34 @@ export const authSwitchCommand: CliCommandDefinition<AuthSwitchInput> = {
         user: z.string().trim().min(1).optional(),
     }),
     handler: async (input, context) => {
+        // Which saved account is active has no bearing on the credential while
+        // OO_API_KEY is set, so rewriting auth.toml here would report a switch
+        // that no later command honors.
+        if (buildEnvApiKeyAccount(context.env) !== undefined) {
+            context.telemetry?.recordProperties({
+                credential_source: "env",
+                has_user_filter: input.user !== undefined,
+            });
+            context.logger.info(
+                {},
+                "Auth switch did nothing: OO_API_KEY provides the active credential.",
+            );
+            writeAuthBlock(context, {
+                tone: "warning",
+                summary: context.translator.t("auth.switch.envOverrideNoop"),
+            });
+            writeLine(
+                context.stdout,
+                context.translator.t("auth.envOverride.unsetHint"),
+            );
+            return;
+        }
+
         const authFile = await context.authStore.read();
 
         context.telemetry?.recordProperties({
             account_count_bucket: bucketTelemetryCount(authFile.auth.length),
+            credential_source: "file",
             has_user_filter: input.user !== undefined,
         });
 

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -72,23 +72,23 @@ const commandTelemetryDecisions = {
     },
     "auth.login": {
         kind: "properties",
-        properties: ["auth_method", "account_count_bucket"],
-        reason: "Records login method and bounded saved-account count.",
+        properties: ["auth_method", "account_count_bucket", "credential_source"],
+        reason: "Records login method, bounded saved-account count, and whether OO_API_KEY outranks the saved account.",
     },
     "auth.logout": {
         kind: "properties",
-        properties: ["account_count_bucket"],
-        reason: "Records bounded saved-account count after logout.",
+        properties: ["account_count_bucket", "credential_source"],
+        reason: "Records bounded saved-account count after logout and whether OO_API_KEY made the command a no-op.",
     },
     "auth.status": {
         kind: "properties",
-        properties: ["account_count_bucket"],
-        reason: "Records bounded saved-account count without account identity.",
+        properties: ["account_count_bucket", "credential_source"],
+        reason: "Records bounded saved-account count and which credential source is in effect, without account identity.",
     },
     "auth.switch": {
         kind: "properties",
-        properties: ["account_count_bucket", "has_user_filter"],
-        reason: "Records bounded saved-account count and whether --user was used, without account identity.",
+        properties: ["account_count_bucket", "credential_source", "has_user_filter"],
+        reason: "Records bounded saved-account count, which credential source is in effect, and whether --user was used, without account identity.",
     },
     "check-update": {
         kind: "properties",
@@ -260,12 +260,12 @@ const commandTelemetryDecisions = {
     },
     "login": {
         kind: "properties",
-        properties: ["auth_method", "account_count_bucket"],
+        properties: ["auth_method", "account_count_bucket", "credential_source"],
         reason: "Top-level auth alias records the same safe auth dimensions as auth.login.",
     },
     "logout": {
         kind: "properties",
-        properties: ["account_count_bucket"],
+        properties: ["account_count_bucket", "credential_source"],
         reason: "Top-level auth alias records the same safe auth dimensions as auth.logout.",
     },
     "team": {

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -6,11 +6,16 @@ export const enMessages = {
     "auth.account.activeAccountMissing":
         "The active account is missing from the auth store.",
     "auth.account.loggedIn": "Logged in to {endpoint} account {name}",
+    "auth.envOverride.unsetHint": "Unset OO_API_KEY to manage saved accounts.",
     "auth.login.waiting": "Waiting for the device login to complete...",
+    "auth.login.envOverrideHint":
+        "Commands keep using the API key from OO_API_KEY, not this account. Unset OO_API_KEY to use the account you just saved.",
     "auth.login.selfHostedConnectorHint":
         "Connector commands keep using your self-hosted connector at {url}. Run `oo connector logout` to switch them back to OOMOL.",
     "auth.login.selfHostedConnectorHintEnv":
         "Connector commands keep using your self-hosted connector at {url} (set via OO_CONNECTOR_URL). Unset that variable to switch them back to OOMOL.",
+    "auth.logout.envOverrideNoop":
+        "Nothing was logged out: the active credential comes from OO_API_KEY, not from a saved account.",
     "auth.logout.success": "Logged out the current account.",
     "auth.status.accountActive": "active",
     "auth.status.accountId": "Account ID",
@@ -22,12 +27,17 @@ export const enMessages = {
         "Request failed (network-restricted sandbox, try requesting elevated permissions)",
     "auth.status.apiKeyStatus": "API key status",
     "auth.status.apiKeyValid": "Valid",
+    "auth.status.envOverride": "Logged in to {endpoint} with the API key from OO_API_KEY",
     "auth.status.loggedOut": "Not logged in to any OOMOL account.",
+    "auth.status.savedAccountsIgnored":
+        "Saved accounts are not in use while OO_API_KEY is set.",
     "auth.status.selfHostedConnector": "Self-hosted connector: {url}",
     "auth.status.selfHostedConnectorSource": "Source",
     "auth.status.selfHostedConnectorToken": "Token configured",
     "auth.status.selfHostedConnectorToken.no": "no",
     "auth.status.selfHostedConnectorToken.yes": "yes",
+    "auth.switch.envOverrideNoop":
+        "Nothing was switched: the active credential comes from OO_API_KEY, not from a saved account.",
     "auth.switch.success": "Switched active account for {endpoint} to {name}",
     "commands.auth.description": "Manage CLI authentication accounts.",
     "commands.auth.login.description":
@@ -1296,8 +1306,13 @@ export const zhMessages = {
     "auth.login.openManually": "请在你的浏览器中打开此登录 URL：",
     "auth.account.activeAccountMissing": "当前激活账号不存在于认证数据中。",
     "auth.account.loggedIn": "已登录 {endpoint} 账号 {name}",
+    "auth.envOverride.unsetHint": "如需管理保存的账号，请取消 OO_API_KEY 环境变量。",
     "auth.login.waiting": "正在等待 device login 完成...",
+    "auth.logout.envOverrideNoop":
+        "没有登出任何账号：当前生效的凭证来自 OO_API_KEY，而不是保存的账号。",
     "auth.logout.success": "已登出当前账号。",
+    "auth.login.envOverrideHint":
+        "命令仍会使用 OO_API_KEY 中的 API key，而不是这个账号。取消 OO_API_KEY 后即可使用刚保存的账号。",
     "auth.login.selfHostedConnectorHint":
         "Connector 命令仍会使用你的自部署 Connector（{url}）。运行 `oo connector logout` 可切回 OOMOL。",
     "auth.login.selfHostedConnectorHintEnv":
@@ -1317,7 +1332,11 @@ export const zhMessages = {
         "请求失败（网络受限沙箱，请尝试提权）",
     "auth.status.apiKeyStatus": "API key 状态",
     "auth.status.apiKeyValid": "有效",
+    "auth.status.envOverride": "已使用 OO_API_KEY 中的 API key 登录 {endpoint}",
     "auth.status.loggedOut": "当前没有登录任何 OOMOL 账号。",
+    "auth.status.savedAccountsIgnored": "设置了 OO_API_KEY 时，保存的账号不会被使用。",
+    "auth.switch.envOverrideNoop":
+        "没有切换任何账号：当前生效的凭证来自 OO_API_KEY，而不是保存的账号。",
     "auth.switch.success": "已将 {endpoint} 的当前激活账号切换为 {name}",
     "commands.auth.description": "管理 CLI 的认证账号。",
     "commands.auth.login.description": "通过 device login、session token 或 API key 登录 OOMOL 账号。",


### PR DESCRIPTION
`requireCurrentAccount()` lets `OO_API_KEY` short-circuit `auth.toml` entirely, and a bare `OO_ENDPOINT` redirects a saved account's endpoint. The `oo auth` commands never learned this: they read the auth file directly and assumed it described the identity in effect.

So `status` named the wrong account, printed the wrong endpoint, and validated the wrong key, while `logout` and `switch` rewrote `auth.toml` to announce a change no later command honors — destroying saved state the caller never chose to lose.

Resolve the reported identity through the same precedence `requireCurrentAccount()` applies. Under `OO_API_KEY`, `status` reports the environment identity (`envOverride` in JSON, synthetic id `oo-env-override`, no saved account marked `[active]`), `logout` and `switch` become explicit no-ops that leave `auth.toml` untouched, and `login` still saves the account but says the variable outranks it.