### PR TITLE
feat(connector): scope search authenticated status by team identity

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -50,7 +50,8 @@ use. Truthy values are `1`, `true`, `yes`, or `on` (case-insensitive).
   `OO_CONNECTOR_URL` > `OO_API_KEY` > the saved self-hosted connector
   configuration (`oo connector login`) > the active account.
 - `OO_TEAM_ID`: Run connector commands (`oo connector run`, `oo connector
-  proxy`, `oo connector apps`) under the team with this id. It takes precedence
+  proxy`, `oo connector apps`, `oo connector search` / `oo search`) under the
+  team with this id. It takes precedence
   over `OO_TEAM_NAME` and the `identity.team` config default; the per-run
   `--team` and `--personal` flags still outrank it. The value is sent as-is
   without a membership check. Ignored when the connector target is
@@ -448,9 +449,9 @@ Persist one configuration value.
   not recorded as telemetry.
 - Value rules: for `identity.team`, use any non-empty team name.
   It sets the default team identity used by `oo connector run`,
-  `oo connector proxy`, and `oo connector apps` when neither `--team` nor
-  `--personal` is passed and no `OO_TEAM_ID` / `OO_TEAM_NAME` environment
-  variable is set.
+  `oo connector proxy`, `oo connector apps`, and `oo connector search` /
+  `oo search` when neither `--team` nor `--personal` is passed and no
+  `OO_TEAM_ID` / `OO_TEAM_NAME` environment variable is set.
 
 ### `oo config unset <key>`
 
@@ -744,11 +745,22 @@ Search connector actions with free-form text.
 - Arguments: `<text>` is the semantic search text.
 - Options: `--format=json` and `--json` print a JSON array of matching action
   entries.
+- Options: `--team <name>` reports each result's `authenticated` state under the
+  given team identity instead of your personal identity. When omitted, the
+  effective identity follows `OO_TEAM_ID` / `OO_TEAM_NAME`, then the
+  `identity.team` config default, otherwise your personal identity.
+- Options: `--personal` reports `authenticated` under your personal identity and
+  ignores the `OO_TEAM_ID` / `OO_TEAM_NAME` environment variables and any
+  configured default team. It cannot be combined with `--team`.
 - Output: every match includes `authenticated`.
 - Output: JSON entries include the stable CLI fields `service`, `name`,
   `description`, and `authenticated`.
 - Output: text output prints one block per action with the service/action
   label, optional description, and authenticated state.
+- Notes: the action list itself does not depend on identity; only each result's
+  `authenticated` state reflects the effective identity's connected apps, so an
+  app connected under a team appears as authenticated only when that team is the
+  effective identity.
 - Notes: use `oo connector schema "<service>.<action>"` to inspect the selected
   action contract.
 - Notes: search results also warm the local action schema cache when schema
@@ -970,11 +982,22 @@ Search connector actions with one free-form query.
 - Arguments: `<text>` is the semantic search text.
 - Options: `--format=json` and `--json` print a JSON array of matching action
   entries.
+- Options: `--team <name>` reports each result's `authenticated` state under the
+  given team identity instead of your personal identity. When omitted, the
+  effective identity follows `OO_TEAM_ID` / `OO_TEAM_NAME`, then the
+  `identity.team` config default, otherwise your personal identity.
+- Options: `--personal` reports `authenticated` under your personal identity and
+  ignores the `OO_TEAM_ID` / `OO_TEAM_NAME` environment variables and any
+  configured default team. It cannot be combined with `--team`.
 - Output: every match includes `authenticated`.
 - Output: JSON entries include the stable CLI fields `service`, `name`,
   `description`, and `authenticated`.
 - Output: text output prints one block per action with the service/action
   label, optional description, and authenticated state.
+- Notes: the action list itself does not depend on identity; only each result's
+  `authenticated` state reflects the effective identity's connected apps, so an
+  app connected under a team appears as authenticated only when that team is the
+  effective identity.
 - Notes: use `oo connector schema "<service>.<action>"` to inspect the full
   connector action contract.
 - Notes: search results also warm the local action schema cache when schema

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -42,7 +42,8 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   `OO_CONNECTOR_URL` > `OO_API_KEY` > 已保存的自部署 Connector 配置
   （`oo connector login`）> 当前激活账号。
 - `OO_TEAM_ID`：让 connector 命令（`oo connector run`、`oo connector proxy`、
-  `oo connector apps`）以该 id 对应的团队身份运行。优先级高于 `OO_TEAM_NAME`
+  `oo connector apps`、`oo connector search` / `oo search`）以该 id 对应的团队
+  身份运行。优先级高于 `OO_TEAM_NAME`
   和 `identity.team` 配置默认值；每次运行的 `--team` 与 `--personal`
   标志仍然优先于它。取值按原样发送，不做成员关系校验。当 connector
   目标为自部署服务时会被忽略。
@@ -387,9 +388,9 @@ apps`）以某个团队身份运行，而非个人账号：既可用每次运行
   CLI 还会立即尝试清空待发送 telemetry 事件，并且本次 `config set` 调用自身不会被记录为
   telemetry。
 - 取值规则：当 `<key>` 为 `identity.team` 时，支持任意非空的团队名称。
-  它设置 `oo connector run`、`oo connector proxy` 和 `oo connector apps`
-  在未传 `--team` 或 `--personal`、且未设置 `OO_TEAM_ID` / `OO_TEAM_NAME`
-  环境变量时使用的默认团队身份。
+  它设置 `oo connector run`、`oo connector proxy`、`oo connector apps` 和
+  `oo connector search` / `oo search` 在未传 `--team` 或 `--personal`、且未
+  设置 `OO_TEAM_ID` / `OO_TEAM_NAME` 环境变量时使用的默认团队身份。
 
 ### `oo config unset <key>`
 
@@ -631,11 +632,19 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 
 - 参数：`<text>` 为语义搜索文本。
 - 选项：`--format=json` 和 `--json` 会输出匹配 action 条目的 JSON 数组。
+- 选项：`--team <name>` 以指定团队身份（而非个人身份）报告每条结果的
+  `authenticated` 状态。省略时有效身份依次取 `OO_TEAM_ID` / `OO_TEAM_NAME`、
+  `identity.team` 配置默认值，最后回退到个人身份。
+- 选项：`--personal` 以个人身份报告 `authenticated`，忽略 `OO_TEAM_ID` /
+  `OO_TEAM_NAME` 环境变量与任何已配置的默认团队；不能与 `--team` 同用。
 - 输出：每条结果都会包含 `authenticated`。
 - 输出：JSON 条目只包含稳定的 CLI 字段：`service`、`name`、`description`、
   `authenticated`。
 - 输出：文本输出会为每个 action 打印一个块，包含 service/action 标识、可选
   描述和认证状态。
+- 说明：action 列表本身与身份无关，只有每条结果的 `authenticated` 状态反映
+  有效身份下的已连接应用；因此连接在团队下的应用只有当该团队为有效身份时才显示
+  为已认证。
 - 说明：使用 `oo connector schema "<service>.<action>"` 查看选中 action 的
   contract。
 - 说明：搜索结果附带 schema 数据时还会更新本地 action schema 缓存，因此随后
@@ -819,11 +828,19 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 
 - 参数：`<text>` 为语义搜索文本。
 - 选项：`--format=json` 和 `--json` 会输出匹配 action 条目的 JSON 数组。
+- 选项：`--team <name>` 以指定团队身份（而非个人身份）报告每条结果的
+  `authenticated` 状态。省略时有效身份依次取 `OO_TEAM_ID` / `OO_TEAM_NAME`、
+  `identity.team` 配置默认值，最后回退到个人身份。
+- 选项：`--personal` 以个人身份报告 `authenticated`，忽略 `OO_TEAM_ID` /
+  `OO_TEAM_NAME` 环境变量与任何已配置的默认团队；不能与 `--team` 同用。
 - 输出：每条结果都会包含 `authenticated`。
 - 输出：JSON 条目只包含稳定的 CLI 字段：`service`、`name`、`description`、
   `authenticated`。
 - 输出：文本输出会为每个 action 打印一个块，包含 service/action 标识、可选
   描述和认证状态。
+- 说明：action 列表本身与身份无关，只有每条结果的 `authenticated` 状态反映
+  有效身份下的已连接应用；因此连接在团队下的应用只有当该团队为有效身份时才显示
+  为已认证。
 - 说明：使用 `oo connector schema "<service>.<action>"` 获取完整 connector
   action contract。
 - 说明：搜索结果附带 schema 数据时还会更新本地 action schema 缓存，因此随后

--- a/src/application/commands/__snapshots__/search.cli.test.ts.snap
+++ b/src/application/commands/__snapshots__/search.cli.test.ts.snap
@@ -47,6 +47,10 @@ Arguments:
   text                   Search text
 
 Options:
+  --team <team>          Report each action's authenticated status under the
+                         given team identity
+  --personal             Report authenticated status under your personal
+                         identity, ignoring any configured default team
   --format <format>      Specify output format (use json for structured output)
   --json                 Alias for --format=json
   --show-schema-version  Include schemaVersion in JSON output (no effect without
@@ -70,6 +74,10 @@ Arguments:
   text                   Search text
 
 Options:
+  --team <team>          Report each action's authenticated status under the
+                         given team identity
+  --personal             Report authenticated status under your personal
+                         identity, ignoring any configured default team
   --format <format>      Specify output format (use json for structured output)
   --json                 Alias for --format=json
   --show-schema-version  Include schemaVersion in JSON output (no effect without

--- a/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/connector/__snapshots__/index.cli.test.ts.snap
@@ -60,6 +60,10 @@ Arguments:
   text                   Search text
 
 Options:
+  --team <team>          Report each action's authenticated status under the
+                         given team identity
+  --personal             Report authenticated status under your personal
+                         identity, ignoring any configured default team
   --format <format>      Specify output format (use json for structured output)
   --json                 Alias for --format=json
   --show-schema-version  Include schemaVersion in JSON output (no effect without
@@ -83,6 +87,10 @@ Arguments:
   text                   Search text
 
 Options:
+  --team <team>          Report each action's authenticated status under the
+                         given team identity
+  --personal             Report authenticated status under your personal
+                         identity, ignoring any configured default team
   --format <format>      Specify output format (use json for structured output)
   --json                 Alias for --format=json
   --show-schema-version  Include schemaVersion in JSON output (no effect without

--- a/src/application/commands/connector/search-provider.ts
+++ b/src/application/commands/connector/search-provider.ts
@@ -1,6 +1,7 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { TerminalColors } from "../../terminal-colors.ts";
 
+import type { ConnectorIdentity } from "./identity.ts";
 import type { ConnectorActionSearchResult } from "./shared.ts";
 import type { ConnectorTarget } from "./target.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
@@ -22,6 +23,7 @@ type ConnectorSearchTextContext = Pick<CliExecutionContext, "stdout" | "translat
 
 export async function loadConnectorSearchResults(
     options: {
+        identity?: ConnectorIdentity;
         target: Pick<
             ConnectorTarget,
             "authorization" | "baseUrl" | "cacheAccountId" | "cacheEndpoint" | "kind"
@@ -34,6 +36,7 @@ export async function loadConnectorSearchResults(
     >,
 ): Promise<ConnectorSearchResult[]> {
     const actions = await searchConnectorActions({
+        identity: options.identity,
         target: options.target,
         text: options.text,
     }, context);

--- a/src/application/commands/connector/search.ts
+++ b/src/application/commands/connector/search.ts
@@ -1,12 +1,15 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
 import {
     bucketTelemetryCount,
     bucketTelemetryStringLength,
 } from "../../telemetry/buckets.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
+import { resolveConnectorIdentityWithEnv } from "./identity.ts";
 import {
     formatConnectorSearchResultsAsText,
     loadConnectorSearchResults,
@@ -16,6 +19,8 @@ import { resolveConnectorTarget } from "./target.ts";
 
 interface ConnectorSearchInput {
     format?: (typeof connectorFormatValues)[number];
+    team?: string;
+    personal?: boolean;
     showSchemaVersion?: boolean;
     text: string;
 }
@@ -33,27 +38,71 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
         },
     ],
     options: [
+        {
+            name: "team",
+            longFlag: "--team",
+            valueName: "team",
+            descriptionKey: "options.searchTeam",
+        },
+        {
+            name: "personal",
+            longFlag: "--personal",
+            descriptionKey: "options.searchPersonal",
+        },
         ...jsonOutputOptions,
     ],
     inputSchema: z.object({
         format: z.enum(connectorFormatValues).optional(),
+        team: z.string().optional(),
+        personal: z.boolean().optional(),
         showSchemaVersion: z.boolean().optional(),
         text: z.string(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
+        if (input.personal === true && input.team !== undefined) {
+            throw new CliUserError("errors.connectorRun.identityConflict", 2);
+        }
+
+        const teamFlag = input.team?.trim();
+        if (input.team !== undefined && teamFlag === "") {
+            throw new CliUserError("errors.connectorRun.teamEmpty", 2);
+        }
+
         context.telemetry?.recordProperties({
             query_length_bucket: bucketTelemetryStringLength(input.text),
         });
 
         const target = await resolveConnectorTarget(context);
 
+        // Mirrors `connector run`: the self-hosted runtime has no team concept,
+        // so an explicit --team is rejected and any configured default identity
+        // is ignored.
+        if (target.kind === "self_hosted" && teamFlag !== undefined) {
+            throw new CliUserError("errors.connector.teamUnsupported", 2);
+        }
+
+        const settings = await context.settingsStore.read();
+        const { identity, source: identitySource } = target.kind === "self_hosted"
+            ? { identity: {}, source: "personal" as const }
+            : await resolveConnectorIdentityWithEnv(
+                    {
+                        configTeam: getConfiguredIdentityTeam(settings),
+                        target,
+                        teamFlag,
+                        personalFlag: input.personal === true,
+                    },
+                    context,
+                );
+
         context.telemetry?.recordProperties({
             connector_kind: target.kind,
+            identity_source: identitySource,
         });
 
         const results = await loadConnectorSearchResults(
             {
+                identity,
                 target,
                 text: input.text,
             },

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -196,6 +196,7 @@ type ConnectorActionFailureResponse = z.output<typeof connectorActionFailureResp
 
 export async function searchConnectorActions(
     options: {
+        identity?: ConnectorIdentity;
         target: ConnectorRequestTarget;
         text: string;
     },
@@ -233,7 +234,13 @@ export async function searchConnectorActions(
             },
         },
         init: {
-            headers: connectorAuthorizationHeaders(options.target),
+            // The action list itself is identity-independent, but each result's
+            // `authenticated` flag reflects the effective identity's connected
+            // apps, so the identity headers are forwarded like `apps`/`run`.
+            headers: {
+                ...connectorAuthorizationHeaders(options.target),
+                ...connectorIdentityHeaders(options.identity),
+            },
         },
         requestLabel: "Connector action search",
         requestUrl,

--- a/src/application/commands/search.cli.test.ts
+++ b/src/application/commands/search.cli.test.ts
@@ -74,6 +74,61 @@ describe("searchCommand CLI", () => {
         }
     });
 
+    test("sends the team identity header and records its source when --team is given", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["search", "send mail", "--team", "acme"],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response(JSON.stringify({
+                            success: true,
+                            message: "ok",
+                            data: [
+                                {
+                                    authenticated: true,
+                                    description: "Send a Gmail message.",
+                                    name: "send_mail",
+                                    service: "gmail",
+                                },
+                            ],
+                        }));
+                    },
+                },
+            );
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(1);
+            // The action list is identity-independent, but the team identity is
+            // forwarded so the backend scopes each result's authenticated flag.
+            expect(requests[0]?.url).toBe(
+                "https://connector.oomol.com/v1/actions/search?q=send+mail",
+            );
+            expect(requests[0]?.headers.get("x-oo-team-name")).toBe("acme");
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    command_full: "search",
+                    identity_source: "flag",
+                },
+            });
+            expect(telemetryPayload?.properties).not.toHaveProperty("team");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("supports connector search with json output", async () => {
         const sandbox = await createCliSandbox();
 

--- a/src/application/commands/search.ts
+++ b/src/application/commands/search.ts
@@ -2,10 +2,13 @@ import type { CliCommandDefinition } from "../contracts/cli.ts";
 
 import { z } from "zod";
 
+import { CliUserError } from "../contracts/cli.ts";
+import { getConfiguredIdentityTeam } from "../schemas/settings.ts";
 import {
     bucketTelemetryCount,
     bucketTelemetryStringLength,
 } from "../telemetry/buckets.ts";
+import { resolveConnectorIdentityWithEnv } from "./connector/identity.ts";
 import {
     formatConnectorSearchResultsAsText,
     loadConnectorSearchResults,
@@ -18,6 +21,8 @@ const searchFormatValues = ["json"] as const;
 
 interface SearchInput {
     format?: (typeof searchFormatValues)[number];
+    team?: string;
+    personal?: boolean;
     showSchemaVersion?: boolean;
     text: string;
 }
@@ -35,27 +40,71 @@ export const searchCommand: CliCommandDefinition<SearchInput> = {
         },
     ],
     options: [
+        {
+            name: "team",
+            longFlag: "--team",
+            valueName: "team",
+            descriptionKey: "options.searchTeam",
+        },
+        {
+            name: "personal",
+            longFlag: "--personal",
+            descriptionKey: "options.searchPersonal",
+        },
         ...jsonOutputOptions,
     ],
     inputSchema: z.object({
         format: z.enum(searchFormatValues).optional(),
+        team: z.string().optional(),
+        personal: z.boolean().optional(),
         showSchemaVersion: z.boolean().optional(),
         text: z.string(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
+        if (input.personal === true && input.team !== undefined) {
+            throw new CliUserError("errors.connectorRun.identityConflict", 2);
+        }
+
+        const teamFlag = input.team?.trim();
+        if (input.team !== undefined && teamFlag === "") {
+            throw new CliUserError("errors.connectorRun.teamEmpty", 2);
+        }
+
         context.telemetry?.recordProperties({
             query_length_bucket: bucketTelemetryStringLength(input.text),
         });
 
         const target = await resolveConnectorTarget(context);
 
+        // Mirrors `connector run`: the self-hosted runtime has no team concept,
+        // so an explicit --team is rejected and any configured default identity
+        // is ignored.
+        if (target.kind === "self_hosted" && teamFlag !== undefined) {
+            throw new CliUserError("errors.connector.teamUnsupported", 2);
+        }
+
+        const settings = await context.settingsStore.read();
+        const { identity, source: identitySource } = target.kind === "self_hosted"
+            ? { identity: {}, source: "personal" as const }
+            : await resolveConnectorIdentityWithEnv(
+                    {
+                        configTeam: getConfiguredIdentityTeam(settings),
+                        target,
+                        teamFlag,
+                        personalFlag: input.personal === true,
+                    },
+                    context,
+                );
+
         context.telemetry?.recordProperties({
             connector_kind: target.kind,
+            identity_source: identitySource,
         });
 
         const results = await loadConnectorSearchResults(
             {
+                identity,
                 target,
                 text: input.text,
             },

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -184,10 +184,11 @@ const commandTelemetryDecisions = {
         kind: "properties",
         properties: [
             "connector_kind",
+            "identity_source",
             "query_length_bucket",
             "result_count_bucket",
         ],
-        reason: "Records query and result buckets plus the connector target kind (oomol/self_hosted) without query text or server URLs.",
+        reason: "Records query and result buckets, the connector target kind (oomol/self_hosted), and the identity source (personal/flag/env_id/env_name/config) whose connected apps set the authenticated flag, without query text, team name/id, or server URLs.",
     },
     "connector.schema": {
         kind: "properties",
@@ -294,10 +295,11 @@ const commandTelemetryDecisions = {
         kind: "properties",
         properties: [
             "connector_kind",
+            "identity_source",
             "query_length_bucket",
             "result_count_bucket",
         ],
-        reason: "Records query and result buckets plus the connector target kind (oomol/self_hosted) without query text or server URLs.",
+        reason: "Records query and result buckets, the connector target kind (oomol/self_hosted), and the identity source (personal/flag/env_id/env_name/config) whose connected apps set the authenticated flag, without query text, team name/id, or server URLs.",
     },
     "skills": {
         kind: "generic",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -917,6 +917,10 @@ export const enMessages = {
         "List connected apps under the given team identity",
     "options.connectorAppsPersonal":
         "List connected apps under your personal identity, ignoring any configured default team",
+    "options.searchTeam":
+        "Report each action's authenticated status under the given team identity",
+    "options.searchPersonal":
+        "Report authenticated status under your personal identity, ignoring any configured default team",
     "options.connectorRunTeam":
         "Run the action under the given team identity",
     "options.connectorRunPersonal":
@@ -2196,6 +2200,10 @@ export const zhMessages = {
         "以指定团队身份列出已连接的 app",
     "options.connectorAppsPersonal":
         "以个人身份列出已连接的 app，忽略已配置的默认团队",
+    "options.searchTeam":
+        "以指定团队身份报告每个 action 的 authenticated 状态",
+    "options.searchPersonal":
+        "以个人身份报告 authenticated 状态，忽略已配置的默认团队",
     "options.connectorRunTeam":
         "以指定团队身份运行该 action",
     "options.connectorRunPersonal":


### PR DESCRIPTION
## What
`oo search` / `oo connector search` were identity-independent, so each result's `authenticated` flag reflected only the personal account — an app connected under a team always showed `no`, even when the user could actually run it under that team.

This makes search team-aware:
- Adds `--team <name>` / `--personal` to both commands, honoring `OO_TEAM_ID` / `OO_TEAM_NAME` and the `identity.team` default (same precedence as `run`/`apps`/`proxy`).
- Forwards `x-oo-team-*` on the search request. The action **list** stays identity-independent; only each result's `authenticated` flag now follows the effective identity (the schema cache is still not keyed by team).
- Records `identity_source` telemetry on both commands (no team name/id leaked); updates docs (en + zh) and tests.

## Depends on
- policy-server oomol/policy-server#6 (registers `GET /v1/actions/search`; stacked on oomol/policy-server#5) — otherwise a team-scoped search hits `route not configured` → 403 at the gateway.
- The connector backend must honor `x-oo-team-*` when computing `authenticated`.

## Test
`bun run lint:fix` / `ts-check` / `knip` / `test` all green (1589 pass, 0 fail). New CLI test asserts `x-oo-team-name` is sent and `identity_source: flag` is recorded without leaking the team name; help snapshots updated with the new options.
