### PR TITLE
refactor(connector): land the connector session module

### DIFF
--- a/src/application/commands/connector/apps.ts
+++ b/src/application/commands/connector/apps.ts
@@ -4,24 +4,21 @@ import type { TerminalColors } from "../../terminal-colors.ts";
 import type { ConnectorAppView } from "./shared.ts";
 
 import { z } from "zod";
-import { CliUserError } from "../../contracts/cli.ts";
-import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
-import {
-    requireValidTeamIdentity,
-    resolveTeamIdentity,
-} from "../team/identity.ts";
-import { connectorTeamAccount } from "./identity.ts";
 import { connectorSearchServiceColor } from "./search-provider.ts";
+import {
+    resolveConnectorSession,
+    teamIdentityInputShape,
+    teamIdentityOptions,
+} from "./session.ts";
 import {
     connectorFormatValues,
     listConnectorApps,
     listConnectorAppsByService,
 } from "./shared.ts";
-import { resolveConnectorTarget } from "./target.ts";
 
 // Connector app connection statuses (from the apps API) mapped to the terminal
 // color that conveys their health at a glance. Unknown statuses fall back to a
@@ -68,70 +65,33 @@ export const connectorAppsCommand: CliCommandDefinition<ConnectorAppsInput> = {
         },
     ],
     options: [
-        {
-            name: "team",
-            longFlag: "--team",
-            valueName: "team",
-            descriptionKey: "options.connectorAppsTeam",
-        },
-        {
-            name: "personal",
-            longFlag: "--personal",
-            descriptionKey: "options.connectorAppsPersonal",
-        },
+        ...teamIdentityOptions({
+            personal: "options.connectorAppsPersonal",
+            team: "options.connectorAppsTeam",
+        }),
         ...jsonOutputOptions,
     ],
     inputSchema: z.object({
         format: z.enum(connectorFormatValues).optional(),
-        team: z.string().optional(),
-        personal: z.boolean().optional(),
+        ...teamIdentityInputShape,
         serviceName: z.string().optional(),
         showSchemaVersion: z.boolean().optional(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        if (input.personal === true && input.team !== undefined) {
-            throw new CliUserError("errors.connectorRun.identityConflict", 2);
-        }
-
-        const teamFlag = input.team?.trim();
-        if (input.team !== undefined && teamFlag === "") {
-            throw new CliUserError("errors.connectorRun.teamEmpty", 2);
-        }
-
         const serviceName = input.serviceName?.trim();
         const hasService = serviceName !== undefined && serviceName !== "";
         const listScope: ConnectorAppsListScope = hasService ? "service" : "all";
 
-        const target = await resolveConnectorTarget(context);
-
-        // Mirrors `connector run`: the self-hosted runtime has no team
-        // concept, so an explicit --team is rejected and any configured
-        // default identity is ignored.
-        if (target.kind === "self_hosted" && teamFlag !== undefined) {
-            throw new CliUserError("errors.connector.teamUnsupported", 2);
-        }
-
-        const settings = await context.settingsStore.read();
-        const identity = target.kind === "self_hosted"
-            ? undefined
-            : requireValidTeamIdentity(
-                    await resolveTeamIdentity(
-                        {
-                            account: connectorTeamAccount(target),
-                            configuredTeam: getConfiguredIdentityTeam(settings),
-                            teamFlag,
-                            personalFlag: input.personal === true,
-                            resolveAgainstBackend: true,
-                        },
-                        context,
-                    ),
-                    context,
-                );
+        const { identity, target } = await resolveConnectorSession(
+            {
+                personal: input.personal,
+                team: input.team,
+            },
+            context,
+        );
 
         context.telemetry?.recordProperties({
-            connector_kind: target.kind,
-            identity_source: identity?.source ?? "personal",
             list_scope: listScope,
         });
 

--- a/src/application/commands/connector/proxy.ts
+++ b/src/application/commands/connector/proxy.ts
@@ -4,21 +4,19 @@ import type { ConnectorProxyResponse } from "./shared.ts";
 import { Buffer } from "node:buffer";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
 import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
 import { readJsonInputValue } from "../shared/json-input.ts";
 import {
-    requireValidTeamIdentity,
-    resolveTeamIdentity,
-} from "../team/identity.ts";
-import { connectorTeamAccount } from "./identity.ts";
+    resolveConnectorSession,
+    teamIdentityInputShape,
+    teamIdentityOptions,
+} from "./session.ts";
 import {
     connectorFormatValues,
     runConnectorProxy,
 } from "./shared.ts";
-import { resolveConnectorTarget } from "./target.ts";
 import { recordConnectorFailureTelemetry } from "./telemetry.ts";
 
 const connectorProxyDataErrorKeys = {
@@ -114,17 +112,10 @@ export const connectorProxyCommand: CliCommandDefinition<ConnectorProxyInput> = 
             valueName: "body",
             descriptionKey: "options.connectorProxyBody",
         },
-        {
-            name: "team",
-            longFlag: "--team",
-            valueName: "team",
-            descriptionKey: "options.connectorProxyTeam",
-        },
-        {
-            name: "personal",
-            longFlag: "--personal",
-            descriptionKey: "options.connectorProxyPersonal",
-        },
+        ...teamIdentityOptions({
+            personal: "options.connectorProxyPersonal",
+            team: "options.connectorProxyTeam",
+        }),
         ...jsonOutputOptions,
     ],
     inputSchema: z.object({
@@ -134,57 +125,29 @@ export const connectorProxyCommand: CliCommandDefinition<ConnectorProxyInput> = 
         format: z.enum(connectorFormatValues).optional(),
         headers: z.string().optional(),
         method: z.string().optional(),
-        team: z.string().optional(),
-        personal: z.boolean().optional(),
+        ...teamIdentityInputShape,
         query: z.string().optional(),
         serviceName: z.string(),
         showSchemaVersion: z.boolean().optional(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        if (input.personal === true && input.team !== undefined) {
-            throw new CliUserError("errors.connectorRun.identityConflict", 2);
-        }
-
-        const teamFlag = input.team?.trim();
-        if (input.team !== undefined && teamFlag === "") {
-            throw new CliUserError("errors.connectorRun.teamEmpty", 2);
-        }
-
+        // Payload parsing must stay ahead of the session: proxy usage errors
+        // are reported before any login requirement.
         const proxyRequest = await buildConnectorProxyRequest(input, context);
-        const target = await resolveConnectorTarget(context);
-
-        // Mirrors `connector run`: the self-hosted runtime has no team
-        // concept, so an explicit --team is rejected and any configured
-        // default identity is ignored.
-        if (target.kind === "self_hosted" && teamFlag !== undefined) {
-            throw new CliUserError("errors.connector.teamUnsupported", 2);
-        }
-
-        const settings = await context.settingsStore.read();
-        const identity = target.kind === "self_hosted"
-            ? undefined
-            : requireValidTeamIdentity(
-                    await resolveTeamIdentity(
-                        {
-                            account: connectorTeamAccount(target),
-                            configuredTeam: getConfiguredIdentityTeam(settings),
-                            teamFlag,
-                            personalFlag: input.personal === true,
-                            resolveAgainstBackend: true,
-                        },
-                        context,
-                    ),
-                    context,
-                );
+        const { identity, target } = await resolveConnectorSession(
+            {
+                personal: input.personal,
+                team: input.team,
+            },
+            context,
+        );
 
         context.telemetry?.recordProperties({
-            connector_kind: target.kind,
             data_size_bucket: bucketTelemetryBytes(
                 Buffer.byteLength(JSON.stringify(proxyRequest)),
             ),
             has_body: hasProxyBody(proxyRequest),
-            identity_source: identity?.source ?? "personal",
             method: readProxyMethod(proxyRequest),
         });
 

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -10,7 +10,6 @@ import type { ConnectorTarget } from "./target.ts";
 import { Buffer } from "node:buffer";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
 import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
@@ -18,21 +17,20 @@ import { createFormatInputError } from "../shared/input-parsing.ts";
 import { readJsonInputValue } from "../shared/json-input.ts";
 import { TerminalProgressRenderer } from "../shared/terminal-progress-renderer.ts";
 import {
-    requireValidTeamIdentity,
-    resolveTeamIdentity,
-} from "../team/identity.ts";
-import { connectorTeamAccount } from "./identity.ts";
-import {
     deleteConnectorActionSchemaCache,
     isConnectorActionSchemaNotFoundError,
     loadConnectorActionSchema,
 } from "./schema-cache.ts";
 import {
+    resolveConnectorSession,
+    teamIdentityInputShape,
+    teamIdentityOptions,
+} from "./session.ts";
+import {
     connectorFormatValues,
     requireConnectorActionName,
     runConnectorAction,
 } from "./shared.ts";
-import { resolveConnectorTarget } from "./target.ts";
 import { recordConnectorFailureTelemetry } from "./telemetry.ts";
 import { validateConnectorActionInput } from "./validation.ts";
 
@@ -127,17 +125,10 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             longFlag: "--wait-result",
             descriptionKey: "options.connectorRunWaitResult",
         },
-        {
-            name: "team",
-            longFlag: "--team",
-            valueName: "team",
-            descriptionKey: "options.connectorRunTeam",
-        },
-        {
-            name: "personal",
-            longFlag: "--personal",
-            descriptionKey: "options.connectorRunPersonal",
-        },
+        ...teamIdentityOptions({
+            personal: "options.connectorRunPersonal",
+            team: "options.connectorRunTeam",
+        }),
         ...jsonOutputOptions,
     ],
     inputSchema: z.object({
@@ -146,8 +137,7 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
         data: z.string().optional(),
         dryRun: z.boolean().optional(),
         format: z.enum(connectorFormatValues).optional(),
-        team: z.string().optional(),
-        personal: z.boolean().optional(),
+        ...teamIdentityInputShape,
         serviceName: z.string(),
         showSchemaVersion: z.boolean().optional(),
         wait: z.boolean().optional(),
@@ -161,10 +151,6 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             throw new CliUserError("errors.connectorRun.waitModeConflict", 2);
         }
 
-        if (input.personal === true && input.team !== undefined) {
-            throw new CliUserError("errors.connectorRun.identityConflict", 2);
-        }
-
         const connectionName = input.connectionName?.trim();
         if (input.connectionName !== undefined && connectionName === "") {
             throw new CliUserError("errors.connectorRun.connectionNameEmpty", 2);
@@ -174,40 +160,18 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
         // legacy `x-oo-connector-alias` header.
         const connectionSelector
             = connectionName === undefined ? undefined : { connectionName };
-        const teamFlag = input.team?.trim();
-        if (input.team !== undefined && teamFlag === "") {
-            throw new CliUserError("errors.connectorRun.teamEmpty", 2);
-        }
 
-        const target = await resolveConnectorTarget(context);
-
-        // The self-hosted runtime is single-user and has no team concept: an
-        // explicit --team is a hard error, while a configured `identity.team`
-        // default is silently ignored so a shared config does not break
-        // self-hosted usage.
-        if (target.kind === "self_hosted" && teamFlag !== undefined) {
-            throw new CliUserError("errors.connector.teamUnsupported", 2);
-        }
-
-        const settings = await context.settingsStore.read();
-        const identity = target.kind === "self_hosted"
-            ? undefined
-            : requireValidTeamIdentity(
-                    await resolveTeamIdentity(
-                        {
-                            account: connectorTeamAccount(target),
-                            configuredTeam: getConfiguredIdentityTeam(settings),
-                            teamFlag,
-                            personalFlag: input.personal === true,
-                            // A dry run never sends the execution request that
-                            // needs the completed identity, so it must not pay
-                            // (or fail on) the validation lookup.
-                            resolveAgainstBackend: input.dryRun !== true,
-                        },
-                        context,
-                    ),
-                    context,
-                );
+        const { identity, target } = await resolveConnectorSession(
+            {
+                personal: input.personal,
+                team: input.team,
+                // A dry run never sends the execution request that needs the
+                // completed identity, so it must not pay (or fail on) the
+                // validation lookup.
+                resolveAgainstBackend: input.dryRun !== true,
+            },
+            context,
+        );
         const inputData = await readJsonInputValue(
             input.data,
             context,
@@ -218,12 +182,10 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
         context.telemetry?.recordProperties({
             action: actionName,
             connection_selector: connectionSelector === undefined ? "none" : "connectionName",
-            connector_kind: target.kind,
             data_size_bucket: bucketTelemetryBytes(
                 Buffer.byteLength(JSON.stringify(inputData)),
             ),
             dry_run: input.dryRun === true,
-            identity_source: identity?.source ?? "personal",
             service: input.serviceName,
             wait: input.wait === true,
             wait_result: input.waitResult === true,

--- a/src/application/commands/connector/search.ts
+++ b/src/application/commands/connector/search.ts
@@ -1,8 +1,6 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
-import { CliUserError } from "../../contracts/cli.ts";
-import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
 import {
     bucketTelemetryCount,
     bucketTelemetryStringLength,
@@ -10,16 +8,15 @@ import {
 import { jsonOutputOptions, writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
 import {
-    requireValidTeamIdentity,
-    resolveTeamIdentity,
-} from "../team/identity.ts";
-import { connectorTeamAccount } from "./identity.ts";
-import {
     formatConnectorSearchResultsAsText,
     loadConnectorSearchResults,
 } from "./search-provider.ts";
+import {
+    resolveConnectorSession,
+    teamIdentityInputShape,
+    teamIdentityOptions,
+} from "./session.ts";
 import { connectorFormatValues } from "./shared.ts";
-import { resolveConnectorTarget } from "./target.ts";
 
 interface ConnectorSearchInput {
     format?: (typeof connectorFormatValues)[number];
@@ -42,71 +39,31 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
         },
     ],
     options: [
-        {
-            name: "team",
-            longFlag: "--team",
-            valueName: "team",
-            descriptionKey: "options.searchTeam",
-        },
-        {
-            name: "personal",
-            longFlag: "--personal",
-            descriptionKey: "options.searchPersonal",
-        },
+        ...teamIdentityOptions({
+            personal: "options.searchPersonal",
+            team: "options.searchTeam",
+        }),
         ...jsonOutputOptions,
     ],
     inputSchema: z.object({
         format: z.enum(connectorFormatValues).optional(),
-        team: z.string().optional(),
-        personal: z.boolean().optional(),
+        ...teamIdentityInputShape,
         showSchemaVersion: z.boolean().optional(),
         text: z.string(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        if (input.personal === true && input.team !== undefined) {
-            throw new CliUserError("errors.connectorRun.identityConflict", 2);
-        }
-
-        const teamFlag = input.team?.trim();
-        if (input.team !== undefined && teamFlag === "") {
-            throw new CliUserError("errors.connectorRun.teamEmpty", 2);
-        }
-
         context.telemetry?.recordProperties({
             query_length_bucket: bucketTelemetryStringLength(input.text),
         });
 
-        const target = await resolveConnectorTarget(context);
-
-        // Mirrors `connector run`: the self-hosted runtime has no team concept,
-        // so an explicit --team is rejected and any configured default identity
-        // is ignored.
-        if (target.kind === "self_hosted" && teamFlag !== undefined) {
-            throw new CliUserError("errors.connector.teamUnsupported", 2);
-        }
-
-        const settings = await context.settingsStore.read();
-        const identity = target.kind === "self_hosted"
-            ? undefined
-            : requireValidTeamIdentity(
-                    await resolveTeamIdentity(
-                        {
-                            account: connectorTeamAccount(target),
-                            configuredTeam: getConfiguredIdentityTeam(settings),
-                            teamFlag,
-                            personalFlag: input.personal === true,
-                            resolveAgainstBackend: true,
-                        },
-                        context,
-                    ),
-                    context,
-                );
-
-        context.telemetry?.recordProperties({
-            connector_kind: target.kind,
-            identity_source: identity?.source ?? "personal",
-        });
+        const { identity, target } = await resolveConnectorSession(
+            {
+                personal: input.personal,
+                team: input.team,
+            },
+            context,
+        );
 
         const results = await loadConnectorSearchResults(
             {

--- a/src/application/commands/connector/session.test.ts
+++ b/src/application/commands/connector/session.test.ts
@@ -1,0 +1,361 @@
+import type { CliTelemetryPropertyValue, Fetcher } from "../../contracts/cli.ts";
+import type { AuthFile } from "../../schemas/auth.ts";
+import type { ConnectorFile } from "../../schemas/connector.ts";
+import type { AppSettings } from "../../schemas/settings.ts";
+
+import { describe, expect, test } from "bun:test";
+import pino from "pino";
+
+import {
+    createAuthStore,
+    createInMemoryConnectorStore,
+    createSettingsStore,
+    expectCliUserError,
+} from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
+import { resolveConnectorSession, teamIdentityOptions } from "./session.ts";
+
+const testAccount = {
+    id: "user-1",
+    name: "Test User",
+    apiKey: "api-secret-1",
+    endpoint: "oomol.com",
+};
+
+const teamsResponse = {
+    teams: [
+        { id: "team-1", name: "acme", role: "creator", system_created: false },
+    ],
+};
+
+const teamByIdResponse = {
+    id: "team-1",
+    name: "platform",
+    role: "member",
+    system_created: false,
+};
+
+describe("resolveConnectorSession flag guards", () => {
+    test("rejects combining --team and --personal before resolving anything", async () => {
+        // No auth on the context: the guard must fire before target
+        // resolution gets a chance to demand a login.
+        const context = createSessionContext();
+
+        const error = await expectCliUserError(
+            resolveConnectorSession({ personal: true, team: "acme" }, context),
+        );
+
+        expect(error.key).toBe("errors.connectorRun.identityConflict");
+        expect(error.exitCode).toBe(2);
+        expect(context.requests).toHaveLength(0);
+    });
+
+    test.each([
+        { case: "an empty --team value", team: "" },
+        { case: "a whitespace --team value", team: "   " },
+    ])("rejects $case", async ({ team }) => {
+        const context = createSessionContext();
+
+        const error = await expectCliUserError(
+            resolveConnectorSession({ team }, context),
+        );
+
+        expect(error.key).toBe("errors.connectorRun.teamEmpty");
+        expect(error.exitCode).toBe(2);
+        expect(context.requests).toHaveLength(0);
+    });
+
+    test("rejects --team for a self-hosted target", async () => {
+        const context = createSessionContext({
+            env: { OO_CONNECTOR_URL: "http://localhost:3000" },
+        });
+
+        const error = await expectCliUserError(
+            resolveConnectorSession({ team: "acme" }, context),
+        );
+
+        expect(error.key).toBe("errors.connector.teamUnsupported");
+        expect(error.exitCode).toBe(2);
+        expect(context.requests).toHaveLength(0);
+    });
+});
+
+describe("resolveConnectorSession on a self-hosted target", () => {
+    test("pins the personal identity, ignoring the config default and the env team", async () => {
+        const context = createSessionContext({
+            env: {
+                OO_CONNECTOR_URL: "http://localhost:3000",
+                OO_CONNECTOR_TOKEN: "oct_1",
+                OO_TEAM_ID: "team-1",
+                OO_TEAM_NAME: "acme",
+            },
+            settings: { identity: { team: "acme" } },
+        });
+
+        const session = await resolveConnectorSession({}, context);
+
+        expect(session.identity).toBeUndefined();
+        expect(session.target).toEqual({
+            authorization: "Bearer oct_1",
+            baseUrl: "http://localhost:3000",
+            cacheAccountId: "self-hosted",
+            cacheEndpoint: "http://localhost:3000",
+            kind: "self_hosted",
+        });
+        expect(context.requests).toHaveLength(0);
+        expect(context.recordedProperties).toEqual([
+            { connector_kind: "self_hosted", identity_source: "personal" },
+        ]);
+    });
+});
+
+describe("resolveConnectorSession identity ladder", () => {
+    test("resolves to personal when nothing selects a team", async () => {
+        const context = createSessionContext({ auth: authFileWith(testAccount) });
+
+        const session = await resolveConnectorSession({}, context);
+
+        expect(session.identity).toBeUndefined();
+        expect(session.target).toEqual({
+            authorization: "api-secret-1",
+            baseUrl: "https://connector.oomol.com",
+            cacheAccountId: "user-1",
+            cacheEndpoint: "oomol.com",
+            kind: "oomol",
+        });
+        expect(context.recordedProperties).toEqual([
+            { connector_kind: "oomol", identity_source: "personal" },
+        ]);
+    });
+
+    test("forces the personal identity with --personal over the config default and env team", async () => {
+        const context = createSessionContext({
+            auth: authFileWith(testAccount),
+            env: { OO_TEAM_ID: "team-1" },
+            settings: { identity: { team: "acme" } },
+        });
+
+        const session = await resolveConnectorSession({ personal: true }, context);
+
+        expect(session.identity).toBeUndefined();
+        expect(context.requests).toHaveLength(0);
+        expect(context.recordedProperties).toEqual([
+            { connector_kind: "oomol", identity_source: "personal" },
+        ]);
+    });
+
+    test("trims the --team flag and selects it without a lookup", async () => {
+        const context = createSessionContext({
+            auth: authFileWith(testAccount),
+            env: { OO_TEAM_ID: "team-1" },
+            settings: { identity: { team: "config-team" } },
+        });
+
+        const session = await resolveConnectorSession({ team: "  acme  " }, context);
+
+        expect(session.identity).toEqual({
+            name: "acme",
+            id: null,
+            source: "flag",
+            status: null,
+        });
+        expect(context.requests).toHaveLength(0);
+        expect(context.recordedProperties).toEqual([
+            { connector_kind: "oomol", identity_source: "flag" },
+        ]);
+    });
+
+    test("selects the config default when no flag or env override is set", async () => {
+        const context = createSessionContext({
+            auth: authFileWith(testAccount),
+            settings: { identity: { team: "acme" } },
+        });
+
+        const session = await resolveConnectorSession({}, context);
+
+        expect(session.identity).toEqual({
+            name: "acme",
+            id: null,
+            source: "config",
+            status: null,
+        });
+        expect(context.requests).toHaveLength(0);
+    });
+
+    test("validates the OO_TEAM_ID env team with the target's credential", async () => {
+        const context = createSessionContext({
+            auth: authFileWith(testAccount),
+            env: { OO_TEAM_ID: "team-1" },
+            fetcher: async () => new Response(JSON.stringify(teamByIdResponse)),
+        });
+
+        const session = await resolveConnectorSession({}, context);
+
+        expect(session.identity).toEqual({
+            name: "platform",
+            id: "team-1",
+            source: "env_id",
+            status: "valid",
+            envVar: "OO_TEAM_ID",
+        });
+        expect(context.requests).toHaveLength(1);
+        // The lookup authenticates with the connector target's credential
+        // against the account endpoint the target resolved.
+        expect(context.requests[0]!.url).toBe(
+            "https://relation-control.oomol.com/v1/teams/team-1",
+        );
+        expect(context.requests[0]!.authorization).toBe("api-secret-1");
+        expect(context.recordedProperties).toEqual([
+            { connector_kind: "oomol", identity_source: "env_id" },
+        ]);
+    });
+
+    test("resolves the OO_TEAM_NAME env team through the memberships", async () => {
+        const context = createSessionContext({
+            auth: authFileWith(testAccount),
+            env: { OO_TEAM_NAME: "acme" },
+            fetcher: async () => new Response(JSON.stringify(teamsResponse)),
+        });
+
+        const session = await resolveConnectorSession({}, context);
+
+        expect(session.identity).toEqual({
+            name: "acme",
+            id: "team-1",
+            source: "env_name",
+            status: "valid",
+            envVar: "OO_TEAM_NAME",
+        });
+        expect(context.requests[0]!.url).toBe(
+            "https://relation-control.oomol.com/v1/me/teams",
+        );
+    });
+});
+
+describe("resolveConnectorSession backend policy", () => {
+    test("skips the env team lookup when resolveAgainstBackend is false", async () => {
+        const context = createSessionContext({
+            auth: authFileWith(testAccount),
+            env: { OO_TEAM_ID: "team-1" },
+        });
+
+        const session = await resolveConnectorSession(
+            { resolveAgainstBackend: false },
+            context,
+        );
+
+        expect(session.identity).toEqual({
+            name: null,
+            id: "team-1",
+            source: "env_id",
+            status: null,
+            envVar: "OO_TEAM_ID",
+        });
+        expect(context.requests).toHaveLength(0);
+    });
+
+    test("blocks the run when the backend refuses the env team", async () => {
+        const context = createSessionContext({
+            auth: authFileWith(testAccount),
+            env: { OO_TEAM_ID: "team-9" },
+            fetcher: async () => new Response("", { status: 404 }),
+        });
+
+        const error = await expectCliUserError(
+            resolveConnectorSession({}, context),
+        );
+
+        expect(error.key).toBe("errors.team.envIdNotAccessible");
+        expect(error.exitCode).toBe(1);
+    });
+
+    test("proceeds with the bare env team when the lookup cannot complete", async () => {
+        const context = createSessionContext({
+            auth: authFileWith(testAccount),
+            env: { OO_TEAM_ID: "team-1" },
+            fetcher: async () => {
+                throw new Error("network down");
+            },
+        });
+
+        const session = await resolveConnectorSession({}, context);
+
+        expect(session.identity).toEqual({
+            name: null,
+            id: "team-1",
+            source: "env_id",
+            status: "request_failed",
+            envVar: "OO_TEAM_ID",
+        });
+        expect(context.recordedProperties).toEqual([
+            { connector_kind: "oomol", identity_source: "env_id" },
+        ]);
+    });
+});
+
+describe("teamIdentityOptions", () => {
+    test("declares the shared flags with the caller's description keys", () => {
+        expect(teamIdentityOptions({
+            personal: "options.connectorRunPersonal",
+            team: "options.connectorRunTeam",
+        })).toEqual([
+            {
+                name: "team",
+                longFlag: "--team",
+                valueName: "team",
+                descriptionKey: "options.connectorRunTeam",
+            },
+            {
+                name: "personal",
+                longFlag: "--personal",
+                descriptionKey: "options.connectorRunPersonal",
+            },
+        ]);
+    });
+});
+
+function authFileWith(account: typeof testAccount): AuthFile {
+    return { auth: [account], id: account.id };
+}
+
+function createSessionContext(
+    options: {
+        auth?: AuthFile;
+        connectorFile?: ConnectorFile;
+        env?: Record<string, string | undefined>;
+        fetcher?: Fetcher;
+        settings?: AppSettings;
+    } = {},
+) {
+    const requests: Array<{ url: string; authorization: string | null }> = [];
+    const recordedProperties: Array<Record<string, CliTelemetryPropertyValue>> = [];
+    const fetcher = options.fetcher ?? (async () => new Response("{}"));
+
+    return {
+        authStore: createAuthStore(options.auth ?? { auth: [], id: "" }),
+        connectorStore: createInMemoryConnectorStore(options.connectorFile ?? {}),
+        env: options.env ?? {},
+        fetcher: (async (url, init) => {
+            requests.push({
+                url: url.toString(),
+                authorization: new Headers(init?.headers).get("Authorization"),
+            });
+
+            return fetcher(url, init);
+        }) satisfies Fetcher,
+        logger: pino({ enabled: false }),
+        settingsStore: createSettingsStore(options.settings ?? {}),
+        telemetry: {
+            directoryPath: "",
+            recordProperties: (
+                properties: Record<string, CliTelemetryPropertyValue>,
+            ) => {
+                recordedProperties.push(properties);
+            },
+            suppressCurrentInvocation: () => {},
+        },
+        translator: createTranslator("en"),
+        recordedProperties,
+        requests,
+    };
+}

--- a/src/application/commands/connector/session.ts
+++ b/src/application/commands/connector/session.ts
@@ -1,0 +1,139 @@
+// The connector session: which connector server this invocation talks to, and
+// under whose team identity — resolved once, behind one call. Handlers do
+// their own pure input validation first, then everything identity-shaped
+// happens here: the --team/--personal flag guards, target resolution, the
+// self-hosted team rejection, the configured default, the team identity
+// ladder with its execution gate, and the identity telemetry.
+//
+// The self-hosted runtime is single-user and has no team concept: an explicit
+// --team is a hard error, while a configured `identity.team` default or a
+// team env override is silently ignored so a shared config does not break
+// self-hosted usage. This module is the only place that rule exists.
+
+import type { CliExecutionContext, CliOptionDefinition } from "../../contracts/cli.ts";
+import type { TeamIdentity } from "../team/identity.ts";
+import type { ConnectorTarget } from "./target.ts";
+
+import { z } from "zod";
+import { CliUserError } from "../../contracts/cli.ts";
+import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
+import {
+    requireValidTeamIdentity,
+    resolveTeamIdentity,
+} from "../team/identity.ts";
+import { connectorTeamAccount } from "./identity.ts";
+import { resolveConnectorTarget } from "./target.ts";
+
+export interface ConnectorSession {
+    // The effective team identity; undefined is the personal identity,
+    // whether picked explicitly, by default, or pinned by a self-hosted
+    // target.
+    identity: TeamIdentity | undefined;
+    target: ConnectorTarget;
+}
+
+export type ConnectorSessionContext = Pick<
+    CliExecutionContext,
+    | "authStore"
+    | "connectorStore"
+    | "env"
+    | "fetcher"
+    | "logger"
+    | "settingsStore"
+    | "telemetry"
+    | "translator"
+>;
+
+/**
+ * Resolves the connector session from the raw `--team` / `--personal` input.
+ *
+ * Guards fire before any resolution: combining the two flags or passing a
+ * blank `--team` is a usage error, and a self-hosted target rejects `--team`
+ * outright. The team identity then resolves through the one ladder
+ * (`--personal` > `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` > `identity.team` >
+ * personal) with the target's credential backing the env lookups, and
+ * `requireValidTeamIdentity` gates execution on the outcome.
+ *
+ * `resolveAgainstBackend: false` (a dry run) keeps the resolution fully
+ * offline. Records the `connector_kind` and `identity_source` telemetry
+ * properties on success.
+ */
+export async function resolveConnectorSession(
+    options: {
+        personal?: boolean;
+        team?: string;
+        resolveAgainstBackend?: boolean;
+    },
+    context: ConnectorSessionContext,
+): Promise<ConnectorSession> {
+    if (options.personal === true && options.team !== undefined) {
+        throw new CliUserError("errors.connectorRun.identityConflict", 2);
+    }
+
+    const teamFlag = options.team?.trim();
+
+    if (options.team !== undefined && teamFlag === "") {
+        throw new CliUserError("errors.connectorRun.teamEmpty", 2);
+    }
+
+    const target = await resolveConnectorTarget(context);
+
+    if (target.kind === "self_hosted" && teamFlag !== undefined) {
+        throw new CliUserError("errors.connector.teamUnsupported", 2);
+    }
+
+    const settings = await context.settingsStore.read();
+    const identity = target.kind === "self_hosted"
+        ? undefined
+        : requireValidTeamIdentity(
+                await resolveTeamIdentity(
+                    {
+                        account: connectorTeamAccount(target),
+                        configuredTeam: getConfiguredIdentityTeam(settings),
+                        teamFlag,
+                        personalFlag: options.personal === true,
+                        resolveAgainstBackend: options.resolveAgainstBackend !== false,
+                    },
+                    context,
+                ),
+                context,
+            );
+
+    context.telemetry?.recordProperties({
+        connector_kind: target.kind,
+        identity_source: identity?.source ?? "personal",
+    });
+
+    return { identity, target };
+}
+
+/**
+ * The `--team` / `--personal` option pair every session-resolving command
+ * declares. Flags and value names live here once; each command supplies its
+ * own description keys so the help text keeps its verb.
+ */
+export function teamIdentityOptions(descriptionKeys: {
+    personal: string;
+    team: string;
+}): readonly CliOptionDefinition[] {
+    return [
+        {
+            name: "team",
+            longFlag: "--team",
+            valueName: "team",
+            descriptionKey: descriptionKeys.team,
+        },
+        {
+            name: "personal",
+            longFlag: "--personal",
+            descriptionKey: descriptionKeys.personal,
+        },
+    ];
+}
+
+// The input-schema counterpart of teamIdentityOptions, spread into each
+// command's zod object so the field pair cannot drift across commands.
+export const teamIdentityInputShape = {
+    personal: z.boolean().optional(),
+    team: z.string().optional(),
+};

--- a/src/application/commands/connector/target.ts
+++ b/src/application/commands/connector/target.ts
@@ -50,7 +50,10 @@ export type ConnectorRequestTarget = Pick<
  *    nobody is logged in).
  */
 export async function resolveConnectorTarget(
-    context: CliExecutionContext,
+    context: Pick<
+        CliExecutionContext,
+        "authStore" | "connectorStore" | "env" | "logger"
+    >,
 ): Promise<ConnectorTarget> {
     const envSelfHosted = readEnvSelfHostedConnectorConfig(context.env);
 

--- a/src/application/commands/search.ts
+++ b/src/application/commands/search.ts
@@ -2,24 +2,21 @@ import type { CliCommandDefinition } from "../contracts/cli.ts";
 
 import { z } from "zod";
 
-import { CliUserError } from "../contracts/cli.ts";
-import { getConfiguredIdentityTeam } from "../schemas/settings.ts";
 import {
     bucketTelemetryCount,
     bucketTelemetryStringLength,
 } from "../telemetry/buckets.ts";
-import { connectorTeamAccount } from "./connector/identity.ts";
 import {
     formatConnectorSearchResultsAsText,
     loadConnectorSearchResults,
 } from "./connector/search-provider.ts";
-import { resolveConnectorTarget } from "./connector/target.ts";
+import {
+    resolveConnectorSession,
+    teamIdentityInputShape,
+    teamIdentityOptions,
+} from "./connector/session.ts";
 import { jsonOutputOptions, writeJsonOutput } from "./json-output.ts";
 import { createFormatInputError } from "./shared/input-parsing.ts";
-import {
-    requireValidTeamIdentity,
-    resolveTeamIdentity,
-} from "./team/identity.ts";
 
 const searchFormatValues = ["json"] as const;
 
@@ -44,71 +41,31 @@ export const searchCommand: CliCommandDefinition<SearchInput> = {
         },
     ],
     options: [
-        {
-            name: "team",
-            longFlag: "--team",
-            valueName: "team",
-            descriptionKey: "options.searchTeam",
-        },
-        {
-            name: "personal",
-            longFlag: "--personal",
-            descriptionKey: "options.searchPersonal",
-        },
+        ...teamIdentityOptions({
+            personal: "options.searchPersonal",
+            team: "options.searchTeam",
+        }),
         ...jsonOutputOptions,
     ],
     inputSchema: z.object({
         format: z.enum(searchFormatValues).optional(),
-        team: z.string().optional(),
-        personal: z.boolean().optional(),
+        ...teamIdentityInputShape,
         showSchemaVersion: z.boolean().optional(),
         text: z.string(),
     }),
     mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        if (input.personal === true && input.team !== undefined) {
-            throw new CliUserError("errors.connectorRun.identityConflict", 2);
-        }
-
-        const teamFlag = input.team?.trim();
-        if (input.team !== undefined && teamFlag === "") {
-            throw new CliUserError("errors.connectorRun.teamEmpty", 2);
-        }
-
         context.telemetry?.recordProperties({
             query_length_bucket: bucketTelemetryStringLength(input.text),
         });
 
-        const target = await resolveConnectorTarget(context);
-
-        // Mirrors `connector run`: the self-hosted runtime has no team concept,
-        // so an explicit --team is rejected and any configured default identity
-        // is ignored.
-        if (target.kind === "self_hosted" && teamFlag !== undefined) {
-            throw new CliUserError("errors.connector.teamUnsupported", 2);
-        }
-
-        const settings = await context.settingsStore.read();
-        const identity = target.kind === "self_hosted"
-            ? undefined
-            : requireValidTeamIdentity(
-                    await resolveTeamIdentity(
-                        {
-                            account: connectorTeamAccount(target),
-                            configuredTeam: getConfiguredIdentityTeam(settings),
-                            teamFlag,
-                            personalFlag: input.personal === true,
-                            resolveAgainstBackend: true,
-                        },
-                        context,
-                    ),
-                    context,
-                );
-
-        context.telemetry?.recordProperties({
-            connector_kind: target.kind,
-            identity_source: identity?.source ?? "personal",
-        });
+        const { identity, target } = await resolveConnectorSession(
+            {
+                personal: input.personal,
+                team: input.team,
+            },
+            context,
+        );
 
         const results = await loadConnectorSearchResults(
             {


### PR DESCRIPTION
## What

"Which connector server do I talk to, and under whose team identity" was a 7-step ritual copy-pasted into five command handlers (`connector run` / `proxy` / `apps` / `search` and the top-level `search`): the `--team`/`--personal` flag guards, target resolution, the self-hosted team rejection, the settings read, the identity ladder with its execution gate, and the `connector_kind` / `identity_source` telemetry. Only `run.ts` passed the dry-run offline flag — a divergence invisible because the other four simply omitted the field.

This PR lands `connector/session.ts`:

- `resolveConnectorSession(options, context)` owns the whole ritual behind one call and returns `{ target, identity }`.
- `teamIdentityOptions(descriptionKeys)` and `teamIdentityInputShape` keep the option descriptors and zod fields in one place; each command keeps its own help-text keys, so help output is unchanged.
- The precedence matrix (`--personal` > `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` > `identity.team` > personal), the guards, the fail-open gate policy, and the self-hosted pinning are table-tested once at the session seam in `session.test.ts`.
- `resolveConnectorTarget`'s context narrows to the exact Pick its callees need.

Each migrated handler loses ~30 lines and 3 imports.

## Accepted behavior deltas

Compound-invalid invocations and failure-path telemetry recording points only; single-error paths, help text, wire headers, and JSON shapes are unchanged:

- Handler-specific input validation now uniformly precedes the identity flag guards, so a doubly-invalid invocation reports the input error first (e.g. proxy payload errors before the `--team`/`--personal` conflict). In the degenerate `proxy --data @unreadable-file --personal --team x` corner the exit code changes 2 → 1 (the payload error wins).
- `connector run --data` failures now record `connector_kind` and `identity_source`; both search commands' flag-guard failures now record `query_length_bucket`. Telemetry property sets on success are unchanged and the telemetry-decision manifest is untouched.

## Notes

- Stacked PR 1/2 — the follow-up makes `ConnectorTarget` honest about its fields (opaque cache scope + oomol-only account endpoint).
- No docs changes: the user-facing CLI contract is unchanged (error precedence between two simultaneous usage errors is not documented behavior).

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#318** 👈 current
2. #319
<!-- stack:links:end -->