### PR TITLE
refactor(connector): migrate connector commands onto the team identity resolver

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -53,16 +53,21 @@ use. Truthy values are `1`, `true`, `yes`, or `on` (case-insensitive).
   proxy`, `oo connector apps`, `oo connector search` / `oo search`) under the
   team with this id. It takes precedence
   over `OO_TEAM_NAME` and the `identity.team` config default; the per-run
-  `--team` and `--personal` flags still outrank it. The value is sent as-is
-  without a membership check. Ignored when the connector target is
+  `--team` and `--personal` flags still outrank it. Before execution the CLI
+  validates the id and resolves its team name (one extra request per
+  invocation), so requests carry both the name and the id; an id the account
+  cannot use — not a member, no such team, team deleted — fails with exit
+  `1`. If the lookup itself cannot complete, the id is sent on its own and
+  the backend stays the judge. Ignored when the connector target is
   self-hosted.
 - `OO_TEAM_NAME`: Same as `OO_TEAM_ID`, but selects the team by name. Before
   execution the CLI resolves the name to its team id through the account's
   team memberships (one extra request per invocation), so requests carry both
   the name and the id; a name the account cannot access fails with exit `1`.
-  `oo connector run --dry-run` sends no execution request and skips the
-  resolution, so it stays offline. Ignored when `OO_TEAM_ID` is set or the
-  connector target is self-hosted.
+  If the lookup itself cannot complete, the name is sent on its own and the
+  backend stays the judge. `oo connector run --dry-run` sends no execution
+  request and skips the lookup entirely, so it stays offline. Ignored when
+  `OO_TEAM_ID` is set or the connector target is self-hosted.
 - Connector commands resolve their team identity with this precedence:
   `--personal` / `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` > the `identity.team`
   config default > your personal identity.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -45,13 +45,16 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   `oo connector apps`、`oo connector search` / `oo search`）以该 id 对应的团队
   身份运行。优先级高于 `OO_TEAM_NAME`
   和 `identity.team` 配置默认值；每次运行的 `--team` 与 `--personal`
-  标志仍然优先于它。取值按原样发送，不做成员关系校验。当 connector
-  目标为自部署服务时会被忽略。
+  标志仍然优先于它。执行前 CLI 会校验该 id 并解析出团队名称（每次调用多一个
+  请求），因此请求会同时携带名称与 id；账号无法使用的 id——不是成员、团队
+  不存在、团队已删除——以退出码 `1` 失败。若查询本身无法完成，则只按原样
+  发送 id，由服务端裁决。当 connector 目标为自部署服务时会被忽略。
 - `OO_TEAM_NAME`：与 `OO_TEAM_ID` 相同，但按名称选择团队。执行前 CLI
   会通过账号的团队成员关系将名称解析为团队 id（每次调用多一个请求），
   因此请求会同时携带名称与 id；账号无法访问的名称以退出码 `1` 失败。
-  `oo connector run --dry-run` 不发送执行请求，也会跳过该解析，保持完全
-  离线。设置了 `OO_TEAM_ID` 或 connector 目标为自部署服务时会被忽略。
+  若查询本身无法完成，则只发送名称，由服务端裁决。`oo connector run
+  --dry-run` 不发送执行请求，也会完全跳过该查询，保持离线。设置了
+  `OO_TEAM_ID` 或 connector 目标为自部署服务时会被忽略。
 - Connector 相关命令按以下优先级解析团队身份：
   `--personal` / `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` >
   `identity.team` 配置默认值 > 个人身份。

--- a/src/application/commands/connector/apps.ts
+++ b/src/application/commands/connector/apps.ts
@@ -10,7 +10,11 @@ import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
-import { resolveConnectorIdentityWithEnv } from "./identity.ts";
+import {
+    requireValidTeamIdentity,
+    resolveTeamIdentity,
+} from "../team/identity.ts";
+import { connectorTeamAccount } from "./identity.ts";
 import { connectorSearchServiceColor } from "./search-provider.ts";
 import {
     connectorFormatValues,
@@ -109,21 +113,25 @@ export const connectorAppsCommand: CliCommandDefinition<ConnectorAppsInput> = {
         }
 
         const settings = await context.settingsStore.read();
-        const { identity, source: identitySource } = target.kind === "self_hosted"
-            ? { identity: {}, source: "personal" as const }
-            : await resolveConnectorIdentityWithEnv(
-                    {
-                        configTeam: getConfiguredIdentityTeam(settings),
-                        target,
-                        teamFlag,
-                        personalFlag: input.personal === true,
-                    },
+        const identity = target.kind === "self_hosted"
+            ? undefined
+            : requireValidTeamIdentity(
+                    await resolveTeamIdentity(
+                        {
+                            account: connectorTeamAccount(target),
+                            configuredTeam: getConfiguredIdentityTeam(settings),
+                            teamFlag,
+                            personalFlag: input.personal === true,
+                            resolveAgainstBackend: true,
+                        },
+                        context,
+                    ),
                     context,
                 );
 
         context.telemetry?.recordProperties({
             connector_kind: target.kind,
-            identity_source: identitySource,
+            identity_source: identity?.source ?? "personal",
             list_scope: listScope,
         });
 

--- a/src/application/commands/connector/identity.test.ts
+++ b/src/application/commands/connector/identity.test.ts
@@ -1,318 +1,64 @@
-import type { Fetcher } from "../../contracts/cli.ts";
-
 import { describe, expect, test } from "bun:test";
-import pino from "pino";
 
-import { expectCliUserError, toRequest } from "../../../../__tests__/helpers.ts";
-import { createTranslator } from "../../../i18n/translator.ts";
-import {
-    connectorIdentityHeaders,
-    resolveConnectorIdentity,
-    resolveConnectorIdentityWithEnv,
-} from "./identity.ts";
-
-const oomolTarget = {
-    authorization: "api-secret-1",
-    cacheEndpoint: "oomol.com",
-};
-
-const teamsResponse = {
-    teams: [
-        { id: "team-1", name: "acme", role: "creator", system_created: false },
-        { id: "team-2", name: "beta", role: "member", system_created: false },
-    ],
-};
-
-describe("resolveConnectorIdentity", () => {
-    test("defaults to personal when nothing is provided", () => {
-        expect(resolveConnectorIdentity({
-            configTeam: undefined,
-            envOverride: undefined,
-            teamFlag: undefined,
-            personalFlag: false,
-        })).toEqual({
-            identity: {},
-            source: "personal",
-        });
-    });
-
-    test("uses the team flag over the configured default", () => {
-        expect(resolveConnectorIdentity({
-            configTeam: "config-team",
-            envOverride: undefined,
-            teamFlag: "flag-team",
-            personalFlag: false,
-        })).toEqual({
-            identity: { team: "flag-team" },
-            source: "flag",
-        });
-    });
-
-    test("falls back to the configured team when no flag is set", () => {
-        expect(resolveConnectorIdentity({
-            configTeam: "config-team",
-            envOverride: undefined,
-            teamFlag: undefined,
-            personalFlag: false,
-        })).toEqual({
-            identity: { team: "config-team" },
-            source: "config",
-        });
-    });
-
-    test("personal flag overrides both the team flag and the configured default", () => {
-        expect(resolveConnectorIdentity({
-            configTeam: "config-team",
-            envOverride: undefined,
-            teamFlag: "flag-team",
-            personalFlag: true,
-        })).toEqual({
-            identity: {},
-            source: "personal",
-        });
-    });
-
-    test("treats an empty team flag as absent and falls back to config", () => {
-        expect(resolveConnectorIdentity({
-            configTeam: "config-team",
-            envOverride: undefined,
-            teamFlag: "",
-            personalFlag: false,
-        })).toEqual({
-            identity: { team: "config-team" },
-            source: "config",
-        });
-    });
-
-    test("uses the env team id over the configured default", () => {
-        expect(resolveConnectorIdentity({
-            configTeam: "config-team",
-            envOverride: { kind: "id", value: "team-1" },
-            teamFlag: undefined,
-            personalFlag: false,
-        })).toEqual({
-            identity: { teamId: "team-1" },
-            source: "env_id",
-        });
-    });
-
-    test("uses the env team name over the configured default", () => {
-        expect(resolveConnectorIdentity({
-            configTeam: "config-team",
-            envOverride: { kind: "name", value: "acme" },
-            teamFlag: undefined,
-            personalFlag: false,
-        })).toEqual({
-            identity: { team: "acme" },
-            source: "env_name",
-        });
-    });
-
-    test("uses the team flag over the env override", () => {
-        expect(resolveConnectorIdentity({
-            configTeam: undefined,
-            envOverride: { kind: "id", value: "team-1" },
-            teamFlag: "flag-team",
-            personalFlag: false,
-        })).toEqual({
-            identity: { team: "flag-team" },
-            source: "flag",
-        });
-    });
-
-    test("personal flag overrides the env override", () => {
-        expect(resolveConnectorIdentity({
-            configTeam: undefined,
-            envOverride: { kind: "name", value: "acme" },
-            teamFlag: undefined,
-            personalFlag: true,
-        })).toEqual({
-            identity: {},
-            source: "personal",
-        });
-    });
-});
-
-describe("resolveConnectorIdentityWithEnv", () => {
-    test("passes the env team id through without a resolution request", async () => {
-        let requested = false;
-        const resolved = await resolveConnectorIdentityWithEnv(
-            {
-                configTeam: "config-team",
-                target: oomolTarget,
-                teamFlag: undefined,
-                personalFlag: false,
-            },
-            createIdentityContext({
-                env: { OO_TEAM_ID: "team-9" },
-                fetcher: async () => {
-                    requested = true;
-
-                    return new Response(JSON.stringify(teamsResponse));
-                },
-            }),
-        );
-
-        expect(resolved).toEqual({
-            identity: { teamId: "team-9" },
-            source: "env_id",
-        });
-        expect(requested).toBe(false);
-    });
-
-    test("resolves the env team name to its id through the membership listing", async () => {
-        const requests: Request[] = [];
-        const resolved = await resolveConnectorIdentityWithEnv(
-            {
-                configTeam: undefined,
-                target: oomolTarget,
-                teamFlag: undefined,
-                personalFlag: false,
-            },
-            createIdentityContext({
-                env: { OO_TEAM_NAME: "beta" },
-                fetcher: async (input, init) => {
-                    requests.push(toRequest(input, init));
-
-                    return new Response(JSON.stringify(teamsResponse));
-                },
-            }),
-        );
-
-        expect(resolved).toEqual({
-            identity: { team: "beta", teamId: "team-2" },
-            source: "env_name",
-        });
-        expect(requests).toHaveLength(1);
-        expect(requests[0]?.url).toBe(
-            "https://relation-control.oomol.com/v1/me/teams",
-        );
-        expect(requests[0]?.headers.get("authorization")).toBe("api-secret-1");
-    });
-
-    test("fails when the env team name is not among the account teams", async () => {
-        const error = await expectCliUserError(resolveConnectorIdentityWithEnv(
-            {
-                configTeam: undefined,
-                target: oomolTarget,
-                teamFlag: undefined,
-                personalFlag: false,
-            },
-            createIdentityContext({
-                env: { OO_TEAM_NAME: "ghost" },
-                fetcher: async () => new Response(JSON.stringify(teamsResponse)),
-            }),
-        ));
-
-        expect(error.key).toBe("errors.team.envNameNotAccessible");
-        expect(error.exitCode).toBe(1);
-    });
-
-    test("prefers the env team id when both env variables are set", async () => {
-        let requested = false;
-        const resolved = await resolveConnectorIdentityWithEnv(
-            {
-                configTeam: undefined,
-                target: oomolTarget,
-                teamFlag: undefined,
-                personalFlag: false,
-            },
-            createIdentityContext({
-                env: { OO_TEAM_ID: "team-1", OO_TEAM_NAME: "beta" },
-                fetcher: async () => {
-                    requested = true;
-
-                    return new Response(JSON.stringify(teamsResponse));
-                },
-            }),
-        );
-
-        expect(resolved).toEqual({
-            identity: { teamId: "team-1" },
-            source: "env_id",
-        });
-        expect(requested).toBe(false);
-    });
-
-    test("skips the env resolution entirely when a flag wins", async () => {
-        let requested = false;
-        const resolved = await resolveConnectorIdentityWithEnv(
-            {
-                configTeam: undefined,
-                target: oomolTarget,
-                teamFlag: "flag-team",
-                personalFlag: false,
-            },
-            createIdentityContext({
-                env: { OO_TEAM_NAME: "beta" },
-                fetcher: async () => {
-                    requested = true;
-
-                    return new Response(JSON.stringify(teamsResponse));
-                },
-            }),
-        );
-
-        expect(resolved).toEqual({
-            identity: { team: "flag-team" },
-            source: "flag",
-        });
-        expect(requested).toBe(false);
-    });
-
-    test("fails the env name resolution when the target carries no credential", async () => {
-        const error = await expectCliUserError(resolveConnectorIdentityWithEnv(
-            {
-                configTeam: undefined,
-                target: { cacheEndpoint: "oomol.com" },
-                teamFlag: undefined,
-                personalFlag: false,
-            },
-            createIdentityContext({
-                env: { OO_TEAM_NAME: "beta" },
-                fetcher: async () => new Response(JSON.stringify(teamsResponse)),
-            }),
-        ));
-
-        expect(error.key).toBe("errors.auth.required");
-    });
-});
+import { connectorIdentityHeaders, connectorTeamAccount } from "./identity.ts";
 
 describe("connectorIdentityHeaders", () => {
-    test("returns the team header for a team identity", () => {
-        expect(connectorIdentityHeaders({ team: "acme" })).toEqual({
+    test("returns the team header for a name-only identity", () => {
+        expect(connectorIdentityHeaders({
+            name: "acme",
+            id: null,
+            source: "config",
+            status: null,
+        })).toEqual({
             "x-oo-team-name": "acme",
         });
     });
 
-    test("returns the team id header for an id identity", () => {
-        expect(connectorIdentityHeaders({ teamId: "team-1" })).toEqual({
+    test("returns the team id header for an id-only identity", () => {
+        expect(connectorIdentityHeaders({
+            name: null,
+            id: "team-1",
+            source: "env_id",
+            status: "request_failed",
+            envVar: "OO_TEAM_ID",
+        })).toEqual({
             "x-oo-team-id": "team-1",
         });
     });
 
     test("returns both headers when the name and id are known", () => {
-        expect(connectorIdentityHeaders({ team: "acme", teamId: "team-1" }))
-            .toEqual({
-                "x-oo-team-name": "acme",
-                "x-oo-team-id": "team-1",
-            });
+        expect(connectorIdentityHeaders({
+            name: "acme",
+            id: "team-1",
+            source: "env_name",
+            status: "valid",
+            envVar: "OO_TEAM_NAME",
+        })).toEqual({
+            "x-oo-team-name": "acme",
+            "x-oo-team-id": "team-1",
+        });
     });
 
     test("returns no headers for the personal identity", () => {
-        expect(connectorIdentityHeaders({})).toEqual({});
         expect(connectorIdentityHeaders(undefined)).toEqual({});
     });
 });
 
-function createIdentityContext(options: {
-    env: Record<string, string | undefined>;
-    fetcher: Fetcher;
-}) {
-    return {
-        env: options.env,
-        fetcher: options.fetcher,
-        logger: pino({ enabled: false }),
-        translator: createTranslator("en"),
-    };
-}
+describe("connectorTeamAccount", () => {
+    test("lends the target credential to the identity lookups", () => {
+        expect(connectorTeamAccount({
+            authorization: "api-secret-1",
+            cacheEndpoint: "oomol.com",
+        })).toEqual({
+            apiKey: "api-secret-1",
+            endpoint: "oomol.com",
+        });
+    });
+
+    test("returns undefined when the target carries no credential", () => {
+        expect(connectorTeamAccount({
+            authorization: undefined,
+            cacheEndpoint: "oomol.com",
+        })).toBeUndefined();
+    });
+});

--- a/src/application/commands/connector/identity.ts
+++ b/src/application/commands/connector/identity.ts
@@ -1,162 +1,48 @@
-// Connector authentication identity.
-//
-// A connector run executes under exactly one identity:
-//   personal => {}                 (no team)
-//   team     => { team? , teamId? } (at least one dimension set)
-//
-// The identity is resolved once per connector invocation and then applied only
-// to execution requests. The action schema / metadata layer is
-// identity-independent and is intentionally left untouched.
-//
-// This struct is the extension point for additional identity dimensions: a new
-// field here plus a branch in the request helpers below is all a future
-// dimension needs.
+// The connector-specific edge of the team identity: how a resolved
+// TeamIdentity travels on the wire, and how a connector target lends its
+// credential to the resolution. The identity itself — the flag/env/config
+// ladder and the validation policy — is owned by team/identity.ts.
 
-import type { CliExecutionContext } from "../../contracts/cli.ts";
-import type { TeamEnvOverride } from "../shared/team-env-override.ts";
+import type { AuthAccount } from "../../schemas/auth.ts";
+import type { TeamIdentity } from "../team/identity.ts";
 import type { ConnectorTarget } from "./target.ts";
 
-import { CliUserError } from "../../contracts/cli.ts";
-import { readTeamEnvOverride } from "../shared/team-env-override.ts";
-import { listMemberTeams } from "../team/shared.ts";
-
-export interface ConnectorIdentity {
-    team?: string;
-    teamId?: string;
-}
-
-// Where the resolved team came from. Recorded as privacy-safe telemetry; it
-// never carries the team name or id itself.
-type ConnectorIdentitySource
-    = "config" | "env_id" | "env_name" | "flag" | "personal";
-
-interface ResolvedConnectorIdentity {
-    identity: ConnectorIdentity;
-    source: ConnectorIdentitySource;
-}
-
-// Resolves the effective identity from the per-run flags, the env override,
-// and the configured default. Precedence: --personal > --team > OO_TEAM_ID >
-// OO_TEAM_NAME > config default > personal. A higher-priority identity fully
-// replaces the lower ones (no field-level merge). An `env_name` result still
-// carries only the name; `resolveConnectorIdentityWithEnv` fills in the id.
-export function resolveConnectorIdentity(input: {
-    configTeam: string | undefined;
-    envOverride: TeamEnvOverride | undefined;
-    teamFlag: string | undefined;
-    personalFlag: boolean;
-}): ResolvedConnectorIdentity {
-    if (input.personalFlag) {
-        return { identity: {}, source: "personal" };
-    }
-
-    if (input.teamFlag !== undefined && input.teamFlag !== "") {
-        return {
-            identity: { team: input.teamFlag },
-            source: "flag",
-        };
-    }
-
-    if (input.envOverride !== undefined) {
-        return input.envOverride.kind === "id"
-            ? {
-                    identity: { teamId: input.envOverride.value },
-                    source: "env_id",
-                }
-            : {
-                    identity: { team: input.envOverride.value },
-                    source: "env_name",
-                };
-    }
-
-    if (input.configTeam !== undefined && input.configTeam !== "") {
-        return {
-            identity: { team: input.configTeam },
-            source: "config",
-        };
-    }
-
-    return { identity: {}, source: "personal" };
-}
-
-// Resolves the effective identity for an OOMOL connector target, including the
-// env override. When OO_TEAM_NAME wins, the name is resolved to its team id
-// through the account's membership listing so execution requests can carry the
-// stable id; a name the account cannot access fails here, before any
-// execution request is sent. Self-hosted targets never reach this function —
-// they have no team concept, and callers pin the personal identity instead.
-// `resolveEnvTeamId: false` skips the membership request and keeps the bare
-// name identity — for validation-only invocations (`--dry-run`) that never
-// send an execution request, so they stay offline like every other identity
-// source.
-export async function resolveConnectorIdentityWithEnv(
-    options: {
-        configTeam: string | undefined;
-        resolveEnvTeamId?: boolean;
-        target: Pick<ConnectorTarget, "authorization" | "cacheEndpoint">;
-        teamFlag: string | undefined;
-        personalFlag: boolean;
-    },
-    context: Pick<CliExecutionContext, "env" | "fetcher" | "logger" | "translator">,
-): Promise<ResolvedConnectorIdentity> {
-    const resolved = resolveConnectorIdentity({
-        configTeam: options.configTeam,
-        envOverride: readTeamEnvOverride(context.env),
-        teamFlag: options.teamFlag,
-        personalFlag: options.personalFlag,
-    });
-
-    if (
-        resolved.source !== "env_name"
-        || resolved.identity.team === undefined
-        || options.resolveEnvTeamId === false
-    ) {
-        return resolved;
-    }
-
-    // OOMOL targets always carry the raw API key; the guard only narrows the
-    // field, which stays optional for self-hosted servers.
-    if (options.target.authorization === undefined) {
-        throw new CliUserError("errors.auth.required", 1);
-    }
-
-    const teams = await listMemberTeams(
-        {
-            apiKey: options.target.authorization,
-            endpoint: options.target.cacheEndpoint,
-        },
-        context,
-    );
-    const teamName = resolved.identity.team;
-    const match = teams.find(team => team.name === teamName);
-
-    if (match === undefined) {
-        throw new CliUserError("errors.team.envNameNotAccessible", 1, {
-            team: teamName,
-        });
-    }
-
-    return {
-        identity: { team: match.name, teamId: match.id },
-        source: "env_name",
-    };
-}
-
-// Builds the identity request headers (`x-oo-team-name` / `x-oo-team-id`).
-// Returns an empty object for the personal identity so callers can spread it
-// unconditionally.
+// Builds the identity request headers (`x-oo-team-name` / `x-oo-team-id`)
+// from whichever dimensions the identity carries. Returns an empty object for
+// the personal identity so callers can spread it unconditionally.
 export function connectorIdentityHeaders(
-    identity: ConnectorIdentity | undefined,
+    identity: TeamIdentity | undefined,
 ): Record<string, string> {
     const headers: Record<string, string> = {};
 
-    if (identity?.team !== undefined) {
-        headers["x-oo-team-name"] = identity.team;
+    if (identity === undefined) {
+        return headers;
     }
 
-    if (identity?.teamId !== undefined) {
-        headers["x-oo-team-id"] = identity.teamId;
+    if (identity.name !== null) {
+        headers["x-oo-team-name"] = identity.name;
+    }
+
+    if (identity.id !== null) {
+        headers["x-oo-team-id"] = identity.id;
     }
 
     return headers;
+}
+
+// Bridges a connector target to the account shape the team identity lookups
+// authenticate with. Undefined when the target carries no credential (a
+// self-hosted server with authentication disabled), which downgrades an
+// env-selected lookup to `no_credential`.
+export function connectorTeamAccount(
+    target: Pick<ConnectorTarget, "authorization" | "cacheEndpoint">,
+): Pick<AuthAccount, "apiKey" | "endpoint"> | undefined {
+    if (target.authorization === undefined) {
+        return undefined;
+    }
+
+    return {
+        apiKey: target.authorization,
+        endpoint: target.cacheEndpoint,
+    };
 }

--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -763,7 +763,17 @@ describe("connectorCommand CLI", () => {
                 ],
                 {
                     fetcher: async (input, init) => {
-                        requests.push(toRequest(input, init));
+                        const request = toRequest(input, init);
+                        requests.push(request);
+
+                        if (new URL(request.url).pathname.startsWith("/v1/teams/")) {
+                            return new Response(JSON.stringify({
+                                id: "team-1",
+                                name: "acme",
+                                role: "member",
+                                system_created: false,
+                            }));
+                        }
 
                         return new Response(JSON.stringify({
                             data: {
@@ -786,10 +796,14 @@ describe("connectorCommand CLI", () => {
                 .find(payload => payload?.properties?.command_full === "connector.proxy");
 
             expect(result.exitCode).toBe(0);
-            // The id needs no resolution, so the proxy request is the only one.
-            expect(requests).toHaveLength(1);
-            expect(requests[0]?.headers.get("x-oo-team-id")).toBe("team-1");
-            expect(requests[0]?.headers.get("x-oo-team-name")).toBeNull();
+            // The id is validated and completed first, then the proxy request
+            // carries both identity dimensions.
+            expect(requests).toHaveLength(2);
+            expect(requests[0]?.url).toBe(
+                "https://relation-control.oomol.com/v1/teams/team-1",
+            );
+            expect(requests[1]?.headers.get("x-oo-team-id")).toBe("team-1");
+            expect(requests[1]?.headers.get("x-oo-team-name")).toBe("acme");
             expect(proxyTelemetryPayload).toMatchObject({
                 properties: {
                     identity_source: "env_id",
@@ -5042,8 +5056,8 @@ describe("connectorCommand CLI", () => {
             await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
             await sandbox.run(["config", "set", "identity.team", "acme"]);
             sandbox.env.OO_TEAM_ID = "team-1";
-            // The id form outranks the name form, so no resolution request
-            // may be sent for this value.
+            // The id form outranks the name form: the lookup validates the
+            // id, and this name value is never consulted.
             sandbox.env.OO_TEAM_NAME = "beta";
 
             const requests: Request[] = [];
@@ -5060,7 +5074,17 @@ describe("connectorCommand CLI", () => {
                 ],
                 {
                     fetcher: async (input, init) => {
-                        requests.push(toRequest(input, init));
+                        const request = toRequest(input, init);
+                        requests.push(request);
+
+                        if (new URL(request.url).pathname.startsWith("/v1/teams/")) {
+                            return new Response(JSON.stringify({
+                                id: "team-1",
+                                name: "acme",
+                                role: "member",
+                                system_created: false,
+                            }));
+                        }
 
                         return new Response(JSON.stringify({
                             data: {
@@ -5080,10 +5104,15 @@ describe("connectorCommand CLI", () => {
                 .find(payload => payload?.properties?.command_full === "connector.run");
 
             expect(result.exitCode).toBe(0);
-            expect(requests).toHaveLength(1);
-            expect(requests[0]?.method).toBe("POST");
-            expect(requests[0]?.headers.get("x-oo-team-id")).toBe("team-1");
-            expect(requests[0]?.headers.get("x-oo-team-name")).toBeNull();
+            // The id is validated and completed first, then the execution
+            // request carries both identity dimensions.
+            expect(requests).toHaveLength(2);
+            expect(requests[0]?.url).toBe(
+                "https://relation-control.oomol.com/v1/teams/team-1",
+            );
+            expect(requests[1]?.method).toBe("POST");
+            expect(requests[1]?.headers.get("x-oo-team-id")).toBe("team-1");
+            expect(requests[1]?.headers.get("x-oo-team-name")).toBe("acme");
             expect(runTelemetryPayload).toMatchObject({
                 properties: {
                     identity_source: "env_id",
@@ -5227,7 +5256,7 @@ describe("connectorCommand CLI", () => {
         }
     });
 
-    test("fails the run when the OO_TEAM_NAME resolution request fails", async () => {
+    test("proceeds with the bare name when the OO_TEAM_NAME lookup cannot complete", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -5249,21 +5278,138 @@ describe("connectorCommand CLI", () => {
                 ],
                 {
                     fetcher: async (input, init) => {
-                        requests.push(toRequest(input, init));
+                        const request = toRequest(input, init);
+                        requests.push(request);
 
-                        return new Response("boom", { status: 500 });
+                        if (new URL(request.url).pathname === "/v1/me/teams") {
+                            return new Response("boom", { status: 500 });
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
                     },
                 },
             );
 
+            // The backend could not answer, so the CLI does not turn its own
+            // connectivity problem into a verdict: the run proceeds with the
+            // name header only and the gateway stays the final judge.
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(2);
+            expect(requests[0]?.url).toBe(
+                "https://relation-control.oomol.com/v1/me/teams",
+            );
+            expect(requests[1]?.headers.get("x-oo-team-name")).toBe("acme");
+            expect(requests[1]?.headers.get("x-oo-team-id")).toBeNull();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("fails the run when OO_TEAM_ID is refused by the backend", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
+            sandbox.env.OO_TEAM_ID = "team-9";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        requests.push(toRequest(input, init));
+
+                        return new Response("{}", { status: 403 });
+                    },
+                },
+            );
+
+            // A definite backend refusal blocks the run before any execution
+            // request, with the reason spelled out.
             expect(result.exitCode).toBe(1);
-            expect(result.stderr).toContain("HTTP 500");
-            // The failed resolution aborts the run: every request went to the
-            // membership endpoint and no action execution was attempted.
-            expect(requests.length).toBeGreaterThan(0);
-            expect(requests.every(request =>
-                request.url === "https://relation-control.oomol.com/v1/me/teams",
-            )).toBe(true);
+            expect(result.stderr).toContain("OO_TEAM_ID");
+            expect(result.stderr).toContain("team-9");
+            expect(result.stderr).toContain(
+                "the active account is not a member of this team",
+            );
+            expect(requests).toHaveLength(1);
+            expect(requests[0]?.url).toBe(
+                "https://relation-control.oomol.com/v1/teams/team-9",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("proceeds with the bare id when the OO_TEAM_ID lookup cannot complete", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            await seedConnectorActionSchema(sandbox, createConnectorActionFixture());
+            sandbox.env.OO_TEAM_ID = "team-1";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "run",
+                    "gmail",
+                    "-a",
+                    "send_mail",
+                    "-d",
+                    "{\"to\":\"foo@bar.com\"}",
+                    "--json",
+                ],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+                        requests.push(request);
+
+                        if (new URL(request.url).pathname.startsWith("/v1/teams/")) {
+                            return new Response("boom", { status: 500 });
+                        }
+
+                        return new Response(JSON.stringify({
+                            data: {
+                                messageId: "message-1",
+                            },
+                            meta: {
+                                executionId: "exec-1",
+                            },
+                        }));
+                    },
+                },
+            );
+
+            // The backend could not answer, so the run proceeds with the id
+            // header only and the gateway stays the final judge.
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(2);
+            expect(requests[0]?.url).toBe(
+                "https://relation-control.oomol.com/v1/teams/team-1",
+            );
+            expect(requests[1]?.headers.get("x-oo-team-id")).toBe("team-1");
+            expect(requests[1]?.headers.get("x-oo-team-name")).toBeNull();
         }
         finally {
             await sandbox.cleanup();
@@ -5485,7 +5631,17 @@ describe("connectorCommand CLI", () => {
                 ["connector", "apps", "--json"],
                 {
                     fetcher: async (input, init) => {
-                        requests.push(toRequest(input, init));
+                        const request = toRequest(input, init);
+                        requests.push(request);
+
+                        if (new URL(request.url).pathname.startsWith("/v1/teams/")) {
+                            return new Response(JSON.stringify({
+                                id: "team-1",
+                                name: "acme",
+                                role: "member",
+                                system_created: false,
+                            }));
+                        }
 
                         return new Response(JSON.stringify({ data: [] }));
                     },
@@ -5498,9 +5654,14 @@ describe("connectorCommand CLI", () => {
                 .find(payload => payload?.properties?.command_full === "connector.apps");
 
             expect(result.exitCode).toBe(0);
-            expect(requests).toHaveLength(1);
-            expect(requests[0]?.headers.get("x-oo-team-id")).toBe("team-1");
-            expect(requests[0]?.headers.get("x-oo-team-name")).toBeNull();
+            // The id is validated and completed first, then the listing
+            // carries both identity dimensions.
+            expect(requests).toHaveLength(2);
+            expect(requests[0]?.url).toBe(
+                "https://relation-control.oomol.com/v1/teams/team-1",
+            );
+            expect(requests[1]?.headers.get("x-oo-team-id")).toBe("team-1");
+            expect(requests[1]?.headers.get("x-oo-team-name")).toBe("acme");
             expect(appsTelemetryPayload).toMatchObject({
                 properties: {
                     identity_source: "env_id",

--- a/src/application/commands/connector/proxy.ts
+++ b/src/application/commands/connector/proxy.ts
@@ -9,7 +9,11 @@ import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
 import { readJsonInputValue } from "../shared/json-input.ts";
-import { resolveConnectorIdentityWithEnv } from "./identity.ts";
+import {
+    requireValidTeamIdentity,
+    resolveTeamIdentity,
+} from "../team/identity.ts";
+import { connectorTeamAccount } from "./identity.ts";
 import {
     connectorFormatValues,
     runConnectorProxy,
@@ -158,15 +162,19 @@ export const connectorProxyCommand: CliCommandDefinition<ConnectorProxyInput> = 
         }
 
         const settings = await context.settingsStore.read();
-        const { identity, source: identitySource } = target.kind === "self_hosted"
-            ? { identity: {}, source: "personal" as const }
-            : await resolveConnectorIdentityWithEnv(
-                    {
-                        configTeam: getConfiguredIdentityTeam(settings),
-                        target,
-                        teamFlag,
-                        personalFlag: input.personal === true,
-                    },
+        const identity = target.kind === "self_hosted"
+            ? undefined
+            : requireValidTeamIdentity(
+                    await resolveTeamIdentity(
+                        {
+                            account: connectorTeamAccount(target),
+                            configuredTeam: getConfiguredIdentityTeam(settings),
+                            teamFlag,
+                            personalFlag: input.personal === true,
+                            resolveAgainstBackend: true,
+                        },
+                        context,
+                    ),
                     context,
                 );
 
@@ -176,7 +184,7 @@ export const connectorProxyCommand: CliCommandDefinition<ConnectorProxyInput> = 
                 Buffer.byteLength(JSON.stringify(proxyRequest)),
             ),
             has_body: hasProxyBody(proxyRequest),
-            identity_source: identitySource,
+            identity_source: identity?.source ?? "personal",
             method: readProxyMethod(proxyRequest),
         });
 

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -1,5 +1,5 @@
 import type { CliCommandDefinition, CliExecutionContext } from "../../contracts/cli.ts";
-import type { ConnectorIdentity } from "./identity.ts";
+import type { TeamIdentity } from "../team/identity.ts";
 import type {
     ConnectorActionAsyncLifecycle,
     ConnectorActionRunResponse,
@@ -17,7 +17,11 @@ import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
 import { readJsonInputValue } from "../shared/json-input.ts";
 import { TerminalProgressRenderer } from "../shared/terminal-progress-renderer.ts";
-import { resolveConnectorIdentityWithEnv } from "./identity.ts";
+import {
+    requireValidTeamIdentity,
+    resolveTeamIdentity,
+} from "../team/identity.ts";
+import { connectorTeamAccount } from "./identity.ts";
 import {
     deleteConnectorActionSchemaCache,
     isConnectorActionSchemaNotFoundError,
@@ -186,19 +190,22 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
         }
 
         const settings = await context.settingsStore.read();
-        const { identity, source: identitySource } = target.kind === "self_hosted"
-            ? { identity: {}, source: "personal" as const }
-            : await resolveConnectorIdentityWithEnv(
-                    {
-                        configTeam: getConfiguredIdentityTeam(settings),
-                        // A dry run never sends the execution request that
-                        // needs the team id, so it must not pay (or fail on)
-                        // the OO_TEAM_NAME membership request.
-                        resolveEnvTeamId: input.dryRun !== true,
-                        target,
-                        teamFlag,
-                        personalFlag: input.personal === true,
-                    },
+        const identity = target.kind === "self_hosted"
+            ? undefined
+            : requireValidTeamIdentity(
+                    await resolveTeamIdentity(
+                        {
+                            account: connectorTeamAccount(target),
+                            configuredTeam: getConfiguredIdentityTeam(settings),
+                            teamFlag,
+                            personalFlag: input.personal === true,
+                            // A dry run never sends the execution request that
+                            // needs the completed identity, so it must not pay
+                            // (or fail on) the validation lookup.
+                            resolveAgainstBackend: input.dryRun !== true,
+                        },
+                        context,
+                    ),
                     context,
                 );
         const inputData = await readJsonInputValue(
@@ -216,7 +223,7 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
                 Buffer.byteLength(JSON.stringify(inputData)),
             ),
             dry_run: input.dryRun === true,
-            identity_source: identitySource,
+            identity_source: identity?.source ?? "personal",
             service: input.serviceName,
             wait: input.wait === true,
             wait_result: input.waitResult === true,
@@ -351,7 +358,7 @@ async function runConnectorActionWithDefaultMode(
     options: {
         actionName: string;
         connectionSelector: ConnectorConnectionSelector | undefined;
-        identity: ConnectorIdentity;
+        identity: TeamIdentity | undefined;
         inputData: unknown;
         progressReporter: ConnectorAsyncLifecycleProgressReporter | undefined;
         resultLifecycle: ConnectorActionAsyncResultLifecycle | undefined;
@@ -419,7 +426,7 @@ async function runConnectorAsyncSubmitAndWaitForResult(
     options: {
         actionName: string;
         connectionSelector: ConnectorConnectionSelector | undefined;
-        identity: ConnectorIdentity;
+        identity: TeamIdentity | undefined;
         inputData: unknown;
         progressReporter: ConnectorAsyncLifecycleProgressReporter | undefined;
         resultLifecycle: ConnectorActionAsyncResultLifecycle;
@@ -488,7 +495,7 @@ async function waitForConnectorAsyncResult(
     options: {
         actionName: string;
         connectionSelector: ConnectorConnectionSelector | undefined;
-        identity: ConnectorIdentity;
+        identity: TeamIdentity | undefined;
         inputData: unknown;
         lifecycle: ConnectorActionAsyncResultLifecycle;
         progressReporter: ConnectorAsyncLifecycleProgressReporter | undefined;

--- a/src/application/commands/connector/search-provider.ts
+++ b/src/application/commands/connector/search-provider.ts
@@ -1,7 +1,7 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { TerminalColors } from "../../terminal-colors.ts";
 
-import type { ConnectorIdentity } from "./identity.ts";
+import type { TeamIdentity } from "../team/identity.ts";
 import type { ConnectorActionSearchResult } from "./shared.ts";
 import type { ConnectorTarget } from "./target.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
@@ -23,7 +23,7 @@ type ConnectorSearchTextContext = Pick<CliExecutionContext, "stdout" | "translat
 
 export async function loadConnectorSearchResults(
     options: {
-        identity?: ConnectorIdentity;
+        identity?: TeamIdentity | undefined;
         target: Pick<
             ConnectorTarget,
             "authorization" | "baseUrl" | "cacheAccountId" | "cacheEndpoint" | "kind"

--- a/src/application/commands/connector/search.ts
+++ b/src/application/commands/connector/search.ts
@@ -9,7 +9,11 @@ import {
 } from "../../telemetry/buckets.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
-import { resolveConnectorIdentityWithEnv } from "./identity.ts";
+import {
+    requireValidTeamIdentity,
+    resolveTeamIdentity,
+} from "../team/identity.ts";
+import { connectorTeamAccount } from "./identity.ts";
 import {
     formatConnectorSearchResultsAsText,
     loadConnectorSearchResults,
@@ -83,21 +87,25 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
         }
 
         const settings = await context.settingsStore.read();
-        const { identity, source: identitySource } = target.kind === "self_hosted"
-            ? { identity: {}, source: "personal" as const }
-            : await resolveConnectorIdentityWithEnv(
-                    {
-                        configTeam: getConfiguredIdentityTeam(settings),
-                        target,
-                        teamFlag,
-                        personalFlag: input.personal === true,
-                    },
+        const identity = target.kind === "self_hosted"
+            ? undefined
+            : requireValidTeamIdentity(
+                    await resolveTeamIdentity(
+                        {
+                            account: connectorTeamAccount(target),
+                            configuredTeam: getConfiguredIdentityTeam(settings),
+                            teamFlag,
+                            personalFlag: input.personal === true,
+                            resolveAgainstBackend: true,
+                        },
+                        context,
+                    ),
                     context,
                 );
 
         context.telemetry?.recordProperties({
             connector_kind: target.kind,
-            identity_source: identitySource,
+            identity_source: identity?.source ?? "personal",
         });
 
         const results = await loadConnectorSearchResults(

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -295,7 +295,10 @@ describe("connector shared requests", () => {
                 actionName: "send_mail",
                 target: createConnectorTargetFixture(),
                 identity: {
-                    team: "acme",
+                    name: "acme",
+                    id: null,
+                    source: "config",
+                    status: null,
                 },
                 inputData: {
                     to: "foo@bar.com",
@@ -436,7 +439,10 @@ describe("connector shared requests", () => {
             {
                 target: createConnectorTargetFixture(),
                 identity: {
-                    team: "acme",
+                    name: "acme",
+                    id: null,
+                    source: "config",
+                    status: null,
                 },
                 proxyRequest: {
                     endpoint: "/search",

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -1,6 +1,6 @@
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 
-import type { ConnectorIdentity } from "./identity.ts";
+import type { TeamIdentity } from "../team/identity.ts";
 import type { ConnectorRequestTarget } from "./target.ts";
 import { Buffer } from "node:buffer";
 import { z } from "zod";
@@ -196,7 +196,7 @@ type ConnectorActionFailureResponse = z.output<typeof connectorActionFailureResp
 
 export async function searchConnectorActions(
     options: {
-        identity?: ConnectorIdentity;
+        identity?: TeamIdentity | undefined;
         target: ConnectorRequestTarget;
         text: string;
     },
@@ -262,7 +262,7 @@ export async function searchConnectorActions(
 // envelope; the self-hosted runtime simply ignores the `status` filter.
 export async function listConnectorApps(
     options: {
-        identity?: ConnectorIdentity;
+        identity?: TeamIdentity | undefined;
         target: ConnectorRequestTarget;
     },
     context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
@@ -293,7 +293,7 @@ export async function listConnectorApps(
 
 export async function listConnectorAppsByService(
     options: {
-        identity?: ConnectorIdentity;
+        identity?: TeamIdentity | undefined;
         serviceName: string;
         target: ConnectorRequestTarget;
     },
@@ -412,7 +412,7 @@ export async function runConnectorAction(
     options: {
         actionName: string;
         connectionSelector?: ConnectorConnectionSelector;
-        identity?: ConnectorIdentity;
+        identity?: TeamIdentity | undefined;
         inputData: unknown;
         serviceName: string;
         target: ConnectorRequestTarget;
@@ -541,7 +541,7 @@ export async function runConnectorAction(
 
 export async function runConnectorProxy(
     options: {
-        identity?: ConnectorIdentity;
+        identity?: TeamIdentity | undefined;
         proxyRequest: unknown;
         serviceName: string;
         target: ConnectorRequestTarget;

--- a/src/application/commands/search.cli.test.ts
+++ b/src/application/commands/search.cli.test.ts
@@ -129,6 +129,66 @@ describe("searchCommand CLI", () => {
         }
     });
 
+    test("validates the OO_TEAM_ID env team and sends both identity headers", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            sandbox.env.OO_TEAM_ID = "team-1";
+
+            const requests: Request[] = [];
+            const result = await sandbox.run(
+                ["search", "send mail"],
+                {
+                    fetcher: async (input, init) => {
+                        const request = toRequest(input, init);
+
+                        requests.push(request);
+
+                        if (new URL(request.url).pathname.startsWith("/v1/teams/")) {
+                            return new Response(JSON.stringify({
+                                id: "team-1",
+                                name: "acme",
+                                role: "member",
+                                system_created: false,
+                            }));
+                        }
+
+                        return new Response(JSON.stringify({
+                            success: true,
+                            message: "ok",
+                            data: [],
+                        }));
+                    },
+                },
+            );
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
+
+            expect(result.exitCode).toBe(0);
+            // The id is validated and completed first, then the search request
+            // carries both identity dimensions.
+            expect(requests).toHaveLength(2);
+            expect(requests[0]?.url).toBe(
+                "https://relation-control.oomol.com/v1/teams/team-1",
+            );
+            expect(requests[1]?.headers.get("x-oo-team-id")).toBe("team-1");
+            expect(requests[1]?.headers.get("x-oo-team-name")).toBe("acme");
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    command_full: "search",
+                    identity_source: "env_id",
+                },
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("supports connector search with json output", async () => {
         const sandbox = await createCliSandbox();
 

--- a/src/application/commands/search.ts
+++ b/src/application/commands/search.ts
@@ -8,7 +8,7 @@ import {
     bucketTelemetryCount,
     bucketTelemetryStringLength,
 } from "../telemetry/buckets.ts";
-import { resolveConnectorIdentityWithEnv } from "./connector/identity.ts";
+import { connectorTeamAccount } from "./connector/identity.ts";
 import {
     formatConnectorSearchResultsAsText,
     loadConnectorSearchResults,
@@ -16,6 +16,10 @@ import {
 import { resolveConnectorTarget } from "./connector/target.ts";
 import { jsonOutputOptions, writeJsonOutput } from "./json-output.ts";
 import { createFormatInputError } from "./shared/input-parsing.ts";
+import {
+    requireValidTeamIdentity,
+    resolveTeamIdentity,
+} from "./team/identity.ts";
 
 const searchFormatValues = ["json"] as const;
 
@@ -85,21 +89,25 @@ export const searchCommand: CliCommandDefinition<SearchInput> = {
         }
 
         const settings = await context.settingsStore.read();
-        const { identity, source: identitySource } = target.kind === "self_hosted"
-            ? { identity: {}, source: "personal" as const }
-            : await resolveConnectorIdentityWithEnv(
-                    {
-                        configTeam: getConfiguredIdentityTeam(settings),
-                        target,
-                        teamFlag,
-                        personalFlag: input.personal === true,
-                    },
+        const identity = target.kind === "self_hosted"
+            ? undefined
+            : requireValidTeamIdentity(
+                    await resolveTeamIdentity(
+                        {
+                            account: connectorTeamAccount(target),
+                            configuredTeam: getConfiguredIdentityTeam(settings),
+                            teamFlag,
+                            personalFlag: input.personal === true,
+                            resolveAgainstBackend: true,
+                        },
+                        context,
+                    ),
                     context,
                 );
 
         context.telemetry?.recordProperties({
             connector_kind: target.kind,
-            identity_source: identitySource,
+            identity_source: identity?.source ?? "personal",
         });
 
         const results = await loadConnectorSearchResults(

--- a/src/application/commands/team/identity.ts
+++ b/src/application/commands/team/identity.ts
@@ -121,11 +121,6 @@ const teamNameStatusTranslationKeys = {
  * could not answer passes through, because the gateway sees every execution
  * request anyway and stays the final judge — the CLI must not turn its own
  * connectivity problem into a verdict about the team.
- *
- * The connector commands migrate onto this gate in the next stacked PR; the
- * tag below only bridges knip until that lands.
- *
- * @public
  */
 export function requireValidTeamIdentity(
     identity: TeamIdentity | undefined,


### PR DESCRIPTION
## Summary

The five connector-family commands (`connector run`, `connector proxy`,
`connector apps`, `connector search`, `search`) resolve their team identity
through `team/identity.ts` instead of the connector-local
`resolveConnectorIdentityWithEnv`, and gate execution with
`requireValidTeamIdentity`. `connector/identity.ts` keeps only the genuinely
connector-specific edge: `connectorIdentityHeaders` (now consuming the
shared `TeamIdentity` record) and the new `connectorTeamAccount` bridge from
a connector target to the lookup credential.

Behavior changes (docs updated in both languages):

- `OO_TEAM_ID` is now validated before execution through the same lookup
  `oo auth status` uses, and the resolved name travels alongside the id, so
  requests carry both identity headers. A definite backend refusal (not a
  member, not found, deleted) fails with exit `1` via the new
  `errors.team.envIdNotAccessible` error instead of sending a bogus id.
- An `OO_TEAM_NAME` membership lookup that cannot complete no longer aborts
  the run: the name is sent on its own and the gateway stays the final
  judge. A name definitely not accessible still fails as before.
- `--dry-run` stays fully offline for both variables.

The `ConnectorIdentity` record and its source enum are gone; internal
plumbing and the search provider carry `TeamIdentity | undefined`, with the
personal identity as `undefined` rather than an empty object. Telemetry
properties and enums are unchanged (`identity_source` still reports
personal/flag/env_id/env_name/config).

---
Stacked PR 2/3, on top of #313.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #313
2. **#314** 👈 current
3. #315
<!-- stack:links:end -->