### PR TITLE
refactor(telemetry): resolve account state via the tolerant auth read

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -905,7 +905,6 @@ export function createAuthStore(authFile: AuthFile): AuthStore {
     return {
         getFilePath: () => "",
         read: async () => currentAuthFile,
-        readTolerant: async () => currentAuthFile,
         readTolerantState: async () => ({
             authFile: currentAuthFile,
             fileState: "ok",

--- a/src/adapters/commander/commander-cli-adapter.test.ts
+++ b/src/adapters/commander/commander-cli-adapter.test.ts
@@ -222,10 +222,6 @@ function createCommanderContext(
                 auth: [],
                 id: "",
             }),
-            readTolerant: async () => ({
-                auth: [],
-                id: "",
-            }),
             readTolerantState: async () => ({
                 authFile: {
                     auth: [],

--- a/src/adapters/store/file-auth-store.test.ts
+++ b/src/adapters/store/file-auth-store.test.ts
@@ -30,7 +30,7 @@ describe("FileAuthStore", () => {
         expect(await readFile(store.getFilePath(), "utf8")).toBe("id = \"\"\n");
     });
 
-    test("readTolerant returns empty auth without creating a missing file", async () => {
+    test("readTolerantState reports a missing file without creating it", async () => {
         const root = await createTemporaryDirectory("auth-store-tolerant-missing");
         const store = new FileAuthStore({
             appName: APP_NAME,
@@ -41,15 +41,18 @@ describe("FileAuthStore", () => {
             platform: "linux",
         });
 
-        expect(await store.readTolerant()).toEqual({
-            auth: [],
-            id: "",
+        expect(await store.readTolerantState()).toEqual({
+            authFile: {
+                auth: [],
+                id: "",
+            },
+            fileState: "missing",
         });
         // Unlike read(), this must leave no file behind.
         expect(await Bun.file(store.getFilePath()).exists()).toBeFalse();
     });
 
-    test("readTolerant returns empty auth for a corrupt file without rewriting it", async () => {
+    test("readTolerantState reports a corrupt file without rewriting it", async () => {
         const root = await createTemporaryDirectory("auth-store-tolerant-corrupt");
         const store = new FileAuthStore({
             appName: APP_NAME,
@@ -64,9 +67,12 @@ describe("FileAuthStore", () => {
         await mkdir(dirname(store.getFilePath()), { recursive: true });
         await writeFile(store.getFilePath(), corruptContent);
 
-        expect(await store.readTolerant()).toEqual({
-            auth: [],
-            id: "",
+        expect(await store.readTolerantState()).toEqual({
+            authFile: {
+                auth: [],
+                id: "",
+            },
+            fileState: "corrupt",
         });
         expect(await readFile(store.getFilePath(), "utf8")).toBe(corruptContent);
         // read() must still surface the corruption to callers that need the file.
@@ -75,7 +81,7 @@ describe("FileAuthStore", () => {
         } satisfies Partial<CliUserError>);
     });
 
-    test("readTolerant returns persisted accounts when the file is valid", async () => {
+    test("readTolerantState returns persisted accounts when the file is valid", async () => {
         const root = await createTemporaryDirectory("auth-store-tolerant-valid");
         const store = new FileAuthStore({
             appName: APP_NAME,
@@ -99,10 +105,13 @@ describe("FileAuthStore", () => {
 
         await store.write(authFile);
 
-        expect(await store.readTolerant()).toEqual(authFile);
+        expect(await store.readTolerantState()).toEqual({
+            authFile,
+            fileState: "ok",
+        });
     });
 
-    test("readTolerant does not hand out a shared mutable default", async () => {
+    test("readTolerantState does not hand out a shared mutable default", async () => {
         const root = await createTemporaryDirectory("auth-store-tolerant-isolation");
         const store = new FileAuthStore({
             appName: APP_NAME,
@@ -113,19 +122,22 @@ describe("FileAuthStore", () => {
             platform: "linux",
         });
 
-        const first = await store.readTolerant();
+        const first = await store.readTolerantState();
 
-        first.auth.push({
+        first.authFile.auth.push({
             apiKey: "secret-1",
             endpoint: "oomol.com",
             id: "user-1",
             name: "Alice",
         });
-        first.id = "user-1";
+        first.authFile.id = "user-1";
 
-        expect(await store.readTolerant()).toEqual({
-            auth: [],
-            id: "",
+        expect(await store.readTolerantState()).toEqual({
+            authFile: {
+                auth: [],
+                id: "",
+            },
+            fileState: "missing",
         });
     });
 

--- a/src/adapters/store/file-auth-store.ts
+++ b/src/adapters/store/file-auth-store.ts
@@ -110,12 +110,6 @@ export class FileAuthStore implements AuthStore {
         }
     }
 
-    async readTolerant(): Promise<AuthFile> {
-        const { authFile } = await this.readTolerantState();
-
-        return authFile;
-    }
-
     async readTolerantState(): Promise<TolerantAuthRead> {
         try {
             const authFile = await this.readPersistedAuth();

--- a/src/application/auth/identity.test.ts
+++ b/src/application/auth/identity.test.ts
@@ -341,7 +341,6 @@ function createThrowingAuthStore(): AuthStore {
     return {
         getFilePath: () => "/should-not-be-read/auth.toml",
         read: async () => fail(),
-        readTolerant: async () => fail(),
         readTolerantState: async () => fail(),
         write: async () => fail(),
         update: async () => fail(),
@@ -360,7 +359,6 @@ function createUnreadableAuthStore(
         read: async () => {
             throw new Error("strict read must not be used by tolerant resolution");
         },
-        readTolerant: async () => emptyAuthFile,
         readTolerantState: async () => ({
             authFile: emptyAuthFile,
             fileState,

--- a/src/application/contracts/auth-store.ts
+++ b/src/application/contracts/auth-store.ts
@@ -17,17 +17,11 @@ export interface AuthStore {
     read: () => Promise<AuthFile>;
     /**
      * Reads the persisted auth for display only: never creates a missing file,
-     * and never throws on a missing or unreadable one (it yields the empty auth
-     * file instead). Callers that hold a credential from somewhere else — an
-     * OO_API_KEY override — must use this instead of `read()`, which initializes
-     * the file on disk and fails the command on a corrupt one.
-     */
-    readTolerant: () => Promise<AuthFile>;
-    /**
-     * Same tolerance contract as `readTolerant()`, but also reports what the
-     * fallback hid: whether the file was missing or corrupt. For callers that
-     * must distinguish "no accounts saved" from "the file is unreadable"
-     * (identity resolution, telemetry account state).
+     * and never throws on a missing or unreadable one (it yields the empty
+     * auth file plus a `fileState` saying why). Callers that hold a credential
+     * from somewhere else — an OO_API_KEY override — must use this instead of
+     * `read()`, which initializes the file on disk and fails the command on a
+     * corrupt one.
      */
     readTolerantState: () => Promise<TolerantAuthRead>;
     write: (auth: AuthFile) => Promise<AuthFile>;

--- a/src/application/telemetry/emitter.ts
+++ b/src/application/telemetry/emitter.ts
@@ -5,12 +5,10 @@ import type { AuthStore } from "../contracts/auth-store.ts";
 import type { AppSettings } from "../schemas/settings.ts";
 import type { TelemetryInvocationRecorder } from "./invocation.ts";
 import type { TelemetryAccountState } from "./payload.ts";
-import { readFile } from "node:fs/promises";
 import { arch, release } from "node:os";
 import process from "node:process";
-import { parse as parseToml } from "smol-toml";
 import { buildEnvApiKeyAccount } from "../auth/identity.ts";
-import { authTomlFileSchema, getCurrentAuthAccount } from "../schemas/auth.ts";
+import { getCurrentAuthAccount } from "../schemas/auth.ts";
 import { detectInstallationMethodFromExecPath } from "../self-update/installation.ts";
 import {
     telemetryInternalCommand,
@@ -216,25 +214,17 @@ async function resolveTelemetryAccountState(
         return "unknown";
     }
 
-    try {
-        const content = await readFile(authStore.getFilePath(), "utf8");
-        const parsed = authTomlFileSchema.safeParse(parseToml(content));
+    const { authFile, fileState } = await authStore.readTolerantState();
 
-        if (!parsed.success) {
-            return "unknown";
-        }
-
-        return getCurrentAuthAccount(parsed.data) === undefined
-            ? "anonymous"
-            : "authenticated";
+    if (fileState !== "ok") {
+        // A missing file means nobody ever logged in; an unreadable one means
+        // the account state cannot be known.
+        return fileState === "missing" ? "anonymous" : "unknown";
     }
-    catch (error) {
-        if (isNodeNotFoundError(error)) {
-            return "anonymous";
-        }
 
-        return "unknown";
-    }
+    return getCurrentAuthAccount(authFile) === undefined
+        ? "anonymous"
+        : "authenticated";
 }
 
 function detectCiEnvironment(
@@ -253,11 +243,4 @@ function detectCiEnvironment(
         isCi: false,
         name: "none",
     };
-}
-
-function isNodeNotFoundError(error: unknown): boolean {
-    return error !== null
-        && typeof error === "object"
-        && "code" in error
-        && error.code === "ENOENT";
 }

--- a/src/application/update/update-notifier.test.ts
+++ b/src/application/update/update-notifier.test.ts
@@ -409,7 +409,6 @@ function createUpdateNotifierHarness(options: {
         authStore: {
             getFilePath: () => "",
             read: async () => defaultAuthFile,
-            readTolerant: async () => defaultAuthFile,
             readTolerantState: async () => ({
                 authFile: defaultAuthFile,
                 fileState: "ok",


### PR DESCRIPTION
## Summary

Final PR of the identity-resolver stack.

- Replaces the telemetry emitter's hand-rolled `readFile` + TOML parse of auth.toml with `AuthStore.readTolerantState`: `missing` maps to `anonymous`, `corrupt` (unreadable or unparsable) maps to `unknown`, and a readable file reports `authenticated`/`anonymous` from its active account — identical semantics, but the no-touch tolerant-read contract now has a single owner.
- With no remaining callers, the redundant `readTolerant()` port method is deleted; `readTolerantState` is the one tolerant read.

No telemetry property changes; the command-telemetry decision manifest is untouched.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #310
2. #311
3. **#312** 👈 current
<!-- stack:links:end -->