### PR TITLE
feat(team): resolve OO_TEAM_ID to its team name

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -177,13 +177,22 @@ Show every saved auth account and validate the API key of the active one.
 - Text output lists all saved accounts under an `Accounts:` block. The active
   account is annotated with `[active]`; the active account additionally shows
   `API key status` resolved from a single profile request to its endpoint.
-  Inactive accounts are not validated, so `oo auth status` performs at most
-  one network request regardless of how many accounts are saved.
-- The active-identity block also shows a `Default team` line, resolved offline
-  the same way `oo team current` resolves it: the `OO_TEAM_ID` /
-  `OO_TEAM_NAME` env override when set (annotated with the variable that
-  supplies it), otherwise the `identity.team` config default, otherwise
-  `personal (no default team)`.
+  Inactive accounts are not validated, so the number of saved accounts never
+  changes how many requests are sent.
+- The active-identity block also shows a `Default team` line, resolved the same
+  way `oo team current` resolves it: the `OO_TEAM_ID` / `OO_TEAM_NAME` env
+  override when set (annotated with the variable that supplies it), otherwise
+  the `identity.team` config default, otherwise `personal (no default team)`.
+- When `OO_TEAM_ID` supplies the identity, the team name is looked up and the
+  line shows `<name> (<id>)`. If the lookup does not succeed, the id is still
+  shown and the reason is appended: the active account is not a member of the
+  team, no team exists with that id, the team has been deleted, or the lookup
+  could not be completed. A failed lookup never changes the exit code and never
+  affects the reported `API key status`. Every other identity source already
+  knows its name, so no lookup is made for it.
+- `oo auth status` therefore sends at most two requests: the API key check, plus
+  the team name lookup when `OO_TEAM_ID` is in effect. The two are independent
+  and are sent concurrently.
 - API key values are never written to stdout in text or JSON output.
 - When a self-hosted connector is configured (`oo connector login` or
   `OO_CONNECTOR_URL`), text output adds a self-hosted connector block showing
@@ -230,15 +239,30 @@ Show every saved auth account and validate the API key of the active one.
 
 - When a default team identity is in effect, the `oo auth status --json` output
   — specifically its `logged-in` shape above — carries an optional top-level
-  `team` field. The CLI fills it from the local default-team identity
-  (`OO_TEAM_ID` / `OO_TEAM_NAME`, otherwise the `identity.team` config); it is
-  not returned by any login or backend request:
+  `team` field. `source` says which mechanism selected it (`env_id`, `env_name`
+  or `config`), and `status` reports the team name lookup:
 
   ```json
   {
-    "team": { "name": "acme", "id": null, "source": "config" }
+    "team": { "name": "acme", "id": null, "source": "config", "status": null }
   }
   ```
+
+  ```json
+  {
+    "team": {
+      "name": "platform",
+      "id": "019ed9dd-57b1-77eb-86b7-09724abe8037",
+      "source": "env_id",
+      "status": "valid"
+    }
+  }
+  ```
+
+  `status` is `null` whenever no lookup was needed, which is every source other
+  than `env_id`. For an `env_id` identity it is one of `valid`, `not_a_member`,
+  `not_found`, `deleted`, `request_failed`, `request_failed_sandbox`, or
+  `no_credential`. `name` is filled only when `status` is `valid`.
 
 - When `OO_API_KEY` supplies the credential, the `oo auth status --json` output
   is always the `logged-in` shape and carries an optional top-level
@@ -340,8 +364,9 @@ account can use and manage that default.
 
 `oo team list` and `oo team use` query OOMOL for your team memberships, so they
 require an OOMOL account and are unavailable when only a self-hosted connector
-is configured. `oo team current` and `oo team clear` only read and write local
-settings, so they work regardless.
+is configured. `oo team current` and `oo team clear` work regardless: they read
+and write local settings, and `oo team current` only enriches its output with a
+team name when an account is available to look one up.
 
 `oo auth login` (and its `oo login` alias) persists the default automatically:
 it keeps a still-valid configured `identity.team`, otherwise adopts the
@@ -369,16 +394,25 @@ read-only.
 
 Show the team identity used by connector commands when no `--team` /
 `--personal` flag is given: the `OO_TEAM_ID` / `OO_TEAM_NAME` environment
-override when set, otherwise the `identity.team` config default. This command
-is offline and does not make a network request (an `OO_TEAM_NAME` value is
-reported as-is, without resolving its id).
+override when set, otherwise the `identity.team` config default.
 
+- Sends one request only when `OO_TEAM_ID` supplies the identity, to resolve the
+  id to its team name. Every other source already knows the name and stays
+  offline, including an `OO_TEAM_NAME` value, which is reported as-is without
+  resolving its id.
+- Works without an OOMOL account. When no account is configured the name lookup
+  is skipped rather than failing, and the id is reported on its own.
 - Options: `--format=json` and `--json` print a JSON object.
 - Output: JSON is `{ "team": <name|null>, "teamId": <id|null>, "source":
-  <"env_id"|"env_name"|"config"|null> }`. `source` says which mechanism
-  selects the team, and is `null` when connector commands run under your
-  personal identity. `team` carries the name when it is known (`env_name` or
-  `config`); `teamId` carries the id only for `env_id`.
+  <"env_id"|"env_name"|"config"|null>, "status": <status|null> }`. `source` says
+  which mechanism selects the team, and is `null` when connector commands run
+  under your personal identity. `status` reports the team name lookup: `null`
+  whenever none was needed (every source other than `env_id`), otherwise one of
+  `valid`, `not_a_member`, `not_found`, `deleted`, `request_failed`,
+  `request_failed_sandbox`, or `no_credential`.
+- Output: under `OO_TEAM_ID` text output shows `<name> (<id>)`. If the lookup
+  does not succeed the id is still shown and the reason is appended; the command
+  still exits `0`.
 - Output: text output names the environment variable when one is set, and
   notes that a configured `identity.team` default is not in use while the
   override is active.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -144,12 +144,18 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   本身就是凭证，因此损坏的文件仍会以非零退出。
 - 文本输出会在 `Accounts:` 区块下列出所有已保存账号。当前激活账号会标注
   `[active]`，并额外显示其 `API key status`——通过一次 profile 请求向该账号
-  对应的 endpoint 校验得到。其它账号不参与校验，所以无论有多少账号，
-  `oo auth status` 最多发送 1 次网络请求。
+  对应的 endpoint 校验得到。其它账号不参与校验，所以已保存账号的数量不会影响
+  发出的请求数。
 - 当前身份区块还会显示一行「默认团队」，其解析方式与 `oo team current`
-  相同且完全离线：设置了 `OO_TEAM_ID` / `OO_TEAM_NAME` 时显示 env 覆盖值
-  （并标注来源变量），否则显示 `identity.team` 配置默认值，都未设置时显示
-  个人身份（未设置默认团队）。
+  相同：设置了 `OO_TEAM_ID` / `OO_TEAM_NAME` 时显示 env 覆盖值（并标注来源
+  变量），否则显示 `identity.team` 配置默认值，都未设置时显示个人身份
+  （未设置默认团队）。
+- 当身份来自 `OO_TEAM_ID` 时，会查询团队名称，该行显示为 `<名称>（<id>）`。
+  查询未成功时仍会显示 id，并附上原因：当前账号不是该团队的成员、不存在该 id
+  对应的团队、该团队已被删除、或无法完成查询。查询失败既不会改变退出码，也不会
+  影响所报告的 `API key status`。其它身份来源本身就带名称，因此不会发起查询。
+- 因此 `oo auth status` 最多发送 2 次请求：API key 校验，以及 `OO_TEAM_ID`
+  生效时的团队名称查询。两者相互独立，并发发出。
 - 文本和 JSON 输出都永远不会包含 API key 实际内容。
 - 当配置了自部署 Connector（`oo connector login` 或 `OO_CONNECTOR_URL`）时，
   文本输出会额外显示一个自部署 Connector 区块，包含服务地址、是否已配置令牌
@@ -194,15 +200,30 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   ```
 
 - 当存在默认团队身份时，`oo auth status --json` 的输出——即上面的 `logged-in`
-  形态——会携带一个可选的顶层 `team` 字段。该字段由 CLI 从本地默认团队身份
-  （`OO_TEAM_ID` / `OO_TEAM_NAME`，否则 `identity.team` 配置）填充，并非由任何
-  login 或后端接口返回：
+  形态——会携带一个可选的顶层 `team` 字段。`source` 表示由哪种机制选中
+  （`env_id`、`env_name` 或 `config`），`status` 报告团队名称查询的结果：
 
   ```json
   {
-    "team": { "name": "acme", "id": null, "source": "config" }
+    "team": { "name": "acme", "id": null, "source": "config", "status": null }
   }
   ```
+
+  ```json
+  {
+    "team": {
+      "name": "platform",
+      "id": "019ed9dd-57b1-77eb-86b7-09724abe8037",
+      "source": "env_id",
+      "status": "valid"
+    }
+  }
+  ```
+
+  无需查询时 `status` 为 `null`，即除 `env_id` 以外的所有来源。`env_id` 身份下
+  取值为 `valid`、`not_a_member`、`not_found`、`deleted`、`request_failed`、
+  `request_failed_sandbox` 或 `no_credential` 之一。只有 `status` 为 `valid`
+  时 `name` 才有值。
 
 - 当由 `OO_API_KEY` 提供凭证时，`oo auth status --json` 的输出恒为 `logged-in`
   形态，并携带一个可选的顶层 `envOverride` 字段：
@@ -289,7 +310,8 @@ apps`）以某个团队身份运行，而非个人账号：既可用每次运行
 
 `oo team list` 与 `oo team use` 需要向 OOMOL 查询团队成员关系，因此需要 OOMOL
 账号；当仅配置了自部署 Connector 时不可用。`oo team current` 与 `oo team clear`
-仅读写本地配置，不受此限制。
+不受此限制：它们读写本地配置，`oo team current` 只在有账号可用时才额外查询
+团队名称来丰富输出。
 
 `oo auth login`（及其别名 `oo login`）会自动持久化该默认值：仍然有效的
 `identity.team` 配置会被保留，否则采用后端创建的 `system_created` 默认团队
@@ -313,14 +335,20 @@ apps`）以某个团队身份运行，而非个人账号：既可用每次运行
 
 显示未传 `--team` / `--personal` 时 connector 命令使用的团队身份：设置了
 `OO_TEAM_ID` / `OO_TEAM_NAME` 环境变量时为 env 指定的团队，否则为
-`identity.team` 配置默认值。该命令离线运行，不发起网络请求（`OO_TEAM_NAME`
-的值按原样展示，不解析其 id）。
+`identity.team` 配置默认值。
 
+- 仅当身份来自 `OO_TEAM_ID` 时才发送 1 次请求，把 id 解析为团队名称。其它来源
+  本身就带名称，保持离线；`OO_TEAM_NAME` 的值按原样展示，不解析其 id。
+- 无 OOMOL 账号时同样可用：此时跳过名称查询而不是让命令失败，只单独展示 id。
 - 选项：`--format=json` 与 `--json` 输出 JSON 对象。
 - 输出：JSON 为 `{ "team": <name|null>, "teamId": <id|null>, "source":
-  <"env_id"|"env_name"|"config"|null> }`。`source` 表示团队由哪种机制选定；
-  connector 命令以个人身份运行时为 `null`。`team` 在名称已知（`env_name` 或
-  `config`）时携带名称；`teamId` 仅在 `env_id` 时携带 id。
+  <"env_id"|"env_name"|"config"|null>, "status": <status|null> }`。`source`
+  表示团队由哪种机制选定；connector 命令以个人身份运行时为 `null`。`status`
+  报告团队名称查询的结果：无需查询时为 `null`（即除 `env_id` 以外的所有来源），
+  否则为 `valid`、`not_a_member`、`not_found`、`deleted`、`request_failed`、
+  `request_failed_sandbox` 或 `no_credential` 之一。
+- 输出：`OO_TEAM_ID` 生效时，文本输出显示 `<名称>（<id>）`。查询未成功时仍会
+  显示 id 并附上原因，命令依然以 `0` 退出。
 - 输出：设置了环境变量时，文本输出会指明变量名，并说明已配置的
   `identity.team` 默认值在覆盖生效期间不会被使用。
 

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -1,4 +1,6 @@
+import type { Fetcher } from "../../contracts/cli.ts";
 import { readFile } from "node:fs/promises";
+
 import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
@@ -2628,17 +2630,16 @@ describe("auth CLI status default team", () => {
                 ["auth", "info", "--json"],
                 { fetcher },
             );
-            const payload = JSON.parse(jsonResult.stdout) as {
-                team?: { name: string | null; id: string | null; source: string };
-            };
-
             expect(textResult.exitCode).toBe(0);
             expect(textResult.stdout).toContain("- Default team: acme");
             expect(jsonResult.exitCode).toBe(0);
-            expect(payload.team).toEqual({
+            // A config default already carries its name, so no lookup runs and
+            // there is no status to report.
+            expect(parseAuthStatusTeam(jsonResult.stdout)).toEqual({
                 name: "acme",
                 id: null,
                 source: "config",
+                status: null,
             });
 
             // Only the source enum reaches telemetry, never the team name.
@@ -2648,6 +2649,7 @@ describe("auth CLI status default team", () => {
             );
             expect(telemetryProperties).toMatchObject({
                 team_source: "config",
+                team_status: "none",
             });
             expectTelemetryFreeOfTeamIdentity(telemetryProperties, ["acme"]);
         }
@@ -2674,7 +2676,6 @@ describe("auth CLI status default team", () => {
             const payload = JSON.parse(jsonResult.stdout) as {
                 status: string;
                 envOverride?: unknown;
-                team?: { name: string | null; id: string | null; source: string };
             };
 
             // The team default is orthogonal to the credential source, so the
@@ -2683,10 +2684,11 @@ describe("auth CLI status default team", () => {
             expect(textResult.stdout).toContain("- Default team: acme");
             expect(payload.status).toBe("logged-in");
             expect(payload.envOverride).toBeDefined();
-            expect(payload.team).toEqual({
+            expect(parseAuthStatusTeam(jsonResult.stdout)).toEqual({
                 name: "acme",
                 id: null,
                 source: "config",
+                status: null,
             });
         }
         finally {
@@ -2694,7 +2696,7 @@ describe("auth CLI status default team", () => {
         }
     });
 
-    test("reports the OO_TEAM_ID override ahead of the configured default", async () => {
+    test("resolves the OO_TEAM_ID override to its name ahead of the configured default", async () => {
         const sandbox = await createCliSandbox();
 
         sandbox.env.OO_TEAM_ID = "team-42";
@@ -2703,31 +2705,105 @@ describe("auth CLI status default team", () => {
             await writeAuthFile(sandbox);
             await sandbox.run(["config", "set", "identity.team", "acme"]);
 
-            const fetcher = async (): Promise<Response> =>
-                new Response(null, { status: 200 });
+            const requests: Request[] = [];
+            const fetcher = createAuthStatusFetcher(requests);
             const textResult = await sandbox.run(["auth", "status"], { fetcher });
             const jsonResult = await sandbox.run(
                 ["auth", "status", "--json"],
                 { fetcher },
             );
-            const payload = JSON.parse(jsonResult.stdout) as {
-                team?: { name: string | null; id: string | null; source: string };
-            };
 
             expect(textResult.exitCode).toBe(0);
+            // The name is the new information; the id is what the reader put in
+            // the environment, so both are shown.
             expect(textResult.stdout).toContain(
-                "- Default team: team-42 (via OO_TEAM_ID)",
+                "- Default team: platform (team-42) (via OO_TEAM_ID)",
             );
-            expect(payload.team).toEqual({
-                name: null,
+            expect(parseAuthStatusTeam(jsonResult.stdout)).toEqual({
+                name: "platform",
                 id: "team-42",
                 source: "env_id",
+                status: "valid",
             });
+            // Two requests per run and no more: the key check and the name
+            // lookup, which the command must not turn into a listing scan.
+            expect(requests.map(request => request.url)).toEqual([
+                "https://api.oomol.com/v1/users/profile",
+                "https://relation-control.oomol.com/v1/teams/team-42",
+                "https://api.oomol.com/v1/users/profile",
+                "https://relation-control.oomol.com/v1/teams/team-42",
+            ]);
         }
         finally {
             await sandbox.cleanup();
         }
     });
+
+    // The status separates a misconfigured id from an unreachable backend; a
+    // bare id with no explanation is the output this feature exists to remove.
+    test.each([
+        {
+            httpStatus: 403,
+            status: "not_a_member",
+            reason: "the active account is not a member of this team",
+        },
+        {
+            httpStatus: 404,
+            status: "not_found",
+            reason: "no team exists with this id",
+        },
+        {
+            httpStatus: 410,
+            status: "deleted",
+            reason: "this team has been deleted",
+        },
+        {
+            httpStatus: 500,
+            status: "request_failed",
+            reason: "could not look up the team name",
+        },
+    ])(
+        "reports OO_TEAM_ID lookup status $status for HTTP $httpStatus",
+        async ({ httpStatus, status, reason }) => {
+            const sandbox = await createCliSandbox();
+
+            sandbox.env.OO_TEAM_ID = "team-42";
+
+            try {
+                await writeAuthFile(sandbox);
+
+                const fetcher = createAuthStatusFetcher([], {
+                    teamHttpStatus: httpStatus,
+                });
+                const textResult = await sandbox.run(["auth", "status"], { fetcher });
+                const jsonResult = await sandbox.run(
+                    ["auth", "status", "--json"],
+                    { fetcher },
+                );
+
+                // A failed name lookup never fails the command, and never
+                // downgrades the API key verdict either.
+                expect(textResult.exitCode).toBe(0);
+                expect(textResult.stdout).toContain("- API key status: Valid");
+                // The id is kept so the reader can see what was tried, and the
+                // reason lands last rather than between the id and its source.
+                expect(textResult.stdout).toContain(
+                    `- Default team: team-42 (via OO_TEAM_ID) — ${reason}`,
+                );
+                expect(parseAuthStatusTeam(jsonResult.stdout)).toEqual({
+                    name: null,
+                    id: "team-42",
+                    source: "env_id",
+                    status,
+                });
+                expect(readCommandTelemetryProperties(sandbox, "auth.status"))
+                    .toMatchObject({ team_source: "env_id", team_status: status });
+            }
+            finally {
+                await sandbox.cleanup();
+            }
+        },
+    );
 
     test("reports the OO_TEAM_NAME override by name", async () => {
         const sandbox = await createCliSandbox();
@@ -2737,25 +2813,29 @@ describe("auth CLI status default team", () => {
         try {
             await writeAuthFile(sandbox);
 
-            const fetcher = async (): Promise<Response> =>
-                new Response(null, { status: 200 });
+            const requests: Request[] = [];
+            const fetcher = createAuthStatusFetcher(requests);
             const textResult = await sandbox.run(["auth", "status"], { fetcher });
             const jsonResult = await sandbox.run(
                 ["auth", "status", "--json"],
                 { fetcher },
             );
-            const payload = JSON.parse(jsonResult.stdout) as {
-                team?: { name: string | null; id: string | null; source: string };
-            };
 
             expect(textResult.stdout).toContain(
                 "- Default team: acme (via OO_TEAM_NAME)",
             );
-            expect(payload.team).toEqual({
+            expect(parseAuthStatusTeam(jsonResult.stdout)).toEqual({
                 name: "acme",
                 id: null,
                 source: "env_name",
+                status: null,
             });
+            // A name-shaped identity has nothing to resolve, so the command
+            // keeps its single-request cost.
+            expect(requests.map(request => request.url)).toEqual([
+                "https://api.oomol.com/v1/users/profile",
+                "https://api.oomol.com/v1/users/profile",
+            ]);
         }
         finally {
             await sandbox.cleanup();
@@ -2786,3 +2866,38 @@ describe("auth CLI status default team", () => {
         }
     });
 });
+
+// Answers both requests `auth status` can make: the API key check and the
+// singular team lookup. Recording every request is what lets a test assert the
+// command's request count, which is part of its documented contract.
+function createAuthStatusFetcher(
+    requests: Request[],
+    options: { teamHttpStatus?: number } = {},
+): Fetcher {
+    return async (input, init) => {
+        const request = toRequest(input, init);
+        requests.push(request);
+
+        if (!new URL(request.url).pathname.startsWith("/v1/teams/")) {
+            return new Response(null, { status: 200 });
+        }
+
+        const teamHttpStatus = options.teamHttpStatus ?? 200;
+
+        return new Response(
+            teamHttpStatus === 200
+                ? JSON.stringify({
+                        id: "team-42",
+                        name: "platform",
+                        role: "member",
+                        system_created: false,
+                    })
+                : "{}",
+            { status: teamHttpStatus },
+        );
+    };
+}
+
+function parseAuthStatusTeam(stdout: string): unknown {
+    return (JSON.parse(stdout) as { team?: unknown }).team;
+}

--- a/src/application/commands/auth/status.ts
+++ b/src/application/commands/auth/status.ts
@@ -3,6 +3,12 @@ import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/
 import type { AuthAccount, AuthFile } from "../../schemas/auth.ts";
 
 import type { ResolvedSelfHostedConnector } from "../shared/self-hosted-connector.ts";
+
+import type {
+    DefaultTeamIdentity,
+    TeamIdentitySource,
+    TeamNameStatus,
+} from "../team/default-identity.ts";
 import { z } from "zod";
 import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
@@ -17,9 +23,11 @@ import { writeLine } from "../shared/output.ts";
 import { isNetworkRestrictedSandboxError } from "../shared/request.ts";
 import { resolveSelfHostedConnectorTolerantly } from "../shared/self-hosted-connector.ts";
 import {
-    readTeamEnvOverride,
-    teamEnvOverrideVariableName,
-} from "../shared/team-env-override.ts";
+    appendTeamIdentityStatus,
+    formatTeamIdentityValue,
+    resolveDefaultTeamIdentity,
+    teamNameStatusForTelemetry,
+} from "../team/default-identity.ts";
 import {
     formatAuthStrong,
     readCurrentAuth,
@@ -85,22 +93,19 @@ interface AuthStatusJsonEnvOverride {
     apiKeyStatus: ApiKeyStatus;
 }
 
-// The default team identity in effect for team-scoped commands, resolved
-// offline the same way `oo team current` does: the OO_TEAM_ID / OO_TEAM_NAME
-// env override outranks the `identity.team` config default. An env id
-// override knows only the id and a name-based source only the name; status
-// never spends a network request resolving one form into the other.
+// The default team identity in effect for team-scoped commands, resolved the
+// same way `oo team current` resolves it: the OO_TEAM_ID / OO_TEAM_NAME env
+// override outranks the `identity.team` config default.
+//
+// `status` reports what happened to the name lookup and is `null` when none was
+// needed — only an OO_TEAM_ID identity starts out as a bare id. `envVar` is
+// deliberately not part of this payload: it is a hint for the text renderer,
+// not a fact about the identity.
 interface AuthStatusJsonTeam {
     name: string | null;
     id: string | null;
-    source: "config" | "env_id" | "env_name";
-}
-
-// Internal resolution of the team identity; `envVar` names the overriding
-// variable for the text hint and is absent for the config source.
-interface StatusTeamIdentity {
-    team: AuthStatusJsonTeam;
-    envVar?: string;
+    source: TeamIdentitySource;
+    status: TeamNameStatus | null;
 }
 
 type AuthStatusJsonPayload
@@ -147,21 +152,35 @@ export const authStatusCommand: CliCommandDefinition<AuthStatusInput> = {
         // every other command is how status ends up naming the wrong account,
         // the wrong endpoint, and validating the wrong key.
         const { authFile, identity } = await resolveStatusState(context);
-        const teamIdentity = await resolveStatusTeamIdentity(context);
+        const settings = await context.settingsStore.read();
+
+        // The key validation and the team name lookup answer independent
+        // questions, so they go out together. Sequencing them would double the
+        // command's latency to report the same two facts.
+        const [apiKeyStatus, teamIdentity] = await Promise.all([
+            identity === undefined
+                ? undefined
+                : readApiKeyStatus(identity.account, context),
+            resolveDefaultTeamIdentity(
+                {
+                    account: identity?.account,
+                    configuredTeam: getConfiguredIdentityTeam(settings),
+                },
+                context,
+            ),
+        ]);
 
         context.telemetry?.recordProperties({
             account_count_bucket: bucketTelemetryCount(authFile.auth.length),
             credential_source: identity?.source ?? "none",
-            team_source: teamIdentity?.team.source ?? "none",
+            team_source: teamIdentity?.source ?? "none",
+            team_status: teamNameStatusForTelemetry(teamIdentity),
         });
 
         const activeStatus: ActiveAccountStatus | undefined
-            = identity === undefined
+            = identity === undefined || apiKeyStatus === undefined
                 ? undefined
-                : {
-                        ...identity,
-                        apiKeyStatus: await readApiKeyStatus(identity.account, context),
-                    };
+                : { ...identity, apiKeyStatus };
 
         if (input.format === "json") {
             writeJsonOutput(
@@ -181,41 +200,6 @@ export const authStatusCommand: CliCommandDefinition<AuthStatusInput> = {
         writeSelfHostedConnectorText(context, selfHostedConnector);
     },
 };
-
-// Resolves the default team identity offline, mirroring `oo team current`:
-// the OO_TEAM_ID / OO_TEAM_NAME env override when set, otherwise the
-// `identity.team` config default, otherwise none (personal identity).
-async function resolveStatusTeamIdentity(
-    context: CliExecutionContext,
-): Promise<StatusTeamIdentity | undefined> {
-    const envOverride = readTeamEnvOverride(context.env);
-
-    if (envOverride !== undefined) {
-        return {
-            team: {
-                name: envOverride.kind === "name" ? envOverride.value : null,
-                id: envOverride.kind === "id" ? envOverride.value : null,
-                source: envOverride.kind === "id" ? "env_id" : "env_name",
-            },
-            envVar: teamEnvOverrideVariableName(envOverride),
-        };
-    }
-
-    const settings = await context.settingsStore.read();
-    const configuredTeam = getConfiguredIdentityTeam(settings);
-
-    if (configuredTeam === undefined) {
-        return undefined;
-    }
-
-    return {
-        team: {
-            name: configuredTeam,
-            id: null,
-            source: "config",
-        },
-    };
-}
 
 /**
  * Resolves what to report, mirroring requireCurrentAccount()'s precedence:
@@ -257,7 +241,7 @@ async function resolveStatusState(
 function buildAuthStatusJsonPayload(
     authFile: AuthFile,
     activeStatus: ActiveAccountStatus | undefined,
-    teamIdentity: StatusTeamIdentity | undefined,
+    teamIdentity: DefaultTeamIdentity | undefined,
     selfHostedConnector: ResolvedSelfHostedConnector | undefined,
 ): AuthStatusJsonPayload {
     const connector: { connector?: AuthStatusJsonConnector }
@@ -293,9 +277,18 @@ function buildAuthStatusJsonPayload(
             status: "logged-in",
             activeAccountId: activeStatus.account.id,
             accounts,
+            // `envVar` is intentionally dropped: it explains the text hint, not
+            // the identity, and would not survive a source change.
             ...(teamIdentity === undefined
                 ? {}
-                : { team: teamIdentity.team }),
+                : {
+                        team: {
+                            name: teamIdentity.name,
+                            id: teamIdentity.id,
+                            source: teamIdentity.source,
+                            status: teamIdentity.status,
+                        },
+                    }),
             ...(activeStatus.source === "env"
                 ? {
                         envOverride: {
@@ -359,7 +352,7 @@ function writeSelfHostedConnectorText(
 // supplies it, or the personal fallback when no default team is set.
 function formatStatusTeamDetail(
     context: CliExecutionContext,
-    teamIdentity: StatusTeamIdentity | undefined,
+    teamIdentity: DefaultTeamIdentity | undefined,
 ): { label: string; value: string } {
     const label = context.translator.t("auth.status.team");
 
@@ -370,26 +363,28 @@ function formatStatusTeamDetail(
         };
     }
 
-    const teamValue = teamIdentity.team.name ?? teamIdentity.team.id ?? "";
+    const teamValue = formatTeamIdentityValue(teamIdentity, context.translator);
 
-    if (teamIdentity.envVar !== undefined) {
-        return {
-            label,
-            value: context.translator.t("auth.status.teamEnvOverride", {
-                team: teamValue,
-                envVar: teamIdentity.envVar,
-            }),
-        };
-    }
-
-    return { label, value: teamValue };
+    return {
+        label,
+        value: appendTeamIdentityStatus(
+            teamIdentity.envVar === undefined
+                ? teamValue
+                : context.translator.t("auth.status.teamEnvOverride", {
+                        team: teamValue,
+                        envVar: teamIdentity.envVar,
+                    }),
+            teamIdentity,
+            context.translator,
+        ),
+    };
 }
 
 function writeAuthStatusText(
     context: CliExecutionContext,
     authFile: AuthFile,
     activeStatus: ActiveAccountStatus | undefined,
-    teamIdentity: StatusTeamIdentity | undefined,
+    teamIdentity: DefaultTeamIdentity | undefined,
 ): void {
     if (activeStatus === undefined) {
         if (authFile.id !== "") {

--- a/src/application/commands/shared/auth-utils.test.ts
+++ b/src/application/commands/shared/auth-utils.test.ts
@@ -20,7 +20,10 @@ import {
     createSettingsStore,
     createTextBuffer,
 } from "../../../../__tests__/helpers.ts";
-import { requireCurrentAccount } from "./auth-utils.ts";
+import {
+    requireCurrentAccount,
+    resolveCurrentAccountTolerantly,
+} from "./auth-utils.ts";
 
 const emptyCatalog: CliCatalog = {
     name: "oo",
@@ -188,6 +191,54 @@ describe("requireCurrentAccount", () => {
         await expect(requireCurrentAccount(context)).rejects.toMatchObject({
             exitCode: 1,
             key: "errors.auth.required",
+        });
+    });
+});
+
+describe("resolveCurrentAccountTolerantly", () => {
+    // Every way of having no usable account collapses to the same absence, so
+    // callers get one case to handle instead of three error shapes.
+    test.each<{ case: string; authFile: AuthFile }>([
+        { case: "no account is configured", authFile: { auth: [], id: "" } },
+        { case: "the active id is stale", authFile: { auth: [], id: "user-1" } },
+    ])("returns undefined when $case", async ({ authFile }) => {
+        await expect(
+            resolveCurrentAccountTolerantly(createAuthContext(authFile)),
+        ).resolves.toBeUndefined();
+    });
+
+    test("returns the active account with a bare OO_ENDPOINT applied", async () => {
+        const account = {
+            id: "user-1",
+            name: "Test User",
+            apiKey: "persisted-key",
+            endpoint: "oomol.com",
+        };
+        const context = createAuthContext(
+            { auth: [account], id: "user-1" },
+            { env: { OO_ENDPOINT: "oomol.dev" } },
+        );
+
+        await expect(resolveCurrentAccountTolerantly(context)).resolves.toEqual({
+            ...account,
+            endpoint: "oomol.dev",
+        });
+    });
+
+    test("resolves the OO_API_KEY override without reading auth.toml", async () => {
+        const context = createAuthContext(
+            { auth: [], id: "" },
+            {
+                authStore: createThrowingAuthStore(),
+                env: { OO_API_KEY: "env-key", OO_ENDPOINT: "oomol.dev" },
+            },
+        );
+
+        await expect(resolveCurrentAccountTolerantly(context)).resolves.toEqual({
+            apiKey: "env-key",
+            endpoint: "oomol.dev",
+            id: "oo-env-override",
+            name: "Environment (OO_API_KEY)",
         });
     });
 });

--- a/src/application/commands/shared/auth-utils.ts
+++ b/src/application/commands/shared/auth-utils.ts
@@ -2,6 +2,7 @@ import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
 
 import { CliUserError } from "../../contracts/cli.ts";
+import { getCurrentAuthAccount } from "../../schemas/auth.ts";
 import { readCurrentAuth } from "../auth/shared.ts";
 import {
     applyEndpointOverride,
@@ -50,6 +51,33 @@ export async function requireCurrentAccount(
             : authErrorKeys.required,
         1,
     );
+}
+
+// Resolves the account commands run as, or `undefined` when there is none.
+// Precedence matches requireCurrentAccount(), but every way of having no
+// usable account — no login, a stale active id, an unreadable auth.toml — comes
+// back as an absence instead of an error.
+//
+// For commands whose own output does not depend on the account, so that an
+// optional enrichment (a name lookup, say) degrades instead of taking the
+// command down. Commands that cannot proceed without credentials must keep
+// using requireCurrentAccount(), which explains what to do about it.
+export async function resolveCurrentAccountTolerantly(
+    context: CliExecutionContext,
+): Promise<AuthAccount | undefined> {
+    const envAccount = buildEnvApiKeyAccount(context.env);
+
+    if (envAccount !== undefined) {
+        return envAccount;
+    }
+
+    const currentAccount = getCurrentAuthAccount(
+        await context.authStore.readTolerant(),
+    );
+
+    return currentAccount === undefined
+        ? undefined
+        : applyEndpointOverride(currentAccount, context.env);
 }
 
 // Resolves the OOMOL endpoint without requiring a logged-in account. Prefers

--- a/src/application/commands/team/current.ts
+++ b/src/application/commands/team/current.ts
@@ -1,14 +1,21 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
+import type {
+    TeamIdentitySource,
+    TeamNameStatus,
+} from "./default-identity.ts";
 import { z } from "zod";
 import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
+import { resolveCurrentAccountTolerantly } from "../shared/auth-utils.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
 import { writeLine } from "../shared/output.ts";
 import {
-    readTeamEnvOverride,
-    teamEnvOverrideVariableName,
-} from "../shared/team-env-override.ts";
+    appendTeamIdentityStatus,
+    formatTeamIdentityValue,
+    resolveDefaultTeamIdentity,
+    teamNameStatusForTelemetry,
+} from "./default-identity.ts";
 import { teamFormatValues } from "./shared.ts";
 
 interface TeamCurrentInput {
@@ -18,20 +25,28 @@ interface TeamCurrentInput {
 
 // `source` says which mechanism selects the team: the OO_TEAM_ID /
 // OO_TEAM_NAME env override, the `identity.team` config default, or none
-// (personal). `team` carries the name when it is known and `teamId` the id;
-// an env id override knows only the id, and this offline command never
-// resolves one form into the other.
+// (personal). `team` carries the name and `teamId` the id.
+//
+// `status` reports what happened to the name lookup and is `null` whenever none
+// was needed — only an OO_TEAM_ID identity starts out as a bare id, so the
+// other sources never spend a request.
 interface TeamCurrentJsonPayload {
     team: string | null;
     teamId: string | null;
-    source: "config" | "env_id" | "env_name" | null;
+    source: TeamIdentitySource | null;
+    status: TeamNameStatus | null;
 }
 
 // Reports the team identity that connector commands use when no `--team` /
 // `--personal` flag is given: the OO_TEAM_ID / OO_TEAM_NAME env override when
-// set, otherwise the config `identity.team` default. Offline by design: it
-// only reads local settings and the environment, so agents can cheaply learn
-// "which identity do I run as by default" without a network round-trip.
+// set, otherwise the `identity.team` config default.
+//
+// Under OO_TEAM_ID the identity is a bare id, which tells a reader nothing and
+// hides the most common misconfiguration there is — an id the account has no
+// membership in. That case, and only that case, spends one request to resolve
+// the name. Every other source already knows it and stays offline, as does an
+// unauthenticated run: having no account skips the lookup rather than failing
+// the command, so reading the local default never requires a login.
 export const teamCurrentCommand: CliCommandDefinition<TeamCurrentInput> = {
     name: "current",
     summaryKey: "commands.team.current.summary",
@@ -43,26 +58,28 @@ export const teamCurrentCommand: CliCommandDefinition<TeamCurrentInput> = {
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        const settings = await context.settingsStore.read();
+        const [settings, account] = await Promise.all([
+            context.settingsStore.read(),
+            resolveCurrentAccountTolerantly(context),
+        ]);
         const configuredTeam = getConfiguredIdentityTeam(settings);
-        const envOverride = readTeamEnvOverride(context.env);
-
-        const source = envOverride !== undefined
-            ? (envOverride.kind === "id" ? "env_id" as const : "env_name" as const)
-            : (configuredTeam !== undefined ? "config" as const : null);
+        const identity = await resolveDefaultTeamIdentity(
+            { account, configuredTeam },
+            context,
+        );
 
         context.telemetry?.recordProperties({
             has_configured_team: configuredTeam !== undefined,
-            team_source: source ?? "none",
+            team_source: identity?.source ?? "none",
+            team_status: teamNameStatusForTelemetry(identity),
         });
 
         if (input.format === "json") {
             const payload: TeamCurrentJsonPayload = {
-                team: envOverride !== undefined
-                    ? (envOverride.kind === "name" ? envOverride.value : null)
-                    : configuredTeam ?? null,
-                teamId: envOverride?.kind === "id" ? envOverride.value : null,
-                source,
+                team: identity?.name ?? null,
+                teamId: identity?.id ?? null,
+                source: identity?.source ?? null,
+                status: identity?.status ?? null,
             };
 
             writeJsonOutput(context.stdout, payload, {
@@ -71,37 +88,53 @@ export const teamCurrentCommand: CliCommandDefinition<TeamCurrentInput> = {
             return;
         }
 
-        if (envOverride !== undefined) {
+        if (identity === undefined) {
             writeLine(
                 context.stdout,
-                envOverride.kind === "id"
-                    ? context.translator.t("team.current.text.envId", {
-                            teamId: envOverride.value,
-                        })
-                    : context.translator.t("team.current.text.envName", {
-                            team: envOverride.value,
-                        }),
+                context.translator.t("team.current.text.personal"),
             );
-
-            if (configuredTeam !== undefined) {
-                writeLine(
-                    context.stdout,
-                    context.translator.t("team.current.text.configIgnored", {
-                        envVar: teamEnvOverrideVariableName(envOverride),
-                        team: configuredTeam,
-                    }),
-                );
-            }
             return;
         }
 
+        const teamValue = formatTeamIdentityValue(identity, context.translator);
+
+        if (identity.source === "config") {
+            writeLine(
+                context.stdout,
+                context.translator.t("team.current.text.configured", {
+                    team: teamValue,
+                }),
+            );
+            return;
+        }
+
+        // The reason is appended to the finished sentence so it lands last,
+        // where the reader looks for it, instead of mid-line.
         writeLine(
             context.stdout,
-            configuredTeam === undefined
-                ? context.translator.t("team.current.text.personal")
-                : context.translator.t("team.current.text.configured", {
-                        team: configuredTeam,
-                    }),
+            appendTeamIdentityStatus(
+                context.translator.t(
+                    identity.source === "env_id"
+                        ? "team.current.text.envId"
+                        : "team.current.text.envName",
+                    { team: teamValue },
+                ),
+                identity,
+                context.translator,
+            ),
         );
+
+        // The config default is still on disk and takes over the moment the
+        // variable is unset, so saying so here heads off a later "my default
+        // did not apply" report.
+        if (configuredTeam !== undefined && identity.envVar !== undefined) {
+            writeLine(
+                context.stdout,
+                context.translator.t("team.current.text.configIgnored", {
+                    envVar: identity.envVar,
+                    team: configuredTeam,
+                }),
+            );
+        }
     },
 };

--- a/src/application/commands/team/default-identity.test.ts
+++ b/src/application/commands/team/default-identity.test.ts
@@ -1,0 +1,253 @@
+import type { Fetcher } from "../../contracts/cli.ts";
+
+import { describe, expect, test } from "bun:test";
+import pino from "pino";
+
+import { toRequest } from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
+import {
+    appendTeamIdentityStatus,
+    formatTeamIdentityValue,
+    resolveDefaultTeamIdentity,
+    teamNameStatusForTelemetry,
+} from "./default-identity.ts";
+
+const testAccount = {
+    apiKey: "api-secret-1",
+    endpoint: "oomol.com",
+};
+
+describe("resolveDefaultTeamIdentity", () => {
+    test("reports no identity when neither the env nor the config selects a team", async () => {
+        expect(await resolveDefaultTeamIdentity(
+            { account: testAccount, configuredTeam: undefined },
+            createContext({}),
+        )).toBeUndefined();
+    });
+
+    // Only an id-shaped identity is missing its name, so it is the only source
+    // that may cost a request.
+    test.each([
+        {
+            case: "config default",
+            env: {},
+            configuredTeam: "acme",
+            expected: { name: "acme", id: null, source: "config", status: null },
+        },
+        {
+            case: "OO_TEAM_NAME override",
+            env: { OO_TEAM_NAME: "beta" },
+            configuredTeam: "acme",
+            expected: {
+                name: "beta",
+                id: null,
+                source: "env_name",
+                status: null,
+                envVar: "OO_TEAM_NAME",
+            },
+        },
+    ])("resolves the $case offline", async ({ configuredTeam, env, expected }) => {
+        let requested = false;
+
+        expect(await resolveDefaultTeamIdentity(
+            { account: testAccount, configuredTeam },
+            createContext(env, async () => {
+                requested = true;
+
+                return new Response("{}", { status: 200 });
+            }),
+        )).toEqual(expected);
+        expect(requested).toBe(false);
+    });
+
+    test("resolves an OO_TEAM_ID override to its team name", async () => {
+        const requests: Request[] = [];
+        const identity = await resolveDefaultTeamIdentity(
+            { account: testAccount, configuredTeam: "acme" },
+            createContext(
+                { OO_TEAM_ID: "team-1" },
+                async (input, init) => {
+                    requests.push(toRequest(input, init));
+
+                    return new Response(JSON.stringify({
+                        id: "team-1",
+                        name: "platform",
+                        role: "member",
+                        system_created: false,
+                    }));
+                },
+            ),
+        );
+
+        expect(identity).toEqual({
+            name: "platform",
+            id: "team-1",
+            source: "env_id",
+            status: "valid",
+            envVar: "OO_TEAM_ID",
+        });
+        expect(requests[0]?.url).toBe(
+            "https://relation-control.oomol.com/v1/teams/team-1",
+        );
+    });
+
+    test("keeps the id and reports the reason when the lookup fails", async () => {
+        expect(await resolveDefaultTeamIdentity(
+            { account: testAccount, configuredTeam: undefined },
+            createContext(
+                { OO_TEAM_ID: "team-1" },
+                async () => new Response("{}", { status: 403 }),
+            ),
+        )).toEqual({
+            name: null,
+            id: "team-1",
+            source: "env_id",
+            status: "not_a_member",
+            envVar: "OO_TEAM_ID",
+        });
+    });
+
+    // Reading the local default must not start requiring a login.
+    test("skips the lookup without an account instead of failing", async () => {
+        let requested = false;
+        const identity = await resolveDefaultTeamIdentity(
+            { account: undefined, configuredTeam: undefined },
+            createContext({ OO_TEAM_ID: "team-1" }, async () => {
+                requested = true;
+
+                return new Response("{}", { status: 200 });
+            }),
+        );
+
+        expect(identity).toEqual({
+            name: null,
+            id: "team-1",
+            source: "env_id",
+            status: "no_credential",
+            envVar: "OO_TEAM_ID",
+        });
+        expect(requested).toBe(false);
+    });
+
+    test("prefers OO_TEAM_ID over OO_TEAM_NAME and the config default", async () => {
+        const identity = await resolveDefaultTeamIdentity(
+            { account: testAccount, configuredTeam: "acme" },
+            createContext(
+                { OO_TEAM_ID: "team-1", OO_TEAM_NAME: "beta" },
+                async () => new Response(JSON.stringify({
+                    id: "team-1",
+                    name: "platform",
+                    role: "member",
+                    system_created: false,
+                })),
+            ),
+        );
+
+        expect(identity).toMatchObject({ source: "env_id", name: "platform" });
+    });
+});
+
+describe("formatTeamIdentityValue", () => {
+    const translator = createTranslator("en");
+
+    test("shows the name with its id once both are known", () => {
+        expect(formatTeamIdentityValue(
+            {
+                name: "platform",
+                id: "team-1",
+                source: "env_id",
+                status: "valid",
+            },
+            translator,
+        )).toBe("platform (team-1)");
+    });
+
+    test.each([
+        {
+            case: "name only",
+            identity: { name: "acme", id: null },
+            expected: "acme",
+        },
+        {
+            case: "id only",
+            identity: { name: null, id: "team-1" },
+            expected: "team-1",
+        },
+    ])("falls back to the $case", ({ expected, identity }) => {
+        expect(formatTeamIdentityValue(
+            { ...identity, source: "config", status: null },
+            translator,
+        )).toBe(expected);
+    });
+});
+
+describe("appendTeamIdentityStatus", () => {
+    const translator = createTranslator("en");
+
+    // A bare id with no explanation is exactly the output this feature removes,
+    // and the reason has to land last rather than mid-line.
+    test("appends the reason a failed lookup gives to the finished line", () => {
+        expect(appendTeamIdentityStatus(
+            "team-1 (via OO_TEAM_ID)",
+            {
+                name: null,
+                id: "team-1",
+                source: "env_id",
+                status: "not_a_member",
+            },
+            translator,
+        )).toBe(
+            "team-1 (via OO_TEAM_ID) — the active account is not a member of this team",
+        );
+    });
+
+    test.each([
+        { case: "a resolved lookup", status: "valid" as const },
+        { case: "an unattempted lookup", status: null },
+    ])("leaves the line untouched for $case", ({ status }) => {
+        expect(appendTeamIdentityStatus(
+            "acme (via OO_TEAM_NAME)",
+            { name: "acme", id: null, source: "env_name", status },
+            translator,
+        )).toBe("acme (via OO_TEAM_NAME)");
+    });
+});
+
+describe("teamNameStatusForTelemetry", () => {
+    test.each([
+        { case: "no identity", identity: undefined, expected: "none" },
+        {
+            case: "an unattempted lookup",
+            identity: {
+                name: "acme",
+                id: null,
+                source: "config" as const,
+                status: null,
+            },
+            expected: "none",
+        },
+        {
+            case: "a resolved lookup",
+            identity: {
+                name: "platform",
+                id: "team-1",
+                source: "env_id" as const,
+                status: "valid" as const,
+            },
+            expected: "valid",
+        },
+    ])("collapses $case to $expected", ({ expected, identity }) => {
+        expect(teamNameStatusForTelemetry(identity)).toBe(expected);
+    });
+});
+
+function createContext(
+    env: Record<string, string | undefined>,
+    fetcher: Fetcher = async () => new Response("{}", { status: 200 }),
+) {
+    return {
+        env,
+        fetcher,
+        logger: pino({ enabled: false }),
+    };
+}

--- a/src/application/commands/team/default-identity.ts
+++ b/src/application/commands/team/default-identity.ts
@@ -1,0 +1,144 @@
+// The default team identity: which team commands run as when no per-run
+// `--team` / `--personal` flag is given.
+//
+// Two commands report it — `oo auth status` and `oo team current` — and they
+// used to derive it separately, which is how they drifted apart. Both now go
+// through this module so "what is my default team, and is that identity real"
+// has exactly one answer.
+
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+import type { AuthAccount } from "../../schemas/auth.ts";
+
+import type { TeamLookupStatus } from "./shared.ts";
+import {
+    readTeamEnvOverride,
+    teamEnvOverrideVariableName,
+} from "../shared/team-env-override.ts";
+import { fetchTeamById } from "./shared.ts";
+
+// Which mechanism selects the identity. `env_id` and `env_name` name the
+// variable that won; `config` is the persisted `identity.team` default.
+export type TeamIdentitySource = "config" | "env_id" | "env_name";
+
+// `no_credential` is the one status the backend cannot produce: it means the
+// lookup never ran because no account was available to authenticate it.
+export type TeamNameStatus = TeamLookupStatus | "no_credential";
+
+export interface DefaultTeamIdentity {
+    name: string | null;
+    id: string | null;
+    source: TeamIdentitySource;
+    // `null` when no lookup was attempted. `config` and `env_name` already
+    // carry the name, so there is nothing to resolve and no request is sent —
+    // only an id-shaped identity costs a round-trip.
+    status: TeamNameStatus | null;
+    // The env variable supplying the override, for user-facing hints; absent
+    // for the config source.
+    envVar?: string;
+}
+
+// Resolves the default team identity, filling in the name when only an id is
+// known. Precedence matches every other team-aware command: OO_TEAM_ID >
+// OO_TEAM_NAME > the `identity.team` config default > personal (undefined).
+//
+// `account` is optional because `oo team current` must keep working without a
+// login: a missing account downgrades the lookup to `no_credential` rather than
+// failing the command.
+export async function resolveDefaultTeamIdentity(
+    input: {
+        account: Pick<AuthAccount, "apiKey" | "endpoint"> | undefined;
+        configuredTeam: string | undefined;
+    },
+    context: Pick<CliExecutionContext, "env" | "fetcher" | "logger">,
+): Promise<DefaultTeamIdentity | undefined> {
+    const envOverride = readTeamEnvOverride(context.env);
+
+    if (envOverride === undefined) {
+        return input.configuredTeam === undefined
+            ? undefined
+            : {
+                    name: input.configuredTeam,
+                    id: null,
+                    source: "config",
+                    status: null,
+                };
+    }
+
+    const envVar = teamEnvOverrideVariableName(envOverride);
+
+    if (envOverride.kind === "name") {
+        return {
+            name: envOverride.value,
+            id: null,
+            source: "env_name",
+            status: null,
+            envVar,
+        };
+    }
+
+    const lookup = input.account === undefined
+        ? { status: "no_credential" as const }
+        : await fetchTeamById(input.account, envOverride.value, context);
+
+    return {
+        name: lookup.status === "valid" ? lookup.team.name : null,
+        id: envOverride.value,
+        source: "env_id",
+        status: lookup.status,
+        envVar,
+    };
+}
+
+// Telemetry uses a closed enum, so the "nothing was attempted" cases collapse
+// to a single value instead of a missing property.
+export function teamNameStatusForTelemetry(
+    identity: DefaultTeamIdentity | undefined,
+): TeamNameStatus | "none" {
+    return identity?.status ?? "none";
+}
+
+const teamNameStatusTranslationKeys = {
+    deleted: "team.identity.status.deleted",
+    no_credential: "team.identity.status.noCredential",
+    not_a_member: "team.identity.status.notAMember",
+    not_found: "team.identity.status.notFound",
+    request_failed: "team.identity.status.requestFailed",
+    request_failed_sandbox: "team.identity.status.requestFailedSandbox",
+} as const satisfies Record<Exclude<TeamNameStatus, "valid">, string>;
+
+// Renders the identity for humans: the name with its id in parentheses when
+// both are known, otherwise whichever one is.
+export function formatTeamIdentityValue(
+    identity: DefaultTeamIdentity,
+    translator: Pick<CliExecutionContext["translator"], "t">,
+): string {
+    return identity.name !== null && identity.id !== null
+        ? translator.t("team.identity.nameWithId", {
+                name: identity.name,
+                teamId: identity.id,
+            })
+        : identity.name ?? identity.id ?? "";
+}
+
+// Appends why a lookup failed, because a bare id with no explanation is exactly
+// the output this whole feature exists to remove — the reader cannot tell a
+// wrong id from an unreachable backend.
+//
+// This takes the finished line rather than the raw value so the reason always
+// lands last. Each caller wraps the value in its own phrasing ("(via
+// OO_TEAM_ID)", a full sentence), and folding the reason in earlier would bury
+// it mid-line.
+export function appendTeamIdentityStatus(
+    line: string,
+    identity: DefaultTeamIdentity,
+    translator: Pick<CliExecutionContext["translator"], "t">,
+): string {
+    if (identity.status === null || identity.status === "valid") {
+        return line;
+    }
+
+    return translator.t("team.identity.statusSuffix", {
+        reason: translator.t(teamNameStatusTranslationKeys[identity.status]),
+        value: line,
+    });
+}

--- a/src/application/commands/team/index.cli.test.ts
+++ b/src/application/commands/team/index.cli.test.ts
@@ -1,3 +1,5 @@
+import type { Fetcher } from "../../contracts/cli.ts";
+
 import { join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
@@ -154,6 +156,7 @@ describe("teamCommand CLI", () => {
                 team: "acme",
                 teamId: null,
                 source: "config",
+                status: null,
             });
             expect(textResult.stdout).toContain("acme");
         }
@@ -176,6 +179,7 @@ describe("teamCommand CLI", () => {
                 team: null,
                 teamId: null,
                 source: null,
+                status: null,
             });
             expect(textResult.stdout).toContain("personal identity");
         }
@@ -206,6 +210,7 @@ describe("teamCommand CLI", () => {
                 team: "beta",
                 teamId: null,
                 source: "config",
+                status: null,
             });
         }
         finally {
@@ -229,6 +234,7 @@ describe("teamCommand CLI", () => {
                 team: null,
                 teamId: null,
                 source: null,
+                status: null,
             });
         }
         finally {
@@ -251,6 +257,7 @@ describe("teamCommand CLI", () => {
                 team: null,
                 teamId: null,
                 source: null,
+                status: null,
             });
         }
         finally {
@@ -274,16 +281,22 @@ describe("teamCommand CLI", () => {
         }
     });
 
-    test("reports the OO_TEAM_ID env override via current", async () => {
+    test("resolves the OO_TEAM_ID env override to its team name via current", async () => {
         const sandbox = await createCliSandbox();
 
         try {
             await writeAuthFile(sandbox);
-            await sandbox.run(["config", "set", "identity.team", "acme"]);
+            await sandbox.run(["config", "set", "identity.team", "beta"]);
             sandbox.env.OO_TEAM_ID = "team-1";
 
-            const jsonResult = await sandbox.run(["team", "current", "--json"]);
-            const textResult = await sandbox.run(["team", "current"]);
+            const requests: Request[] = [];
+            const respondWithTeam = createTeamLookupFetcher(requests);
+            const jsonResult = await sandbox.run(["team", "current", "--json"], {
+                fetcher: respondWithTeam,
+            });
+            const textResult = await sandbox.run(["team", "current"], {
+                fetcher: respondWithTeam,
+            });
             const telemetryPayload = readTelemetryRowsForTest(
                 join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
             )
@@ -292,26 +305,114 @@ describe("teamCommand CLI", () => {
 
             expect(jsonResult.exitCode).toBe(0);
             expect(JSON.parse(jsonResult.stdout)).toEqual({
-                team: null,
+                team: "acme",
                 teamId: "team-1",
                 source: "env_id",
+                status: "valid",
             });
+            // The id is resolved through the singular team route, not by
+            // pulling the whole membership listing.
+            expect(requests[0]?.url).toBe(
+                "https://relation-control.oomol.com/v1/teams/team-1",
+            );
+            expect(requests[0]?.headers.get("Authorization")).toBe("secret-1");
             expect(textResult.stdout).toContain("OO_TEAM_ID");
+            // Both halves are shown: the name is the new information, the id is
+            // what the reader put in the environment.
+            expect(textResult.stdout).toContain("acme");
             expect(textResult.stdout).toContain("team-1");
             // The configured default is reported as inactive.
-            expect(textResult.stdout).toContain("acme");
+            expect(textResult.stdout).toContain("beta");
             expect(telemetryPayload).toMatchObject({
                 properties: {
                     has_configured_team: true,
                     team_source: "env_id",
+                    team_status: "valid",
                 },
             });
-            // Only the source enum is reported: neither the env-selected id
-            // nor the configured team name reaches telemetry.
+            // Only the source and status enums are reported: neither the
+            // env-selected id nor either team name reaches telemetry.
             expectTelemetryFreeOfTeamIdentity(
                 telemetryPayload?.properties,
-                ["team-1", "acme"],
+                ["team-1", "acme", "beta"],
             );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    // Each backend answer means a different fix, so `current` must keep them
+    // apart instead of collapsing them into a bare unresolved id.
+    test.each([
+        { httpStatus: 403, status: "not_a_member" },
+        { httpStatus: 404, status: "not_found" },
+        { httpStatus: 410, status: "deleted" },
+        { httpStatus: 500, status: "request_failed" },
+    ])(
+        "reports OO_TEAM_ID lookup status $status for HTTP $httpStatus via current",
+        async ({ httpStatus, status }) => {
+            const sandbox = await createCliSandbox();
+
+            try {
+                await writeAuthFile(sandbox);
+                sandbox.env.OO_TEAM_ID = "team-1";
+
+                const respond = async (): Promise<Response> =>
+                    new Response("{}", { status: httpStatus });
+                const jsonResult = await sandbox.run(["team", "current", "--json"], {
+                    fetcher: respond,
+                });
+                const textResult = await sandbox.run(["team", "current"], {
+                    fetcher: respond,
+                });
+
+                // A failed lookup is a diagnostic, never a command failure.
+                expect(jsonResult.exitCode).toBe(0);
+                expect(textResult.exitCode).toBe(0);
+                expect(JSON.parse(jsonResult.stdout)).toEqual({
+                    team: null,
+                    teamId: "team-1",
+                    source: "env_id",
+                    status,
+                });
+                // The id still prints, so the reader can see what was tried.
+                expect(textResult.stdout).toContain("team-1");
+            }
+            finally {
+                await sandbox.cleanup();
+            }
+        },
+    );
+
+    test("skips the OO_TEAM_ID name lookup when no account is configured", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            sandbox.env.OO_TEAM_ID = "team-1";
+
+            let requested = false;
+            const fetcher = async (): Promise<Response> => {
+                requested = true;
+
+                return new Response("{}", { status: 200 });
+            };
+            const jsonResult = await sandbox.run(["team", "current", "--json"], {
+                fetcher,
+            });
+            const textResult = await sandbox.run(["team", "current"], { fetcher });
+
+            // Reading the local default must not start requiring a login.
+            expect(jsonResult.exitCode).toBe(0);
+            expect(textResult.exitCode).toBe(0);
+            expect(requested).toBe(false);
+            expect(JSON.parse(jsonResult.stdout)).toEqual({
+                team: null,
+                teamId: "team-1",
+                source: "env_id",
+                status: "no_credential",
+            });
+            expect(textResult.stdout).toContain("team-1");
         }
         finally {
             await sandbox.cleanup();
@@ -346,8 +447,10 @@ describe("teamCommand CLI", () => {
                 team: "beta",
                 teamId: null,
                 source: "env_name",
+                status: null,
             });
-            // `team current` stays offline even under the env override.
+            // A name-shaped identity already knows its name, so it stays
+            // offline; only OO_TEAM_ID costs a request.
             expect(requested).toBe(false);
             expect(textResult.stdout).toContain("OO_TEAM_NAME");
             expect(textResult.stdout).toContain("beta");
@@ -445,3 +548,13 @@ describe("teamCommand CLI", () => {
         }
     });
 });
+
+// Answers the singular team route with the first fixture team and records what
+// was asked, so a test can assert both the resolved name and the route used.
+function createTeamLookupFetcher(requests: Request[]): Fetcher {
+    return async (input, init) => {
+        requests.push(toRequest(input, init));
+
+        return new Response(JSON.stringify(teamsResponse.teams[0]));
+    };
+}

--- a/src/application/commands/team/shared.test.ts
+++ b/src/application/commands/team/shared.test.ts
@@ -3,9 +3,13 @@ import type { Fetcher } from "../../contracts/cli.ts";
 import { describe, expect, test } from "bun:test";
 import pino from "pino";
 
-import { expectCliUserError, toRequest } from "../../../../__tests__/helpers.ts";
+import {
+    createFailedToOpenSocketError,
+    expectCliUserError,
+    toRequest,
+} from "../../../../__tests__/helpers.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
-import { listMemberTeams } from "./shared.ts";
+import { fetchTeamById, listMemberTeams } from "./shared.ts";
 
 const testAccount = {
     apiKey: "api-secret-1",
@@ -157,6 +161,110 @@ describe("listMemberTeams", () => {
         ));
 
         expect(error.key).toBe("errors.team.requestFailed");
+    });
+});
+
+describe("fetchTeamById", () => {
+    test("requests the singular team route and maps the membership entry", async () => {
+        const requests: Request[] = [];
+        const result = await fetchTeamById(
+            testAccount,
+            "team-1",
+            createRequestContext({
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+
+                    return new Response(JSON.stringify({
+                        id: "team-1",
+                        name: "acme",
+                        avatar: "",
+                        creator_user_id: "user-1",
+                        role: "creator",
+                        system_created: true,
+                    }));
+                },
+            }),
+        );
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0]?.url).toBe(
+            "https://relation-control.oomol.com/v1/teams/team-1",
+        );
+        expect(requests[0]?.headers.get("authorization")).toBe("api-secret-1");
+        expect(result).toEqual({
+            status: "valid",
+            team: {
+                id: "team-1",
+                name: "acme",
+                role: "creator",
+                systemCreated: true,
+            },
+        });
+    });
+
+    test("percent-encodes the team id so a hostile value cannot reshape the path", async () => {
+        const requests: Request[] = [];
+        await fetchTeamById(
+            testAccount,
+            "../me/teams",
+            createRequestContext({
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+
+                    return new Response("{}", { status: 404 });
+                },
+            }),
+        );
+
+        expect(requests[0]?.url).toBe(
+            "https://relation-control.oomol.com/v1/teams/..%2Fme%2Fteams",
+        );
+    });
+
+    // Each backend answer means a different fix for the caller, so they must
+    // stay distinguishable rather than collapse into one failure.
+    test.each([
+        { httpStatus: 403, status: "not_a_member" },
+        { httpStatus: 404, status: "not_found" },
+        { httpStatus: 410, status: "deleted" },
+        { httpStatus: 401, status: "request_failed" },
+        { httpStatus: 500, status: "request_failed" },
+    ])("maps HTTP $httpStatus to $status", async ({ httpStatus, status }) => {
+        const result = await fetchTeamById(
+            testAccount,
+            "team-1",
+            createRequestContext({
+                fetcher: async () => new Response("{}", { status: httpStatus }),
+            }),
+        );
+
+        expect(result).toEqual({ status });
+    });
+
+    test("reports a sandbox-blocked request separately from a plain failure", async () => {
+        const result = await fetchTeamById(
+            testAccount,
+            "team-1",
+            createRequestContext({
+                fetcher: async () => {
+                    throw createFailedToOpenSocketError("network is restricted");
+                },
+            }),
+        );
+
+        expect(result).toEqual({ status: "request_failed_sandbox" });
+    });
+
+    test("treats a malformed success body as a failed lookup rather than throwing", async () => {
+        const result = await fetchTeamById(
+            testAccount,
+            "team-1",
+            createRequestContext({
+                fetcher: async () => new Response(JSON.stringify({ id: "team-1" })),
+            }),
+        );
+
+        expect(result).toEqual({ status: "request_failed" });
     });
 });
 

--- a/src/application/commands/team/shared.ts
+++ b/src/application/commands/team/shared.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import {
     getUnexpectedRequestErrorMessage,
+    isNetworkRestrictedSandboxError,
     requestText,
 } from "../shared/request.ts";
 
@@ -82,6 +83,103 @@ export async function listMemberTeams(
     }
     catch {
         throw new CliUserError("errors.team.invalidResponse", 1);
+    }
+}
+
+// How a team-id lookup ended. Only `valid` carries a team; every other value
+// explains why the name stays unknown, and the distinction is the whole point:
+// "this id is not a team you belong to" and "the lookup could not run" call for
+// different fixes, and collapsing them into one "unknown" sends the reader down
+// the wrong path.
+export type TeamLookupStatus
+    = | "valid"
+        | "not_a_member"
+        | "not_found"
+        | "deleted"
+        | "request_failed"
+        | "request_failed_sandbox";
+
+export type TeamLookupResult
+    = | { status: "valid"; team: TeamView }
+        | { status: Exclude<TeamLookupStatus, "valid"> };
+
+// The three statuses the backend distinguishes for a member-gated team read.
+// Anything else — including 401 from a rejected key — is a failed lookup rather
+// than a statement about the team.
+const teamLookupStatusByHttpStatus: Record<number, Exclude<TeamLookupStatus, "valid">> = {
+    403: "not_a_member",
+    404: "not_found",
+    410: "deleted",
+};
+
+// Resolves one team id to its team. Backed by
+// `GET https://relation-control.{endpoint}/v1/teams/{teamId}`, the singular form
+// of `/v1/me/teams`, so the response is a single membership entry and parses
+// with the same schema.
+//
+// This never throws: callers are diagnostic commands that must still report the
+// rest of their output when the lookup fails, so every failure comes back as a
+// status instead of an error.
+export async function fetchTeamById(
+    account: Pick<AuthAccount, "apiKey" | "endpoint">,
+    teamId: string,
+    context: Pick<CliExecutionContext, "fetcher" | "logger">,
+): Promise<TeamLookupResult> {
+    const requestUrl = new URL(
+        `https://relation-control.${account.endpoint}/v1/teams/${encodeURIComponent(teamId)}`,
+    );
+    const requestStartedAt = Date.now();
+
+    context.logger.debug(
+        { endpoint: account.endpoint },
+        "Team lookup request started.",
+    );
+
+    try {
+        const response = await context.fetcher(requestUrl, {
+            headers: {
+                Authorization: account.apiKey,
+            },
+        });
+
+        context.logger.debug(
+            {
+                durationMs: Date.now() - requestStartedAt,
+                endpoint: account.endpoint,
+                status: response.status,
+            },
+            "Team lookup request completed.",
+        );
+
+        if (response.status !== 200) {
+            return {
+                status: teamLookupStatusByHttpStatus[response.status]
+                    ?? "request_failed",
+            };
+        }
+
+        return {
+            status: "valid",
+            team: toTeamView(
+                teamResponseItemSchema.parse(await response.json() as unknown),
+            ),
+        };
+    }
+    catch (error) {
+        context.logger.warn(
+            {
+                durationMs: Date.now() - requestStartedAt,
+                endpoint: account.endpoint,
+                err: error,
+            },
+            "Team lookup request failed unexpectedly.",
+        );
+
+        return {
+            status: isNetworkRestrictedSandboxError(error)
+                ? "request_failed_sandbox"
+                : "request_failed",
+        };
     }
 }
 

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -88,8 +88,13 @@ const commandTelemetryDecisions = {
     },
     "auth.status": {
         kind: "properties",
-        properties: ["account_count_bucket", "credential_source", "team_source"],
-        reason: "Records bounded saved-account count, which credential source is in effect, and which mechanism selects the default team (enum only), without account or team identity.",
+        properties: [
+            "account_count_bucket",
+            "credential_source",
+            "team_source",
+            "team_status",
+        ],
+        reason: "Records bounded saved-account count, which credential source is in effect, which mechanism selects the default team (enum only), and how the team name lookup ended (valid/not_a_member/not_found/deleted/request_failed/request_failed_sandbox/no_credential/none), without account or team identity.",
     },
     "auth.switch": {
         kind: "properties",
@@ -292,8 +297,8 @@ const commandTelemetryDecisions = {
     },
     "team.current": {
         kind: "properties",
-        properties: ["has_configured_team", "team_source"],
-        reason: "Records whether a default team identity is configured and which mechanism selects the effective team (env_id/env_name/config/none), without the team name or id.",
+        properties: ["has_configured_team", "team_source", "team_status"],
+        reason: "Records whether a default team identity is configured, which mechanism selects the effective team (env_id/env_name/config/none), and how the team name lookup ended (valid/not_a_member/not_found/deleted/request_failed/request_failed_sandbox/no_credential/none), without the team name or id.",
     },
     "team.use": {
         kind: "generic",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -1240,11 +1240,22 @@ export const enMessages = {
     "team.current.text.personal":
         "No default team; connector commands run under your personal identity.",
     "team.current.text.envId":
-        "Team identity comes from the OO_TEAM_ID environment variable: {teamId}",
+        "Team identity comes from the OO_TEAM_ID environment variable: {team}",
     "team.current.text.envName":
         "Team identity comes from the OO_TEAM_NAME environment variable: {team}",
     "team.current.text.configIgnored":
         "The `identity.team` config default ({team}) is not in use while {envVar} is set.",
+    "team.identity.nameWithId": "{name} ({teamId})",
+    "team.identity.statusSuffix": "{value} — {reason}",
+    "team.identity.status.notAMember":
+        "the active account is not a member of this team",
+    "team.identity.status.notFound": "no team exists with this id",
+    "team.identity.status.deleted": "this team has been deleted",
+    "team.identity.status.requestFailed": "could not look up the team name",
+    "team.identity.status.requestFailedSandbox":
+        "could not look up the team name; the sandbox blocked the request",
+    "team.identity.status.noCredential":
+        "log in to look up the team name",
     "team.use.success": "Set the default team identity to {team}.",
     "team.use.envOverrideHint":
         "Connector commands keep using the team from {envVar}, not this default. Unset {envVar} to use the saved default.",
@@ -2528,11 +2539,20 @@ export const zhMessages = {
     "team.current.text.personal":
         "未设置默认团队；connector 命令以个人身份运行。",
     "team.current.text.envId":
-        "团队身份来自 OO_TEAM_ID 环境变量：{teamId}",
+        "团队身份来自 OO_TEAM_ID 环境变量：{team}",
     "team.current.text.envName":
         "团队身份来自 OO_TEAM_NAME 环境变量：{team}",
     "team.current.text.configIgnored":
         "设置了 {envVar} 时，`identity.team` 配置的默认值（{team}）不会生效。",
+    "team.identity.nameWithId": "{name}（{teamId}）",
+    "team.identity.statusSuffix": "{value} —— {reason}",
+    "team.identity.status.notAMember": "当前账号不是该团队的成员",
+    "team.identity.status.notFound": "不存在该 id 对应的团队",
+    "team.identity.status.deleted": "该团队已被删除",
+    "team.identity.status.requestFailed": "无法查询团队名称",
+    "team.identity.status.requestFailedSandbox":
+        "无法查询团队名称：沙箱拦截了该请求",
+    "team.identity.status.noCredential": "登录后才能查询团队名称",
     "team.use.success": "已将默认团队身份设置为 {team}。",
     "team.use.envOverrideHint":
         "connector 命令仍会使用 {envVar} 指定的团队，而不是这个默认值。取消 {envVar} 后保存的默认值才会生效。",


### PR DESCRIPTION
`oo auth status` and `oo team current` printed an `OO_TEAM_ID` override as a bare id, which is the one thing the reader already knew — they typed it. What they could not tell apart was a correct id, a typo, and a team they had been removed from; all three rendered identically.

Both commands now resolve the id through `GET https://relation-control.{endpoint}/v1/teams/{teamId}` (the singular form of `/v1/me/teams`, so the response parses with the same schema) and print `<name> (<id>)`. When the lookup does not succeed the id is still shown with the reason appended, so a misconfigured id reads differently from an unreachable backend: `not_a_member`, `not_found`, `deleted`, `request_failed`, `request_failed_sandbox`, or `no_credential`.

The lookup is optional enrichment, and stays optional in every direction — it never changes the exit code, never downgrades the reported API key status, and in `auth status` it runs concurrently with the key check rather than adding latency. `oo team current` keeps working with no account at all: a missing credential downgrades to `no_credential` instead of failing the command, via the new `resolveCurrentAccountTolerantly()`.

The two commands derived the default identity separately, which is how their output drifted apart in the first place. `team/default-identity` now owns that resolution, its rendering, and its telemetry status enum for both. Only id-shaped identities cost a request — `env_name` and the `identity.team` config default already carry a name, so they stay offline and report `status: null`, and the CLI tests assert the exact request list to keep it that way.

Reviewer note: this depends on `GET /v1/teams/{teamId}` being served by relation-control. Worth confirming it is registered there before this ships, since an unregistered route would come back as `not_found` and read as "no team exists with this id".