### PR TITLE
refactor(auth): land deep identity resolver module

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -906,6 +906,10 @@ export function createAuthStore(authFile: AuthFile): AuthStore {
         getFilePath: () => "",
         read: async () => currentAuthFile,
         readTolerant: async () => currentAuthFile,
+        readTolerantState: async () => ({
+            authFile: currentAuthFile,
+            fileState: "ok",
+        }),
         write: async (nextAuthFile) => {
             currentAuthFile = nextAuthFile;
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -36,9 +36,7 @@ use. Truthy values are `1`, `true`, `yes`, or `on` (case-insensitive).
   used to derive every service URL for execution commands. It pairs with
   `OO_API_KEY`, overrides the endpoint of a saved account (including the
   endpoint `oo auth status` reports and validates against), and selects the
-  endpoint `oo auth login` authenticates against. Takes precedence over the
-  legacy `OOMOL_ENDPOINT`, which remains only as a fallback and is slated for
-  removal.
+  endpoint `oo auth login` authenticates against.
 - `OO_CONNECTOR_URL`: Self-hosted connector server URL. It overrides the
   configuration saved by `oo connector login`. Only connector commands
   (`oo connector search/schema/run/proxy/apps` and top-level `oo search`)
@@ -151,10 +149,9 @@ with an existing API key, then save the authenticated account.
 - When `OO_API_KEY` is set, login still validates and saves the account, but
   that variable keeps outranking it. The success output prints a hint that the
   saved account takes effect only once `OO_API_KEY` is unset.
-- `OO_ENDPOINT` (falling back to the legacy `OOMOL_ENDPOINT`) selects the host
-  login authenticates against for all three methods (device login, session
-  token, and API key), and the saved account records that endpoint. Without
-  either variable the public default is used.
+- `OO_ENDPOINT` selects the host login authenticates against for all three
+  methods (device login, session token, and API key), and the saved account
+  records that endpoint. Without it the public default is used.
 
 ### `oo auth logout`
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -30,8 +30,7 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
 - `OO_ENDPOINT`：基础域名（例如 `oomol.com` 或 `oomol.dev`），用于派生执行命令的
   所有服务 URL。它与 `OO_API_KEY` 搭配使用，会覆盖已保存账号的 endpoint（包括
   `oo auth status` 展示与校验所用的 endpoint），并决定 `oo auth login` 校验所用的
-  endpoint。优先级高于历史遗留的 `OOMOL_ENDPOINT`；后者仅作为回退保留，计划在
-  未来移除。
+  endpoint。
 - `OO_CONNECTOR_URL`：自部署 Connector 服务地址。它会覆盖 `oo connector login`
   保存的配置。只有 connector 相关命令（`oo connector
   search/schema/run/proxy/apps` 及顶层 `oo search`）会将请求路由到该地址；
@@ -122,9 +121,8 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   `oo connector logout` 切回 OOMOL。
 - 设置了 `OO_API_KEY` 时，登录仍会校验并保存账号，但该变量的优先级依然高于它。
   成功输出会打印一行提示，说明取消 `OO_API_KEY` 后刚保存的账号才会生效。
-- `OO_ENDPOINT`（回退到历史遗留的 `OOMOL_ENDPOINT`）决定三种登录方式（device
-  login、session token、API key）校验所用的 host，保存的账号也会记录该 endpoint；
-  两者都未设置时使用公有默认值。
+- `OO_ENDPOINT` 决定三种登录方式（device login、session token、API key）校验所用
+  的 host，保存的账号也会记录该 endpoint；未设置时使用公有默认值。
 
 ### `oo auth logout`
 

--- a/src/adapters/commander/commander-cli-adapter.test.ts
+++ b/src/adapters/commander/commander-cli-adapter.test.ts
@@ -226,6 +226,13 @@ function createCommanderContext(
                 auth: [],
                 id: "",
             }),
+            readTolerantState: async () => ({
+                authFile: {
+                    auth: [],
+                    id: "",
+                },
+                fileState: "ok",
+            }),
             update: async updater => updater({
                 auth: [],
                 id: "",

--- a/src/adapters/store/file-auth-store.ts
+++ b/src/adapters/store/file-auth-store.ts
@@ -1,5 +1,8 @@
 import type { Logger } from "pino";
-import type { AuthStore } from "../../application/contracts/auth-store.ts";
+import type {
+    AuthStore,
+    TolerantAuthRead,
+} from "../../application/contracts/auth-store.ts";
 import type { AuthFile } from "../../application/schemas/auth.ts";
 import type { FileStoreLocationOptions } from "./store-path.ts";
 
@@ -108,8 +111,17 @@ export class FileAuthStore implements AuthStore {
     }
 
     async readTolerant(): Promise<AuthFile> {
+        const { authFile } = await this.readTolerantState();
+
+        return authFile;
+    }
+
+    async readTolerantState(): Promise<TolerantAuthRead> {
         try {
-            return await this.readPersistedAuth();
+            return {
+                authFile: await this.readPersistedAuth(),
+                fileState: "ok",
+            };
         }
         catch (error) {
             // A caller reaching for this already has its credential elsewhere,
@@ -125,7 +137,10 @@ export class FileAuthStore implements AuthStore {
 
             // A fresh copy: defaultAuthFile is a shared module-level value and
             // must not be handed out where a caller could mutate it.
-            return { ...defaultAuthFile, auth: [] };
+            return {
+                authFile: { ...defaultAuthFile, auth: [] },
+                fileState: isFileMissingError(error) ? "missing" : "corrupt",
+            };
         }
     }
 

--- a/src/application/auth/identity.test.ts
+++ b/src/application/auth/identity.test.ts
@@ -1,0 +1,452 @@
+import type { AuthStore } from "../contracts/auth-store.ts";
+import type {
+    CliCatalog,
+    CliExecutionContext,
+    CliTelemetryPropertyValue,
+    InteractiveInput,
+} from "../contracts/cli.ts";
+import type { ConnectorStore } from "../contracts/connector-store.ts";
+import type { Translator } from "../contracts/translator.ts";
+import type { AuthFile } from "../schemas/auth.ts";
+
+import { describe, expect, test } from "bun:test";
+import pino from "pino";
+
+import {
+    createAuthStore,
+    createCacheStore,
+    createInMemoryConnectorStore,
+    createNoopFileDownloadSessionStore,
+    createNoopFileUploadStore,
+    createSettingsStore,
+    createTextBuffer,
+} from "../../../__tests__/helpers.ts";
+import {
+    reportOverriddenWrite,
+    requireIdentity,
+    resolveIdentity,
+    resolveLoginEndpoint,
+} from "./identity.ts";
+
+const activeAccount = {
+    apiKey: "persisted-key",
+    endpoint: "custom.oomol.test",
+    id: "user-1",
+    name: "Alice",
+};
+
+describe("resolveIdentity", () => {
+    test("resolves the OO_API_KEY override without touching the auth store", async () => {
+        const { context } = createIdentityContext({
+            authStore: createThrowingAuthStore(),
+            env: { OO_API_KEY: "env-key", OO_ENDPOINT: "oomol.dev" },
+        });
+
+        await expect(resolveIdentity(context)).resolves.toEqual({
+            account: {
+                apiKey: "env-key",
+                endpoint: "oomol.dev",
+                id: "oo-env-override",
+                name: "Environment (OO_API_KEY)",
+            },
+            endpoint: "oomol.dev",
+            fileState: "unread",
+            overriddenBy: "OO_API_KEY",
+            source: "env",
+        });
+    });
+
+    test("treats a blank OO_API_KEY as unset", async () => {
+        const { context } = createIdentityContext({
+            authFile: { auth: [activeAccount], id: "user-1" },
+            env: { OO_API_KEY: "   " },
+        });
+
+        const identity = await resolveIdentity(context);
+
+        expect(identity.source).toBe("file");
+        expect(identity.account).toEqual(activeAccount);
+    });
+
+    test("resolves the active account with its own endpoint", async () => {
+        const { context } = createIdentityContext({
+            authFile: { auth: [activeAccount], id: "user-1" },
+        });
+
+        await expect(resolveIdentity(context)).resolves.toEqual({
+            account: activeAccount,
+            endpoint: "custom.oomol.test",
+            fileState: "ok",
+            source: "file",
+        });
+    });
+
+    test("redirects the active account endpoint with a bare OO_ENDPOINT", async () => {
+        const { context } = createIdentityContext({
+            authFile: { auth: [activeAccount], id: "user-1" },
+            env: { OO_ENDPOINT: "oomol.dev" },
+        });
+
+        const identity = await resolveIdentity(context);
+
+        expect(identity.account).toEqual({
+            ...activeAccount,
+            endpoint: "oomol.dev",
+        });
+        expect(identity.endpoint).toBe("oomol.dev");
+    });
+
+    test.each<{ case: string; authFile: AuthFile }>([
+        { case: "no account is saved", authFile: { auth: [], id: "" } },
+        { case: "the active id is stale", authFile: { auth: [], id: "user-1" } },
+    ])("resolves to no identity when $case", async ({ authFile }) => {
+        const { context } = createIdentityContext({ authFile });
+
+        await expect(resolveIdentity(context)).resolves.toEqual({
+            account: undefined,
+            endpoint: "oomol.com",
+            fileState: "ok",
+            source: "none",
+        });
+    });
+
+    test("uses OO_ENDPOINT for the endpoint when no account is available", async () => {
+        const { context } = createIdentityContext({
+            env: { OO_ENDPOINT: "oomol.dev" },
+        });
+
+        const identity = await resolveIdentity(context);
+
+        expect(identity.source).toBe("none");
+        expect(identity.endpoint).toBe("oomol.dev");
+    });
+
+    test("ignores the removed legacy OOMOL_ENDPOINT variable", async () => {
+        const { context } = createIdentityContext({
+            env: { OOMOL_ENDPOINT: "legacy.oomol.test" },
+        });
+
+        const identity = await resolveIdentity(context);
+
+        expect(identity.endpoint).toBe("oomol.com");
+    });
+
+    test.each<{ fileState: "corrupt" | "missing" }>([
+        { fileState: "missing" },
+        { fileState: "corrupt" },
+    ])("reports fileState $fileState from the tolerant read", async ({ fileState }) => {
+        const { context } = createIdentityContext({
+            authStore: createUnreadableAuthStore(fileState),
+        });
+
+        await expect(resolveIdentity(context)).resolves.toEqual({
+            account: undefined,
+            endpoint: "oomol.com",
+            fileState,
+            source: "none",
+        });
+    });
+});
+
+describe("requireIdentity", () => {
+    test("resolves the OO_API_KEY override without touching the auth store", async () => {
+        const { context } = createIdentityContext({
+            authStore: createThrowingAuthStore(),
+            env: { OO_API_KEY: "env-key" },
+        });
+
+        const identity = await requireIdentity(context);
+
+        expect(identity.source).toBe("env");
+        expect(identity.overriddenBy).toBe("OO_API_KEY");
+        // OO_ENDPOINT is unset, so the override falls back to the public default.
+        expect(identity.account.endpoint).toBe("oomol.com");
+    });
+
+    test("prefers OO_API_KEY over a persisted active account", async () => {
+        const { context } = createIdentityContext({
+            authFile: { auth: [activeAccount], id: "user-1" },
+            env: { OO_API_KEY: "env-key" },
+        });
+
+        const identity = await requireIdentity(context);
+
+        expect(identity.account.apiKey).toBe("env-key");
+        expect(identity.account.id).toBe("oo-env-override");
+    });
+
+    test("returns the active account with a bare OO_ENDPOINT applied", async () => {
+        const { context } = createIdentityContext({
+            authFile: { auth: [activeAccount], id: "user-1" },
+            env: { OO_ENDPOINT: "oomol.dev" },
+        });
+
+        await expect(requireIdentity(context)).resolves.toEqual({
+            account: { ...activeAccount, endpoint: "oomol.dev" },
+            endpoint: "oomol.dev",
+            fileState: "ok",
+            source: "file",
+        });
+    });
+
+    test("uses the shared auth-required key when no account is active", async () => {
+        const { context } = createIdentityContext();
+
+        await expect(requireIdentity(context)).rejects.toMatchObject({
+            exitCode: 1,
+            key: "errors.auth.required",
+        });
+    });
+
+    test("uses the missing-account key when the active id is stale", async () => {
+        const { context } = createIdentityContext({
+            authFile: { auth: [], id: "user-1" },
+        });
+
+        await expect(requireIdentity(context)).rejects.toMatchObject({
+            exitCode: 1,
+            key: "auth.account.activeAccountMissing",
+        });
+    });
+
+    test("uses the connector-only auth key when only connector.toml is configured", async () => {
+        const { context } = createIdentityContext({
+            connectorStore: createInMemoryConnectorStore({
+                selfHosted: { url: "http://localhost:3000" },
+            }),
+        });
+
+        await expect(requireIdentity(context)).rejects.toMatchObject({
+            exitCode: 1,
+            key: "errors.auth.requiredConnectorOnly",
+        });
+    });
+
+    test("uses the connector-only auth key when OO_CONNECTOR_URL is set", async () => {
+        const { context } = createIdentityContext({
+            env: { OO_CONNECTOR_URL: "http://localhost:3000" },
+        });
+
+        await expect(requireIdentity(context)).rejects.toMatchObject({
+            exitCode: 1,
+            key: "errors.auth.requiredConnectorOnly",
+        });
+    });
+
+    test("keeps the missing-account key for a stale id even with a self-hosted connector", async () => {
+        const { context } = createIdentityContext({
+            authFile: { auth: [], id: "user-1" },
+            connectorStore: createInMemoryConnectorStore({
+                selfHosted: { url: "http://localhost:3000" },
+            }),
+        });
+
+        await expect(requireIdentity(context)).rejects.toMatchObject({
+            exitCode: 1,
+            key: "auth.account.activeAccountMissing",
+        });
+    });
+
+    test("falls back to the shared auth-required key when the connector store read fails", async () => {
+        const { context } = createIdentityContext({
+            connectorStore: createThrowingConnectorStore(),
+        });
+
+        await expect(requireIdentity(context)).rejects.toMatchObject({
+            exitCode: 1,
+            key: "errors.auth.required",
+        });
+    });
+});
+
+describe("resolveLoginEndpoint", () => {
+    test.each<{
+        case: string;
+        env: Record<string, string | undefined>;
+        expected: string;
+    }>([
+        { case: "prefers OO_ENDPOINT", env: { OO_ENDPOINT: "oomol.dev" }, expected: "oomol.dev" },
+        { case: "defaults to the public endpoint", env: {}, expected: "oomol.com" },
+        { case: "treats a blank OO_ENDPOINT as unset", env: { OO_ENDPOINT: "  " }, expected: "oomol.com" },
+        {
+            case: "ignores the removed legacy OOMOL_ENDPOINT variable",
+            env: { OOMOL_ENDPOINT: "legacy.oomol.test" },
+            expected: "oomol.com",
+        },
+        {
+            // The saved account's endpoint is deliberately not consulted:
+            // logging in starts a new session and must not be steered by
+            // where an old account points.
+            case: "never consults the active account",
+            env: {},
+            expected: "oomol.com",
+        },
+    ])("$case", ({ env, expected }) => {
+        expect(resolveLoginEndpoint(env)).toBe(expected);
+    });
+});
+
+describe("reportOverriddenWrite", () => {
+    test("emits telemetry, the warning block, and the unset hint", () => {
+        const { context, readStdout, recordedProperties } = createIdentityContext({
+            env: { OO_API_KEY: "env-key" },
+        });
+
+        reportOverriddenWrite(context, {
+            extraTelemetry: { has_user_filter: true },
+            summaryKey: "auth.switch.envOverrideNoop",
+        });
+
+        expect(recordedProperties).toEqual([
+            { credential_source: "env", has_user_filter: true },
+        ]);
+
+        const output = readStdout();
+
+        expect(output).toContain("auth.switch.envOverrideNoop");
+        expect(output).toContain("auth.envOverride.unsetHint");
+    });
+
+    test("tolerates a context without telemetry", () => {
+        const { context, readStdout } = createIdentityContext({
+            env: { OO_API_KEY: "env-key" },
+            telemetry: false,
+        });
+
+        reportOverriddenWrite(context, {
+            summaryKey: "auth.logout.envOverrideNoop",
+        });
+
+        expect(readStdout()).toContain("auth.logout.envOverrideNoop");
+    });
+});
+
+function createThrowingAuthStore(): AuthStore {
+    const fail = (): never => {
+        throw new Error("auth.toml must not be accessed when OO_API_KEY is set");
+    };
+
+    return {
+        getFilePath: () => "/should-not-be-read/auth.toml",
+        read: async () => fail(),
+        readTolerant: async () => fail(),
+        readTolerantState: async () => fail(),
+        write: async () => fail(),
+        update: async () => fail(),
+    };
+}
+
+// Simulates a missing or unreadable auth.toml as the file store reports it:
+// the tolerant read falls back to the empty file and only fileState says why.
+function createUnreadableAuthStore(
+    fileState: "corrupt" | "missing",
+): AuthStore {
+    const emptyAuthFile: AuthFile = { auth: [], id: "" };
+
+    return {
+        getFilePath: () => "/unreadable/auth.toml",
+        read: async () => {
+            throw new Error("strict read must not be used by tolerant resolution");
+        },
+        readTolerant: async () => emptyAuthFile,
+        readTolerantState: async () => ({
+            authFile: emptyAuthFile,
+            fileState,
+        }),
+        write: async () => {
+            throw new Error("write is not expected");
+        },
+        update: async () => {
+            throw new Error("update is not expected");
+        },
+    };
+}
+
+function createThrowingConnectorStore(): ConnectorStore {
+    const fail = (): never => {
+        throw new Error("connector.toml is corrupted");
+    };
+
+    return {
+        getFilePath: () => "<broken-connector-store>",
+        read: async () => fail(),
+        write: async () => fail(),
+        update: async () => fail(),
+    };
+}
+
+function createIdentityContext(
+    overrides: {
+        authFile?: AuthFile;
+        authStore?: AuthStore;
+        connectorStore?: ConnectorStore;
+        env?: Record<string, string | undefined>;
+        telemetry?: false;
+    } = {},
+): {
+    context: CliExecutionContext;
+    readStdout: () => string;
+    recordedProperties: Record<string, CliTelemetryPropertyValue>[];
+} {
+    const emptyCatalog: CliCatalog = {
+        name: "oo",
+        descriptionKey: "catalog.description",
+        globalOptions: [],
+        commands: [],
+    };
+    const translator: Translator = {
+        locale: "en",
+        t: key => key,
+        resolveLocale: () => "en",
+    };
+    const stdin: InteractiveInput = {
+        on() {},
+        off() {},
+    };
+    const stdout = createTextBuffer();
+    const stderr = createTextBuffer();
+    const recordedProperties: Record<string, CliTelemetryPropertyValue>[] = [];
+
+    const context: CliExecutionContext = {
+        authStore: overrides.authStore
+            ?? createAuthStore(overrides.authFile ?? { auth: [], id: "" }),
+        cacheStore: createCacheStore(),
+        connectorStore: overrides.connectorStore ?? createInMemoryConnectorStore(),
+        currentLogFilePath: "",
+        execPath: process.execPath,
+        fetcher: async () => new Response(null),
+        cwd: process.cwd(),
+        env: overrides.env ?? {},
+        fileDownloadSessionStore: createNoopFileDownloadSessionStore(),
+        fileUploadStore: createNoopFileUploadStore(),
+        stdin,
+        logger: pino({ enabled: false }),
+        packageName: "@oomol-lab/oo-cli",
+        settingsStore: createSettingsStore({}),
+        stdout: stdout.writer,
+        stderr: stderr.writer,
+        translator,
+        completionRenderer: {
+            render: () => "",
+        },
+        catalog: emptyCatalog,
+        version: "0.1.0",
+        ...(overrides.telemetry === false
+            ? {}
+            : {
+                    telemetry: {
+                        directoryPath: "",
+                        recordProperties: (properties) => {
+                            recordedProperties.push(properties);
+                        },
+                        suppressCurrentInvocation: () => {},
+                    },
+                }),
+    };
+
+    return {
+        context,
+        readStdout: () => stdout.read(),
+        recordedProperties,
+    };
+}

--- a/src/application/auth/identity.ts
+++ b/src/application/auth/identity.ts
@@ -1,0 +1,313 @@
+import type { AuthFileState } from "../contracts/auth-store.ts";
+import type {
+    CliExecutionContext,
+    CliTelemetryPropertyValue,
+} from "../contracts/cli.ts";
+import type { AuthAccount } from "../schemas/auth.ts";
+
+import { writeAuthBlock } from "../commands/auth/shared.ts";
+import { writeLine } from "../commands/shared/output.ts";
+import { resolveSelfHostedConnectorTolerantly } from "../commands/shared/self-hosted-connector.ts";
+import { CliUserError } from "../contracts/cli.ts";
+import { getCurrentAuthAccount } from "../schemas/auth.ts";
+
+// ---------------------------------------------------------------------------
+// This module is the single owner of identity precedence: which credential
+// authenticates an invocation, and against which endpoint. The full ordering
+// is OO_API_KEY (with OO_ENDPOINT or the public default) over the auth.toml
+// active account (with OO_ENDPOINT applied) over OO_ENDPOINT alone over the
+// public default. Callers consume ResolvedIdentity instead of re-deriving any
+// part of that chain.
+// ---------------------------------------------------------------------------
+
+// Public base endpoint used when nothing else is configured. Service URLs are
+// derived by prefixing subdomains (api./llm./connector./search./...), so a
+// single base value is enough to switch between environments.
+export const defaultOomolEndpoint = "oomol.com";
+
+// Environment variables that let embedded callers drive execution commands
+// without an interactive login or a persisted auth.toml.
+const apiKeyEnvName = "OO_API_KEY";
+const endpointEnvName = "OO_ENDPOINT";
+
+// Synthetic identity for the in-memory account built from OO_API_KEY. It is
+// never written to disk; the id/name only satisfy the auth account schema and
+// surface in diagnostics. The id is stable so callers can recognize the env
+// override (it has no real account scope, so e.g. publish must not derive a
+// package name from it).
+export const envOverrideAccountId = "oo-env-override";
+const envOverrideAccountName = "Environment (OO_API_KEY)";
+
+const authErrorKeys = {
+    activeAccountMissing: "auth.account.activeAccountMissing",
+    required: "errors.auth.required",
+    requiredConnectorOnly: "errors.auth.requiredConnectorOnly",
+} as const;
+
+export type IdentitySource = "env" | "file" | "none";
+
+/**
+ * The answer to "which credential authenticates this invocation, and against
+ * which endpoint." `endpoint` is always usable, even when no account exists,
+ * so unauthenticated reads share the same precedence as execution commands.
+ * `fileState` reports what a tolerant auth-file read observed; it stays
+ * "unread" when the env override short-circuits before any file access.
+ */
+export interface ResolvedIdentity {
+    account: AuthAccount | undefined;
+    endpoint: string;
+    fileState: AuthFileState | "unread";
+    overriddenBy?: "OO_API_KEY";
+    source: IdentitySource;
+}
+
+/** A ResolvedIdentity that is guaranteed to carry a usable account. */
+export interface RequiredIdentity extends ResolvedIdentity {
+    account: AuthAccount;
+    source: "env" | "file";
+}
+
+type ResolveIdentityContext = Pick<
+    CliExecutionContext,
+    "authStore" | "env" | "logger"
+>;
+
+type RequireIdentityContext = Pick<
+    CliExecutionContext,
+    "authStore" | "connectorStore" | "env" | "logger"
+>;
+
+/**
+ * Resolves the identity tolerantly: every way of having no usable account —
+ * no login, a stale active id, a missing or corrupt auth.toml — comes back as
+ * `source: "none"` (with `fileState` saying why) instead of an error, and the
+ * auth file is never created as a side effect. For commands whose own output
+ * does not depend on the account, and for unauthenticated endpoint reads.
+ */
+export async function resolveIdentity(
+    context: ResolveIdentityContext,
+): Promise<ResolvedIdentity> {
+    const envIdentity = resolveEnvIdentity(context.env);
+
+    if (envIdentity !== undefined) {
+        return envIdentity;
+    }
+
+    const { authFile, fileState } = await context.authStore.readTolerantState();
+    const currentAccount = getCurrentAuthAccount(authFile);
+
+    logResolvedAccount(context, authFile.auth.length, authFile.id, currentAccount);
+
+    if (currentAccount !== undefined) {
+        const account = applyEndpointOverride(currentAccount, context.env);
+
+        return {
+            account,
+            endpoint: account.endpoint,
+            fileState,
+            source: "file",
+        };
+    }
+
+    return {
+        account: undefined,
+        endpoint: readEndpointOverride(context.env) ?? defaultOomolEndpoint,
+        fileState,
+        source: "none",
+    };
+}
+
+/**
+ * Resolves the identity strictly, for commands that cannot proceed without a
+ * credential: a corrupt auth.toml surfaces the store error instead of
+ * misreporting "not logged in", and having no usable account throws the
+ * auth-required error that explains what to do about it (including the
+ * connector-only variant when only a self-hosted connector is configured).
+ */
+export async function requireIdentity(
+    context: RequireIdentityContext,
+): Promise<RequiredIdentity> {
+    const envIdentity = resolveEnvIdentity(context.env);
+
+    if (envIdentity !== undefined) {
+        return envIdentity;
+    }
+
+    const authFile = await context.authStore.read();
+    const currentAccount = getCurrentAuthAccount(authFile);
+
+    logResolvedAccount(context, authFile.auth.length, authFile.id, currentAccount);
+
+    if (currentAccount !== undefined) {
+        const account = applyEndpointOverride(currentAccount, context.env);
+
+        return {
+            account,
+            endpoint: account.endpoint,
+            fileState: "ok",
+            source: "file",
+        };
+    }
+
+    if (authFile.id !== "") {
+        throw new CliUserError(authErrorKeys.activeAccountMissing, 1);
+    }
+
+    // A user who only configured a self-hosted connector gets a dedicated
+    // explanation: the self-hosted server covers connector commands only, and
+    // everything else still needs an OOMOL account. The tolerant lookup keeps
+    // a broken connector.toml from changing which auth error is shown.
+    throw new CliUserError(
+        await resolveSelfHostedConnectorTolerantly(context) !== undefined
+            ? authErrorKeys.requiredConnectorOnly
+            : authErrorKeys.required,
+        1,
+    );
+}
+
+/**
+ * Resolves the endpoint the login flow authenticates against: OO_ENDPOINT or
+ * the public default. The saved account's endpoint is deliberately not
+ * consulted — logging in starts a new session and must not be steered by
+ * where an old account points.
+ */
+export function resolveLoginEndpoint(
+    env: Record<string, string | undefined>,
+): string {
+    return readEndpointOverride(env) ?? defaultOomolEndpoint;
+}
+
+/**
+ * Standard report for a write command that an env override outranks: records
+ * the credential-source telemetry, logs the no-op, renders the warning block,
+ * and prints the unset hint. The summary wording stays per-command; only the
+ * structure is owned here, so a new write command cannot forget a step.
+ */
+export function reportOverriddenWrite(
+    context: CliExecutionContext,
+    options: {
+        extraTelemetry?: Record<string, CliTelemetryPropertyValue>;
+        summaryKey: string;
+    },
+): void {
+    context.telemetry?.recordProperties({
+        credential_source: "env",
+        ...options.extraTelemetry,
+    });
+    context.logger.info(
+        { summaryKey: options.summaryKey },
+        "Write command did nothing: OO_API_KEY provides the active credential.",
+    );
+    writeAuthBlock(context, {
+        summary: context.translator.t(options.summaryKey),
+        tone: "warning",
+    });
+    writeLine(
+        context.stdout,
+        context.translator.t("auth.envOverride.unsetHint"),
+    );
+}
+
+// Shared by every env-override reader: a set-but-blank variable behaves
+// exactly like an unset one.
+export function readTrimmedEnv(
+    env: Record<string, string | undefined>,
+    name: string,
+): string | undefined {
+    const value = env[name]?.trim();
+
+    return value === undefined || value === "" ? undefined : value;
+}
+
+// Returns the OO_ENDPOINT override when set to a non-empty value, otherwise
+// undefined. OO_ENDPOINT is the only endpoint override across execution,
+// login, and unauthenticated reads.
+export function readEndpointOverride(
+    env: Record<string, string | undefined>,
+): string | undefined {
+    return readTrimmedEnv(env, endpointEnvName);
+}
+
+// Builds an in-memory account from OO_API_KEY (paired with OO_ENDPOINT, or the
+// public default). Returns undefined when OO_API_KEY is absent so callers fall
+// back to the persisted auth.toml. When defined, callers must NOT read or
+// require auth.toml.
+export function buildEnvApiKeyAccount(
+    env: Record<string, string | undefined>,
+): AuthAccount | undefined {
+    const apiKey = readTrimmedEnv(env, apiKeyEnvName);
+
+    if (apiKey === undefined) {
+        return undefined;
+    }
+
+    return {
+        apiKey,
+        endpoint: readEndpointOverride(env) ?? defaultOomolEndpoint,
+        id: envOverrideAccountId,
+        name: envOverrideAccountName,
+    };
+}
+
+// True when the account is the in-memory identity built from OO_API_KEY rather
+// than a persisted account. Such an account has no real scope/username, so
+// scope-deriving callers (e.g. skill publish) must require explicit input.
+export function isEnvOverrideAccount(
+    account: Pick<AuthAccount, "id">,
+): boolean {
+    return account.id === envOverrideAccountId;
+}
+
+// Applies the OO_ENDPOINT override to an account resolved from auth.toml so a
+// bare OO_ENDPOINT (without OO_API_KEY) still redirects execution endpoints.
+export function applyEndpointOverride(
+    account: AuthAccount,
+    env: Record<string, string | undefined>,
+): AuthAccount {
+    const endpointOverride = readEndpointOverride(env);
+
+    if (endpointOverride === undefined) {
+        return account;
+    }
+
+    return {
+        ...account,
+        endpoint: endpointOverride,
+    };
+}
+
+function resolveEnvIdentity(
+    env: Record<string, string | undefined>,
+): RequiredIdentity | undefined {
+    const envAccount = buildEnvApiKeyAccount(env);
+
+    if (envAccount === undefined) {
+        return undefined;
+    }
+
+    return {
+        account: envAccount,
+        endpoint: envAccount.endpoint,
+        fileState: "unread",
+        overriddenBy: "OO_API_KEY",
+        source: "env",
+    };
+}
+
+function logResolvedAccount(
+    context: Pick<CliExecutionContext, "logger">,
+    accountCount: number,
+    currentAuthId: string,
+    currentAccount: AuthAccount | undefined,
+): void {
+    context.logger.debug(
+        {
+            accountCount,
+            currentAuthId,
+            hasCurrentAccount: currentAccount !== undefined,
+        },
+        currentAccount === undefined
+            ? "Current auth account is not available."
+            : "Current auth account resolved.",
+    );
+}

--- a/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
+++ b/src/application/commands/auth/__snapshots__/index.cli.test.ts.snap
@@ -105,22 +105,6 @@ Default team identity: alice-team
 }
 `;
 
-exports[`auth CLI supports auth login with a custom OOMOL_ENDPOINT 1`] = `
-{
-  "exitCode": 0,
-  "stderr": "",
-  "stdout": 
-"Open this login URL in your browser:
-<LOGIN_URL>
-Waiting for the device login to complete...
-✓ Logged in to staging.oomol.test account Alice
-  - Active account: true
-Default team identity: alice-team
-"
-,
-}
-`;
-
 exports[`auth CLI supports login as an alias for auth login 1`] = `
 {
   "exitCode": 0,

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -213,31 +213,6 @@ describe("auth CLI", () => {
         }
     });
 
-    test("supports auth login with a custom OOMOL_ENDPOINT", async () => {
-        const sandbox = await createCliSandbox();
-
-        sandbox.env.OOMOL_ENDPOINT = "staging.oomol.test";
-
-        try {
-            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
-                accountEndpoint: sandbox.env.OOMOL_ENDPOINT,
-            });
-            const loginUrl = findLoginUrl(result.stdout);
-
-            expect(result.exitCode).toBe(0);
-            expect(new URL(loginUrl!).searchParams.get("user_code")).toBe(
-                "M0KO41",
-            );
-            expect(loginUrl).toStartWith(
-                readAuthLoginUrlPrefix("staging.oomol.test"),
-            );
-            expect(createAuthLoginSnapshot(result)).toMatchSnapshot();
-        }
-        finally {
-            await sandbox.cleanup();
-        }
-    });
-
     test("supports auth login with a custom OO_ENDPOINT", async () => {
         const sandbox = await createCliSandbox();
 
@@ -259,24 +234,21 @@ describe("auth CLI", () => {
         }
     });
 
-    test("prefers OO_ENDPOINT over OOMOL_ENDPOINT for auth login", async () => {
+    test("ignores the removed legacy OOMOL_ENDPOINT variable", async () => {
         const sandbox = await createCliSandbox();
 
         // runPrintedAuthLogin only answers api.${accountEndpoint}; if login
-        // resolved the legacy host instead, the request would hit the unmocked
-        // host and throw, so a green run proves OO_ENDPOINT wins the precedence.
-        sandbox.env.OO_ENDPOINT = "override.oomol.test";
+        // still resolved the legacy host, the request would hit the unmocked
+        // host and throw, so a green run proves OOMOL_ENDPOINT has no effect.
         sandbox.env.OOMOL_ENDPOINT = "legacy.oomol.test";
 
         try {
-            const result = await runPrintedAuthLogin(sandbox, "secret-1", {
-                accountEndpoint: sandbox.env.OO_ENDPOINT,
-            });
+            const result = await runPrintedAuthLogin(sandbox, "secret-1", {});
             const loginUrl = findLoginUrl(result.stdout);
 
             expect(result.exitCode).toBe(0);
             expect(loginUrl).toStartWith(
-                readAuthLoginUrlPrefix("override.oomol.test"),
+                readAuthLoginUrlPrefix("oomol.com"),
             );
         }
         finally {

--- a/src/application/commands/auth/login.ts
+++ b/src/application/commands/auth/login.ts
@@ -8,6 +8,10 @@ import type { TeamView } from "../team/shared.ts";
 
 import { z } from "zod";
 import {
+    buildEnvApiKeyAccount,
+    resolveLoginEndpoint,
+} from "../../auth/identity.ts";
+import {
     requestAuthAccountWithApiKey,
     requestAuthAccountWithSessionToken,
     startAuthLoginSession,
@@ -20,11 +24,6 @@ import {
 } from "../../schemas/settings.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
-import {
-    buildEnvApiKeyAccount,
-    readEndpointOverride,
-    readTrimmedEnv,
-} from "../shared/auth-env-override.ts";
 import { writeLine } from "../shared/output.ts";
 import { resolveSelfHostedConnectorTolerantly } from "../shared/self-hosted-connector.ts";
 import {
@@ -38,10 +37,6 @@ import {
 } from "./shared.ts";
 
 const loginUrlColor = "#c09ff5";
-const defaultAuthEndpoint = "oomol.com";
-// Legacy endpoint override, kept only as a fallback below OO_ENDPOINT. Slated
-// for removal once callers have migrated to OO_ENDPOINT.
-const legacyEndpointEnvName = "OOMOL_ENDPOINT";
 
 type LoginMethod = "api_key" | "device_login" | "session_token";
 
@@ -100,7 +95,7 @@ export const authLoginCommand: CliCommandDefinition<AuthLoginCommandInput> = {
     inputSchema: authLoginCommandInputSchema,
     mapInputError: (_error, rawInput) => mapLoginInputError(rawInput),
     handler: async (input: AuthLoginCommandInput, context) => {
-        const authEndpoint = readAuthEndpoint(context.env);
+        const authEndpoint = resolveLoginEndpoint(context.env);
         const loginMethod = resolveLoginMethod(input);
 
         context.telemetry?.recordProperties({ auth_method: loginMethod });
@@ -426,17 +421,4 @@ async function runDeviceLogin(
     );
 
     return session.waitForAccount();
-}
-
-// Resolves the endpoint the login flow authenticates against. OO_ENDPOINT wins
-// so `oo auth login` targets the same host execution commands use, matching the
-// precedence in resolveCurrentEndpoint(). The legacy OOMOL_ENDPOINT stays only
-// as a fallback and is slated for removal, after which OO_ENDPOINT and the
-// public default are the only sources.
-function readAuthEndpoint(
-    env: CliExecutionContext["env"],
-): string {
-    return readEndpointOverride(env)
-        ?? readTrimmedEnv(env, legacyEndpointEnvName)
-        ?? defaultAuthEndpoint;
 }

--- a/src/application/commands/auth/logout.ts
+++ b/src/application/commands/auth/logout.ts
@@ -1,10 +1,13 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
+import {
+    buildEnvApiKeyAccount,
+    reportOverriddenWrite,
+} from "../../auth/identity.ts";
 import { removeCurrentAuthAccount } from "../../schemas/auth.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
-import { buildEnvApiKeyAccount } from "../shared/auth-env-override.ts";
 import { writeLine } from "../shared/output.ts";
-import { emptyAuthCommandInputSchema, writeAuthBlock } from "./shared.ts";
+import { emptyAuthCommandInputSchema } from "./shared.ts";
 
 export const authLogoutCommand: CliCommandDefinition = {
     name: "logout",
@@ -18,19 +21,9 @@ export const authLogoutCommand: CliCommandDefinition = {
         // while destroying state they never asked to lose, so do nothing and
         // say so.
         if (buildEnvApiKeyAccount(context.env) !== undefined) {
-            context.telemetry?.recordProperties({ credential_source: "env" });
-            context.logger.info(
-                {},
-                "Auth logout did nothing: OO_API_KEY provides the active credential.",
-            );
-            writeAuthBlock(context, {
-                tone: "warning",
-                summary: context.translator.t("auth.logout.envOverrideNoop"),
+            reportOverriddenWrite(context, {
+                summaryKey: "auth.logout.envOverrideNoop",
             });
-            writeLine(
-                context.stdout,
-                context.translator.t("auth.envOverride.unsetHint"),
-            );
             return;
         }
 

--- a/src/application/commands/auth/switch.ts
+++ b/src/application/commands/auth/switch.ts
@@ -2,11 +2,13 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import type { AuthAccount, AuthFile } from "../../schemas/auth.ts";
 
 import { z } from "zod";
+import {
+    buildEnvApiKeyAccount,
+    reportOverriddenWrite,
+} from "../../auth/identity.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { getNextAuthAccount, setCurrentAuthId } from "../../schemas/auth.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
-import { buildEnvApiKeyAccount } from "../shared/auth-env-override.ts";
-import { writeLine } from "../shared/output.ts";
 import {
     formatAuthStrong,
     writeAuthBlock,
@@ -39,22 +41,10 @@ export const authSwitchCommand: CliCommandDefinition<AuthSwitchInput> = {
         // OO_API_KEY is set, so rewriting auth.toml here would report a switch
         // that no later command honors.
         if (buildEnvApiKeyAccount(context.env) !== undefined) {
-            context.telemetry?.recordProperties({
-                credential_source: "env",
-                has_user_filter: input.user !== undefined,
+            reportOverriddenWrite(context, {
+                extraTelemetry: { has_user_filter: input.user !== undefined },
+                summaryKey: "auth.switch.envOverrideNoop",
             });
-            context.logger.info(
-                {},
-                "Auth switch did nothing: OO_API_KEY provides the active credential.",
-            );
-            writeAuthBlock(context, {
-                tone: "warning",
-                summary: context.translator.t("auth.switch.envOverrideNoop"),
-            });
-            writeLine(
-                context.stdout,
-                context.translator.t("auth.envOverride.unsetHint"),
-            );
             return;
         }
 

--- a/src/application/commands/shared/auth-env-override.ts
+++ b/src/application/commands/shared/auth-env-override.ts
@@ -1,87 +1,12 @@
-import type { AuthAccount } from "../../schemas/auth.ts";
-
-// Public base endpoint used when nothing else is configured. Service URLs are
-// derived by prefixing subdomains (api./llm./connector./search./...), so a
-// single base value is enough to switch between environments.
-export const defaultOomolEndpoint = "oomol.com";
-
-// Environment variables that let embedded callers drive execution commands
-// without an interactive login or a persisted auth.toml.
-const apiKeyEnvName = "OO_API_KEY";
-const endpointEnvName = "OO_ENDPOINT";
-
-// Synthetic identity for the in-memory account built from OO_API_KEY. It is
-// never written to disk; the id/name only satisfy the auth account schema and
-// surface in diagnostics. The id is stable so callers can recognize the env
-// override (it has no real account scope, so e.g. publish must not derive a
-// package name from it).
-export const envOverrideAccountId = "oo-env-override";
-const envOverrideAccountName = "Environment (OO_API_KEY)";
-
-// Shared by every env-override reader: a set-but-blank variable behaves
-// exactly like an unset one.
-export function readTrimmedEnv(
-    env: Record<string, string | undefined>,
-    name: string,
-): string | undefined {
-    const value = env[name]?.trim();
-    return value === undefined || value === "" ? undefined : value;
-}
-
-// Returns the OO_ENDPOINT override when set to a non-empty value, otherwise
-// undefined. OO_ENDPOINT is the primary endpoint override across execution,
-// login, and unauthenticated reads; the legacy OOMOL_ENDPOINT remains only as a
-// fallback and is slated for removal.
-export function readEndpointOverride(
-    env: Record<string, string | undefined>,
-): string | undefined {
-    return readTrimmedEnv(env, endpointEnvName);
-}
-
-// Builds an in-memory account from OO_API_KEY (paired with OO_ENDPOINT, or the
-// public default). Returns undefined when OO_API_KEY is absent so callers fall
-// back to the persisted auth.toml. When defined, callers must NOT read or
-// require auth.toml.
-export function buildEnvApiKeyAccount(
-    env: Record<string, string | undefined>,
-): AuthAccount | undefined {
-    const apiKey = readTrimmedEnv(env, apiKeyEnvName);
-
-    if (apiKey === undefined) {
-        return undefined;
-    }
-
-    return {
-        apiKey,
-        endpoint: readEndpointOverride(env) ?? defaultOomolEndpoint,
-        id: envOverrideAccountId,
-        name: envOverrideAccountName,
-    };
-}
-
-// True when the account is the in-memory identity built from OO_API_KEY rather
-// than a persisted account. Such an account has no real scope/username, so
-// scope-deriving callers (e.g. skill publish) must require explicit input.
-export function isEnvOverrideAccount(
-    account: Pick<AuthAccount, "id">,
-): boolean {
-    return account.id === envOverrideAccountId;
-}
-
-// Applies the OO_ENDPOINT override to an account resolved from auth.toml so a
-// bare OO_ENDPOINT (without OO_API_KEY) still redirects execution endpoints.
-export function applyEndpointOverride(
-    account: AuthAccount,
-    env: Record<string, string | undefined>,
-): AuthAccount {
-    const endpointOverride = readEndpointOverride(env);
-
-    if (endpointOverride === undefined) {
-        return account;
-    }
-
-    return {
-        ...account,
-        endpoint: endpointOverride,
-    };
-}
+// Thin compatibility shell: the env-override primitives moved into the deep
+// identity module. Import from ../../auth/identity.ts directly; this file is
+// deleted once every caller has migrated.
+export {
+    applyEndpointOverride,
+    buildEnvApiKeyAccount,
+    defaultOomolEndpoint,
+    envOverrideAccountId,
+    isEnvOverrideAccount,
+    readEndpointOverride,
+    readTrimmedEnv,
+} from "../../auth/identity.ts";

--- a/src/application/commands/shared/auth-utils.test.ts
+++ b/src/application/commands/shared/auth-utils.test.ts
@@ -252,6 +252,7 @@ function createThrowingAuthStore(): AuthStore {
         getFilePath: () => "/should-not-be-read/auth.toml",
         read: async () => fail(),
         readTolerant: async () => fail(),
+        readTolerantState: async () => fail(),
         write: async () => fail(),
         update: async () => fail(),
     };

--- a/src/application/commands/shared/auth-utils.ts
+++ b/src/application/commands/shared/auth-utils.ts
@@ -1,110 +1,26 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
 
-import { CliUserError } from "../../contracts/cli.ts";
-import { getCurrentAuthAccount } from "../../schemas/auth.ts";
-import { readCurrentAuth } from "../auth/shared.ts";
-import {
-    applyEndpointOverride,
-    buildEnvApiKeyAccount,
-    defaultOomolEndpoint,
-    readEndpointOverride,
-} from "./auth-env-override.ts";
-import { resolveSelfHostedConnectorTolerantly } from "./self-hosted-connector.ts";
+import { requireIdentity, resolveIdentity } from "../../auth/identity.ts";
 
-const authErrorKeys = {
-    activeAccountMissing: "auth.account.activeAccountMissing",
-    required: "errors.auth.required",
-    requiredConnectorOnly: "errors.auth.requiredConnectorOnly",
-} as const;
+// Thin compatibility shells: identity precedence lives in the deep identity
+// module. Call requireIdentity/resolveIdentity directly for new code; this
+// file is deleted once every caller has migrated.
 
 export async function requireCurrentAccount(
     context: CliExecutionContext,
 ): Promise<AuthAccount> {
-    // OO_API_KEY short-circuits before any auth.toml access so embedded callers
-    // can run execution commands without a login or a persisted account.
-    const envAccount = buildEnvApiKeyAccount(context.env);
-
-    if (envAccount !== undefined) {
-        return envAccount;
-    }
-
-    const { authFile, currentAccount } = await readCurrentAuth(context);
-
-    if (currentAccount !== undefined) {
-        // A bare OO_ENDPOINT (without OO_API_KEY) still redirects the execution
-        // endpoint of the persisted account.
-        return applyEndpointOverride(currentAccount, context.env);
-    }
-
-    if (authFile.id !== "") {
-        throw new CliUserError(authErrorKeys.activeAccountMissing, 1);
-    }
-
-    // A user who only configured a self-hosted connector gets a dedicated
-    // explanation: the self-hosted server covers connector commands only, and
-    // everything else still needs an OOMOL account. The tolerant lookup keeps
-    // a broken connector.toml from changing which auth error is shown.
-    throw new CliUserError(
-        await resolveSelfHostedConnectorTolerantly(context) !== undefined
-            ? authErrorKeys.requiredConnectorOnly
-            : authErrorKeys.required,
-        1,
-    );
+    return (await requireIdentity(context)).account;
 }
 
-// Resolves the account commands run as, or `undefined` when there is none.
-// Precedence matches requireCurrentAccount(), but every way of having no
-// usable account — no login, a stale active id, an unreadable auth.toml — comes
-// back as an absence instead of an error.
-//
-// For commands whose own output does not depend on the account, so that an
-// optional enrichment (a name lookup, say) degrades instead of taking the
-// command down. Commands that cannot proceed without credentials must keep
-// using requireCurrentAccount(), which explains what to do about it.
 export async function resolveCurrentAccountTolerantly(
     context: CliExecutionContext,
 ): Promise<AuthAccount | undefined> {
-    const envAccount = buildEnvApiKeyAccount(context.env);
-
-    if (envAccount !== undefined) {
-        return envAccount;
-    }
-
-    const currentAccount = getCurrentAuthAccount(
-        await context.authStore.readTolerant(),
-    );
-
-    return currentAccount === undefined
-        ? undefined
-        : applyEndpointOverride(currentAccount, context.env);
+    return (await resolveIdentity(context)).account;
 }
 
-// Resolves the OOMOL endpoint without requiring a logged-in account. Prefers
-// the OO_API_KEY/OO_ENDPOINT overrides, then the active account's endpoint (so
-// non-default environments are honored), then the legacy OOMOL_ENDPOINT
-// override, then the public default. Used by unauthenticated reads such as the
-// skill-recommendation registry existence check.
 export async function resolveCurrentEndpoint(
     context: CliExecutionContext,
 ): Promise<string> {
-    const envAccount = buildEnvApiKeyAccount(context.env);
-
-    if (envAccount !== undefined) {
-        return envAccount.endpoint;
-    }
-
-    const endpointOverride = readEndpointOverride(context.env);
-
-    if (endpointOverride !== undefined) {
-        return endpointOverride;
-    }
-
-    const { currentAccount } = await readCurrentAuth(context);
-
-    if (currentAccount !== undefined) {
-        return currentAccount.endpoint;
-    }
-
-    return context.env.OOMOL_ENDPOINT?.trim() || defaultOomolEndpoint;
+    return (await resolveIdentity(context)).endpoint;
 }

--- a/src/application/contracts/auth-store.ts
+++ b/src/application/contracts/auth-store.ts
@@ -1,5 +1,17 @@
 import type { AuthFile } from "../schemas/auth.ts";
 
+/**
+ * Condition of the persisted auth file as observed by a tolerant read:
+ * "missing" when it does not exist, "corrupt" when it exists but cannot be
+ * read or parsed, "ok" otherwise.
+ */
+export type AuthFileState = "corrupt" | "missing" | "ok";
+
+export interface TolerantAuthRead {
+    authFile: AuthFile;
+    fileState: AuthFileState;
+}
+
 export interface AuthStore {
     getFilePath: () => string;
     read: () => Promise<AuthFile>;
@@ -11,6 +23,13 @@ export interface AuthStore {
      * the file on disk and fails the command on a corrupt one.
      */
     readTolerant: () => Promise<AuthFile>;
+    /**
+     * Same tolerance contract as `readTolerant()`, but also reports what the
+     * fallback hid: whether the file was missing or corrupt. For callers that
+     * must distinguish "no accounts saved" from "the file is unreadable"
+     * (identity resolution, telemetry account state).
+     */
+    readTolerantState: () => Promise<TolerantAuthRead>;
     write: (auth: AuthFile) => Promise<AuthFile>;
     update: (
         updater: (auth: AuthFile) => AuthFile,

--- a/src/application/update/update-notifier.test.ts
+++ b/src/application/update/update-notifier.test.ts
@@ -410,6 +410,10 @@ function createUpdateNotifierHarness(options: {
             getFilePath: () => "",
             read: async () => defaultAuthFile,
             readTolerant: async () => defaultAuthFile,
+            readTolerantState: async () => ({
+                authFile: defaultAuthFile,
+                fileState: "ok",
+            }),
             write: async auth => auth,
             update: async updater => updater(defaultAuthFile),
         },


### PR DESCRIPTION
## Summary

Introduces `src/application/auth/identity.ts` as the single owner of identity precedence — `OO_API_KEY` > auth.toml active account (with `OO_ENDPOINT` applied) > `OO_ENDPOINT` alone > the public default. Until now that ordering was re-derived at seven call sites (auth-utils ×3, status, connector target, login, telemetry emitter) and had drifted three ways.

- `resolveIdentity` / `requireIdentity` return one `ResolvedIdentity` record (`account`, `source`, `endpoint`, `fileState`, `overriddenBy`). Read tolerance follows the entry point: `resolve*` never creates or fails on the auth file, `require*` surfaces corruption.
- `resolveLoginEndpoint` names the deliberate deviation that login ignores the saved account's endpoint.
- `reportOverriddenWrite` owns the overridden-write no-op structure (telemetry + log + warning block + unset hint); wording stays per-command. `logout`/`switch` consume it.
- `AuthStore` gains `readTolerantState` so tolerant reads can report missing vs corrupt without creating the file.
- `auth-utils.ts` / `auth-env-override.ts` become thin delegating shells; callers migrate in the next PR of this stack.

## Behavior changes

1. **Fixes a live defect**: `resolveCurrentEndpoint` used the file-creating, corrupt-failing `read()` on unauthenticated read paths (its own doc promised otherwise). Those paths are now tolerant.
2. **`OOMOL_ENDPOINT` is removed entirely** (code, docs, tests) — verified unused; `OO_ENDPOINT` is the only endpoint override. Guard tests pin that the variable is ignored.

## Tests

26 table-driven tests over the resolver seam (`identity.test.ts`): precedence matrix, blank/whitespace env vars, corrupt/missing auth.toml, strict-vs-tolerant entry points, the self-hosted-connector error chain, and `reportOverriddenWrite` output. `bun run lint:fix` / `ts-check` / `knip` / `test` all green.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#310** 👈 current
2. #311
3. #312
<!-- stack:links:end -->