### PR TITLE
fix(auth): honor OO_ENDPOINT when resolving login endpoint

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,9 +34,11 @@ use. Truthy values are `1`, `true`, `yes`, or `on` (case-insensitive).
   outranks it. `oo auth status` reports the identity this variable provides.
 - `OO_ENDPOINT`: Base endpoint domain (for example `oomol.com` or `oomol.dev`)
   used to derive every service URL for execution commands. It pairs with
-  `OO_API_KEY` and also overrides the endpoint of a saved account, including
-  the endpoint `oo auth status` reports and validates against. Takes
-  precedence over the legacy `OOMOL_ENDPOINT`.
+  `OO_API_KEY`, overrides the endpoint of a saved account (including the
+  endpoint `oo auth status` reports and validates against), and selects the
+  endpoint `oo auth login` authenticates against. Takes precedence over the
+  legacy `OOMOL_ENDPOINT`, which remains only as a fallback and is slated for
+  removal.
 - `OO_CONNECTOR_URL`: Self-hosted connector server URL. It overrides the
   configuration saved by `oo connector login`. Only connector commands
   (`oo connector search/schema/run/proxy/apps` and top-level `oo search`)
@@ -149,6 +151,10 @@ with an existing API key, then save the authenticated account.
 - When `OO_API_KEY` is set, login still validates and saves the account, but
   that variable keeps outranking it. The success output prints a hint that the
   saved account takes effect only once `OO_API_KEY` is unset.
+- `OO_ENDPOINT` (falling back to the legacy `OOMOL_ENDPOINT`) selects the host
+  login authenticates against for all three methods (device login, session
+  token, and API key), and the saved account records that endpoint. Without
+  either variable the public default is used.
 
 ### `oo auth logout`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -28,9 +28,10 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   会成为空操作并保持 `auth.toml` 不变；`oo auth login` 仍会保存账号，但会说明该
   变量的优先级高于它。`oo auth status` 会展示该变量提供的身份。
 - `OO_ENDPOINT`：基础域名（例如 `oomol.com` 或 `oomol.dev`），用于派生执行命令的
-  所有服务 URL。它与 `OO_API_KEY` 搭配使用，也会覆盖已保存账号的 endpoint，
-  包括 `oo auth status` 展示与校验所用的 endpoint。优先级高于历史遗留的
-  `OOMOL_ENDPOINT`。
+  所有服务 URL。它与 `OO_API_KEY` 搭配使用，会覆盖已保存账号的 endpoint（包括
+  `oo auth status` 展示与校验所用的 endpoint），并决定 `oo auth login` 校验所用的
+  endpoint。优先级高于历史遗留的 `OOMOL_ENDPOINT`；后者仅作为回退保留，计划在
+  未来移除。
 - `OO_CONNECTOR_URL`：自部署 Connector 服务地址。它会覆盖 `oo connector login`
   保存的配置。只有 connector 相关命令（`oo connector
   search/schema/run/proxy/apps` 及顶层 `oo search`）会将请求路由到该地址；
@@ -121,6 +122,9 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   `oo connector logout` 切回 OOMOL。
 - 设置了 `OO_API_KEY` 时，登录仍会校验并保存账号，但该变量的优先级依然高于它。
   成功输出会打印一行提示，说明取消 `OO_API_KEY` 后刚保存的账号才会生效。
+- `OO_ENDPOINT`（回退到历史遗留的 `OOMOL_ENDPOINT`）决定三种登录方式（device
+  login、session token、API key）校验所用的 host，保存的账号也会记录该 endpoint；
+  两者都未设置时使用公有默认值。
 
 ### `oo auth logout`
 

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -238,6 +238,52 @@ describe("auth CLI", () => {
         }
     });
 
+    test("supports auth login with a custom OO_ENDPOINT", async () => {
+        const sandbox = await createCliSandbox();
+
+        sandbox.env.OO_ENDPOINT = "staging.oomol.test";
+
+        try {
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
+                accountEndpoint: sandbox.env.OO_ENDPOINT,
+            });
+            const loginUrl = findLoginUrl(result.stdout);
+
+            expect(result.exitCode).toBe(0);
+            expect(loginUrl).toStartWith(
+                readAuthLoginUrlPrefix("staging.oomol.test"),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("prefers OO_ENDPOINT over OOMOL_ENDPOINT for auth login", async () => {
+        const sandbox = await createCliSandbox();
+
+        // runPrintedAuthLogin only answers api.${accountEndpoint}; if login
+        // resolved the legacy host instead, the request would hit the unmocked
+        // host and throw, so a green run proves OO_ENDPOINT wins the precedence.
+        sandbox.env.OO_ENDPOINT = "override.oomol.test";
+        sandbox.env.OOMOL_ENDPOINT = "legacy.oomol.test";
+
+        try {
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
+                accountEndpoint: sandbox.env.OO_ENDPOINT,
+            });
+            const loginUrl = findLoginUrl(result.stdout);
+
+            expect(result.exitCode).toBe(0);
+            expect(loginUrl).toStartWith(
+                readAuthLoginUrlPrefix("override.oomol.test"),
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("supports login as an alias for auth login", async () => {
         const sandbox = await createCliSandbox();
 
@@ -408,6 +454,70 @@ describe("auth CLI", () => {
             expect(content).toContain(`"msg":"Auth account persisted after api key login."`);
             expect(content).not.toContain(apiKey);
             expect(result.stdout).not.toContain(apiKey);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("logs in with an API key against the OO_ENDPOINT host", async () => {
+        const sandbox = await createCliSandbox();
+        const apiKey = "secret-api-1";
+        const endpoint = "oomol.dev";
+        const requests: Request[] = [];
+
+        sandbox.env.OO_ENDPOINT = endpoint;
+
+        try {
+            const authFilePath = join(
+                sandbox.env.XDG_CONFIG_HOME!,
+                APP_NAME,
+                "auth.toml",
+            );
+            const result = await sandbox.run(
+                ["login", "--api-key", apiKey],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+                        const requestUrl = new URL(request.url);
+
+                        requests.push(request);
+
+                        if (
+                            request.method === "GET"
+                            && requestUrl.host === `api.${endpoint}`
+                            && requestUrl.pathname === "/v1/users/profile"
+                            && request.headers.get("Authorization") === apiKey
+                        ) {
+                            return new Response(JSON.stringify({
+                                displayname: "Kevin Cui",
+                                email: "bh@bugs.cc",
+                                nickname: "Kevin Cui",
+                                uid: "019343c2-c43d-710f-81b2-dfa68d3079de",
+                                username: "BlackHole1",
+                            }));
+                        }
+
+                        if (
+                            request.method === "GET"
+                            && requestUrl.host === `relation-control.${endpoint}`
+                            && requestUrl.pathname === "/v1/me/teams"
+                        ) {
+                            return new Response(
+                                JSON.stringify(defaultLoginTeamsResponse),
+                            );
+                        }
+
+                        throw new Error(`Unexpected auth api key login request: ${request.method} ${requestUrl}`);
+                    },
+                },
+            );
+            const authFileContent = await readFile(authFilePath, "utf8");
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(2);
+            expect(result.stdout).toContain("Logged in to oomol.dev");
+            expect(authFileContent).toContain("endpoint = \"oomol.dev\"");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/auth/login.ts
+++ b/src/application/commands/auth/login.ts
@@ -20,7 +20,11 @@ import {
 } from "../../schemas/settings.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
-import { buildEnvApiKeyAccount } from "../shared/auth-env-override.ts";
+import {
+    buildEnvApiKeyAccount,
+    readEndpointOverride,
+    readTrimmedEnv,
+} from "../shared/auth-env-override.ts";
 import { writeLine } from "../shared/output.ts";
 import { resolveSelfHostedConnectorTolerantly } from "../shared/self-hosted-connector.ts";
 import {
@@ -35,6 +39,9 @@ import {
 
 const loginUrlColor = "#c09ff5";
 const defaultAuthEndpoint = "oomol.com";
+// Legacy endpoint override, kept only as a fallback below OO_ENDPOINT. Slated
+// for removal once callers have migrated to OO_ENDPOINT.
+const legacyEndpointEnvName = "OOMOL_ENDPOINT";
 
 type LoginMethod = "api_key" | "device_login" | "session_token";
 
@@ -421,8 +428,15 @@ async function runDeviceLogin(
     return session.waitForAccount();
 }
 
+// Resolves the endpoint the login flow authenticates against. OO_ENDPOINT wins
+// so `oo auth login` targets the same host execution commands use, matching the
+// precedence in resolveCurrentEndpoint(). The legacy OOMOL_ENDPOINT stays only
+// as a fallback and is slated for removal, after which OO_ENDPOINT and the
+// public default are the only sources.
 function readAuthEndpoint(
     env: CliExecutionContext["env"],
 ): string {
-    return env.OOMOL_ENDPOINT?.trim() || defaultAuthEndpoint;
+    return readEndpointOverride(env)
+        ?? readTrimmedEnv(env, legacyEndpointEnvName)
+        ?? defaultAuthEndpoint;
 }

--- a/src/application/commands/shared/auth-env-override.ts
+++ b/src/application/commands/shared/auth-env-override.ts
@@ -29,8 +29,9 @@ export function readTrimmedEnv(
 }
 
 // Returns the OO_ENDPOINT override when set to a non-empty value, otherwise
-// undefined. OO_ENDPOINT only affects the new override path; the legacy
-// OOMOL_ENDPOINT keeps its historical login/unauthenticated-read behavior.
+// undefined. OO_ENDPOINT is the primary endpoint override across execution,
+// login, and unauthenticated reads; the legacy OOMOL_ENDPOINT remains only as a
+// fallback and is slated for removal.
 export function readEndpointOverride(
     env: Record<string, string | undefined>,
 ): string | undefined {


### PR DESCRIPTION
`oo auth login` resolved its endpoint from only the legacy `OOMOL_ENDPOINT`, ignoring `OO_ENDPOINT` — the variable every execution command already honors. So setting `OO_ENDPOINT` to a self-hosted or dev host and running `oo auth login --api-key ...` sent the profile request to the default `api.oomol.com`, where a dev-scoped key is rejected as invalid and the login fails. It also broke the documented contract that `OO_ENDPOINT` takes precedence over the legacy `OOMOL_ENDPOINT`.

`readAuthEndpoint()` now resolves through `readEndpointOverride()` first, falling back to `OOMOL_ENDPOINT` and then the public default — the same precedence as `resolveCurrentEndpoint()`. This applies to all three login methods (device login, session token, and API key). `OOMOL_ENDPOINT` is kept only as a fallback and is slated for removal.

Regression tests cover an `OO_ENDPOINT`-driven login, `OO_ENDPOINT` winning when both variables are set, and the reported `--api-key` case landing on `api.oomol.dev`. Docs (`docs/commands.md` and its zh-CN copy) are updated for the new precedence.