### PR TITLE
feat(auth): persist default team identity on login

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -119,7 +119,23 @@ export interface PrintedAuthLoginOptions {
     argv?: readonly string[];
     verificationUrl?: string;
     stdoutHasColors?: boolean;
+    teamsResponse?: unknown;
+    teamsStatus?: number;
 }
+
+// Default membership answered by the login-flow teams request: the backend
+// provisions exactly one `system_created` team per account, so this is the
+// common shape a fresh login sees.
+export const defaultLoginTeamsResponse = {
+    teams: [
+        {
+            id: "team-system-1",
+            name: "alice-team",
+            role: "creator",
+            system_created: true,
+        },
+    ],
+} as const;
 
 export const defaultAuthEndpoint = "oomol.com";
 
@@ -532,6 +548,19 @@ export async function runPrintedAuthLogin(
                     name: "Alice",
                     status: "verified",
                 }));
+            }
+
+            if (
+                request.method === "GET"
+                && requestUrl.host === `relation-control.${accountEndpoint}`
+                && requestUrl.pathname === "/v1/me/teams"
+            ) {
+                return new Response(
+                    JSON.stringify(
+                        options.teamsResponse ?? defaultLoginTeamsResponse,
+                    ),
+                    { status: options.teamsStatus ?? 200 },
+                );
             }
 
             throw new Error(`Unexpected auth login request: ${request.method} ${requestUrl}`);

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -124,6 +124,25 @@ with an existing API key, then save the authenticated account.
     validates the key against the account profile and saves the account without
     a device-login URL or polling. Exits with an error if the key is invalid or
     expired. `--api-key` and `--session-token` cannot be combined.
+  - `--team <name>`: Set the default team identity (the `identity.team` config
+    key) to the named team after login. The name must be one of the account's
+    team memberships; otherwise the command exits `1` (the account itself is
+    still saved). Works with all three login methods.
+- Default team: after a successful login the CLI fetches the account's team
+  memberships and persists a default team identity. Without `--team`, a
+  configured `identity.team` that is still one of the memberships is kept;
+  otherwise the backend-provisioned default team (`system_created`) is
+  adopted. When neither exists — the membership list carries no
+  `system_created` team (an older backend) or is empty — nothing is persisted,
+  no default-team line is printed, and login still exits `0`. Otherwise the
+  success output prints the resulting default
+  (`Default team identity: <name>`), and when the account belongs to more than
+  one team it also prints how many teams the account has (naming at most five,
+  truncating the rest with an ellipsis) and that `oo team use <name>` switches
+  the default. When the membership request fails and no `--team` was given,
+  login still exits `0` and prints that the default team is unchanged. When
+  `OO_TEAM_ID` / `OO_TEAM_NAME` is set, the default is still saved but a hint
+  notes that the env override keeps outranking it.
 - Notes: when a self-hosted connector is configured (`oo connector login`), it
   keeps handling connector commands after login; the success output prints a
   hint that `oo connector logout` switches them back to OOMOL.
@@ -160,6 +179,11 @@ Show every saved auth account and validate the API key of the active one.
   `API key status` resolved from a single profile request to its endpoint.
   Inactive accounts are not validated, so `oo auth status` performs at most
   one network request regardless of how many accounts are saved.
+- The active-identity block also shows a `Default team` line, resolved offline
+  the same way `oo team current` resolves it: the `OO_TEAM_ID` /
+  `OO_TEAM_NAME` env override when set (annotated with the variable that
+  supplies it), otherwise the `identity.team` config default, otherwise
+  `personal (no default team)`.
 - API key values are never written to stdout in text or JSON output.
 - When a self-hosted connector is configured (`oo connector login` or
   `OO_CONNECTOR_URL`), text output adds a self-hosted connector block showing
@@ -204,8 +228,21 @@ Show every saved auth account and validate the API key of the active one.
   }
   ```
 
-- When `OO_API_KEY` supplies the credential, the payload is `logged-in` and
-  carries an optional top-level `envOverride` field:
+- When a default team identity is in effect, the `oo auth status --json` output
+  — specifically its `logged-in` shape above — carries an optional top-level
+  `team` field. The CLI fills it from the local default-team identity
+  (`OO_TEAM_ID` / `OO_TEAM_NAME`, otherwise the `identity.team` config); it is
+  not returned by any login or backend request:
+
+  ```json
+  {
+    "team": { "name": "acme", "id": null, "source": "config" }
+  }
+  ```
+
+- When `OO_API_KEY` supplies the credential, the `oo auth status --json` output
+  is always the `logged-in` shape and carries an optional top-level
+  `envOverride` field:
 
   ```json
   {
@@ -239,6 +276,14 @@ Show every saved auth account and validate the API key of the active one.
   - `accounts[].endpoint` is the endpoint saved in `auth.toml`. A bare
     `OO_ENDPOINT` (without `OO_API_KEY`) redirects the endpoint used for text
     output and API key validation, but does not rewrite this field.
+  - `team` is present only on the `logged-in` shape and only when a default
+    team identity is in effect. It is resolved locally from the env/config
+    default-team identity, never from a login or backend response. `source` is
+    `config` (the `identity.team` default), `env_id` (`OO_TEAM_ID`), or
+    `env_name` (`OO_TEAM_NAME`). `name` carries the team name when the source
+    knows it (`config` / `env_name`) and `id` the team id (`env_id` only); the
+    command never spends a network request resolving one form into the other
+    (so `id` stays `null` for the `config` source).
   - `missingAccountId` appears only when the auth file records an active id
     that is no longer present in `accounts[]`.
   - `connector` is present only when a self-hosted connector is configured
@@ -277,8 +322,8 @@ Switch the active auth account.
 
 ### `oo login`
 
-Alias for `oo auth login`. Supports the same `--session-token <session-token>`
-and `--api-key <api-key>` options.
+Alias for `oo auth login`. Supports the same `--session-token <session-token>`,
+`--api-key <api-key>`, and `--team <name>` options.
 
 ### `oo logout`
 
@@ -297,6 +342,11 @@ account can use and manage that default.
 require an OOMOL account and are unavailable when only a self-hosted connector
 is configured. `oo team current` and `oo team clear` only read and write local
 settings, so they work regardless.
+
+`oo auth login` (and its `oo login` alias) persists the default automatically:
+it keeps a still-valid configured `identity.team`, otherwise adopts the
+backend-provisioned `system_created` team (when one exists), and accepts
+`--team <name>` to pick one explicitly.
 
 ### `oo team list`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -103,6 +103,19 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   - `--api-key <api-key>`：使用已有 API key 登录。CLI 会通过账号 profile 校验该 key，
     校验通过后直接保存账号，不会打印 device-login URL 或轮询；若 key 无效或已过期则以
     错误退出。`--api-key` 与 `--session-token` 不能同时使用。
+  - `--team <name>`：登录后将默认团队身份（配置项 `identity.team`）设置为指定
+    团队。该名称必须是当前账号的团队成员关系之一，否则命令以 `1` 退出（账号
+    本身仍会被保存）。与三种登录方式均可组合。
+- 默认团队：登录成功后，CLI 会获取账号的团队成员关系并持久化默认团队身份。
+  未传 `--team` 时，若已配置的 `identity.team` 仍在成员关系中则保留；否则采用
+  后端为每个账号创建的默认团队（`system_created`）。两者都不存在时——成员
+  关系中没有 `system_created` 团队（旧版后端）或列表为空——不会持久化任何
+  内容，也不打印默认团队行，登录仍以 `0` 退出。否则成功输出会打印生效的
+  默认团队（`当前默认团队身份：<name>`）；当账号拥有多个团队时，还会打印团队
+  数量（最多列出 5 个名称，其余以省略号截断）以及使用 `oo team use <name>`
+  切换的提示。未传 `--team` 且成员关系请求失败时，登录仍以 `0` 退出，并提示
+  默认团队保持不变。设置了 `OO_TEAM_ID` / `OO_TEAM_NAME` 时默认值仍会被保存，
+  但会提示 env 覆盖的优先级依然更高。
 - 说明：如果已配置自部署 Connector（`oo connector login`），登录后 connector
   相关命令仍会继续使用它；成功输出会打印一行提示，说明可运行
   `oo connector logout` 切回 OOMOL。
@@ -133,6 +146,10 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   `[active]`，并额外显示其 `API key status`——通过一次 profile 请求向该账号
   对应的 endpoint 校验得到。其它账号不参与校验，所以无论有多少账号，
   `oo auth status` 最多发送 1 次网络请求。
+- 当前身份区块还会显示一行「默认团队」，其解析方式与 `oo team current`
+  相同且完全离线：设置了 `OO_TEAM_ID` / `OO_TEAM_NAME` 时显示 env 覆盖值
+  （并标注来源变量），否则显示 `identity.team` 配置默认值，都未设置时显示
+  个人身份（未设置默认团队）。
 - 文本和 JSON 输出都永远不会包含 API key 实际内容。
 - 当配置了自部署 Connector（`oo connector login` 或 `OO_CONNECTOR_URL`）时，
   文本输出会额外显示一个自部署 Connector 区块，包含服务地址、是否已配置令牌
@@ -176,8 +193,19 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   }
   ```
 
-- 当由 `OO_API_KEY` 提供凭证时，payload 恒为 `logged-in`，并携带一个可选的顶层
-  `envOverride` 字段：
+- 当存在默认团队身份时，`oo auth status --json` 的输出——即上面的 `logged-in`
+  形态——会携带一个可选的顶层 `team` 字段。该字段由 CLI 从本地默认团队身份
+  （`OO_TEAM_ID` / `OO_TEAM_NAME`，否则 `identity.team` 配置）填充，并非由任何
+  login 或后端接口返回：
+
+  ```json
+  {
+    "team": { "name": "acme", "id": null, "source": "config" }
+  }
+  ```
+
+- 当由 `OO_API_KEY` 提供凭证时，`oo auth status --json` 的输出恒为 `logged-in`
+  形态，并携带一个可选的顶层 `envOverride` 字段：
 
   ```json
   {
@@ -208,6 +236,12 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   - `accounts[].endpoint` 是 `auth.toml` 中保存的 endpoint。单独设置
     `OO_ENDPOINT`（不设 `OO_API_KEY`）会重定向文本输出与 API key 校验所用的
     endpoint，但不会改写该字段。
+  - `team` 仅在 `logged-in` 形态且存在默认团队身份时出现。它由本地 env/config
+    的默认团队身份解析而来，绝不来自任何 login 或后端接口响应。`source` 为
+    `config`（`identity.team` 默认值）、`env_id`（`OO_TEAM_ID`）或
+    `env_name`（`OO_TEAM_NAME`）。`name` 在来源已知名称时携带团队名称
+    （`config` / `env_name`），`id` 仅在 `env_id` 时携带团队 id；该命令不会
+    发起网络请求在两种形式之间互相解析（因此 `config` 来源下 `id` 恒为 `null`）。
   - `missingAccountId` 仅在 auth file 记录的 active id 已不存在于
     `accounts[]` 时出现。
   - `connector` 仅在配置了自部署 Connector 时出现，报告已配置的自部署
@@ -238,8 +272,8 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
 
 ### `oo login`
 
-`oo auth login` 的别名。支持相同的 `--session-token <session-token>` 与
-`--api-key <api-key>` 选项。
+`oo auth login` 的别名。支持相同的 `--session-token <session-token>`、
+`--api-key <api-key>` 与 `--team <name>` 选项。
 
 ### `oo logout`
 
@@ -256,6 +290,10 @@ apps`）以某个团队身份运行，而非个人账号：既可用每次运行
 `oo team list` 与 `oo team use` 需要向 OOMOL 查询团队成员关系，因此需要 OOMOL
 账号；当仅配置了自部署 Connector 时不可用。`oo team current` 与 `oo team clear`
 仅读写本地配置，不受此限制。
+
+`oo auth login`（及其别名 `oo login`）会自动持久化该默认值：仍然有效的
+`identity.team` 配置会被保留，否则采用后端创建的 `system_created` 默认团队
+（存在时）；也可通过 `--team <name>` 显式指定。
 
 ### `oo team list`
 

--- a/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
@@ -10,6 +10,7 @@ exports[`auth CLI writes auth device login logs without persisting secrets 1`] =
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
+Default team identity: alice-team
 "
 ,
 }
@@ -23,6 +24,7 @@ exports[`auth CLI writes auth-store and auth status logs 1`] = `
 "✓ Logged in to oomol.com account Alice
   - Active account: true
   - API key status: Valid
+  - Default team: personal (no default team)
   - Accounts:
     * Alice [active] (oomol.com)
 "
@@ -42,6 +44,7 @@ Alias for auth login.
 Options:
   --api-key <api-key>              Log in with an existing API key
   --session-token <session-token>  Log in with a session token
+  --team <name>                    Set the default team identity after login
   -h, --help                       Show help for command
 
 Global Options:
@@ -82,6 +85,7 @@ exports[`auth CLI supports auth login and updates the existing account without d
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
+Default team identity: alice-team
 "
 ,
   },
@@ -94,6 +98,7 @@ Waiting for the device login to complete...
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
+Default team identity: alice-team
 "
 ,
   },
@@ -110,6 +115,7 @@ exports[`auth CLI supports auth login with a custom OOMOL_ENDPOINT 1`] = `
 Waiting for the device login to complete...
 ✓ Logged in to staging.oomol.test account Alice
   - Active account: true
+Default team identity: alice-team
 "
 ,
 }
@@ -125,6 +131,7 @@ exports[`auth CLI supports login as an alias for auth login 1`] = `
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
+Default team identity: alice-team
 "
 ,
 }
@@ -140,6 +147,7 @@ exports[`auth CLI renders the auth login url and success block with color stylin
 Waiting for the device login to complete...
 ✓ Logged in to oomol.com account Alice
   - Active account: true
+Default team identity: alice-team
 "
 ,
 }
@@ -176,6 +184,7 @@ exports[`auth CLI supports auth status for valid and invalid api keys 1`] = `
 "X Logged in to oomol.com account Alice
   - Active account: true
   - API key status: Invalid
+  - Default team: personal (no default team)
   - Accounts:
     * Alice [active] (oomol.com)
 "
@@ -188,6 +197,7 @@ exports[`auth CLI supports auth status for valid and invalid api keys 1`] = `
 "✓ Logged in to oomol.com account Alice
   - Active account: true
   - API key status: Valid
+  - Default team: personal (no default team)
   - Accounts:
     * Alice [active] (oomol.com)
 "

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -9,6 +9,8 @@ import {
     createConnectionRefusedError,
     createFailedToOpenSocketError,
     defaultAuthEndpoint,
+    defaultLoginTeamsResponse,
+    expectTelemetryFreeOfTeamIdentity,
     findLoginUrl,
     readAuthLoginUrlPrefix,
     readLatestLogContent,
@@ -18,6 +20,10 @@ import {
     writeConnectorFile,
 } from "../../../../__tests__/helpers.ts";
 import { APP_NAME } from "../../config/app-config.ts";
+import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../../telemetry/outbox.ts";
 import { createTerminalColors } from "../../terminal-colors.ts";
 import { JSON_OUTPUT_SCHEMA_VERSION } from "../json-output.ts";
 
@@ -287,6 +293,16 @@ describe("auth CLI", () => {
                             }));
                         }
 
+                        if (
+                            request.method === "GET"
+                            && requestUrl.host === `relation-control.${defaultAuthEndpoint}`
+                            && requestUrl.pathname === "/v1/me/teams"
+                        ) {
+                            return new Response(
+                                JSON.stringify(defaultLoginTeamsResponse),
+                            );
+                        }
+
                         throw new Error(`Unexpected auth fast login request: ${request.method} ${requestUrl}`);
                     },
                 },
@@ -295,7 +311,7 @@ describe("auth CLI", () => {
             const content = await readLatestLogContent(sandbox);
 
             expect(result.exitCode).toBe(0);
-            expect(requests).toHaveLength(1);
+            expect(requests).toHaveLength(2);
             expect(result.stdout).not.toContain("Open this login URL");
             expect(result.stdout).not.toContain("Enter this code");
             expect(result.stdout).not.toContain("Waiting for the device login");
@@ -303,7 +319,7 @@ describe("auth CLI", () => {
                 exitCode: 0,
                 stderr: "",
                 stdout:
-                    "✓ Logged in to oomol.com account Alice\n  - Active account: true\n",
+                    "✓ Logged in to oomol.com account Alice\n  - Active account: true\nDefault team identity: alice-team\n",
             });
             expect(authFileContent).toContain("id = \"0193438c-238f-703c-8754-e4a04e0be0c1\"");
             expect(authFileContent).toContain("api_key = \"secret-1\"");
@@ -354,6 +370,16 @@ describe("auth CLI", () => {
                             }));
                         }
 
+                        if (
+                            request.method === "GET"
+                            && requestUrl.host === `relation-control.${defaultAuthEndpoint}`
+                            && requestUrl.pathname === "/v1/me/teams"
+                        ) {
+                            return new Response(
+                                JSON.stringify(defaultLoginTeamsResponse),
+                            );
+                        }
+
                         throw new Error(`Unexpected auth api key login request: ${request.method} ${requestUrl}`);
                     },
                 },
@@ -362,14 +388,14 @@ describe("auth CLI", () => {
             const content = await readLatestLogContent(sandbox);
 
             expect(result.exitCode).toBe(0);
-            expect(requests).toHaveLength(1);
+            expect(requests).toHaveLength(2);
             expect(result.stdout).not.toContain("Open this login URL");
             expect(result.stdout).not.toContain("Waiting for the device login");
             expect(createCliSnapshot(result)).toEqual({
                 exitCode: 0,
                 stderr: "",
                 stdout:
-                    "✓ Logged in to oomol.com account BlackHole1\n  - Active account: true\n",
+                    "✓ Logged in to oomol.com account BlackHole1\n  - Active account: true\nDefault team identity: alice-team\n",
             });
             expect(authFileContent).toContain("id = \"019343c2-c43d-710f-81b2-dfa68d3079de\"");
             expect(authFileContent).toContain("name = \"BlackHole1\"");
@@ -2061,3 +2087,702 @@ function expectForbiddenDeviceLoginPhrases(output: string): void {
         expect(output).not.toContain(phrase);
     }
 }
+
+// Reads the command-specific telemetry properties recorded for the given
+// command path, so tests can pin the safe property shape (enums/buckets only)
+// and assert raw team identity never reaches telemetry.
+function readCommandTelemetryProperties(
+    sandbox: { env: Record<string, string | undefined> },
+    commandFull: string,
+): Record<string, unknown> | undefined {
+    return readTelemetryRowsForTest(
+        join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+    )
+        .map(row => parseTelemetryRowPayload(row))
+        .find(payload => payload?.properties?.command_full === commandFull)
+        ?.properties;
+}
+
+describe("auth CLI login default team", () => {
+    function readSettingsFilePath(sandbox: {
+        env: Record<string, string | undefined>;
+    }): string {
+        return join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "settings.toml");
+    }
+
+    // The settings file may not exist yet when login never persisted a
+    // default team; treat a missing file as empty content.
+    async function readOptionalSettingsContent(sandbox: {
+        env: Record<string, string | undefined>;
+    }): Promise<string> {
+        const settingsFile = Bun.file(readSettingsFilePath(sandbox));
+
+        return (await settingsFile.exists()) ? await settingsFile.text() : "";
+    }
+
+    test("adopts the system-created team and persists it as the default", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await runPrintedAuthLogin(sandbox, "secret-1");
+            const settingsContent = await readFile(
+                readSettingsFilePath(sandbox),
+                "utf8",
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toContain(
+                "Default team identity: alice-team",
+            );
+            expect(result.stdout).not.toContain("You belong to");
+            expect(settingsContent).toContain("team = \"alice-team\"");
+
+            // Only the selection enum and the bounded count reach telemetry.
+            const telemetryProperties = readCommandTelemetryProperties(
+                sandbox,
+                "auth.login",
+            );
+            expect(telemetryProperties).toMatchObject({
+                auth_method: "device_login",
+                team_count_bucket: "1-5",
+                team_selection: "system_default",
+            });
+            expectTelemetryFreeOfTeamIdentity(
+                telemetryProperties,
+                ["alice-team", "team-system-1"],
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("lists at most five team names and truncates the rest with an ellipsis", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
+                teamsResponse: {
+                    teams: [
+                        {
+                            id: "team-system-1",
+                            name: "alice-team",
+                            role: "creator",
+                            system_created: true,
+                        },
+                        { id: "team-2", name: "beta", role: "member", system_created: false },
+                        { id: "team-3", name: "gamma", role: "member", system_created: false },
+                        { id: "team-4", name: "delta", role: "member", system_created: false },
+                        { id: "team-5", name: "epsilon", role: "member", system_created: false },
+                        { id: "team-6", name: "zeta", role: "member", system_created: false },
+                        { id: "team-7", name: "eta", role: "member", system_created: false },
+                    ],
+                },
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                "Default team identity: alice-team",
+            );
+            expect(result.stdout).toContain(
+                "You belong to 7 teams: alice-team, beta, gamma, delta, epsilon, …. Switch with `oo team use <name>`.",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("sets the explicitly requested team with --team", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
+                argv: ["auth", "login", "--team", "beta"],
+                teamsResponse: {
+                    teams: [
+                        {
+                            id: "team-system-1",
+                            name: "alice-team",
+                            role: "creator",
+                            system_created: true,
+                        },
+                        { id: "team-2", name: "beta", role: "member", system_created: false },
+                    ],
+                },
+            });
+            const settingsContent = await readFile(
+                readSettingsFilePath(sandbox),
+                "utf8",
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("Default team identity: beta");
+            expect(result.stdout).toContain(
+                "You belong to 2 teams: alice-team, beta. Switch with `oo team use <name>`.",
+            );
+            expect(result.stdout).not.toContain("…");
+            expect(settingsContent).toContain("team = \"beta\"");
+
+            const telemetryProperties = readCommandTelemetryProperties(
+                sandbox,
+                "auth.login",
+            );
+            expect(telemetryProperties).toMatchObject({
+                team_count_bucket: "1-5",
+                team_selection: "flag",
+            });
+            expectTelemetryFreeOfTeamIdentity(
+                telemetryProperties,
+                ["alice-team", "beta", "team-system-1", "team-2"],
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails when the membership request fails under an explicit --team", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const authFilePath = join(
+                sandbox.env.XDG_CONFIG_HOME!,
+                APP_NAME,
+                "auth.toml",
+            );
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
+                argv: ["auth", "login", "--team", "beta"],
+                teamsStatus: 500,
+            });
+
+            // The caller asked for exactly that team, so a failed membership
+            // request must fail loudly instead of degrading to a hint.
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain(
+                "The team list request returned HTTP 500.",
+            );
+            expect(await readFile(authFilePath, "utf8")).toContain(
+                "id = \"user-1\"",
+            );
+            expect(await readOptionalSettingsContent(sandbox))
+                .not
+                .toContain("\nteam = ");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails when the requested team is not a membership but keeps the login", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const authFilePath = join(
+                sandbox.env.XDG_CONFIG_HOME!,
+                APP_NAME,
+                "auth.toml",
+            );
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
+                argv: ["auth", "login", "--team", "ghost"],
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain(
+                "The active account cannot access the team \"ghost\".",
+            );
+            // The account itself logged in fine; only the team request failed.
+            expect(await readFile(authFilePath, "utf8")).toContain(
+                "id = \"user-1\"",
+            );
+            // The commented settings template mentions `# team = ...`, so only
+            // an uncommented assignment counts as a persisted default.
+            expect(await readOptionalSettingsContent(sandbox))
+                .not
+                .toContain("\nteam = ");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects a blank --team value without starting a login", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["auth", "login", "--team", " "],
+                {
+                    fetcher: async () => {
+                        throw new Error("No request should be made for a blank team.");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("The team name must not be empty.");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("keeps a still-valid configured team on re-login", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await sandbox.run(["config", "set", "identity.team", "beta"]);
+
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
+                teamsResponse: {
+                    teams: [
+                        {
+                            id: "team-system-1",
+                            name: "alice-team",
+                            role: "creator",
+                            system_created: true,
+                        },
+                        { id: "team-2", name: "beta", role: "member", system_created: false },
+                    ],
+                },
+            });
+            const settingsContent = await readFile(
+                readSettingsFilePath(sandbox),
+                "utf8",
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("Default team identity: beta");
+            expect(settingsContent).toContain("team = \"beta\"");
+
+            const telemetryProperties = readCommandTelemetryProperties(
+                sandbox,
+                "auth.login",
+            );
+            expect(telemetryProperties).toMatchObject({
+                team_count_bucket: "1-5",
+                team_selection: "kept_config",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("changes nothing when no system-created team matches", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await sandbox.run(["config", "set", "identity.team", "ghost"]);
+
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
+                teamsResponse: {
+                    teams: [{ id: "team-2", name: "beta", role: "member", system_created: false }],
+                },
+            });
+            const settingsContent = await readFile(
+                readSettingsFilePath(sandbox),
+                "utf8",
+            );
+
+            // No membership carries system_created, so the stale configured
+            // default is left alone instead of being replaced or cleared.
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).not.toContain("Default team identity:");
+            expect(settingsContent).toContain("team = \"ghost\"");
+            expect(readCommandTelemetryProperties(sandbox, "auth.login"))
+                .toMatchObject({ team_selection: "none" });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("changes nothing when the account has no teams", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
+                teamsResponse: { teams: [] },
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).not.toContain("Default team identity:");
+            expect(result.stdout).not.toContain("You belong to");
+            expect(await readOptionalSettingsContent(sandbox))
+                .not
+                .toContain("\nteam = ");
+            expect(readCommandTelemetryProperties(sandbox, "auth.login"))
+                .toMatchObject({
+                    team_count_bucket: "0",
+                    team_selection: "none",
+                });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("replaces a stale configured team with the system-created default", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await sandbox.run(["config", "set", "identity.team", "ghost"]);
+
+            const result = await runPrintedAuthLogin(sandbox, "secret-1");
+            const settingsContent = await readFile(
+                readSettingsFilePath(sandbox),
+                "utf8",
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                "Default team identity: alice-team",
+            );
+            expect(settingsContent).toContain("team = \"alice-team\"");
+            expect(settingsContent).not.toContain("team = \"ghost\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("keeps login successful when the team listing cannot be parsed", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
+                teamsResponse: "boom",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                "Could not load your teams, so the default team identity is unchanged.",
+            );
+            expect(await readOptionalSettingsContent(sandbox))
+                .not
+                .toContain("\nteam = ");
+
+            // No membership data resolved, so no count bucket is recorded.
+            const telemetryProperties = readCommandTelemetryProperties(
+                sandbox,
+                "auth.login",
+            );
+            expect(telemetryProperties).toMatchObject({
+                team_selection: "unresolved",
+            });
+            expect(telemetryProperties).not.toHaveProperty("team_count_bucket");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("prints the env override hint when OO_TEAM_ID outranks the new default", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_TEAM_ID = "team-42";
+
+        try {
+            const result = await runPrintedAuthLogin(sandbox, "secret-1");
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                "Default team identity: alice-team",
+            );
+            expect(result.stdout).toContain(
+                "Connector commands keep using the team from OO_TEAM_ID, not this default.",
+            );
+            // The default is still persisted; only its effect is deferred
+            // while the env override is set.
+            expect(await readFile(readSettingsFilePath(sandbox), "utf8"))
+                .toContain("team = \"alice-team\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("prints the env override hint naming OO_TEAM_NAME", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_TEAM_NAME = "other";
+
+        try {
+            const result = await runPrintedAuthLogin(sandbox, "secret-1");
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain(
+                "Connector commands keep using the team from OO_TEAM_NAME, not this default.",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("supports --team combined with --api-key login", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["auth", "login", "--api-key", "secret-api-1", "--team", "beta"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+                        const requestUrl = new URL(request.url);
+
+                        if (
+                            request.method === "GET"
+                            && requestUrl.host === `api.${defaultAuthEndpoint}`
+                            && requestUrl.pathname === "/v1/users/profile"
+                        ) {
+                            return new Response(JSON.stringify({
+                                displayname: "Alice",
+                                email: "alice@example.com",
+                                nickname: "Alice",
+                                uid: "user-1",
+                                username: "Alice",
+                            }));
+                        }
+
+                        if (
+                            request.method === "GET"
+                            && requestUrl.host === `relation-control.${defaultAuthEndpoint}`
+                            && requestUrl.pathname === "/v1/me/teams"
+                        ) {
+                            return new Response(JSON.stringify({
+                                teams: [
+                                    {
+                                        id: "team-system-1",
+                                        name: "alice-team",
+                                        role: "creator",
+                                        system_created: true,
+                                    },
+                                    { id: "team-2", name: "beta", role: "member", system_created: false },
+                                ],
+                            }));
+                        }
+
+                        throw new Error(`Unexpected api key login request: ${request.method} ${requestUrl}`);
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("Default team identity: beta");
+            expect(await readFile(readSettingsFilePath(sandbox), "utf8"))
+                .toContain("team = \"beta\"");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("prints localized team tips under --lang zh", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
+                argv: ["--lang", "zh", "auth", "login"],
+                teamsResponse: {
+                    teams: [
+                        {
+                            id: "team-system-1",
+                            name: "alice-team",
+                            role: "creator",
+                            system_created: true,
+                        },
+                        { id: "team-2", name: "beta", role: "member", system_created: false },
+                    ],
+                },
+            });
+
+            // Pins the zh placeholder substitution ({team}/{count}/{teams});
+            // a mistyped placeholder name would render literally.
+            expect(result.exitCode).toBe(0);
+            expect(result.stdout).toContain("当前默认团队身份：alice-team");
+            expect(result.stdout).toContain(
+                "你共有 2 个团队：alice-team, beta。可使用 `oo team use <name>` 切换。",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});
+
+describe("auth CLI status default team", () => {
+    test("reports the configured default team in text and JSON", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await sandbox.run(["config", "set", "identity.team", "acme"]);
+
+            const fetcher = async (): Promise<Response> =>
+                new Response(null, { status: 200 });
+            const textResult = await sandbox.run(["auth", "status"], { fetcher });
+            const jsonResult = await sandbox.run(
+                ["auth", "info", "--json"],
+                { fetcher },
+            );
+            const payload = JSON.parse(jsonResult.stdout) as {
+                team?: { name: string | null; id: string | null; source: string };
+            };
+
+            expect(textResult.exitCode).toBe(0);
+            expect(textResult.stdout).toContain("- Default team: acme");
+            expect(jsonResult.exitCode).toBe(0);
+            expect(payload.team).toEqual({
+                name: "acme",
+                id: null,
+                source: "config",
+            });
+
+            // Only the source enum reaches telemetry, never the team name.
+            const telemetryProperties = readCommandTelemetryProperties(
+                sandbox,
+                "auth.status",
+            );
+            expect(telemetryProperties).toMatchObject({
+                team_source: "config",
+            });
+            expectTelemetryFreeOfTeamIdentity(telemetryProperties, ["acme"]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports the default team alongside the OO_API_KEY identity", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_API_KEY = "env-key-1";
+
+        try {
+            await sandbox.run(["config", "set", "identity.team", "acme"]);
+
+            const fetcher = async (): Promise<Response> =>
+                new Response(null, { status: 200 });
+            const textResult = await sandbox.run(["auth", "status"], { fetcher });
+            const jsonResult = await sandbox.run(
+                ["auth", "status", "--json"],
+                { fetcher },
+            );
+            const payload = JSON.parse(jsonResult.stdout) as {
+                status: string;
+                envOverride?: unknown;
+                team?: { name: string | null; id: string | null; source: string };
+            };
+
+            // The team default is orthogonal to the credential source, so the
+            // env-credential block reports it too.
+            expect(textResult.exitCode).toBe(0);
+            expect(textResult.stdout).toContain("- Default team: acme");
+            expect(payload.status).toBe("logged-in");
+            expect(payload.envOverride).toBeDefined();
+            expect(payload.team).toEqual({
+                name: "acme",
+                id: null,
+                source: "config",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports the OO_TEAM_ID override ahead of the configured default", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_TEAM_ID = "team-42";
+
+        try {
+            await writeAuthFile(sandbox);
+            await sandbox.run(["config", "set", "identity.team", "acme"]);
+
+            const fetcher = async (): Promise<Response> =>
+                new Response(null, { status: 200 });
+            const textResult = await sandbox.run(["auth", "status"], { fetcher });
+            const jsonResult = await sandbox.run(
+                ["auth", "status", "--json"],
+                { fetcher },
+            );
+            const payload = JSON.parse(jsonResult.stdout) as {
+                team?: { name: string | null; id: string | null; source: string };
+            };
+
+            expect(textResult.exitCode).toBe(0);
+            expect(textResult.stdout).toContain(
+                "- Default team: team-42 (via OO_TEAM_ID)",
+            );
+            expect(payload.team).toEqual({
+                name: null,
+                id: "team-42",
+                source: "env_id",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports the OO_TEAM_NAME override by name", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_TEAM_NAME = "acme";
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const fetcher = async (): Promise<Response> =>
+                new Response(null, { status: 200 });
+            const textResult = await sandbox.run(["auth", "status"], { fetcher });
+            const jsonResult = await sandbox.run(
+                ["auth", "status", "--json"],
+                { fetcher },
+            );
+            const payload = JSON.parse(jsonResult.stdout) as {
+                team?: { name: string | null; id: string | null; source: string };
+            };
+
+            expect(textResult.stdout).toContain(
+                "- Default team: acme (via OO_TEAM_NAME)",
+            );
+            expect(payload.team).toEqual({
+                name: "acme",
+                id: null,
+                source: "env_name",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("omits the team field from JSON when no default is configured", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const jsonResult = await sandbox.run(
+                ["auth", "status", "--json"],
+                {
+                    fetcher: async () => new Response(null, { status: 200 }),
+                },
+            );
+            const payload = JSON.parse(jsonResult.stdout) as {
+                team?: unknown;
+            };
+
+            expect(jsonResult.exitCode).toBe(0);
+            expect(payload.team).toBeUndefined();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});

--- a/src/application/commands/auth/login.ts
+++ b/src/application/commands/auth/login.ts
@@ -4,6 +4,8 @@ import type {
 } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
 
+import type { TeamView } from "../team/shared.ts";
+
 import { z } from "zod";
 import {
     requestAuthAccountWithApiKey,
@@ -12,11 +14,20 @@ import {
 } from "../../auth/login-flow.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { upsertAuthAccount } from "../../schemas/auth.ts";
+import {
+    getConfiguredIdentityTeam,
+    setIdentityTeam,
+} from "../../schemas/settings.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { buildEnvApiKeyAccount } from "../shared/auth-env-override.ts";
 import { writeLine } from "../shared/output.ts";
 import { resolveSelfHostedConnectorTolerantly } from "../shared/self-hosted-connector.ts";
+import {
+    readTeamEnvOverride,
+    teamEnvOverrideVariableName,
+} from "../shared/team-env-override.ts";
+import { listMemberTeams } from "../team/shared.ts";
 import {
     formatAuthStrong,
     writeAuthBlock,
@@ -36,10 +47,22 @@ const persistedLogMessages = {
 const authLoginCommandInputSchema = z.object({
     apiKey: z.string().trim().min(1).optional(),
     sessionToken: z.string().trim().min(1).optional(),
+    team: z.string().trim().min(1).optional(),
 }).refine(
     input => !(input.apiKey !== undefined && input.sessionToken !== undefined),
     { message: "Use only one of --api-key or --session-token." },
 );
+
+// Which mechanism decided the default team after login. `flag` is an explicit
+// `--team`, `kept_config` preserves a still-valid `identity.team`,
+// `system_default` adopts the backend-provisioned team, `none` found nothing
+// to adopt, and `unresolved` means the membership request failed.
+type LoginTeamSelection
+    = "flag" | "kept_config" | "none" | "system_default" | "unresolved";
+
+// How many team names the multi-team hint spells out before truncating with
+// an ellipsis.
+const loginTeamHintLimit = 5;
 
 export type AuthLoginCommandInput = z.output<typeof authLoginCommandInputSchema>;
 
@@ -59,6 +82,12 @@ export const authLoginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
             longFlag: "--session-token",
             valueName: "session-token",
             descriptionKey: "options.sessionToken",
+        },
+        {
+            name: "team",
+            longFlag: "--team",
+            valueName: "name",
+            descriptionKey: "options.loginTeam",
         },
     ],
     inputSchema: authLoginCommandInputSchema,
@@ -118,6 +147,8 @@ export const authLoginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
                 context.translator.t("auth.login.envOverrideHint"),
             );
         }
+
+        await applyLoginTeamIdentity(account, input.team, context);
 
         // Connector routing does not change with this login: a configured
         // self-hosted connector keeps handling connector commands, which is
@@ -194,11 +225,165 @@ function mapLoginInputError(
         return new CliUserError("errors.auth.loginMethodConflict", 2);
     }
 
+    // A blank `--team` is its own input error; without this check it would be
+    // misreported as a missing api key / session token below.
+    if (typeof rawInput.team === "string" && rawInput.team.trim() === "") {
+        return new CliUserError("errors.team.nameEmpty", 2);
+    }
+
     if (hasApiKey) {
         return new CliUserError("errors.auth.apiKeyRequired", 2);
     }
 
     return new CliUserError("errors.auth.sessionTokenRequired", 2);
+}
+
+// Persists the default team identity (`identity.team`) right after login so
+// later commands run as a team by default. An explicit `--team` must fail
+// loudly (the caller asked for exactly that team), while the implicit flow is
+// tolerant: login already succeeded, so a failed membership request only
+// prints a hint instead of flipping the exit code.
+async function applyLoginTeamIdentity(
+    account: AuthAccount,
+    requestedTeam: string | undefined,
+    context: CliExecutionContext,
+): Promise<void> {
+    let teams: TeamView[];
+
+    try {
+        teams = await listMemberTeams(account, context);
+    }
+    catch (error) {
+        if (requestedTeam !== undefined) {
+            throw error;
+        }
+
+        context.telemetry?.recordProperties({
+            team_selection: "unresolved" satisfies LoginTeamSelection,
+        });
+        context.logger.warn(
+            { err: error },
+            "Login team membership request failed; default team unchanged.",
+        );
+        writeLine(
+            context.stdout,
+            context.translator.t("auth.login.teamUnresolved"),
+        );
+        return;
+    }
+
+    const selection = await resolveLoginTeamSelection(
+        requestedTeam,
+        teams,
+        context,
+    );
+
+    context.telemetry?.recordProperties({
+        team_count_bucket: bucketTelemetryCount(teams.length),
+        team_selection: selection.kind,
+    });
+
+    if (selection.team !== undefined) {
+        writeLine(
+            context.stdout,
+            context.translator.t("auth.login.teamDefault", {
+                team: selection.team,
+            }),
+        );
+    }
+
+    if (teams.length > 1) {
+        writeLine(
+            context.stdout,
+            context.translator.t("auth.login.teamOverview", {
+                count: teams.length,
+                teams: formatLoginTeamNames(teams),
+            }),
+        );
+    }
+
+    // Mirrors `oo team use`: the default is saved, but OO_TEAM_ID /
+    // OO_TEAM_NAME keeps outranking it, so say so instead of letting the tip
+    // above imply the new default is in effect.
+    const envOverride = readTeamEnvOverride(context.env);
+
+    if (selection.team !== undefined && envOverride !== undefined) {
+        writeLine(
+            context.stdout,
+            context.translator.t("team.use.envOverrideHint", {
+                envVar: teamEnvOverrideVariableName(envOverride),
+            }),
+        );
+    }
+}
+
+// Picks the default team and persists it when it changes. Precedence:
+// an explicit `--team` (must be a membership), then a still-valid configured
+// `identity.team` (a re-login must not clobber a deliberate `oo team use`),
+// then the backend-provisioned `system_created` team. A stale configured team
+// is replaced rather than kept: after switching accounts the old name is not
+// usable anyway.
+async function resolveLoginTeamSelection(
+    requestedTeam: string | undefined,
+    teams: readonly TeamView[],
+    context: CliExecutionContext,
+): Promise<{ kind: LoginTeamSelection; team?: string }> {
+    if (requestedTeam !== undefined) {
+        if (!teams.some(team => team.name === requestedTeam)) {
+            throw new CliUserError("errors.team.notAccessible", 1, {
+                team: requestedTeam,
+            });
+        }
+
+        await persistLoginTeamIdentity(requestedTeam, context);
+        return { kind: "flag", team: requestedTeam };
+    }
+
+    const settings = await context.settingsStore.read();
+    const configuredTeam = getConfiguredIdentityTeam(settings);
+
+    if (
+        configuredTeam !== undefined
+        && teams.some(team => team.name === configuredTeam)
+    ) {
+        return { kind: "kept_config", team: configuredTeam };
+    }
+
+    const systemTeam = teams.find(team => team.systemCreated);
+
+    if (systemTeam === undefined) {
+        return { kind: "none" };
+    }
+
+    await persistLoginTeamIdentity(systemTeam.name, context);
+    return { kind: "system_default", team: systemTeam.name };
+}
+
+async function persistLoginTeamIdentity(
+    teamName: string,
+    context: CliExecutionContext,
+): Promise<void> {
+    await context.settingsStore.update(settings =>
+        setIdentityTeam(settings, teamName),
+    );
+    context.logger.info(
+        { teamConfigured: true },
+        "Default team identity persisted after login.",
+    );
+}
+
+// Spells out at most `loginTeamHintLimit` team names and truncates the rest
+// with an ellipsis so a large account does not flood the login output.
+function formatLoginTeamNames(teams: readonly TeamView[]): string {
+    const names = teams
+        .slice(0, loginTeamHintLimit)
+        .map(team => team.name);
+
+    if (teams.length > loginTeamHintLimit) {
+        names.push("…");
+    }
+
+    return names.join(", ");
 }
 
 async function runDeviceLogin(

--- a/src/application/commands/auth/status.ts
+++ b/src/application/commands/auth/status.ts
@@ -4,6 +4,7 @@ import type { AuthAccount, AuthFile } from "../../schemas/auth.ts";
 
 import type { ResolvedSelfHostedConnector } from "../shared/self-hosted-connector.ts";
 import { z } from "zod";
+import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
@@ -15,6 +16,10 @@ import { createFormatInputError } from "../shared/input-parsing.ts";
 import { writeLine } from "../shared/output.ts";
 import { isNetworkRestrictedSandboxError } from "../shared/request.ts";
 import { resolveSelfHostedConnectorTolerantly } from "../shared/self-hosted-connector.ts";
+import {
+    readTeamEnvOverride,
+    teamEnvOverrideVariableName,
+} from "../shared/team-env-override.ts";
 import {
     formatAuthStrong,
     readCurrentAuth,
@@ -80,11 +85,30 @@ interface AuthStatusJsonEnvOverride {
     apiKeyStatus: ApiKeyStatus;
 }
 
+// The default team identity in effect for team-scoped commands, resolved
+// offline the same way `oo team current` does: the OO_TEAM_ID / OO_TEAM_NAME
+// env override outranks the `identity.team` config default. An env id
+// override knows only the id and a name-based source only the name; status
+// never spends a network request resolving one form into the other.
+interface AuthStatusJsonTeam {
+    name: string | null;
+    id: string | null;
+    source: "config" | "env_id" | "env_name";
+}
+
+// Internal resolution of the team identity; `envVar` names the overriding
+// variable for the text hint and is absent for the config source.
+interface StatusTeamIdentity {
+    team: AuthStatusJsonTeam;
+    envVar?: string;
+}
+
 type AuthStatusJsonPayload
     = | {
         status: "logged-in";
         activeAccountId: string;
         accounts: AuthStatusJsonAccount[];
+        team?: AuthStatusJsonTeam;
         envOverride?: AuthStatusJsonEnvOverride;
         connector?: AuthStatusJsonConnector;
     }
@@ -123,10 +147,12 @@ export const authStatusCommand: CliCommandDefinition<AuthStatusInput> = {
         // every other command is how status ends up naming the wrong account,
         // the wrong endpoint, and validating the wrong key.
         const { authFile, identity } = await resolveStatusState(context);
+        const teamIdentity = await resolveStatusTeamIdentity(context);
 
         context.telemetry?.recordProperties({
             account_count_bucket: bucketTelemetryCount(authFile.auth.length),
             credential_source: identity?.source ?? "none",
+            team_source: teamIdentity?.team.source ?? "none",
         });
 
         const activeStatus: ActiveAccountStatus | undefined
@@ -140,16 +166,56 @@ export const authStatusCommand: CliCommandDefinition<AuthStatusInput> = {
         if (input.format === "json") {
             writeJsonOutput(
                 context.stdout,
-                buildAuthStatusJsonPayload(authFile, activeStatus, selfHostedConnector),
+                buildAuthStatusJsonPayload(
+                    authFile,
+                    activeStatus,
+                    teamIdentity,
+                    selfHostedConnector,
+                ),
                 { showSchemaVersion: input.showSchemaVersion },
             );
             return;
         }
 
-        writeAuthStatusText(context, authFile, activeStatus);
+        writeAuthStatusText(context, authFile, activeStatus, teamIdentity);
         writeSelfHostedConnectorText(context, selfHostedConnector);
     },
 };
+
+// Resolves the default team identity offline, mirroring `oo team current`:
+// the OO_TEAM_ID / OO_TEAM_NAME env override when set, otherwise the
+// `identity.team` config default, otherwise none (personal identity).
+async function resolveStatusTeamIdentity(
+    context: CliExecutionContext,
+): Promise<StatusTeamIdentity | undefined> {
+    const envOverride = readTeamEnvOverride(context.env);
+
+    if (envOverride !== undefined) {
+        return {
+            team: {
+                name: envOverride.kind === "name" ? envOverride.value : null,
+                id: envOverride.kind === "id" ? envOverride.value : null,
+                source: envOverride.kind === "id" ? "env_id" : "env_name",
+            },
+            envVar: teamEnvOverrideVariableName(envOverride),
+        };
+    }
+
+    const settings = await context.settingsStore.read();
+    const configuredTeam = getConfiguredIdentityTeam(settings);
+
+    if (configuredTeam === undefined) {
+        return undefined;
+    }
+
+    return {
+        team: {
+            name: configuredTeam,
+            id: null,
+            source: "config",
+        },
+    };
+}
 
 /**
  * Resolves what to report, mirroring requireCurrentAccount()'s precedence:
@@ -191,6 +257,7 @@ async function resolveStatusState(
 function buildAuthStatusJsonPayload(
     authFile: AuthFile,
     activeStatus: ActiveAccountStatus | undefined,
+    teamIdentity: StatusTeamIdentity | undefined,
     selfHostedConnector: ResolvedSelfHostedConnector | undefined,
 ): AuthStatusJsonPayload {
     const connector: { connector?: AuthStatusJsonConnector }
@@ -226,6 +293,9 @@ function buildAuthStatusJsonPayload(
             status: "logged-in",
             activeAccountId: activeStatus.account.id,
             accounts,
+            ...(teamIdentity === undefined
+                ? {}
+                : { team: teamIdentity.team }),
             ...(activeStatus.source === "env"
                 ? {
                         envOverride: {
@@ -284,10 +354,42 @@ function writeSelfHostedConnectorText(
     });
 }
 
+// Renders the default-team detail row. The value spells out the identity in
+// effect: the config default by name, an env override with the variable that
+// supplies it, or the personal fallback when no default team is set.
+function formatStatusTeamDetail(
+    context: CliExecutionContext,
+    teamIdentity: StatusTeamIdentity | undefined,
+): { label: string; value: string } {
+    const label = context.translator.t("auth.status.team");
+
+    if (teamIdentity === undefined) {
+        return {
+            label,
+            value: context.translator.t("auth.status.teamPersonal"),
+        };
+    }
+
+    const teamValue = teamIdentity.team.name ?? teamIdentity.team.id ?? "";
+
+    if (teamIdentity.envVar !== undefined) {
+        return {
+            label,
+            value: context.translator.t("auth.status.teamEnvOverride", {
+                team: teamValue,
+                envVar: teamIdentity.envVar,
+            }),
+        };
+    }
+
+    return { label, value: teamValue };
+}
+
 function writeAuthStatusText(
     context: CliExecutionContext,
     authFile: AuthFile,
     activeStatus: ActiveAccountStatus | undefined,
+    teamIdentity: StatusTeamIdentity | undefined,
 ): void {
     if (activeStatus === undefined) {
         if (authFile.id !== "") {
@@ -319,6 +421,7 @@ function writeAuthStatusText(
         label: context.translator.t("auth.status.apiKeyStatus"),
         value: context.translator.t(statusConfig.translationKey),
     };
+    const teamDetail = formatStatusTeamDetail(context, teamIdentity);
 
     if (source === "env") {
         writeAuthBlock(context, {
@@ -326,7 +429,7 @@ function writeAuthStatusText(
             summary: context.translator.t("auth.status.envOverride", {
                 endpoint: formatAuthStrong(context, account.endpoint),
             }),
-            details: [apiKeyStatusDetail],
+            details: [apiKeyStatusDetail, teamDetail],
         });
 
         // Without this the accounts list below reads as a bug: every saved
@@ -354,6 +457,7 @@ function writeAuthStatusText(
                 value: "true",
             },
             apiKeyStatusDetail,
+            teamDetail,
         ],
     });
     writeAuthAccountsList(context, authFile, account.id);

--- a/src/application/commands/connector/identity.test.ts
+++ b/src/application/commands/connector/identity.test.ts
@@ -18,8 +18,8 @@ const oomolTarget = {
 
 const teamsResponse = {
     teams: [
-        { id: "team-1", name: "acme", role: "creator" },
-        { id: "team-2", name: "beta", role: "member" },
+        { id: "team-1", name: "acme", role: "creator", system_created: false },
+        { id: "team-2", name: "beta", role: "member", system_created: false },
     ],
 };
 

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -692,7 +692,7 @@ describe("connectorCommand CLI", () => {
                         if (request.url.includes("relation-control")) {
                             return new Response(JSON.stringify({
                                 teams: [
-                                    { id: "team-1", name: "acme", role: "creator" },
+                                    { id: "team-1", name: "acme", role: "creator", system_created: false },
                                 ],
                             }));
                         }
@@ -826,7 +826,7 @@ describe("connectorCommand CLI", () => {
 
                         return new Response(JSON.stringify({
                             teams: [
-                                { id: "team-1", name: "acme", role: "creator" },
+                                { id: "team-1", name: "acme", role: "creator", system_created: false },
                             ],
                         }));
                     },
@@ -5130,7 +5130,7 @@ describe("connectorCommand CLI", () => {
                         if (request.url.includes("relation-control")) {
                             return new Response(JSON.stringify({
                                 teams: [
-                                    { id: "team-1", name: "acme", role: "creator" },
+                                    { id: "team-1", name: "acme", role: "creator", system_created: false },
                                 ],
                             }));
                         }
@@ -5206,7 +5206,7 @@ describe("connectorCommand CLI", () => {
 
                         return new Response(JSON.stringify({
                             teams: [
-                                { id: "team-1", name: "acme", role: "creator" },
+                                { id: "team-1", name: "acme", role: "creator", system_created: false },
                             ],
                         }));
                     },

--- a/src/application/commands/team/index.cli.test.ts
+++ b/src/application/commands/team/index.cli.test.ts
@@ -22,11 +22,13 @@ const teamsResponse = {
             avatar: "",
             creator_user_id: "user-1",
             role: "creator",
+            system_created: false,
         },
         {
             id: "team-2",
             name: "beta",
             role: "member",
+            system_created: false,
         },
     ],
 };

--- a/src/application/commands/team/shared.test.ts
+++ b/src/application/commands/team/shared.test.ts
@@ -29,11 +29,13 @@ describe("listMemberTeams", () => {
                                 avatar: "",
                                 creator_user_id: "user-1",
                                 role: "creator",
+                                system_created: false,
                             },
                             {
                                 id: "team-2",
                                 name: "beta",
                                 role: "member",
+                                system_created: false,
                             },
                         ],
                     }));
@@ -47,28 +49,79 @@ describe("listMemberTeams", () => {
         );
         expect(requests[0]?.headers.get("authorization")).toBe("api-secret-1");
         expect(teams).toEqual([
-            { id: "team-1", name: "acme", role: "creator" },
-            { id: "team-2", name: "beta", role: "member" },
+            { id: "team-1", name: "acme", role: "creator", systemCreated: false },
+            { id: "team-2", name: "beta", role: "member", systemCreated: false },
         ]);
     });
 
-    test("treats an unknown or missing role as a plain membership", async () => {
+    test("maps the system_created marker onto the team view", async () => {
         const teams = await listMemberTeams(
             testAccount,
             createRequestContext({
                 fetcher: async () => new Response(JSON.stringify({
                     teams: [
-                        { id: "team-1", name: "acme", role: "owner" },
-                        { id: "team-2", name: "beta" },
+                        {
+                            id: "team-1",
+                            name: "acme",
+                            role: "creator",
+                            system_created: true,
+                        },
+                        {
+                            id: "team-2",
+                            name: "beta",
+                            role: "member",
+                            system_created: false,
+                        },
                     ],
                 })),
             }),
         );
 
         expect(teams).toEqual([
-            { id: "team-1", name: "acme", role: "member" },
-            { id: "team-2", name: "beta", role: "member" },
+            { id: "team-1", name: "acme", role: "creator", systemCreated: true },
+            { id: "team-2", name: "beta", role: "member", systemCreated: false },
         ]);
+    });
+
+    test("treats an unrecognized role as a plain membership", async () => {
+        const teams = await listMemberTeams(
+            testAccount,
+            createRequestContext({
+                fetcher: async () => new Response(JSON.stringify({
+                    teams: [
+                        { id: "team-1", name: "acme", role: "owner", system_created: false },
+                        { id: "team-2", name: "beta", role: "guest", system_created: false },
+                    ],
+                })),
+            }),
+        );
+
+        expect(teams).toEqual([
+            { id: "team-1", name: "acme", role: "member", systemCreated: false },
+            { id: "team-2", name: "beta", role: "member", systemCreated: false },
+        ]);
+    });
+
+    test("rejects a team item missing the required role or system_created field", async () => {
+        const missingRole = await expectCliUserError(listMemberTeams(
+            testAccount,
+            createRequestContext({
+                fetcher: async () => new Response(JSON.stringify({
+                    teams: [{ id: "team-1", name: "acme", system_created: false }],
+                })),
+            }),
+        ));
+        expect(missingRole.key).toBe("errors.team.invalidResponse");
+
+        const missingSystemCreated = await expectCliUserError(listMemberTeams(
+            testAccount,
+            createRequestContext({
+                fetcher: async () => new Response(JSON.stringify({
+                    teams: [{ id: "team-1", name: "acme", role: "creator" }],
+                })),
+            }),
+        ));
+        expect(missingSystemCreated.key).toBe("errors.team.invalidResponse");
     });
 
     test("returns an empty list when the account has no teams", async () => {

--- a/src/application/commands/team/shared.ts
+++ b/src/application/commands/team/shared.ts
@@ -10,13 +10,17 @@ import {
 
 export const teamFormatValues = ["json"] as const;
 
-// One team the current account belongs to. The backend membership listing
-// carries a role of exactly `creator` or `member`; anything else is treated as
-// a plain membership.
+// One team the current account belongs to. The membership listing always
+// carries `role` (exactly `creator` or `member`; any other value is treated as
+// a plain membership) and `system_created`, which marks the team the backend
+// provisions for every account (at most one at a time, and it cannot be
+// deleted). Both fields are always present in the response, so both are
+// required — a missing one is a malformed response, not a defaulted value.
 const teamResponseItemSchema = z.object({
     id: z.string().min(1),
     name: z.string().min(1),
-    role: z.string().optional(),
+    role: z.string(),
+    system_created: z.boolean(),
 });
 
 // `GET /v1/me/teams` wraps the memberships in a `teams` array. The array is
@@ -32,6 +36,7 @@ export interface TeamView {
     id: string;
     name: string;
     role: TeamRole;
+    systemCreated: boolean;
 }
 
 // Lists every team the account can authenticate as. Backed by
@@ -87,5 +92,6 @@ function toTeamView(
         id: item.id,
         name: item.name,
         role: item.role === "creator" ? "creator" : "member",
+        systemCreated: item.system_created,
     };
 }

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -72,8 +72,14 @@ const commandTelemetryDecisions = {
     },
     "auth.login": {
         kind: "properties",
-        properties: ["auth_method", "account_count_bucket", "credential_source"],
-        reason: "Records login method, bounded saved-account count, and whether OO_API_KEY outranks the saved account.",
+        properties: [
+            "auth_method",
+            "account_count_bucket",
+            "credential_source",
+            "team_count_bucket",
+            "team_selection",
+        ],
+        reason: "Records login method, bounded saved-account count, whether OO_API_KEY outranks the saved account, bounded team count, and which mechanism picked the default team (enum only, never the team name).",
     },
     "auth.logout": {
         kind: "properties",
@@ -82,8 +88,8 @@ const commandTelemetryDecisions = {
     },
     "auth.status": {
         kind: "properties",
-        properties: ["account_count_bucket", "credential_source"],
-        reason: "Records bounded saved-account count and which credential source is in effect, without account identity.",
+        properties: ["account_count_bucket", "credential_source", "team_source"],
+        reason: "Records bounded saved-account count, which credential source is in effect, and which mechanism selects the default team (enum only), without account or team identity.",
     },
     "auth.switch": {
         kind: "properties",
@@ -261,7 +267,13 @@ const commandTelemetryDecisions = {
     },
     "login": {
         kind: "properties",
-        properties: ["auth_method", "account_count_bucket", "credential_source"],
+        properties: [
+            "auth_method",
+            "account_count_bucket",
+            "credential_source",
+            "team_count_bucket",
+            "team_selection",
+        ],
         reason: "Top-level auth alias records the same safe auth dimensions as auth.login.",
     },
     "logout": {

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -14,6 +14,11 @@ export const enMessages = {
         "Connector commands keep using your self-hosted connector at {url}. Run `oo connector logout` to switch them back to OOMOL.",
     "auth.login.selfHostedConnectorHintEnv":
         "Connector commands keep using your self-hosted connector at {url} (set via OO_CONNECTOR_URL). Unset that variable to switch them back to OOMOL.",
+    "auth.login.teamDefault": "Default team identity: {team}",
+    "auth.login.teamOverview":
+        "You belong to {count} teams: {teams}. Switch with `oo team use <name>`.",
+    "auth.login.teamUnresolved":
+        "Could not load your teams, so the default team identity is unchanged. Run `oo team list` to inspect them later.",
     "auth.logout.envOverrideNoop":
         "Nothing was logged out: the active credential comes from OO_API_KEY, not from a saved account.",
     "auth.logout.success": "Logged out the current account.",
@@ -36,6 +41,9 @@ export const enMessages = {
     "auth.status.selfHostedConnectorToken": "Token configured",
     "auth.status.selfHostedConnectorToken.no": "no",
     "auth.status.selfHostedConnectorToken.yes": "yes",
+    "auth.status.team": "Default team",
+    "auth.status.teamEnvOverride": "{team} (via {envVar})",
+    "auth.status.teamPersonal": "personal (no default team)",
     "auth.switch.envOverrideNoop":
         "Nothing was switched: the active credential comes from OO_API_KEY, not from a saved account.",
     "auth.switch.success": "Switched active account for {endpoint} to {name}",
@@ -992,6 +1000,7 @@ export const enMessages = {
     "options.status": "Filter by task status",
     "options.apiKey": "Log in with an existing API key",
     "options.sessionToken": "Log in with a session token",
+    "options.loginTeam": "Set the default team identity after login",
     "options.schema": "Provide response JSON Schema or @path to a JSON file",
     "options.system": "System prompt text or @path to a text file",
     "options.timeout":
@@ -1335,6 +1344,11 @@ export const zhMessages = {
         "Connector 命令仍会使用你的自部署 Connector（{url}）。运行 `oo connector logout` 可切回 OOMOL。",
     "auth.login.selfHostedConnectorHintEnv":
         "Connector 命令仍会使用你的自部署 Connector（{url}，由 OO_CONNECTOR_URL 指定）。取消该环境变量可切回 OOMOL。",
+    "auth.login.teamDefault": "当前默认团队身份：{team}",
+    "auth.login.teamOverview":
+        "你共有 {count} 个团队：{teams}。可使用 `oo team use <name>` 切换。",
+    "auth.login.teamUnresolved":
+        "无法获取团队列表，默认团队身份保持不变。可稍后运行 `oo team list` 查看。",
     "auth.status.accountActive": "激活",
     "auth.status.accountId": "账号 ID",
     "auth.status.accountsLabel": "账号列表",
@@ -1353,6 +1367,9 @@ export const zhMessages = {
     "auth.status.envOverride": "已使用 OO_API_KEY 中的 API key 登录 {endpoint}",
     "auth.status.loggedOut": "当前没有登录任何 OOMOL 账号。",
     "auth.status.savedAccountsIgnored": "设置了 OO_API_KEY 时，保存的账号不会被使用。",
+    "auth.status.team": "默认团队",
+    "auth.status.teamEnvOverride": "{team}（来自 {envVar}）",
+    "auth.status.teamPersonal": "个人身份（未设置默认团队）",
     "auth.switch.envOverrideNoop":
         "没有切换任何账号：当前生效的凭证来自 OO_API_KEY，而不是保存的账号。",
     "auth.switch.success": "已将 {endpoint} 的当前激活账号切换为 {name}",
@@ -2273,6 +2290,7 @@ export const zhMessages = {
     "options.status": "按任务状态过滤",
     "options.apiKey": "使用已有 API key 登录",
     "options.sessionToken": "使用 session token 登录",
+    "options.loginTeam": "登录后设置的默认团队身份",
     "options.schema": "提供响应 JSON Schema，或使用 @路径 读取 JSON 文件",
     "options.system": "System prompt 文本，或使用 @路径 读取文本文件",
     "options.timeout": "设置等待超时时间（默认 6h，范围 10s 到 24h）",


### PR DESCRIPTION
Team-scoped commands previously required a manual `oo team use` after every login: a fresh account or a new machine fell back to the personal identity even though the backend provisions a team for every account. This makes login establish a default team identity (`identity.team`) automatically, so team commands work out of the box.

Selection follows a clear precedence: an explicit `--team <name>` (must name a real membership, otherwise login exits `1` with the account still saved), then a still-valid configured `identity.team` so a deliberate `oo team use` survives a re-login, then the backend-provisioned `system_created` team. When none apply — an older backend with no system team, or an empty list — nothing is persisted and login still exits `0`. The implicit flow is deliberately tolerant: login already succeeded, so a failed membership request only prints a hint rather than flipping the exit code (an explicit `--team` still fails loudly).

`oo auth status` now surfaces the resolved default — a `Default team` text row and an optional top-level `team` field in `--json` — resolved entirely offline the same way `oo team current` does (`OO_TEAM_ID` / `OO_TEAM_NAME` env override, else the `identity.team` config), never from a login or backend response.

Notable changes:
- The `GET /v1/me/teams` membership schema now requires `role` and the new `system_created` flag, and `TeamView` carries `systemCreated` so the login flow can find the backend default.
- Telemetry records only low-cardinality signals (`team_selection`, `team_count_bucket`, `team_source`); tests pin that raw team names/ids never reach the payload.
- `docs/commands.md` and `docs/commands.zh-CN.md` document the new `--team` option, the default-team behavior, and the status output.