### PR TITLE
feat(team): add OO_TEAM_ID/OO_TEAM_NAME env overrides

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -990,3 +990,26 @@ export function createCache<Value>(handlers: {
         clear: () => {},
     };
 }
+
+// Asserts that a command's telemetry properties carry no raw team identity.
+// Command telemetry may record the identity *source* enum but never the team
+// name or id itself, so a leak has to fail a test rather than reach the
+// telemetry backend: this checks both that no property is named like a team
+// field and that no property value contains one of the raw values under test
+// (the team names/ids the command was driven with).
+export function expectTelemetryFreeOfTeamIdentity(
+    properties: Record<string, unknown> | undefined,
+    rawValues: readonly string[],
+): void {
+    expect(properties).toBeDefined();
+
+    for (const forbiddenKey of ["team", "team_id", "team_name", "org", "org_id"]) {
+        expect(properties).not.toHaveProperty(forbiddenKey);
+    }
+
+    for (const [key, value] of Object.entries(properties ?? {})) {
+        for (const rawValue of rawValues) {
+            expect(`${key}=${JSON.stringify(value)}`).not.toContain(rawValue);
+        }
+    }
+}

--- a/contrib/skills/shared/oo/references/connector-execution.md
+++ b/contrib/skills/shared/oo/references/connector-execution.md
@@ -169,9 +169,10 @@ A connector action or proxy request runs under one identity. Pick it from what
 the user said:
 
 - If the user does not mention any team, add nothing extra. The run then uses
-  the `identity.team` config default when one is set, and their personal
-  identity otherwise — omitting the flags does not force a personal run. Check
-  `oo team current` when you need to know which one applies.
+  the team selected by the `OO_TEAM_ID` / `OO_TEAM_NAME` environment variables
+  when set, then the `identity.team` config default when one is set, and their
+  personal identity otherwise — omitting the flags does not force a personal
+  run. Check `oo team current` when you need to know which one applies.
 - If the user asks to run as a specific team (for example "run this as Acme" or
   "use my Acme team"), add `--team "<name>"`, using the team name the user gave:
 
@@ -193,9 +194,9 @@ oo connector proxy "<serviceName>" \
   --json
 ```
 
-- If the user has a configured default team but explicitly asks for this one run
-  to be personal, add `--personal`. This is the only way to force a personal
-  run when a default team is configured.
+- If the user has a default team (from the env variables or the config default)
+  but explicitly asks for this one run to be personal, add `--personal`. This is
+  the only way to force a personal run when a default team is in effect.
 
 Facts:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -49,6 +49,22 @@ use. Truthy values are `1`, `true`, `yes`, or `on` (case-insensitive).
 - Connector commands resolve their target server with this precedence:
   `OO_CONNECTOR_URL` > `OO_API_KEY` > the saved self-hosted connector
   configuration (`oo connector login`) > the active account.
+- `OO_TEAM_ID`: Run connector commands (`oo connector run`, `oo connector
+  proxy`, `oo connector apps`) under the team with this id. It takes precedence
+  over `OO_TEAM_NAME` and the `identity.team` config default; the per-run
+  `--team` and `--personal` flags still outrank it. The value is sent as-is
+  without a membership check. Ignored when the connector target is
+  self-hosted.
+- `OO_TEAM_NAME`: Same as `OO_TEAM_ID`, but selects the team by name. Before
+  execution the CLI resolves the name to its team id through the account's
+  team memberships (one extra request per invocation), so requests carry both
+  the name and the id; a name the account cannot access fails with exit `1`.
+  `oo connector run --dry-run` sends no execution request and skips the
+  resolution, so it stays offline. Ignored when `OO_TEAM_ID` is set or the
+  connector target is self-hosted.
+- Connector commands resolve their team identity with this precedence:
+  `--personal` / `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` > the `identity.team`
+  config default > your personal identity.
 - `OO_SKILLS_SYNC_DISABLED`: A truthy value disables the startup managed-skill
   synchronization and legacy-cleanup side effects, so the CLI writes no skill
   files into agent home directories such as `~/.agents` or `~/.claude`.
@@ -271,9 +287,10 @@ Alias for `oo auth logout`.
 
 Team identity lets connector commands (`oo connector run`, `oo connector proxy`,
 `oo connector apps`) act as a team instead of your personal account, selected
-per run with `--team <name>` or as a default with the `identity.team` config
-key. These commands help discover which teams your account can use and manage
-that default.
+per run with `--team <name>`, per environment with `OO_TEAM_ID` /
+`OO_TEAM_NAME`, or as a default with the `identity.team` config key
+(precedence in that order). These commands help discover which teams your
+account can use and manage that default.
 
 `oo team list` and `oo team use` query OOMOL for your team memberships, so they
 require an OOMOL account and are unavailable when only a self-hosted connector
@@ -288,21 +305,32 @@ read-only.
 - Options: `--format=json` and `--json` print a JSON array.
 - Output: JSON entries include the stable CLI fields `name`, `id`, `role`, and
   `current`. `role` is `creator` or `member`. `current` is `true` for the team
-  that matches the `identity.team` default.
-- Output: pass the `name` value to `--team <name>` (or `oo team use <name>`).
+  connector commands use by default: the team selected by `OO_TEAM_ID`
+  (matched by id) or `OO_TEAM_NAME` (matched by name) when set, otherwise the
+  team matching the `identity.team` default.
+- Output: pass the `name` value to `--team <name>` (or `oo team use <name>`),
+  and the `id` value to `OO_TEAM_ID`.
 - Output: text output prints one column-aligned row per team and marks the
   current default. When the account has no teams, it reports that connector
   commands run under your personal identity.
 
 ### `oo team current`
 
-Show the default team identity (`identity.team`) used by connector commands
-when no `--team` / `--personal` flag is given. This command is offline and does
-not make a network request.
+Show the team identity used by connector commands when no `--team` /
+`--personal` flag is given: the `OO_TEAM_ID` / `OO_TEAM_NAME` environment
+override when set, otherwise the `identity.team` config default. This command
+is offline and does not make a network request (an `OO_TEAM_NAME` value is
+reported as-is, without resolving its id).
 
 - Options: `--format=json` and `--json` print a JSON object.
-- Output: JSON is `{ "team": "<name>" }`, or `{ "team": null }` when no default
-  is configured.
+- Output: JSON is `{ "team": <name|null>, "teamId": <id|null>, "source":
+  <"env_id"|"env_name"|"config"|null> }`. `source` says which mechanism
+  selects the team, and is `null` when connector commands run under your
+  personal identity. `team` carries the name when it is known (`env_name` or
+  `config`); `teamId` carries the id only for `env_id`.
+- Output: text output names the environment variable when one is set, and
+  notes that a configured `identity.team` default is not in use while the
+  override is active.
 
 ### `oo team use <name>`
 
@@ -313,6 +341,9 @@ access it.
 - Behavior: the name is validated against the teams the account can access; an
   inaccessible name is rejected with exit `1` and the default is left unchanged.
   On success it is persisted to the `identity.team` config key.
+- Behavior: when `OO_TEAM_ID` / `OO_TEAM_NAME` is set, the default is still
+  saved, but the output reports that the environment variable keeps outranking
+  it until unset.
 
 ### `oo team clear`
 
@@ -322,6 +353,8 @@ identity. This command is offline.
 - Behavior: removes the `identity.team` config key. When no default is
   configured it reports that connector commands already run under your personal
   identity.
+- Behavior: when `OO_TEAM_ID` / `OO_TEAM_NAME` is set, the output reports that
+  the environment variable still selects a team for connector commands.
 
 ## LLM
 
@@ -410,9 +443,10 @@ Persist one configuration value.
   pending telemetry events immediately and the current `config set` invocation is
   not recorded as telemetry.
 - Value rules: for `identity.team`, use any non-empty team name.
-  It sets the default team identity used by `oo connector run` and
-  `oo connector proxy` when neither `--team` nor `--personal` is
-  passed.
+  It sets the default team identity used by `oo connector run`,
+  `oo connector proxy`, and `oo connector apps` when neither `--team` nor
+  `--personal` is passed and no `OO_TEAM_ID` / `OO_TEAM_NAME` environment
+  variable is set.
 
 ### `oo config unset <key>`
 
@@ -768,10 +802,11 @@ Validate input data and run one connector action.
   schema declares an async submit lifecycle.
 - Options: `--team <name>` runs the action under the given team identity
   instead of your personal identity. When omitted, the action runs under the
-  `identity.team` config default if set, otherwise your personal identity.
+  team selected by `OO_TEAM_ID` / `OO_TEAM_NAME` if set, then the
+  `identity.team` config default, otherwise your personal identity.
 - Options: `--personal` runs the action under your personal identity and
-  ignores any configured default team. It cannot be combined with
-  `--team`.
+  ignores the `OO_TEAM_ID` / `OO_TEAM_NAME` environment variables and any
+  configured default team. It cannot be combined with `--team`.
 - Options: `--format=json` and `--json` print a JSON object.
 - Output: non-dry-run JSON output mirrors the stable response shape
   `{ data, meta: { executionId } }`.
@@ -793,10 +828,11 @@ Validate input data and run one connector action.
 - Notes: while waiting for an async result action in text mode, interactive
   terminals show progress on stderr. JSON output does not include progress text.
 - Notes: against a self-hosted connector, `--team` is rejected with
-  exit `2`, a configured `identity.team` default is ignored, and
-  `--personal` is accepted. `--wait` and `--wait-result` fail with the
-  existing unsupported errors because the self-hosted runtime does not expose
-  the async lifecycle contract.
+  exit `2`, a configured `identity.team` default and the `OO_TEAM_ID` /
+  `OO_TEAM_NAME` environment variables are ignored, and `--personal` is
+  accepted. `--wait` and `--wait-result` fail with the existing unsupported
+  errors because the self-hosted runtime does not expose the async lifecycle
+  contract.
 
 ### `oo connector apps [serviceName]`
 
@@ -807,11 +843,12 @@ read-only.
   connected app across all providers. When provided, the listing is scoped to
   that one service.
 - Options: `--team <name>` lists connected apps under the given team identity
-  instead of your personal identity. When omitted, the listing uses the
-  `identity.team` config default if set, otherwise your personal identity.
+  instead of your personal identity. When omitted, the listing uses the team
+  selected by `OO_TEAM_ID` / `OO_TEAM_NAME` if set, then the `identity.team`
+  config default, otherwise your personal identity.
 - Options: `--personal` lists connected apps under your personal identity and
-  ignores any configured default team. It cannot be combined with
-  `--team`.
+  ignores the `OO_TEAM_ID` / `OO_TEAM_NAME` environment variables and any
+  configured default team. It cannot be combined with `--team`.
 - Options: `--format=json` and `--json` print a JSON array.
 - Output: JSON entries include the stable CLI fields `service`,
   `connectionName`, `displayName`, `accountLabel`, `status`, `authType`,
@@ -826,8 +863,9 @@ read-only.
 - Notes: use the listed `connectionName` value with
   `oo connector run <serviceName> --connection-name <connection-name>`.
 - Notes: against a self-hosted connector, `--team` is rejected with exit
-  `2`, a configured `identity.team` default is ignored, and `--personal`
-  is accepted.
+  `2`, a configured `identity.team` default and the `OO_TEAM_ID` /
+  `OO_TEAM_NAME` environment variables are ignored, and `--personal` is
+  accepted.
 
 ### `oo connector proxy <serviceName>`
 
@@ -856,10 +894,11 @@ Proxy a provider API request through a connected connector app.
   such as `"hello"`.
 - Options: `--team <name>` runs the proxy request under the given team identity
   instead of your personal identity. When omitted, the request runs under the
-  `identity.team` config default if set, otherwise your personal identity.
+  team selected by `OO_TEAM_ID` / `OO_TEAM_NAME` if set, then the
+  `identity.team` config default, otherwise your personal identity.
 - Options: `--personal` runs the proxy request under your personal identity and
-  ignores any configured default team. It cannot be combined with
-  `--team`.
+  ignores the `OO_TEAM_ID` / `OO_TEAM_NAME` environment variables and any
+  configured default team. It cannot be combined with `--team`.
 - Options: `--format=json` and `--json` print a JSON object.
 - Output: JSON output keeps the stable shape
   `{ data: { status, headers, data }, meta: { executionId, service } }`.
@@ -871,9 +910,9 @@ Proxy a provider API request through a connected connector app.
   cache. Use it when the selected connector supports proxy execution and no
   purpose-built connector action is available.
 - Notes: against a self-hosted connector, `--team` is rejected with
-  exit `2` and a configured `identity.team` default is ignored. Proxy
-  execution depends on server support; the open-source runtime currently
-  returns an error.
+  exit `2` and a configured `identity.team` default and the `OO_TEAM_ID` /
+  `OO_TEAM_NAME` environment variables are ignored. Proxy execution depends on
+  server support; the open-source runtime currently returns an error.
 
 ### `oo connector login <url>`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -347,14 +347,18 @@ access it.
 
 ### `oo team clear`
 
-Clear the default team identity so connector commands run under your personal
-identity. This command is offline.
+Clear the persisted default team identity (`identity.team`). Connector commands
+then run under your personal identity, unless `OO_TEAM_ID` / `OO_TEAM_NAME`
+still selects a team — this command removes only the config default and does
+not affect the environment override. This command is offline.
 
 - Behavior: removes the `identity.team` config key. When no default is
   configured it reports that connector commands already run under your personal
   identity.
 - Behavior: when `OO_TEAM_ID` / `OO_TEAM_NAME` is set, the output reports that
-  the environment variable still selects a team for connector commands.
+  the environment variable still selects a team for connector commands, so
+  clearing the default does not switch them to your personal identity. Unset
+  the variable to do that.
 
 ## LLM
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -41,6 +41,19 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
 - Connector 相关命令按以下优先级解析目标服务：
   `OO_CONNECTOR_URL` > `OO_API_KEY` > 已保存的自部署 Connector 配置
   （`oo connector login`）> 当前激活账号。
+- `OO_TEAM_ID`：让 connector 命令（`oo connector run`、`oo connector proxy`、
+  `oo connector apps`）以该 id 对应的团队身份运行。优先级高于 `OO_TEAM_NAME`
+  和 `identity.team` 配置默认值；每次运行的 `--team` 与 `--personal`
+  标志仍然优先于它。取值按原样发送，不做成员关系校验。当 connector
+  目标为自部署服务时会被忽略。
+- `OO_TEAM_NAME`：与 `OO_TEAM_ID` 相同，但按名称选择团队。执行前 CLI
+  会通过账号的团队成员关系将名称解析为团队 id（每次调用多一个请求），
+  因此请求会同时携带名称与 id；账号无法访问的名称以退出码 `1` 失败。
+  `oo connector run --dry-run` 不发送执行请求，也会跳过该解析，保持完全
+  离线。设置了 `OO_TEAM_ID` 或 connector 目标为自部署服务时会被忽略。
+- Connector 相关命令按以下优先级解析团队身份：
+  `--personal` / `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` >
+  `identity.team` 配置默认值 > 个人身份。
 - `OO_SKILLS_SYNC_DISABLED`：设为真值会禁用启动时的 managed skill 同步与 legacy
   清理副作用，使 CLI 不会向 `~/.agents`、`~/.claude` 等代理主目录写入任何 skill
   文件。
@@ -235,7 +248,8 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
 
 团队身份让 connector 命令（`oo connector run`、`oo connector proxy`、`oo connector
 apps`）以某个团队身份运行，而非个人账号：既可用每次运行的 `--team <name>`
-指定，也可用配置项 `identity.team` 设为默认。下列命令用于发现当前账号可用的
+指定，也可用环境变量 `OO_TEAM_ID` / `OO_TEAM_NAME` 指定，还可用配置项
+`identity.team` 设为默认（优先级依此排序）。下列命令用于发现当前账号可用的
 团队并管理该默认值。
 
 `oo team list` 与 `oo team use` 需要向 OOMOL 查询团队成员关系，因此需要 OOMOL
@@ -248,20 +262,28 @@ apps`）以某个团队身份运行，而非个人账号：既可用每次运行
 
 - 选项：`--format=json` 与 `--json` 输出 JSON 数组。
 - 输出：JSON 条目包含稳定的 CLI 字段 `name`、`id`、`role`、`current`。`role` 为
-  `creator` 或 `member`。`current` 对与 `identity.team` 默认值匹配的团队为
-  `true`。
-- 输出：将 `name` 的值传给 `--team <name>`（或 `oo team use <name>`）。
+  `creator` 或 `member`。`current` 对 connector 命令默认使用的团队为 `true`：
+  设置了 `OO_TEAM_ID`（按 id 匹配）或 `OO_TEAM_NAME`（按名称匹配）时为
+  env 指定的团队，否则为与 `identity.team` 默认值匹配的团队。
+- 输出：将 `name` 的值传给 `--team <name>`（或 `oo team use <name>`），将 `id`
+  的值传给 `OO_TEAM_ID`。
 - 输出：文本输出为每个团队打印一行列对齐的记录，并标出当前默认团队。当账号没有任何
   团队时，会提示 connector 命令以个人身份运行。
 
 ### `oo team current`
 
-显示未传 `--team` / `--personal` 时 connector 命令使用的默认团队身份
-（`identity.team`）。该命令离线运行，不发起网络请求。
+显示未传 `--team` / `--personal` 时 connector 命令使用的团队身份：设置了
+`OO_TEAM_ID` / `OO_TEAM_NAME` 环境变量时为 env 指定的团队，否则为
+`identity.team` 配置默认值。该命令离线运行，不发起网络请求（`OO_TEAM_NAME`
+的值按原样展示，不解析其 id）。
 
 - 选项：`--format=json` 与 `--json` 输出 JSON 对象。
-- 输出：JSON 为 `{ "team": "<name>" }`；未配置默认值时为
-  `{ "team": null }`。
+- 输出：JSON 为 `{ "team": <name|null>, "teamId": <id|null>, "source":
+  <"env_id"|"env_name"|"config"|null> }`。`source` 表示团队由哪种机制选定；
+  connector 命令以个人身份运行时为 `null`。`team` 在名称已知（`env_name` 或
+  `config`）时携带名称；`teamId` 仅在 `env_id` 时携带 id。
+- 输出：设置了环境变量时，文本输出会指明变量名，并说明已配置的
+  `identity.team` 默认值在覆盖生效期间不会被使用。
 
 ### `oo team use <name>`
 
@@ -270,6 +292,8 @@ apps`）以某个团队身份运行，而非个人账号：既可用每次运行
 - 参数：`<name>` 为团队名称，取值见 `oo team list`。
 - 行为：会用账号可访问的团队校验该名称；无法访问的名称以退出码 `1` 拒绝，且默认值保持
   不变。成功时持久化到配置项 `identity.team`。
+- 行为：设置了 `OO_TEAM_ID` / `OO_TEAM_NAME` 时，默认值仍会保存，但输出会说明该
+  环境变量在取消之前持续优先于它。
 
 ### `oo team clear`
 
@@ -277,6 +301,8 @@ apps`）以某个团队身份运行，而非个人账号：既可用每次运行
 
 - 行为：移除配置项 `identity.team`。当未配置默认值时，会提示 connector 命令
   本就以个人身份运行。
+- 行为：设置了 `OO_TEAM_ID` / `OO_TEAM_NAME` 时，输出会说明该环境变量仍会为
+  connector 命令选择团队。
 
 ## LLM
 
@@ -358,8 +384,9 @@ apps`）以某个团队身份运行，而非个人账号：既可用每次运行
   CLI 还会立即尝试清空待发送 telemetry 事件，并且本次 `config set` 调用自身不会被记录为
   telemetry。
 - 取值规则：当 `<key>` 为 `identity.team` 时，支持任意非空的团队名称。
-  它设置 `oo connector run` 和 `oo connector proxy` 在未传 `--team` 或
-  `--personal` 时使用的默认团队身份。
+  它设置 `oo connector run`、`oo connector proxy` 和 `oo connector apps`
+  在未传 `--team` 或 `--personal`、且未设置 `OO_TEAM_ID` / `OO_TEAM_NAME`
+  环境变量时使用的默认团队身份。
 
 ### `oo config unset <key>`
 
@@ -655,10 +682,11 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   schema 声明了异步结果 lifecycle 时，这个选项才有效。
 - 选项：`--wait-result` 会提交异步 submit action，然后轮询它配置的结果
   action。只有选中 action 的 schema 声明了异步 submit lifecycle 时，这个选项才有效。
-- 选项：`--team <name>` 以指定团队身份运行该 action，而非个人身份。省略时，若配置了
-  `identity.team` 默认值则使用该团队，否则使用个人身份。
-- 选项：`--personal` 以个人身份运行该 action，并忽略已配置的默认团队。
-  不能与 `--team` 同时使用。
+- 选项：`--team <name>` 以指定团队身份运行该 action，而非个人身份。省略时，若设置了
+  `OO_TEAM_ID` / `OO_TEAM_NAME` 则使用 env 选定的团队，其次使用
+  `identity.team` 配置默认值，否则使用个人身份。
+- 选项：`--personal` 以个人身份运行该 action，并忽略 `OO_TEAM_ID` /
+  `OO_TEAM_NAME` 环境变量和已配置的默认团队。不能与 `--team` 同时使用。
 - 选项：`--format=json` 和 `--json` 会输出 JSON 对象。
 - 输出：非 dry-run 的 JSON 输出会保持稳定结构
   `{ data, meta: { executionId } }`。
@@ -676,7 +704,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 说明：text 模式下等待 async result action 时，交互式终端会在 stderr
   显示进度。JSON 输出不会混入进度文本。
 - 说明：面向自部署 Connector 时，传入 `--team` 会被拒绝（exit `2`），
-  已配置的 `identity.team` 默认值会被忽略，`--personal` 仍可使用。
+  已配置的 `identity.team` 默认值和 `OO_TEAM_ID` / `OO_TEAM_NAME`
+  环境变量会被忽略，`--personal` 仍可使用。
   由于自部署 runtime 不提供异步 lifecycle contract，`--wait` 和
   `--wait-result` 会以现有的“不支持”错误失败。
 
@@ -686,10 +715,11 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 
 - 参数：`[serviceName]` 可选。省略时列出所有 provider 下已连接的 app；提供时仅列出
   该服务的 app。
-- 选项：`--team <name>` 以指定团队身份列出已连接的 app，而非个人身份。省略时，若配置了
-  `identity.team` 默认值则按该团队列出，否则按个人身份列出。
-- 选项：`--personal` 以个人身份列出已连接的 app，并忽略已配置的默认团队。该选项不能与
-  `--team` 同时使用。
+- 选项：`--team <name>` 以指定团队身份列出已连接的 app，而非个人身份。省略时，若设置了
+  `OO_TEAM_ID` / `OO_TEAM_NAME` 则按 env 选定的团队列出，其次按
+  `identity.team` 配置默认值列出，否则按个人身份列出。
+- 选项：`--personal` 以个人身份列出已连接的 app，并忽略 `OO_TEAM_ID` /
+  `OO_TEAM_NAME` 环境变量和已配置的默认团队。该选项不能与 `--team` 同时使用。
 - 选项：`--format=json` 和 `--json` 会输出 JSON 数组。
 - 输出：JSON 条目包含稳定 CLI 字段 `service`、`connectionName`、`displayName`、
   `accountLabel`、`status`、`authType`、`isDefault` 和 `scopes`。不会包含
@@ -701,7 +731,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 说明：可将列出的 `connectionName` 值传给
   `oo connector run <serviceName> --connection-name <connection-name>`。
 - 说明：对自部署 Connector，`--team` 会以退出码 `2` 拒绝，已配置的
-  `identity.team` 默认值会被忽略，`--personal` 可正常使用。
+  `identity.team` 默认值和 `OO_TEAM_ID` / `OO_TEAM_NAME` 环境变量会被忽略，
+  `--personal` 可正常使用。
 
 ### `oo connector proxy <serviceName>`
 
@@ -726,10 +757,11 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   credential。
 - 选项：`--body` 会按 JSON 解析。如需发送文本 body，请传 JSON string，例如
   `"hello"`。
-- 选项：`--team <name>` 以指定团队身份运行该 proxy 请求，而非个人身份。省略时，若配置了
-  `identity.team` 默认值则使用该团队，否则使用个人身份。
-- 选项：`--personal` 以个人身份运行该 proxy 请求，并忽略已配置的默认团队。
-  不能与 `--team` 同时使用。
+- 选项：`--team <name>` 以指定团队身份运行该 proxy 请求，而非个人身份。省略时，若设置了
+  `OO_TEAM_ID` / `OO_TEAM_NAME` 则使用 env 选定的团队，其次使用
+  `identity.team` 配置默认值，否则使用个人身份。
+- 选项：`--personal` 以个人身份运行该 proxy 请求，并忽略 `OO_TEAM_ID` /
+  `OO_TEAM_NAME` 环境变量和已配置的默认团队。不能与 `--team` 同时使用。
 - 选项：`--format=json` 和 `--json` 会输出 JSON 对象。
 - 输出：JSON 输出保持稳定结构
   `{ data: { status, headers, data }, meta: { executionId, service } }`。
@@ -739,8 +771,9 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 说明：`oo connector proxy` 不使用 connector action schema 或 schema cache。
   当选中的 connector 支持 proxy execution 且没有专用 connector action 时使用。
 - 说明：面向自部署 Connector 时，传入 `--team` 会被拒绝（exit `2`），
-  已配置的 `identity.team` 默认值会被忽略。proxy execution 取决于
-  服务端支持；开源 runtime 目前会返回错误。
+  已配置的 `identity.team` 默认值和 `OO_TEAM_ID` / `OO_TEAM_NAME`
+  环境变量会被忽略。proxy execution 取决于服务端支持；开源 runtime
+  目前会返回错误。
 
 ### `oo connector login <url>`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -297,12 +297,15 @@ apps`）以某个团队身份运行，而非个人账号：既可用每次运行
 
 ### `oo team clear`
 
-清除默认团队身份，让 connector 命令以个人身份运行。该命令离线运行。
+清除持久化的默认团队身份（`identity.team`）。之后 connector 命令以个人身份
+运行；但若 `OO_TEAM_ID` / `OO_TEAM_NAME` 仍在选择团队则不然——该命令只移除
+配置默认值，不影响环境变量覆盖。该命令离线运行。
 
 - 行为：移除配置项 `identity.team`。当未配置默认值时，会提示 connector 命令
   本就以个人身份运行。
 - 行为：设置了 `OO_TEAM_ID` / `OO_TEAM_NAME` 时，输出会说明该环境变量仍会为
-  connector 命令选择团队。
+  connector 命令选择团队，因此清除默认值并不会让它们切换到个人身份；需要取消
+  该环境变量才可以。
 
 ## LLM
 

--- a/docs/self-hosted-connector.md
+++ b/docs/self-hosted-connector.md
@@ -179,8 +179,9 @@ adapts as follows:
 
 - **Team identity is not supported.** `--team` is rejected with exit code `2` on
   `oo connector run`, `oo connector proxy`, and `oo connector apps`, and any
-  configured `identity.team` default is ignored. `--personal` is accepted (it is
-  already the effective behavior).
+  configured `identity.team` default and the `OO_TEAM_ID` / `OO_TEAM_NAME`
+  environment variables are ignored. `--personal` is accepted (it is already
+  the effective behavior).
 - **Async lifecycle waiting is unavailable.** `--wait` and `--wait-result` fail
   with the existing "unsupported" errors because the self-hosted runtime does
   not expose the async result-lifecycle contract.

--- a/docs/self-hosted-connector.zh-CN.md
+++ b/docs/self-hosted-connector.zh-CN.md
@@ -160,7 +160,8 @@ oo connector run gmail --action send_email --data '@payload.json'
 
 - **不支持团队身份。** `oo connector run`、`oo connector proxy` 与 `oo connector
   apps` 上的 `--team` 会以退出码 `2` 被拒绝，任何已配置的 `identity.team` 默认值
-  都会被忽略；`--personal` 可以使用（它本就是实际行为）。
+  和 `OO_TEAM_ID` / `OO_TEAM_NAME` 环境变量都会被忽略；`--personal` 可以使用
+  （它本就是实际行为）。
 - **无法等待异步生命周期。** `--wait` 与 `--wait-result` 会以既有的「不支持」
   错误失败，因为自部署运行时未暴露异步结果生命周期契约。
 - **Proxy 取决于服务支持。** 只有当你的服务实现了 proxy 端点时，

--- a/src/application/commands/connector/apps.ts
+++ b/src/application/commands/connector/apps.ts
@@ -10,7 +10,7 @@ import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
-import { resolveConnectorIdentity } from "./identity.ts";
+import { resolveConnectorIdentityWithEnv } from "./identity.ts";
 import { connectorSearchServiceColor } from "./search-provider.ts";
 import {
     connectorFormatValues,
@@ -111,11 +111,15 @@ export const connectorAppsCommand: CliCommandDefinition<ConnectorAppsInput> = {
         const settings = await context.settingsStore.read();
         const { identity, source: identitySource } = target.kind === "self_hosted"
             ? { identity: {}, source: "personal" as const }
-            : resolveConnectorIdentity({
-                    configTeam: getConfiguredIdentityTeam(settings),
-                    teamFlag,
-                    personalFlag: input.personal === true,
-                });
+            : await resolveConnectorIdentityWithEnv(
+                    {
+                        configTeam: getConfiguredIdentityTeam(settings),
+                        target,
+                        teamFlag,
+                        personalFlag: input.personal === true,
+                    },
+                    context,
+                );
 
         context.telemetry?.recordProperties({
             connector_kind: target.kind,

--- a/src/application/commands/connector/identity.test.ts
+++ b/src/application/commands/connector/identity.test.ts
@@ -1,14 +1,33 @@
-import { describe, expect, test } from "bun:test";
+import type { Fetcher } from "../../contracts/cli.ts";
 
+import { describe, expect, test } from "bun:test";
+import pino from "pino";
+
+import { expectCliUserError, toRequest } from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
 import {
     connectorIdentityHeaders,
     resolveConnectorIdentity,
+    resolveConnectorIdentityWithEnv,
 } from "./identity.ts";
+
+const oomolTarget = {
+    authorization: "api-secret-1",
+    cacheEndpoint: "oomol.com",
+};
+
+const teamsResponse = {
+    teams: [
+        { id: "team-1", name: "acme", role: "creator" },
+        { id: "team-2", name: "beta", role: "member" },
+    ],
+};
 
 describe("resolveConnectorIdentity", () => {
     test("defaults to personal when nothing is provided", () => {
         expect(resolveConnectorIdentity({
             configTeam: undefined,
+            envOverride: undefined,
             teamFlag: undefined,
             personalFlag: false,
         })).toEqual({
@@ -20,6 +39,7 @@ describe("resolveConnectorIdentity", () => {
     test("uses the team flag over the configured default", () => {
         expect(resolveConnectorIdentity({
             configTeam: "config-team",
+            envOverride: undefined,
             teamFlag: "flag-team",
             personalFlag: false,
         })).toEqual({
@@ -31,6 +51,7 @@ describe("resolveConnectorIdentity", () => {
     test("falls back to the configured team when no flag is set", () => {
         expect(resolveConnectorIdentity({
             configTeam: "config-team",
+            envOverride: undefined,
             teamFlag: undefined,
             personalFlag: false,
         })).toEqual({
@@ -42,6 +63,7 @@ describe("resolveConnectorIdentity", () => {
     test("personal flag overrides both the team flag and the configured default", () => {
         expect(resolveConnectorIdentity({
             configTeam: "config-team",
+            envOverride: undefined,
             teamFlag: "flag-team",
             personalFlag: true,
         })).toEqual({
@@ -53,12 +75,206 @@ describe("resolveConnectorIdentity", () => {
     test("treats an empty team flag as absent and falls back to config", () => {
         expect(resolveConnectorIdentity({
             configTeam: "config-team",
+            envOverride: undefined,
             teamFlag: "",
             personalFlag: false,
         })).toEqual({
             identity: { team: "config-team" },
             source: "config",
         });
+    });
+
+    test("uses the env team id over the configured default", () => {
+        expect(resolveConnectorIdentity({
+            configTeam: "config-team",
+            envOverride: { kind: "id", value: "team-1" },
+            teamFlag: undefined,
+            personalFlag: false,
+        })).toEqual({
+            identity: { teamId: "team-1" },
+            source: "env_id",
+        });
+    });
+
+    test("uses the env team name over the configured default", () => {
+        expect(resolveConnectorIdentity({
+            configTeam: "config-team",
+            envOverride: { kind: "name", value: "acme" },
+            teamFlag: undefined,
+            personalFlag: false,
+        })).toEqual({
+            identity: { team: "acme" },
+            source: "env_name",
+        });
+    });
+
+    test("uses the team flag over the env override", () => {
+        expect(resolveConnectorIdentity({
+            configTeam: undefined,
+            envOverride: { kind: "id", value: "team-1" },
+            teamFlag: "flag-team",
+            personalFlag: false,
+        })).toEqual({
+            identity: { team: "flag-team" },
+            source: "flag",
+        });
+    });
+
+    test("personal flag overrides the env override", () => {
+        expect(resolveConnectorIdentity({
+            configTeam: undefined,
+            envOverride: { kind: "name", value: "acme" },
+            teamFlag: undefined,
+            personalFlag: true,
+        })).toEqual({
+            identity: {},
+            source: "personal",
+        });
+    });
+});
+
+describe("resolveConnectorIdentityWithEnv", () => {
+    test("passes the env team id through without a resolution request", async () => {
+        let requested = false;
+        const resolved = await resolveConnectorIdentityWithEnv(
+            {
+                configTeam: "config-team",
+                target: oomolTarget,
+                teamFlag: undefined,
+                personalFlag: false,
+            },
+            createIdentityContext({
+                env: { OO_TEAM_ID: "team-9" },
+                fetcher: async () => {
+                    requested = true;
+
+                    return new Response(JSON.stringify(teamsResponse));
+                },
+            }),
+        );
+
+        expect(resolved).toEqual({
+            identity: { teamId: "team-9" },
+            source: "env_id",
+        });
+        expect(requested).toBe(false);
+    });
+
+    test("resolves the env team name to its id through the membership listing", async () => {
+        const requests: Request[] = [];
+        const resolved = await resolveConnectorIdentityWithEnv(
+            {
+                configTeam: undefined,
+                target: oomolTarget,
+                teamFlag: undefined,
+                personalFlag: false,
+            },
+            createIdentityContext({
+                env: { OO_TEAM_NAME: "beta" },
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+
+                    return new Response(JSON.stringify(teamsResponse));
+                },
+            }),
+        );
+
+        expect(resolved).toEqual({
+            identity: { team: "beta", teamId: "team-2" },
+            source: "env_name",
+        });
+        expect(requests).toHaveLength(1);
+        expect(requests[0]?.url).toBe(
+            "https://relation-control.oomol.com/v1/me/teams",
+        );
+        expect(requests[0]?.headers.get("authorization")).toBe("api-secret-1");
+    });
+
+    test("fails when the env team name is not among the account teams", async () => {
+        const error = await expectCliUserError(resolveConnectorIdentityWithEnv(
+            {
+                configTeam: undefined,
+                target: oomolTarget,
+                teamFlag: undefined,
+                personalFlag: false,
+            },
+            createIdentityContext({
+                env: { OO_TEAM_NAME: "ghost" },
+                fetcher: async () => new Response(JSON.stringify(teamsResponse)),
+            }),
+        ));
+
+        expect(error.key).toBe("errors.team.envNameNotAccessible");
+        expect(error.exitCode).toBe(1);
+    });
+
+    test("prefers the env team id when both env variables are set", async () => {
+        let requested = false;
+        const resolved = await resolveConnectorIdentityWithEnv(
+            {
+                configTeam: undefined,
+                target: oomolTarget,
+                teamFlag: undefined,
+                personalFlag: false,
+            },
+            createIdentityContext({
+                env: { OO_TEAM_ID: "team-1", OO_TEAM_NAME: "beta" },
+                fetcher: async () => {
+                    requested = true;
+
+                    return new Response(JSON.stringify(teamsResponse));
+                },
+            }),
+        );
+
+        expect(resolved).toEqual({
+            identity: { teamId: "team-1" },
+            source: "env_id",
+        });
+        expect(requested).toBe(false);
+    });
+
+    test("skips the env resolution entirely when a flag wins", async () => {
+        let requested = false;
+        const resolved = await resolveConnectorIdentityWithEnv(
+            {
+                configTeam: undefined,
+                target: oomolTarget,
+                teamFlag: "flag-team",
+                personalFlag: false,
+            },
+            createIdentityContext({
+                env: { OO_TEAM_NAME: "beta" },
+                fetcher: async () => {
+                    requested = true;
+
+                    return new Response(JSON.stringify(teamsResponse));
+                },
+            }),
+        );
+
+        expect(resolved).toEqual({
+            identity: { team: "flag-team" },
+            source: "flag",
+        });
+        expect(requested).toBe(false);
+    });
+
+    test("fails the env name resolution when the target carries no credential", async () => {
+        const error = await expectCliUserError(resolveConnectorIdentityWithEnv(
+            {
+                configTeam: undefined,
+                target: { cacheEndpoint: "oomol.com" },
+                teamFlag: undefined,
+                personalFlag: false,
+            },
+            createIdentityContext({
+                env: { OO_TEAM_NAME: "beta" },
+                fetcher: async () => new Response(JSON.stringify(teamsResponse)),
+            }),
+        ));
+
+        expect(error.key).toBe("errors.auth.required");
     });
 });
 
@@ -69,8 +285,34 @@ describe("connectorIdentityHeaders", () => {
         });
     });
 
+    test("returns the team id header for an id identity", () => {
+        expect(connectorIdentityHeaders({ teamId: "team-1" })).toEqual({
+            "x-oo-team-id": "team-1",
+        });
+    });
+
+    test("returns both headers when the name and id are known", () => {
+        expect(connectorIdentityHeaders({ team: "acme", teamId: "team-1" }))
+            .toEqual({
+                "x-oo-team-name": "acme",
+                "x-oo-team-id": "team-1",
+            });
+    });
+
     test("returns no headers for the personal identity", () => {
         expect(connectorIdentityHeaders({})).toEqual({});
         expect(connectorIdentityHeaders(undefined)).toEqual({});
     });
 });
+
+function createIdentityContext(options: {
+    env: Record<string, string | undefined>;
+    fetcher: Fetcher;
+}) {
+    return {
+        env: options.env,
+        fetcher: options.fetcher,
+        logger: pino({ enabled: false }),
+        translator: createTranslator("en"),
+    };
+}

--- a/src/application/commands/connector/identity.ts
+++ b/src/application/commands/connector/identity.ts
@@ -1,8 +1,8 @@
 // Connector authentication identity.
 //
 // A connector run executes under exactly one identity:
-//   personal => {}       (no team)
-//   team     => { team }
+//   personal => {}                 (no team)
+//   team     => { team? , teamId? } (at least one dimension set)
 //
 // The identity is resolved once per connector invocation and then applied only
 // to execution requests. The action schema / metadata layer is
@@ -11,24 +11,38 @@
 // This struct is the extension point for additional identity dimensions: a new
 // field here plus a branch in the request helpers below is all a future
 // dimension needs.
+
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+import type { TeamEnvOverride } from "../shared/team-env-override.ts";
+import type { ConnectorTarget } from "./target.ts";
+
+import { CliUserError } from "../../contracts/cli.ts";
+import { readTeamEnvOverride } from "../shared/team-env-override.ts";
+import { listMemberTeams } from "../team/shared.ts";
+
 export interface ConnectorIdentity {
     team?: string;
+    teamId?: string;
 }
 
 // Where the resolved team came from. Recorded as privacy-safe telemetry; it
-// never carries the team name itself.
-type ConnectorIdentitySource = "config" | "flag" | "personal";
+// never carries the team name or id itself.
+type ConnectorIdentitySource
+    = "config" | "env_id" | "env_name" | "flag" | "personal";
 
 interface ResolvedConnectorIdentity {
     identity: ConnectorIdentity;
     source: ConnectorIdentitySource;
 }
 
-// Resolves the effective identity from the per-run flags and the configured
-// default. Precedence: --personal > --team > config default > personal.
-// A flag identity fully replaces the configured default (no field-level merge).
+// Resolves the effective identity from the per-run flags, the env override,
+// and the configured default. Precedence: --personal > --team > OO_TEAM_ID >
+// OO_TEAM_NAME > config default > personal. A higher-priority identity fully
+// replaces the lower ones (no field-level merge). An `env_name` result still
+// carries only the name; `resolveConnectorIdentityWithEnv` fills in the id.
 export function resolveConnectorIdentity(input: {
     configTeam: string | undefined;
+    envOverride: TeamEnvOverride | undefined;
     teamFlag: string | undefined;
     personalFlag: boolean;
 }): ResolvedConnectorIdentity {
@@ -43,6 +57,18 @@ export function resolveConnectorIdentity(input: {
         };
     }
 
+    if (input.envOverride !== undefined) {
+        return input.envOverride.kind === "id"
+            ? {
+                    identity: { teamId: input.envOverride.value },
+                    source: "env_id",
+                }
+            : {
+                    identity: { team: input.envOverride.value },
+                    source: "env_name",
+                };
+    }
+
     if (input.configTeam !== undefined && input.configTeam !== "") {
         return {
             identity: { team: input.configTeam },
@@ -53,8 +79,72 @@ export function resolveConnectorIdentity(input: {
     return { identity: {}, source: "personal" };
 }
 
-// Builds the identity request headers (`x-oo-team-name`). Returns an empty
-// object for the personal identity so callers can spread it unconditionally.
+// Resolves the effective identity for an OOMOL connector target, including the
+// env override. When OO_TEAM_NAME wins, the name is resolved to its team id
+// through the account's membership listing so execution requests can carry the
+// stable id; a name the account cannot access fails here, before any
+// execution request is sent. Self-hosted targets never reach this function —
+// they have no team concept, and callers pin the personal identity instead.
+// `resolveEnvTeamId: false` skips the membership request and keeps the bare
+// name identity — for validation-only invocations (`--dry-run`) that never
+// send an execution request, so they stay offline like every other identity
+// source.
+export async function resolveConnectorIdentityWithEnv(
+    options: {
+        configTeam: string | undefined;
+        resolveEnvTeamId?: boolean;
+        target: Pick<ConnectorTarget, "authorization" | "cacheEndpoint">;
+        teamFlag: string | undefined;
+        personalFlag: boolean;
+    },
+    context: Pick<CliExecutionContext, "env" | "fetcher" | "logger" | "translator">,
+): Promise<ResolvedConnectorIdentity> {
+    const resolved = resolveConnectorIdentity({
+        configTeam: options.configTeam,
+        envOverride: readTeamEnvOverride(context.env),
+        teamFlag: options.teamFlag,
+        personalFlag: options.personalFlag,
+    });
+
+    if (
+        resolved.source !== "env_name"
+        || resolved.identity.team === undefined
+        || options.resolveEnvTeamId === false
+    ) {
+        return resolved;
+    }
+
+    // OOMOL targets always carry the raw API key; the guard only narrows the
+    // field, which stays optional for self-hosted servers.
+    if (options.target.authorization === undefined) {
+        throw new CliUserError("errors.auth.required", 1);
+    }
+
+    const teams = await listMemberTeams(
+        {
+            apiKey: options.target.authorization,
+            endpoint: options.target.cacheEndpoint,
+        },
+        context,
+    );
+    const teamName = resolved.identity.team;
+    const match = teams.find(team => team.name === teamName);
+
+    if (match === undefined) {
+        throw new CliUserError("errors.team.envNameNotAccessible", 1, {
+            team: teamName,
+        });
+    }
+
+    return {
+        identity: { team: match.name, teamId: match.id },
+        source: "env_name",
+    };
+}
+
+// Builds the identity request headers (`x-oo-team-name` / `x-oo-team-id`).
+// Returns an empty object for the personal identity so callers can spread it
+// unconditionally.
 export function connectorIdentityHeaders(
     identity: ConnectorIdentity | undefined,
 ): Record<string, string> {
@@ -62,6 +152,10 @@ export function connectorIdentityHeaders(
 
     if (identity?.team !== undefined) {
         headers["x-oo-team-name"] = identity.team;
+    }
+
+    if (identity?.teamId !== undefined) {
+        headers["x-oo-team-id"] = identity.teamId;
     }
 
     return headers;

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -4851,6 +4851,475 @@ describe("connectorCommand CLI", () => {
         }
     });
 
+    test("runs under the OO_TEAM_ID env team and sends the id header", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
+            await sandbox.run(["config", "set", "identity.team", "acme"]);
+            sandbox.env.OO_TEAM_ID = "team-1";
+            // The id form outranks the name form, so no resolution request
+            // may be sent for this value.
+            sandbox.env.OO_TEAM_NAME = "beta";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+            const runTelemetryPayload = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            )
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "connector.run");
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.method).toBe("POST");
+            expect(requests[0]?.headers.get("x-oo-team-id")).toBe("team-1");
+            expect(requests[0]?.headers.get("x-oo-team-name")).toBeNull();
+            expect(runTelemetryPayload).toMatchObject({
+                properties: {
+                    identity_source: "env_id",
+                },
+            });
+            expect(runTelemetryPayload?.properties).not.toHaveProperty("team");
+            expect(runTelemetryPayload?.properties).not.toHaveProperty("team_id");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("resolves OO_TEAM_NAME to its team id before running the action", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
+            sandbox.env.OO_TEAM_NAME = "acme";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.url.includes("relation-control")) {
+                            return new Response(JSON.stringify({
+                                teams: [
+                                    { id: "team-1", name: "acme", role: "creator" },
+                                ],
+                            }));
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+            const runTelemetryPayload = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            )
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "connector.run");
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(2);
+            // The membership listing resolves the name to its id first.
+            expect(requests[0]?.url).toBe(
+                "https://relation-control.oomol.com/v1/me/teams",
+            );
+            expect(requests[0]?.headers.get("authorization")).toBe("secret-1");
+            // The run POST carries both identity dimensions.
+            expect(requests[1]?.method).toBe("POST");
+            expect(requests[1]?.headers.get("x-oo-team-name")).toBe("acme");
+            expect(requests[1]?.headers.get("x-oo-team-id")).toBe("team-1");
+            expect(runTelemetryPayload).toMatchObject({
+                properties: {
+                    identity_source: "env_name",
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails the run when OO_TEAM_NAME is not an accessible team", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
+            sandbox.env.OO_TEAM_NAME = "ghost";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            teams: [
+                                { id: "team-1", name: "acme", role: "creator" },
+                            ],
+                        }));
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("OO_TEAM_NAME");
+            expect(result.stderr).toContain("ghost");
+            // Only the membership listing was attempted; no action ran.
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.url).toBe(
+                "https://relation-control.oomol.com/v1/me/teams",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails the run when the OO_TEAM_NAME resolution request fails", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
+            sandbox.env.OO_TEAM_NAME = "acme";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response("boom", { status: 500 });
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("HTTP 500");
+            // The failed resolution aborts the run: every request went to the
+            // membership endpoint and no action execution was attempted.
+            expect(requests.length).toBeGreaterThan(0);
+            expect(requests.every(request =>
+                request.url === "https://relation-control.oomol.com/v1/me/teams",
+            )).toBe(true);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("keeps a dry run offline when OO_TEAM_NAME is set", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
+            sandbox.env.OO_TEAM_NAME = "acme";
+
+            let requestCount = 0;
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--dry-run",
+                    "--json",
+                ],
+                {
+                    fetcher: async () => {
+                        requestCount += 1;
+
+                        return new Response(JSON.stringify({ teams: [] }));
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(JSON.parse(result.stdout)).toEqual({ dryRun: true, ok: true });
+            // A dry run sends no execution request, so the env team name is
+            // not resolved either — the whole invocation stays offline.
+            expect(requestCount).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("prefers the --team flag over the env team", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
+            sandbox.env.OO_TEAM_ID = "team-9";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--team",
+                    "acme",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+            const runTelemetryPayload = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            )
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "connector.run");
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.headers.get("x-oo-team-name")).toBe("acme");
+            expect(requests[0]?.headers.get("x-oo-team-id")).toBeNull();
+            expect(runTelemetryPayload).toMatchObject({
+                properties: {
+                    identity_source: "flag",
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("forces the personal identity with --personal even when the env team is set", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
+            sandbox.env.OO_TEAM_NAME = "acme";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--personal",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+            const runTelemetryPayload = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            )
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "connector.run");
+
+            expect(result.exitCode).toBe(0);
+            // No membership resolution and no identity headers.
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.headers.get("x-oo-team-name")).toBeNull();
+            expect(requests[0]?.headers.get("x-oo-team-id")).toBeNull();
+            expect(runTelemetryPayload).toMatchObject({
+                properties: {
+                    identity_source: "personal",
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("ignores the env team for a self-hosted connector", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeConnectorFile(sandbox, {
+                url: "http://localhost:3000",
+                token: "oct_test",
+            });
+            sandbox.env.OO_TEAM_ID = "team-1";
+            sandbox.env.OO_TEAM_NAME = "acme";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["connector", "apps", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({ data: [] }));
+                    },
+                },
+            );
+            const appsTelemetryPayload = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            )
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "connector.apps");
+
+            expect(result.exitCode).toBe(0);
+            // Ambient team identity is ignored for self-hosted targets, like
+            // the `identity.team` config default.
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.headers.get("x-oo-team-name")).toBeNull();
+            expect(requests[0]?.headers.get("x-oo-team-id")).toBeNull();
+            expect(appsTelemetryPayload).toMatchObject({
+                properties: {
+                    connector_kind: "self_hosted",
+                    identity_source: "personal",
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("applies the env team to the apps listing", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_TEAM_ID = "team-1";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["connector", "apps", "--json"],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({ data: [] }));
+                    },
+                },
+            );
+            const appsTelemetryPayload = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            )
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "connector.apps");
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.headers.get("x-oo-team-id")).toBe("team-1");
+            expect(requests[0]?.headers.get("x-oo-team-name")).toBeNull();
+            expect(appsTelemetryPayload).toMatchObject({
+                properties: {
+                    identity_source: "env_id",
+                    list_scope: "all",
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("rejects an empty --team value before sending requests", async () => {
         const sandbox = await createCliSandbox();
 

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -13,6 +13,7 @@ import {
     createCliSandbox,
     createCliSnapshot,
     createConnectorActionFixture,
+    expectTelemetryFreeOfTeamIdentity,
     readLatestLogContent,
     toRequest,
     writeAuthFile,
@@ -657,6 +658,188 @@ describe("connectorCommand CLI", () => {
             expect(telemetryPayload?.properties).not.toHaveProperty("headers");
             expect(telemetryPayload?.properties).not.toHaveProperty("team");
             expect(telemetryPayload?.properties).not.toHaveProperty("service");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("resolves OO_TEAM_NAME to its id for a proxy request", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_TEAM_NAME = "acme";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "proxy",
+                    "tavily",
+                    "--endpoint",
+                    "/search",
+                    "--method",
+                    "POST",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (request.url.includes("relation-control")) {
+                            return new Response(JSON.stringify({
+                                teams: [
+                                    { id: "team-1", name: "acme", role: "creator" },
+                                ],
+                            }));
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                data: {},
+                                headers: {},
+                                status: 200,
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                                service: "tavily",
+                            },
+                        }));
+                    },
+                },
+            );
+            const proxyTelemetryPayload = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            )
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "connector.proxy");
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(2);
+            expect(requests[0]?.url).toBe(
+                "https://relation-control.oomol.com/v1/me/teams",
+            );
+            // The proxy request carries both identity dimensions.
+            expect(requests[1]?.url).toBe("https://connector.oomol.com/v1/proxy/tavily");
+            expect(requests[1]?.headers.get("x-oo-team-name")).toBe("acme");
+            expect(requests[1]?.headers.get("x-oo-team-id")).toBe("team-1");
+            expect(proxyTelemetryPayload).toMatchObject({
+                properties: {
+                    identity_source: "env_name",
+                },
+            });
+            expectTelemetryFreeOfTeamIdentity(
+                proxyTelemetryPayload?.properties,
+                ["acme", "team-1"],
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("applies the OO_TEAM_ID env team to a proxy request", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await sandbox.run(["config", "set", "identity.team", "acme"]);
+            sandbox.env.OO_TEAM_ID = "team-1";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "proxy",
+                    "tavily",
+                    "--endpoint",
+                    "/search",
+                    "--method",
+                    "POST",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                data: {},
+                                headers: {},
+                                status: 200,
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                                service: "tavily",
+                            },
+                        }));
+                    },
+                },
+            );
+            const proxyTelemetryPayload = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            )
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "connector.proxy");
+
+            expect(result.exitCode).toBe(0);
+            // The id needs no resolution, so the proxy request is the only one.
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.headers.get("x-oo-team-id")).toBe("team-1");
+            expect(requests[0]?.headers.get("x-oo-team-name")).toBeNull();
+            expect(proxyTelemetryPayload).toMatchObject({
+                properties: {
+                    identity_source: "env_id",
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails a proxy request when OO_TEAM_NAME is not an accessible team", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_TEAM_NAME = "ghost";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "proxy",
+                    "tavily",
+                    "--endpoint",
+                    "/search",
+                    "--method",
+                    "POST",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            teams: [
+                                { id: "team-1", name: "acme", role: "creator" },
+                            ],
+                        }));
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("OO_TEAM_NAME");
+            // The failed resolution aborts before the proxy request.
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.url).toBe(
+                "https://relation-control.oomol.com/v1/me/teams",
+            );
         }
         finally {
             await sandbox.cleanup();
@@ -4906,8 +5089,12 @@ describe("connectorCommand CLI", () => {
                     identity_source: "env_id",
                 },
             });
-            expect(runTelemetryPayload?.properties).not.toHaveProperty("team");
-            expect(runTelemetryPayload?.properties).not.toHaveProperty("team_id");
+            // Only the source enum is reported; neither env variable's raw
+            // value reaches telemetry.
+            expectTelemetryFreeOfTeamIdentity(
+                runTelemetryPayload?.properties,
+                ["team-1", "beta"],
+            );
         }
         finally {
             await sandbox.cleanup();
@@ -4981,6 +5168,12 @@ describe("connectorCommand CLI", () => {
                     identity_source: "env_name",
                 },
             });
+            // The resolved name and id travel in headers only; telemetry keeps
+            // just the source enum.
+            expectTelemetryFreeOfTeamIdentity(
+                runTelemetryPayload?.properties,
+                ["acme", "team-1"],
+            );
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/connector/proxy.ts
+++ b/src/application/commands/connector/proxy.ts
@@ -9,7 +9,7 @@ import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
 import { readJsonInputValue } from "../shared/json-input.ts";
-import { resolveConnectorIdentity } from "./identity.ts";
+import { resolveConnectorIdentityWithEnv } from "./identity.ts";
 import {
     connectorFormatValues,
     runConnectorProxy,
@@ -160,11 +160,15 @@ export const connectorProxyCommand: CliCommandDefinition<ConnectorProxyInput> = 
         const settings = await context.settingsStore.read();
         const { identity, source: identitySource } = target.kind === "self_hosted"
             ? { identity: {}, source: "personal" as const }
-            : resolveConnectorIdentity({
-                    configTeam: getConfiguredIdentityTeam(settings),
-                    teamFlag,
-                    personalFlag: input.personal === true,
-                });
+            : await resolveConnectorIdentityWithEnv(
+                    {
+                        configTeam: getConfiguredIdentityTeam(settings),
+                        target,
+                        teamFlag,
+                        personalFlag: input.personal === true,
+                    },
+                    context,
+                );
 
         context.telemetry?.recordProperties({
             connector_kind: target.kind,

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -17,7 +17,7 @@ import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
 import { readJsonInputValue } from "../shared/json-input.ts";
 import { TerminalProgressRenderer } from "../shared/terminal-progress-renderer.ts";
-import { resolveConnectorIdentity } from "./identity.ts";
+import { resolveConnectorIdentityWithEnv } from "./identity.ts";
 import {
     deleteConnectorActionSchemaCache,
     isConnectorActionSchemaNotFoundError,
@@ -188,11 +188,19 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
         const settings = await context.settingsStore.read();
         const { identity, source: identitySource } = target.kind === "self_hosted"
             ? { identity: {}, source: "personal" as const }
-            : resolveConnectorIdentity({
-                    configTeam: getConfiguredIdentityTeam(settings),
-                    teamFlag,
-                    personalFlag: input.personal === true,
-                });
+            : await resolveConnectorIdentityWithEnv(
+                    {
+                        configTeam: getConfiguredIdentityTeam(settings),
+                        // A dry run never sends the execution request that
+                        // needs the team id, so it must not pay (or fail on)
+                        // the OO_TEAM_NAME membership request.
+                        resolveEnvTeamId: input.dryRun !== true,
+                        target,
+                        teamFlag,
+                        personalFlag: input.personal === true,
+                    },
+                    context,
+                );
         const inputData = await readJsonInputValue(
             input.data,
             context,

--- a/src/application/commands/shared/auth-env-override.ts
+++ b/src/application/commands/shared/auth-env-override.ts
@@ -18,7 +18,9 @@ const endpointEnvName = "OO_ENDPOINT";
 export const envOverrideAccountId = "oo-env-override";
 const envOverrideAccountName = "Environment (OO_API_KEY)";
 
-function readTrimmedEnv(
+// Shared by every env-override reader: a set-but-blank variable behaves
+// exactly like an unset one.
+export function readTrimmedEnv(
     env: Record<string, string | undefined>,
     name: string,
 ): string | undefined {

--- a/src/application/commands/shared/team-env-override.test.ts
+++ b/src/application/commands/shared/team-env-override.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+    readTeamEnvOverride,
+    teamEnvOverrideVariableName,
+} from "./team-env-override.ts";
+
+describe("readTeamEnvOverride", () => {
+    test("returns undefined when neither variable is set", () => {
+        expect(readTeamEnvOverride({})).toBeUndefined();
+    });
+
+    test("treats blank values as unset", () => {
+        expect(readTeamEnvOverride({
+            OO_TEAM_ID: "   ",
+            OO_TEAM_NAME: "",
+        })).toBeUndefined();
+    });
+
+    test("reads a trimmed team id", () => {
+        expect(readTeamEnvOverride({ OO_TEAM_ID: " team-1 " })).toEqual({
+            kind: "id",
+            value: "team-1",
+        });
+    });
+
+    test("reads a trimmed team name", () => {
+        expect(readTeamEnvOverride({ OO_TEAM_NAME: " acme " })).toEqual({
+            kind: "name",
+            value: "acme",
+        });
+    });
+
+    test("prefers the team id when both variables are set", () => {
+        expect(readTeamEnvOverride({
+            OO_TEAM_ID: "team-1",
+            OO_TEAM_NAME: "acme",
+        })).toEqual({
+            kind: "id",
+            value: "team-1",
+        });
+    });
+
+    test("falls back to the name when the id is blank", () => {
+        expect(readTeamEnvOverride({
+            OO_TEAM_ID: "  ",
+            OO_TEAM_NAME: "acme",
+        })).toEqual({
+            kind: "name",
+            value: "acme",
+        });
+    });
+});
+
+describe("teamEnvOverrideVariableName", () => {
+    test("names the variable that supplied the override", () => {
+        expect(teamEnvOverrideVariableName({ kind: "id", value: "team-1" }))
+            .toBe("OO_TEAM_ID");
+        expect(teamEnvOverrideVariableName({ kind: "name", value: "acme" }))
+            .toBe("OO_TEAM_NAME");
+    });
+});

--- a/src/application/commands/shared/team-env-override.ts
+++ b/src/application/commands/shared/team-env-override.ts
@@ -1,0 +1,45 @@
+import { readTrimmedEnv } from "./auth-env-override.ts";
+
+// Environment variables that let embedded and automated callers pin the team
+// identity without touching the `identity.team` config default. OO_TEAM_ID
+// carries the stable team id and is used as-is; OO_TEAM_NAME carries the team
+// name and must be resolved to its id through the account's team memberships
+// before execution.
+export const teamIdEnvName = "OO_TEAM_ID";
+export const teamNameEnvName = "OO_TEAM_NAME";
+
+// The env-selected team, discriminated by which variable supplied it. An `id`
+// override is complete; a `name` override still needs the membership lookup
+// that maps the name to its team id.
+export type TeamEnvOverride
+    = | { kind: "id"; value: string }
+        | { kind: "name"; value: string };
+
+// Reads the team env override. OO_TEAM_ID outranks OO_TEAM_NAME when both are
+// set because the id form is exact and needs no resolution request.
+export function readTeamEnvOverride(
+    env: Record<string, string | undefined>,
+): TeamEnvOverride | undefined {
+    const teamId = readTrimmedEnv(env, teamIdEnvName);
+
+    if (teamId !== undefined) {
+        return { kind: "id", value: teamId };
+    }
+
+    const teamName = readTrimmedEnv(env, teamNameEnvName);
+
+    if (teamName !== undefined) {
+        return { kind: "name", value: teamName };
+    }
+
+    return undefined;
+}
+
+// Names the env variable that supplies the override, for user-facing hints
+// ("unset {envVar} ..."). Kept next to the reader so messages never drift from
+// the actual precedence.
+export function teamEnvOverrideVariableName(
+    override: TeamEnvOverride,
+): string {
+    return override.kind === "id" ? teamIdEnvName : teamNameEnvName;
+}

--- a/src/application/commands/team/clear.ts
+++ b/src/application/commands/team/clear.ts
@@ -48,15 +48,17 @@ export const teamClearCommand: CliCommandDefinition = {
             { teamConfigured: false },
             "Default team identity cleared.",
         );
-        writeLine(context.stdout, context.translator.t("team.clear.success"));
-
-        if (envOverride !== undefined) {
-            writeLine(
-                context.stdout,
-                context.translator.t("team.clear.envOverrideHint", {
-                    envVar: teamEnvOverrideVariableName(envOverride),
-                }),
-            );
-        }
+        // One line per outcome: the plain success message promises a personal
+        // identity, which is untrue while the env override still selects a
+        // team, so the override case gets its own message instead of a
+        // follow-up hint that contradicts the line above it.
+        writeLine(
+            context.stdout,
+            envOverride === undefined
+                ? context.translator.t("team.clear.success")
+                : context.translator.t("team.clear.successEnvOverride", {
+                        envVar: teamEnvOverrideVariableName(envOverride),
+                    }),
+        );
     },
 };

--- a/src/application/commands/team/clear.ts
+++ b/src/application/commands/team/clear.ts
@@ -6,10 +6,16 @@ import {
     unsetIdentityTeam,
 } from "../../schemas/settings.ts";
 import { writeLine } from "../shared/output.ts";
+import {
+    readTeamEnvOverride,
+    teamEnvOverrideVariableName,
+} from "../shared/team-env-override.ts";
 
 // Clears the default team identity (config `identity.team`), returning
 // connector commands to the personal identity. Offline: it only rewrites local
-// settings.
+// settings. When OO_TEAM_ID / OO_TEAM_NAME is set, the env override keeps
+// selecting a team regardless of the cleared default, so the output says so
+// instead of promising a personal identity.
 export const teamClearCommand: CliCommandDefinition = {
     name: "clear",
     summaryKey: "commands.team.clear.summary",
@@ -19,11 +25,19 @@ export const teamClearCommand: CliCommandDefinition = {
         const settings = await context.settingsStore.read();
         const hadConfiguredTeam
             = getConfiguredIdentityTeam(settings) !== undefined;
+        const envOverride = readTeamEnvOverride(context.env);
 
         if (!hadConfiguredTeam) {
             writeLine(
                 context.stdout,
-                context.translator.t("team.clear.alreadyPersonal"),
+                envOverride === undefined
+                    ? context.translator.t("team.clear.alreadyPersonal")
+                    : context.translator.t(
+                            "team.clear.alreadyPersonalEnvHint",
+                            {
+                                envVar: teamEnvOverrideVariableName(envOverride),
+                            },
+                        ),
             );
             return;
         }
@@ -35,5 +49,14 @@ export const teamClearCommand: CliCommandDefinition = {
             "Default team identity cleared.",
         );
         writeLine(context.stdout, context.translator.t("team.clear.success"));
+
+        if (envOverride !== undefined) {
+            writeLine(
+                context.stdout,
+                context.translator.t("team.clear.envOverrideHint", {
+                    envVar: teamEnvOverrideVariableName(envOverride),
+                }),
+            );
+        }
     },
 };

--- a/src/application/commands/team/current.ts
+++ b/src/application/commands/team/current.ts
@@ -5,6 +5,10 @@ import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
 import { writeLine } from "../shared/output.ts";
+import {
+    readTeamEnvOverride,
+    teamEnvOverrideVariableName,
+} from "../shared/team-env-override.ts";
 import { teamFormatValues } from "./shared.ts";
 
 interface TeamCurrentInput {
@@ -12,14 +16,22 @@ interface TeamCurrentInput {
     showSchemaVersion?: boolean;
 }
 
+// `source` says which mechanism selects the team: the OO_TEAM_ID /
+// OO_TEAM_NAME env override, the `identity.team` config default, or none
+// (personal). `team` carries the name when it is known and `teamId` the id;
+// an env id override knows only the id, and this offline command never
+// resolves one form into the other.
 interface TeamCurrentJsonPayload {
     team: string | null;
+    teamId: string | null;
+    source: "config" | "env_id" | "env_name" | null;
 }
 
-// Reports the default team identity (config `identity.team`) that connector
-// commands use when no `--team` / `--personal` flag is given. Offline by
-// design: it only reads local settings, so agents can cheaply learn "which
-// identity do I run as by default" without a network round-trip.
+// Reports the team identity that connector commands use when no `--team` /
+// `--personal` flag is given: the OO_TEAM_ID / OO_TEAM_NAME env override when
+// set, otherwise the config `identity.team` default. Offline by design: it
+// only reads local settings and the environment, so agents can cheaply learn
+// "which identity do I run as by default" without a network round-trip.
 export const teamCurrentCommand: CliCommandDefinition<TeamCurrentInput> = {
     name: "current",
     summaryKey: "commands.team.current.summary",
@@ -33,19 +45,53 @@ export const teamCurrentCommand: CliCommandDefinition<TeamCurrentInput> = {
     handler: async (input, context) => {
         const settings = await context.settingsStore.read();
         const configuredTeam = getConfiguredIdentityTeam(settings);
+        const envOverride = readTeamEnvOverride(context.env);
+
+        const source = envOverride !== undefined
+            ? (envOverride.kind === "id" ? "env_id" as const : "env_name" as const)
+            : (configuredTeam !== undefined ? "config" as const : null);
 
         context.telemetry?.recordProperties({
             has_configured_team: configuredTeam !== undefined,
+            team_source: source ?? "none",
         });
 
         if (input.format === "json") {
             const payload: TeamCurrentJsonPayload = {
-                team: configuredTeam ?? null,
+                team: envOverride !== undefined
+                    ? (envOverride.kind === "name" ? envOverride.value : null)
+                    : configuredTeam ?? null,
+                teamId: envOverride?.kind === "id" ? envOverride.value : null,
+                source,
             };
 
             writeJsonOutput(context.stdout, payload, {
                 showSchemaVersion: input.showSchemaVersion,
             });
+            return;
+        }
+
+        if (envOverride !== undefined) {
+            writeLine(
+                context.stdout,
+                envOverride.kind === "id"
+                    ? context.translator.t("team.current.text.envId", {
+                            teamId: envOverride.value,
+                        })
+                    : context.translator.t("team.current.text.envName", {
+                            team: envOverride.value,
+                        }),
+            );
+
+            if (configuredTeam !== undefined) {
+                writeLine(
+                    context.stdout,
+                    context.translator.t("team.current.text.configIgnored", {
+                        envVar: teamEnvOverrideVariableName(envOverride),
+                        team: configuredTeam,
+                    }),
+                );
+            }
             return;
         }
 

--- a/src/application/commands/team/index.cli.test.ts
+++ b/src/application/commands/team/index.cli.test.ts
@@ -147,7 +147,11 @@ describe("teamCommand CLI", () => {
             const textResult = await sandbox.run(["team", "current"]);
 
             expect(jsonResult.exitCode).toBe(0);
-            expect(JSON.parse(jsonResult.stdout)).toEqual({ team: "acme" });
+            expect(JSON.parse(jsonResult.stdout)).toEqual({
+                team: "acme",
+                teamId: null,
+                source: "config",
+            });
             expect(textResult.stdout).toContain("acme");
         }
         finally {
@@ -165,7 +169,11 @@ describe("teamCommand CLI", () => {
             const textResult = await sandbox.run(["team", "current"]);
 
             expect(jsonResult.exitCode).toBe(0);
-            expect(JSON.parse(jsonResult.stdout)).toEqual({ team: null });
+            expect(JSON.parse(jsonResult.stdout)).toEqual({
+                team: null,
+                teamId: null,
+                source: null,
+            });
             expect(textResult.stdout).toContain("personal identity");
         }
         finally {
@@ -191,7 +199,11 @@ describe("teamCommand CLI", () => {
 
             expect(useResult.exitCode).toBe(0);
             expect(requests).toHaveLength(1);
-            expect(JSON.parse(currentResult.stdout)).toEqual({ team: "beta" });
+            expect(JSON.parse(currentResult.stdout)).toEqual({
+                team: "beta",
+                teamId: null,
+                source: "config",
+            });
         }
         finally {
             await sandbox.cleanup();
@@ -210,7 +222,11 @@ describe("teamCommand CLI", () => {
             const currentResult = await sandbox.run(["team", "current", "--json"]);
 
             expect(result.exitCode).toBe(1);
-            expect(JSON.parse(currentResult.stdout)).toEqual({ team: null });
+            expect(JSON.parse(currentResult.stdout)).toEqual({
+                team: null,
+                teamId: null,
+                source: null,
+            });
         }
         finally {
             await sandbox.cleanup();
@@ -228,7 +244,11 @@ describe("teamCommand CLI", () => {
             const currentResult = await sandbox.run(["team", "current", "--json"]);
 
             expect(clearResult.exitCode).toBe(0);
-            expect(JSON.parse(currentResult.stdout)).toEqual({ team: null });
+            expect(JSON.parse(currentResult.stdout)).toEqual({
+                team: null,
+                teamId: null,
+                source: null,
+            });
         }
         finally {
             await sandbox.cleanup();
@@ -245,6 +265,162 @@ describe("teamCommand CLI", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toContain("personal identity");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports the OO_TEAM_ID env override via current", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await sandbox.run(["config", "set", "identity.team", "acme"]);
+            sandbox.env.OO_TEAM_ID = "team-1";
+
+            const jsonResult = await sandbox.run(["team", "current", "--json"]);
+            const textResult = await sandbox.run(["team", "current"]);
+            const telemetryPayload = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            )
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "team.current");
+
+            expect(jsonResult.exitCode).toBe(0);
+            expect(JSON.parse(jsonResult.stdout)).toEqual({
+                team: null,
+                teamId: "team-1",
+                source: "env_id",
+            });
+            expect(textResult.stdout).toContain("OO_TEAM_ID");
+            expect(textResult.stdout).toContain("team-1");
+            // The configured default is reported as inactive.
+            expect(textResult.stdout).toContain("acme");
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    has_configured_team: true,
+                    team_source: "env_id",
+                },
+            });
+            expect(telemetryPayload?.properties).not.toHaveProperty("team");
+            expect(telemetryPayload?.properties).not.toHaveProperty("team_id");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports the OO_TEAM_NAME env override via current without resolving it", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await sandbox.run(["config", "set", "identity.team", "acme"]);
+            sandbox.env.OO_TEAM_NAME = "beta";
+
+            let requested = false;
+            const jsonResult = await sandbox.run(["team", "current", "--json"], {
+                fetcher: async () => {
+                    requested = true;
+
+                    return new Response(JSON.stringify(teamsResponse));
+                },
+            });
+            const textResult = await sandbox.run(["team", "current"]);
+            const telemetryPayload = readTelemetryRowsForTest(
+                join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+            )
+                .map(row => parseTelemetryRowPayload(row))
+                .find(payload => payload?.properties?.command_full === "team.current");
+
+            expect(jsonResult.exitCode).toBe(0);
+            expect(JSON.parse(jsonResult.stdout)).toEqual({
+                team: "beta",
+                teamId: null,
+                source: "env_name",
+            });
+            // `team current` stays offline even under the env override.
+            expect(requested).toBe(false);
+            expect(textResult.stdout).toContain("OO_TEAM_NAME");
+            expect(textResult.stdout).toContain("beta");
+            // The ignored config default is reported alongside.
+            expect(textResult.stdout).toContain("acme");
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    has_configured_team: true,
+                    team_source: "env_name",
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("marks the env-selected team as current in the listing", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await sandbox.run(["config", "set", "identity.team", "acme"]);
+            sandbox.env.OO_TEAM_ID = "team-2";
+
+            const result = await sandbox.run(["team", "list", "--json"], {
+                fetcher: async () => new Response(JSON.stringify(teamsResponse)),
+            });
+
+            expect(result.exitCode).toBe(0);
+            // The env override outranks the configured default, so the marker
+            // follows the id from OO_TEAM_ID instead of the `acme` name.
+            expect(JSON.parse(result.stdout)).toEqual([
+                { name: "acme", id: "team-1", role: "creator", current: false },
+                { name: "beta", id: "team-2", role: "member", current: true },
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("hints that the env override still outranks a newly set default", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_TEAM_NAME = "acme";
+
+            const result = await sandbox.run(["team", "use", "beta"], {
+                fetcher: async () => new Response(JSON.stringify(teamsResponse)),
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("Set the default team identity to beta.");
+            expect(result.stdout).toContain("OO_TEAM_NAME");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("hints that the env override still selects a team after clearing", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await sandbox.run(["config", "set", "identity.team", "acme"]);
+            sandbox.env.OO_TEAM_ID = "team-1";
+
+            const clearResult = await sandbox.run(["team", "clear"]);
+            const repeatResult = await sandbox.run(["team", "clear"]);
+
+            expect(clearResult.exitCode).toBe(0);
+            expect(clearResult.stdout).toContain("OO_TEAM_ID");
+            // The follow-up clear has nothing to remove but still points at
+            // the env override instead of promising a personal identity.
+            expect(repeatResult.exitCode).toBe(0);
+            expect(repeatResult.stdout).toContain("OO_TEAM_ID");
+            expect(repeatResult.stdout).not.toContain("personal identity");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/team/index.cli.test.ts
+++ b/src/application/commands/team/index.cli.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
     createCliSandbox,
+    expectTelemetryFreeOfTeamIdentity,
     toRequest,
     writeAuthFile,
 } from "../../../../__tests__/helpers.ts";
@@ -303,8 +304,12 @@ describe("teamCommand CLI", () => {
                     team_source: "env_id",
                 },
             });
-            expect(telemetryPayload?.properties).not.toHaveProperty("team");
-            expect(telemetryPayload?.properties).not.toHaveProperty("team_id");
+            // Only the source enum is reported: neither the env-selected id
+            // nor the configured team name reaches telemetry.
+            expectTelemetryFreeOfTeamIdentity(
+                telemetryPayload?.properties,
+                ["team-1", "acme"],
+            );
         }
         finally {
             await sandbox.cleanup();
@@ -352,6 +357,10 @@ describe("teamCommand CLI", () => {
                     team_source: "env_name",
                 },
             });
+            expectTelemetryFreeOfTeamIdentity(
+                telemetryPayload?.properties,
+                ["beta", "acme"],
+            );
         }
         finally {
             await sandbox.cleanup();
@@ -416,6 +425,13 @@ describe("teamCommand CLI", () => {
 
             expect(clearResult.exitCode).toBe(0);
             expect(clearResult.stdout).toContain("OO_TEAM_ID");
+            // The saved default is gone, but the env override still selects a
+            // team, so the output must not claim connector commands now run
+            // personally — it reports the override instead.
+            expect(clearResult.stdout).toContain("Cleared the default team identity");
+            expect(clearResult.stdout).not.toContain(
+                "connector commands now run under your personal identity",
+            );
             // The follow-up clear has nothing to remove but still points at
             // the env override instead of promising a personal identity.
             expect(repeatResult.exitCode).toBe(0);

--- a/src/application/commands/team/list.ts
+++ b/src/application/commands/team/list.ts
@@ -1,5 +1,6 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
 import type { TerminalColors } from "../../terminal-colors.ts";
+import type { TeamEnvOverride } from "../shared/team-env-override.ts";
 
 import type { TeamRole, TeamView } from "./shared.ts";
 
@@ -10,6 +11,7 @@ import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
+import { readTeamEnvOverride } from "../shared/team-env-override.ts";
 import { listMemberTeams, teamFormatValues } from "./shared.ts";
 
 interface TeamListInput {
@@ -37,10 +39,13 @@ export const teamListCommand: CliCommandDefinition<TeamListInput> = {
     handler: async (input, context) => {
         const account = await requireCurrentAccount(context);
         const settings = await context.settingsStore.read();
-        const configuredTeam = getConfiguredIdentityTeam(settings);
+        const isCurrent = createCurrentTeamMatcher(
+            readTeamEnvOverride(context.env),
+            getConfiguredIdentityTeam(settings),
+        );
 
         const teams = await listMemberTeams(account, context);
-        const output = teams.map(team => createTeamListItem(team, configuredTeam));
+        const output = teams.map(team => createTeamListItem(team, isCurrent));
 
         context.telemetry?.recordProperties({
             result_count_bucket: bucketTelemetryCount(output.length),
@@ -63,12 +68,29 @@ export const teamListCommand: CliCommandDefinition<TeamListInput> = {
     },
 };
 
+// Decides which row is the effective default for connector commands: the
+// OO_TEAM_ID / OO_TEAM_NAME env override when set (matched by id or name
+// respectively), otherwise the `identity.team` config default (matched by
+// name).
+function createCurrentTeamMatcher(
+    envOverride: TeamEnvOverride | undefined,
+    configuredTeam: string | undefined,
+): (team: TeamView) => boolean {
+    if (envOverride !== undefined) {
+        return envOverride.kind === "id"
+            ? team => team.id === envOverride.value
+            : team => team.name === envOverride.value;
+    }
+
+    return team => configuredTeam !== undefined && team.name === configuredTeam;
+}
+
 function createTeamListItem(
     team: TeamView,
-    configuredTeam: string | undefined,
+    isCurrent: (team: TeamView) => boolean,
 ): TeamListItem {
     return {
-        current: team.name === configuredTeam,
+        current: isCurrent(team),
         id: team.id,
         name: team.name,
         role: team.role,
@@ -82,9 +104,10 @@ interface TeamListColumn {
     render: (team: TeamListItem) => string;
 }
 
-// Renders the team listing as a color-coded, column-aligned table. The current
-// default (matching `identity.team`) is marked so callers can see at a glance
-// which value `oo connector run` uses without `--team`.
+// Renders the team listing as a color-coded, column-aligned table. The
+// effective default (the OO_TEAM_ID / OO_TEAM_NAME env override, or
+// `identity.team`) is marked so callers can see at a glance which team
+// `oo connector run` uses without `--team`.
 export function formatTeamsAsText(
     teams: readonly TeamListItem[],
     translator: TeamListTranslator,

--- a/src/application/commands/team/use.ts
+++ b/src/application/commands/team/use.ts
@@ -5,6 +5,10 @@ import { CliUserError } from "../../contracts/cli.ts";
 import { setIdentityTeam } from "../../schemas/settings.ts";
 import { requireCurrentAccount } from "../shared/auth-utils.ts";
 import { writeLine } from "../shared/output.ts";
+import {
+    readTeamEnvOverride,
+    teamEnvOverrideVariableName,
+} from "../shared/team-env-override.ts";
 import { listMemberTeams } from "./shared.ts";
 
 interface TeamUseInput {
@@ -57,5 +61,18 @@ export const teamUseCommand: CliCommandDefinition<TeamUseInput> = {
             context.stdout,
             context.translator.t("team.use.success", { team: name }),
         );
+
+        // Mirrors `oo auth login` under OO_API_KEY: the default is saved, but
+        // the env override keeps outranking it, so say so instead of letting
+        // the success line imply the new default is in effect.
+        const envOverride = readTeamEnvOverride(context.env);
+        if (envOverride !== undefined) {
+            writeLine(
+                context.stdout,
+                context.translator.t("team.use.envOverrideHint", {
+                    envVar: teamEnvOverrideVariableName(envOverride),
+                }),
+            );
+        }
     },
 };

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -139,7 +139,7 @@ const commandTelemetryDecisions = {
             "list_scope",
             "result_count_bucket",
         ],
-        reason: "Records bounded connector app list size, the connector target kind (oomol/self_hosted), the identity source (personal/flag/config), and whether the listing was scoped to all apps or one service, without app ids, connection names, account labels, team names, or server URLs.",
+        reason: "Records bounded connector app list size, the connector target kind (oomol/self_hosted), the identity source (personal/flag/env_id/env_name/config), and whether the listing was scoped to all apps or one service, without app ids, connection names, account labels, team names or ids, or server URLs.",
     },
     "connector.login": {
         kind: "properties",
@@ -165,7 +165,7 @@ const commandTelemetryDecisions = {
             "wait",
             "wait_result",
         ],
-        reason: "Records connector product dimensions, bucketed payload size, async wait modes, stable error code, identity source (personal/flag/config), and none/connectionName selector mode without the team name or connection name value.",
+        reason: "Records connector product dimensions, bucketed payload size, async wait modes, stable error code, identity source (personal/flag/env_id/env_name/config), and none/connectionName selector mode without the team name/id or connection name value.",
     },
     "connector.proxy": {
         kind: "properties",
@@ -178,7 +178,7 @@ const commandTelemetryDecisions = {
             "identity_source",
             "method",
         ],
-        reason: "Records connector proxy bucketed payload size, method enum, identity source, stable error code, and HTTP status without service name, endpoint, headers, body, or team name.",
+        reason: "Records connector proxy bucketed payload size, method enum, identity source (personal/flag/env_id/env_name/config), stable error code, and HTTP status without service name, endpoint, headers, body, or team name/id.",
     },
     "connector.search": {
         kind: "properties",
@@ -279,8 +279,8 @@ const commandTelemetryDecisions = {
     },
     "team.current": {
         kind: "properties",
-        properties: ["has_configured_team"],
-        reason: "Records whether a default team identity is configured, without the team name.",
+        properties: ["has_configured_team", "team_source"],
+        reason: "Records whether a default team identity is configured and which mechanism selects the effective team (env_id/env_name/config/none), without the team name or id.",
     },
     "team.use": {
         kind: "generic",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -350,6 +350,8 @@ export const enMessages = {
         "The connector apps request failed: {message}",
     "errors.connectorApps.requestFailed":
         "The connector apps request returned HTTP {status}.",
+    "errors.team.envNameNotAccessible":
+        "The active account cannot access the team \"{team}\" from OO_TEAM_NAME. Run `oo team list` to see the teams you can use.",
     "errors.team.invalidResponse":
         "The team list response body is unsupported.",
     "errors.team.nameEmpty": "The team name must not be empty.",
@@ -1224,11 +1226,23 @@ export const enMessages = {
     "team.current.text.configured": "Default team identity: {team}",
     "team.current.text.personal":
         "No default team; connector commands run under your personal identity.",
+    "team.current.text.envId":
+        "Team identity comes from the OO_TEAM_ID environment variable: {teamId}",
+    "team.current.text.envName":
+        "Team identity comes from the OO_TEAM_NAME environment variable: {team}",
+    "team.current.text.configIgnored":
+        "The `identity.team` config default ({team}) is not in use while {envVar} is set.",
     "team.use.success": "Set the default team identity to {team}.",
+    "team.use.envOverrideHint":
+        "Connector commands keep using the team from {envVar}, not this default. Unset {envVar} to use the saved default.",
     "team.clear.success":
         "Cleared the default team identity; connector commands now run under your personal identity.",
     "team.clear.alreadyPersonal":
         "No default team was set; connector commands already run under your personal identity.",
+    "team.clear.envOverrideHint":
+        "Connector commands still use the team from {envVar}. Unset {envVar} to run under your personal identity.",
+    "team.clear.alreadyPersonalEnvHint":
+        "No default team was set, but {envVar} still selects a team for connector commands.",
     "connector.run.text.dryRunPassed": "Validation passed.",
     "connector.login.manageTokens": "Manage runtime tokens at {accessUrl}",
     "connector.login.noToken":
@@ -1620,6 +1634,8 @@ export const zhMessages = {
         "获取 connector app 列表失败：{message}",
     "errors.connectorApps.requestFailed":
         "获取 connector app 列表返回了 HTTP {status}。",
+    "errors.team.envNameNotAccessible":
+        "当前活动账号无法访问 OO_TEAM_NAME 指定的团队 “{team}”。运行 `oo team list` 查看可用的团队。",
     "errors.team.invalidResponse":
         "团队列表返回了不受支持的响应内容。",
     "errors.team.nameEmpty": "团队名称不能为空。",
@@ -2485,11 +2501,23 @@ export const zhMessages = {
     "team.current.text.configured": "默认团队身份：{team}",
     "team.current.text.personal":
         "未设置默认团队；connector 命令以个人身份运行。",
+    "team.current.text.envId":
+        "团队身份来自 OO_TEAM_ID 环境变量：{teamId}",
+    "team.current.text.envName":
+        "团队身份来自 OO_TEAM_NAME 环境变量：{team}",
+    "team.current.text.configIgnored":
+        "设置了 {envVar} 时，`identity.team` 配置的默认值（{team}）不会生效。",
     "team.use.success": "已将默认团队身份设置为 {team}。",
+    "team.use.envOverrideHint":
+        "connector 命令仍会使用 {envVar} 指定的团队，而不是这个默认值。取消 {envVar} 后保存的默认值才会生效。",
     "team.clear.success":
         "已清除默认团队身份；connector 命令现在以个人身份运行。",
     "team.clear.alreadyPersonal":
         "未设置默认团队；connector 命令本就以个人身份运行。",
+    "team.clear.envOverrideHint":
+        "connector 命令仍会使用 {envVar} 指定的团队。取消 {envVar} 后才会以个人身份运行。",
+    "team.clear.alreadyPersonalEnvHint":
+        "未设置默认团队，但 {envVar} 仍会为 connector 命令选择团队。",
     "connector.run.text.dryRunPassed": "校验通过。",
     "connector.login.manageTokens": "可在 {accessUrl} 管理 Runtime Token。",
     "connector.login.noToken":

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -1239,8 +1239,8 @@ export const enMessages = {
         "Cleared the default team identity; connector commands now run under your personal identity.",
     "team.clear.alreadyPersonal":
         "No default team was set; connector commands already run under your personal identity.",
-    "team.clear.envOverrideHint":
-        "Connector commands still use the team from {envVar}. Unset {envVar} to run under your personal identity.",
+    "team.clear.successEnvOverride":
+        "Cleared the default team identity, but {envVar} still selects the team for connector commands. Unset {envVar} to run under your personal identity.",
     "team.clear.alreadyPersonalEnvHint":
         "No default team was set, but {envVar} still selects a team for connector commands.",
     "connector.run.text.dryRunPassed": "Validation passed.",
@@ -2514,8 +2514,8 @@ export const zhMessages = {
         "已清除默认团队身份；connector 命令现在以个人身份运行。",
     "team.clear.alreadyPersonal":
         "未设置默认团队；connector 命令本就以个人身份运行。",
-    "team.clear.envOverrideHint":
-        "connector 命令仍会使用 {envVar} 指定的团队。取消 {envVar} 后才会以个人身份运行。",
+    "team.clear.successEnvOverride":
+        "已清除默认团队身份，但 {envVar} 仍会为 connector 命令选择团队。取消 {envVar} 后才会以个人身份运行。",
     "team.clear.alreadyPersonalEnvHint":
         "未设置默认团队，但 {envVar} 仍会为 connector 命令选择团队。",
     "connector.run.text.dryRunPassed": "校验通过。",


### PR DESCRIPTION
Embedded and automated callers (CI jobs, agent wrappers) need to pin the connector team identity per process — the same way `OO_API_KEY` pins the credential — without rewriting the shared `identity.team` config default. This adds two environment variables that select the team for `oo connector run/proxy/apps`, with precedence `--personal` / `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` > `identity.team` config > personal identity.

The canonical value is the stable team id, since names are mutable. `OO_TEAM_ID` is used as-is (no request, no membership check) and sent as a new `x-oo-team-id` header. `OO_TEAM_NAME` is resolved to its id through `GET /v1/me/teams` before execution, and the request then carries both `x-oo-team-name` and `x-oo-team-id`, so the name path keeps working against a gateway that only knows the name header. An inaccessible name fails with exit `1` before any execution request is sent; `oo connector run --dry-run` skips the resolution entirely and stays offline; self-hosted targets ignore both variables, like they already ignore the config default.

⚠️ One thing for the backend side: `x-oo-team-id` is a **new header** — until now the whole ecosystem (CLI and connector-sdk) identified teams only by `x-oo-team-name`. The gateway needs to accept team ids for `OO_TEAM_ID`-only runs to take effect; until then such runs would be treated as personal. The `OO_TEAM_NAME` path is backward compatible since it always carries the name header too.

The team commands stay truthful under the override, mirroring the `OO_API_KEY` treatment in the auth commands (#301, #302): `oo team current` reports the env-selected team (its JSON gains additive `teamId` and `source` fields), `oo team use` / `oo team clear` warn that the variable keeps outranking the saved default, and the `oo team list` current marker follows the effective selection. Telemetry only extends the `identity_source` enum with `env_id` / `env_name` and adds a `team_source` enum to `team.current` — team names and ids are still never recorded.

Tests cover the precedence chain, the name→id resolution (including an aborted run when the membership request fails), the dry-run offline guarantee, and the env-aware team command output in both JSON and text.