### PR TITLE
refactor(shared): land the oo-request module, migrate variables and team

### DIFF
--- a/src/application/commands/shared/oo-request.test.ts
+++ b/src/application/commands/shared/oo-request.test.ts
@@ -1,0 +1,753 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+
+import {
+    createConnectionRefusedError,
+    createFailedToOpenSocketError,
+    createLogCapture,
+} from "../../../../__tests__/helpers.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
+import { CliUserError } from "../../contracts/cli.ts";
+import { billingTokenRechargeUrl } from "./billing.ts";
+import {
+    isNetworkRestrictedSandboxError,
+    probeOo,
+    requestOo,
+    requestOoResponse,
+} from "./oo-request.ts";
+
+const itemSchema = z.object({ name: z.string() });
+
+describe("requestOo", () => {
+    test.each([
+        {
+            expectedUrl: "https://relation-control.oomol.com/v1/me/teams",
+            host: { endpoint: "oomol.com", service: "relation-control" } as const,
+            path: "/v1/me/teams",
+            title: "service host",
+        },
+        {
+            expectedUrl: "https://fusion-api.oomol.com/v1/file-upload/action/create-multipart-upload",
+            host: { endpoint: "oomol.com", service: "fusion-api" } as const,
+            path: "/v1/file-upload/action/create-multipart-upload",
+            title: "second service host",
+        },
+        {
+            expectedUrl: "http://localhost:3000/prefix/v1/actions",
+            host: { baseUrl: "http://localhost:3000/prefix" },
+            path: "/v1/actions",
+            title: "base URL keeps a self-hosted path prefix",
+        },
+        {
+            expectedUrl: "https://cli-api.oomol.com/v1/variables/a%2Fb%20c",
+            host: { endpoint: "oomol.com", service: "cli-api" } as const,
+            path: `/v1/variables/${encodeURIComponent("a/b c")}`,
+            title: "pre-encoded path segment",
+        },
+    ])("builds the request URL from a $title", async ({ expectedUrl, host, path }) => {
+        await withRequestCapture(async (capture) => {
+            const result = await requestOo({
+                context: capture.context,
+                errors: { scope: "team" },
+                host,
+                label: "Team list",
+                path,
+                schema: itemSchema,
+            });
+
+            expect(result).toEqual({ name: "a" });
+            expect(capture.requests[0]?.url).toBe(expectedUrl);
+        });
+    });
+
+    test("appends query params including repeated array keys in order", async () => {
+        await withRequestCapture(async (capture) => {
+            await requestOo({
+                context: capture.context,
+                errors: { scope: "skillsSearch" },
+                host: { endpoint: "oomol.com", service: "search" },
+                label: "Skills search",
+                path: "/v1/packages/-/skills-search",
+                query: {
+                    keywords: ["bar", "baz"],
+                    size: "10",
+                    text: "send mail",
+                },
+                schema: itemSchema,
+            });
+
+            const url = new URL(capture.requests[0]?.url ?? "");
+
+            expect(url.searchParams.getAll("keywords")).toEqual(["bar", "baz"]);
+            expect(url.searchParams.get("size")).toBe("10");
+            expect(url.search).toContain("text=send+mail");
+        });
+    });
+
+    test("preserves a query embedded in a full-URL host with no path", async () => {
+        await withRequestCapture(async (capture) => {
+            await requestOo({
+                context: capture.context,
+                errors: { scope: "team" },
+                host: { baseUrl: "https://example.com/files/report.txt?download=1" },
+                label: "Team list",
+                schema: itemSchema,
+            });
+
+            expect(capture.requests[0]?.url).toBe(
+                "https://example.com/files/report.txt?download=1",
+            );
+        });
+    });
+
+    test("sends no Authorization header when authorization is absent", async () => {
+        await withRequestCapture(async (capture) => {
+            await requestOo({
+                context: capture.context,
+                errors: { scope: "packageInfo" },
+                host: { endpoint: "oomol.com", service: "registry" },
+                label: "Package info",
+                path: "/-/oomol/package-info/a/latest",
+                schema: itemSchema,
+            });
+
+            expect(capture.requests[0]?.headers).toEqual({});
+        });
+    });
+
+    test("sends the authorization value verbatim and merges extras over defaults", async () => {
+        await withRequestCapture(async (capture) => {
+            await requestOo({
+                authorization: "Bearer token-1",
+                context: capture.context,
+                errors: { scope: "llmJson" },
+                headers: { Accept: "application/json" },
+                host: { baseUrl: "https://llm.oomol.com/v1" },
+                jsonBody: { messages: [] },
+                label: "LLM chat completions",
+                method: "POST",
+                path: "/chat/completions",
+                schema: itemSchema,
+            });
+
+            const request = capture.requests[0];
+
+            expect(request?.headers).toEqual({
+                "Accept": "application/json",
+                "Authorization": "Bearer token-1",
+                "Content-Type": "application/json",
+            });
+            expect(request?.method).toBe("POST");
+            expect(request?.body).toBe(JSON.stringify({ messages: [] }));
+        });
+    });
+
+    test.each([
+        { body: "not json", title: "non-JSON body" },
+        { body: JSON.stringify({ name: 42 }), title: "schema mismatch" },
+    ])("maps a $title to the scope invalidResponse error", async ({ body }) => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response(body, { status: 200 }));
+
+            await expect(requestOo({
+                context: capture.context,
+                errors: { scope: "variables" },
+                host: { endpoint: "oomol.com", service: "cli-api" },
+                label: "Variables list",
+                path: "/v1/variables",
+                schema: itemSchema,
+            })).rejects.toMatchObject({
+                exitCode: 1,
+                key: "errors.variables.invalidResponse",
+            });
+        });
+    });
+
+    test.each([
+        {
+            expectedKey: "errors.skills.install.invalidPackageInfo",
+            response: () => new Response("nope", { status: 200 }),
+            title: "decode failure",
+        },
+        {
+            expectedKey: "errors.skills.install.packageInfoRequestFailed",
+            response: () => new Response("missing", { status: 404 }),
+            title: "non-success status",
+        },
+        {
+            expectedKey: "errors.skills.install.packageInfoRequestError",
+            response: () => {
+                throw new Error("network down");
+            },
+            title: "transport failure",
+        },
+    ])("uses explicit error keys for an irregular-namespace $title", async ({ expectedKey, response }) => {
+        await withRequestCapture(async (capture) => {
+            await expect(requestOo({
+                context: {
+                    ...capture.context,
+                    fetcher: async () => response(),
+                },
+                errors: {
+                    invalidResponse: "errors.skills.install.invalidPackageInfo",
+                    requestError: "errors.skills.install.packageInfoRequestError",
+                    requestFailed: "errors.skills.install.packageInfoRequestFailed",
+                },
+                host: { endpoint: "oomol.com", service: "registry" },
+                label: "Skills install package info",
+                path: "/-/oomol/package-info/a/latest",
+                schema: itemSchema,
+            })).rejects.toMatchObject({
+                key: expectedKey,
+            });
+        });
+    });
+
+    test("maps a non-success status to the scope requestFailed error", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response("missing", { status: 404 }));
+
+            await expect(requestOo({
+                context: capture.context,
+                errors: { scope: "team" },
+                host: { endpoint: "oomol.com", service: "relation-control" },
+                label: "Team list",
+                path: "/v1/me/teams",
+                schema: itemSchema,
+            })).rejects.toMatchObject({
+                exitCode: 1,
+                key: "errors.team.requestFailed",
+                params: { status: 404 },
+            });
+        });
+    });
+
+    test("prefers a statusErrors match and falls through on undefined", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response("gone", { status: 404 }));
+
+            const request = () => requestOo({
+                context: capture.context,
+                errors: { scope: "variables" },
+                host: { endpoint: "oomol.com", service: "cli-api" },
+                label: "Variables get",
+                path: "/v1/variables/k",
+                schema: itemSchema,
+                statusErrors: failure => failure.status === 404
+                    ? new CliUserError("errors.variables.notFound", 1, { name: "k" })
+                    : undefined,
+            });
+
+            await expect(request()).rejects.toMatchObject({
+                key: "errors.variables.notFound",
+                params: { name: "k" },
+            });
+
+            capture.respondWith(new Response("boom", { status: 500 }));
+            await expect(request()).rejects.toMatchObject({
+                key: "errors.variables.requestFailed",
+                params: { status: 500 },
+            });
+        });
+    });
+
+    test("passes the failure body to statusErrors and the nonSuccess log resolver", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response("{\"errorCode\":\"bad\"}", { status: 422 }));
+            let seenBodyText: string | undefined;
+
+            await expect(requestOo({
+                context: capture.context,
+                errors: { scope: "connectorRun" },
+                host: { baseUrl: "https://connector.oomol.com" },
+                label: "Connector action run",
+                logFields: {
+                    nonSuccess: failure => ({
+                        responseBodyLength: failure.bodyText?.length,
+                    }),
+                },
+                path: "/v1/actions/a.b",
+                schema: itemSchema,
+                statusErrors: (failure) => {
+                    seenBodyText = failure.bodyText;
+
+                    return new CliUserError("errors.connectorRun.requestFailedWithCode", 1, {
+                        errorCode: "bad",
+                        status: failure.status,
+                    });
+                },
+            })).rejects.toMatchObject({
+                key: "errors.connectorRun.requestFailedWithCode",
+            });
+
+            expect(seenBodyText).toBe("{\"errorCode\":\"bad\"}");
+            expect(capture.logs()).toContain("\"responseBodyLength\":19");
+        });
+    });
+
+    test("hands statusErrors an undefined body when the failure body is unreadable", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response(createBrokenBodyStream(), { status: 500 }));
+            let seenBodyText: string | undefined = "sentinel";
+
+            await expect(requestOo({
+                context: capture.context,
+                errors: { scope: "team" },
+                host: { endpoint: "oomol.com", service: "relation-control" },
+                label: "Team list",
+                path: "/v1/me/teams",
+                schema: itemSchema,
+                statusErrors: (failure) => {
+                    seenBodyText = failure.bodyText;
+
+                    return undefined;
+                },
+            })).rejects.toMatchObject({
+                key: "errors.team.requestFailed",
+            });
+
+            expect(seenBodyText).toBeUndefined();
+        });
+    });
+
+    test("maps HTTP 402 to the billing error before statusErrors runs", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response("payment required", { status: 402 }));
+            let statusErrorsCalled = false;
+
+            await expect(requestOo({
+                context: capture.context,
+                errors: { scope: "variables" },
+                host: { endpoint: "oomol.com", service: "cli-api" },
+                label: "Variables list",
+                path: "/v1/variables",
+                schema: itemSchema,
+                statusErrors: () => {
+                    statusErrorsCalled = true;
+
+                    return undefined;
+                },
+            })).rejects.toMatchObject({
+                key: "errors.billing.insufficientCredit",
+                params: { url: billingTokenRechargeUrl },
+            });
+
+            expect(statusErrorsCalled).toBeFalse();
+        });
+    });
+
+    test("maps a transport error to the scope requestError error", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.failWith(new Error("network down"));
+
+            await expect(requestOo({
+                context: capture.context,
+                errors: { scope: "team" },
+                host: { endpoint: "oomol.com", service: "relation-control" },
+                label: "Team list",
+                path: "/v1/me/teams",
+                schema: itemSchema,
+            })).rejects.toMatchObject({
+                exitCode: 1,
+                key: "errors.team.requestError",
+                params: { message: "network down" },
+            });
+
+            expect(capture.logs()).toContain(
+                "\"msg\":\"Team list request failed unexpectedly.\"",
+            );
+        });
+    });
+
+    test.each([
+        { createError: createFailedToOpenSocketError, title: "socket" },
+        { createError: createConnectionRefusedError, title: "connection-refused" },
+    ])("appends the sandbox hint exactly once on a $title error", async ({ createError }) => {
+        await withRequestCapture(async (capture) => {
+            capture.failWith(createError("network down"));
+
+            await expect(requestOo({
+                context: capture.context,
+                errors: { scope: "team" },
+                host: { endpoint: "oomol.com", service: "relation-control" },
+                label: "Team list",
+                path: "/v1/me/teams",
+                schema: itemSchema,
+            })).rejects.toMatchObject({
+                key: "errors.team.requestError",
+                params: {
+                    message: "network down\nCurrent environment may be running in a "
+                        + "network-restricted sandbox. Try requesting elevated permissions.",
+                },
+            });
+        });
+    });
+
+    test("appends the localized sandbox hint under the zh translator", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.failWith(createFailedToOpenSocketError("network down"));
+
+            await expect(requestOo({
+                context: { ...capture.context, translator: createTranslator("zh") },
+                errors: { scope: "team" },
+                host: { endpoint: "oomol.com", service: "relation-control" },
+                label: "Team list",
+                path: "/v1/me/teams",
+                schema: itemSchema,
+            })).rejects.toMatchObject({
+                params: {
+                    message: "network down\n当前环境可能在网络受限的沙箱中，请尝试提权。",
+                },
+            });
+        });
+    });
+
+    test("lets unexpectedMessage override the transport message on a still-classifiable error", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.failWith(createConnectionRefusedError("refused"));
+            let sandboxClassifiable = false;
+
+            await expect(requestOo({
+                context: capture.context,
+                errors: { scope: "connectorApps" },
+                host: { baseUrl: "http://localhost:3000" },
+                label: "Connector apps list",
+                path: "/v1/apps",
+                schema: itemSchema,
+                unexpectedMessage: (error) => {
+                    sandboxClassifiable = isNetworkRestrictedSandboxError(error);
+
+                    return "self-hosted server unreachable";
+                },
+            })).rejects.toMatchObject({
+                key: "errors.connectorApps.requestError",
+                params: { message: "self-hosted server unreachable" },
+            });
+
+            expect(sandboxClassifiable).toBeTrue();
+        });
+    });
+
+    test("falls back to the hinted message when unexpectedMessage returns undefined", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.failWith(createFailedToOpenSocketError("network down"));
+
+            await expect(requestOo({
+                context: capture.context,
+                errors: { scope: "connectorApps" },
+                host: { baseUrl: "https://connector.oomol.com" },
+                label: "Connector apps list",
+                path: "/v1/apps",
+                schema: itemSchema,
+                unexpectedMessage: () => undefined,
+            })).rejects.toMatchObject({
+                params: {
+                    message: "network down\nCurrent environment may be running in a "
+                        + "network-restricted sandbox. Try requesting elevated permissions.",
+                },
+            });
+        });
+    });
+
+    test("maps a body read failure on a success response to requestError", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response(createBrokenBodyStream(), { status: 200 }));
+
+            await expect(requestOo({
+                context: capture.context,
+                errors: { scope: "team" },
+                host: { endpoint: "oomol.com", service: "relation-control" },
+                label: "Team list",
+                path: "/v1/me/teams",
+                schema: itemSchema,
+            })).rejects.toMatchObject({
+                key: "errors.team.requestError",
+            });
+        });
+    });
+
+    test("logs lifecycle fields including method, bodyLength, and durationMs", async () => {
+        await withRequestCapture(async (capture) => {
+            await requestOo({
+                context: capture.context,
+                errors: { scope: "variables" },
+                host: { endpoint: "oomol.com", service: "cli-api" },
+                jsonBody: { value: "v" },
+                label: "Variables create",
+                logFields: {
+                    common: { name: "k" },
+                    start: { traceId: "trace-1" },
+                    success: response => ({ finalStatus: response.status }),
+                },
+                method: "PUT",
+                path: "/v1/variables/k",
+                schema: itemSchema,
+            });
+
+            const logs = capture.logs();
+
+            expect(logs).toContain("\"msg\":\"Variables create request started.\"");
+            expect(logs).toContain("\"msg\":\"Variables create request completed.\"");
+            expect(logs).toContain("\"method\":\"PUT\"");
+            expect(logs).toContain(`"bodyLength":${JSON.stringify({ value: "v" }).length}`);
+            expect(logs).toContain("\"traceId\":\"trace-1\"");
+            expect(logs).toContain("\"finalStatus\":200");
+            expect(logs).toContain("\"name\":\"k\"");
+            expect(logs).toContain("\"durationMs\":");
+            expect(logs).toContain("\"endpoint\":\"cli-api.oomol.com\"");
+            expect(logs).toContain("\"path\":\"/v1/variables/k\"");
+        });
+    });
+});
+
+describe("requestOoResponse", () => {
+    test("returns the response with its body unconsumed", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response("raw bytes", { status: 200 }));
+
+            const response = await requestOoResponse({
+                context: capture.context,
+                errors: { scope: "fileDownload" },
+                host: { baseUrl: "https://example.com/files/report.txt" },
+                label: "File download",
+            });
+
+            expect(response.status).toBe(200);
+            expect(await response.text()).toBe("raw bytes");
+        });
+    });
+
+    test("lets an allowed status bypass failure handling with a readable body", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response("range start", { status: 416 }));
+            let statusErrorsCalled = false;
+
+            const response = await requestOoResponse({
+                allowedStatuses: [416],
+                context: capture.context,
+                errors: { scope: "fileDownload" },
+                host: { baseUrl: "https://example.com/files/report.txt" },
+                label: "File download",
+                statusErrors: () => {
+                    statusErrorsCalled = true;
+
+                    return undefined;
+                },
+            });
+
+            expect(response.status).toBe(416);
+            expect(await response.text()).toBe("range start");
+            expect(statusErrorsCalled).toBeFalse();
+            expect(capture.logs()).not.toContain("non-success");
+        });
+    });
+
+    test("lets an allowed status bypass even the credit check", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response("payment required", { status: 402 }));
+
+            const response = await requestOoResponse({
+                allowedStatuses: [402],
+                context: capture.context,
+                errors: { scope: "fileDownload" },
+                host: { baseUrl: "https://example.com/files/report.txt" },
+                label: "File download",
+            });
+
+            expect(response.status).toBe(402);
+        });
+    });
+
+    test("maps a disallowed status through the pair scope requestFailed", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response("missing", { status: 404 }));
+
+            await expect(requestOoResponse({
+                context: capture.context,
+                errors: { scope: "fileDownload" },
+                host: { baseUrl: "https://example.com/files/report.txt" },
+                label: "File download",
+            })).rejects.toMatchObject({
+                key: "errors.fileDownload.requestFailed",
+                params: { status: 404 },
+            });
+        });
+    });
+
+    test("sends a raw body without an automatic content type", async () => {
+        await withRequestCapture(async (capture) => {
+            const partBytes = new Uint8Array([1, 2, 3]);
+
+            await requestOoResponse({
+                body: partBytes,
+                context: capture.context,
+                errors: { scope: "fileUpload" },
+                headers: { "Content-Type": "application/octet-stream" },
+                host: { baseUrl: "https://storage.example.com/part-1?signature=s" },
+                label: "File upload part",
+                method: "PUT",
+            });
+
+            const request = capture.requests[0];
+
+            expect(request?.body).toBe(partBytes);
+            expect(request?.headers).toEqual({
+                "Content-Type": "application/octet-stream",
+            });
+        });
+    });
+});
+
+describe("probeOo", () => {
+    test("returns the status and body text on any response", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response("{\"teams\":[]}", { status: 403 }));
+
+            const result = await probeOo({
+                authorization: "secret-1",
+                context: { fetcher: capture.context.fetcher, logger: capture.context.logger },
+                host: { endpoint: "oomol.com", service: "relation-control" },
+                label: "Team lookup",
+                logFields: { direction: "id" },
+                path: "/v1/teams/team-1",
+            });
+
+            expect(result).toEqual({
+                bodyText: "{\"teams\":[]}",
+                kind: "response",
+                status: 403,
+            });
+            expect(capture.requests[0]?.headers).toEqual({ Authorization: "secret-1" });
+            expect(capture.logs()).toContain("\"msg\":\"Team lookup request started.\"");
+            expect(capture.logs()).toContain("\"msg\":\"Team lookup request completed.\"");
+            expect(capture.logs()).toContain("\"direction\":\"id\"");
+        });
+    });
+
+    test("keeps the status and yields no body text when the body read fails", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.respondWith(new Response(createBrokenBodyStream(), { status: 200 }));
+
+            const result = await probeOo({
+                context: { fetcher: capture.context.fetcher, logger: capture.context.logger },
+                host: { endpoint: "oomol.com", service: "api" },
+                label: "Auth status",
+                path: "/v1/users/profile",
+            });
+
+            expect(result).toEqual({
+                bodyText: undefined,
+                kind: "response",
+                status: 200,
+            });
+        });
+    });
+
+    test("classifies a thrown fetch error without throwing", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.failWith(new Error("boom"));
+
+            const result = await probeOo({
+                context: { fetcher: capture.context.fetcher, logger: capture.context.logger },
+                host: { endpoint: "oomol.com", service: "api" },
+                label: "Auth status",
+                path: "/v1/users/profile",
+            });
+
+            expect(result).toEqual({ kind: "failed" });
+            expect(capture.logs()).toContain(
+                "\"msg\":\"Auth status request failed unexpectedly.\"",
+            );
+        });
+    });
+
+    test("classifies a sandbox network error as failed_sandbox", async () => {
+        await withRequestCapture(async (capture) => {
+            capture.failWith(createFailedToOpenSocketError("network down"));
+
+            const result = await probeOo({
+                context: { fetcher: capture.context.fetcher, logger: capture.context.logger },
+                host: { endpoint: "oomol.com", service: "api" },
+                label: "Auth status",
+                path: "/v1/users/profile",
+            });
+
+            expect(result).toEqual({ kind: "failed_sandbox" });
+        });
+    });
+});
+
+interface CapturedRequest {
+    body: unknown;
+    headers: Record<string, string>;
+    method: string;
+    url: string;
+}
+
+interface RequestCapture {
+    context: {
+        fetcher: (url: URL | string | Request, init?: RequestInit) => Promise<Response>;
+        logger: ReturnType<typeof createLogCapture>["logger"];
+        translator: ReturnType<typeof createTranslator>;
+    };
+    failWith: (error: Error) => void;
+    logs: () => string;
+    requests: CapturedRequest[];
+    respondWith: (response: Response) => void;
+}
+
+async function withRequestCapture(
+    run: (capture: RequestCapture) => Promise<void>,
+): Promise<void> {
+    const logCapture = createLogCapture();
+    const requests: CapturedRequest[] = [];
+    let nextResponse: Response | undefined;
+    let nextError: Error | undefined;
+
+    const capture: RequestCapture = {
+        context: {
+            fetcher: async (url, init) => {
+                requests.push({
+                    body: init?.body,
+                    headers: { ...(init?.headers as Record<string, string> | undefined) },
+                    method: init?.method ?? "GET",
+                    url: url.toString(),
+                });
+
+                if (nextError !== undefined) {
+                    throw nextError;
+                }
+
+                return nextResponse ?? new Response(JSON.stringify({ name: "a" }), {
+                    status: 200,
+                });
+            },
+            logger: logCapture.logger,
+            translator: createTranslator("en"),
+        },
+        failWith: (error) => {
+            nextError = error;
+        },
+        logs: () => logCapture.read(),
+        requests,
+        respondWith: (response) => {
+            nextResponse = response;
+            nextError = undefined;
+        },
+    };
+
+    try {
+        await run(capture);
+    }
+    finally {
+        logCapture.close();
+    }
+}
+
+function createBrokenBodyStream(): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            controller.error(new Error("body stream failed"));
+        },
+    });
+}

--- a/src/application/commands/shared/oo-request.ts
+++ b/src/application/commands/shared/oo-request.ts
@@ -1,0 +1,471 @@
+import type { MessageKey } from "../../../i18n/catalog.ts";
+import type { CliExecutionContext } from "../../contracts/cli.ts";
+
+import { CliUserError } from "../../contracts/cli.ts";
+import { withRequestTarget } from "../../logging/log-fields.ts";
+import {
+    createInsufficientCreditError,
+    isInsufficientCreditHttpStatus,
+} from "./billing.ts";
+
+type OoRequestContext = Pick<CliExecutionContext, "fetcher" | "logger" | "translator">;
+type LogFields = Record<string, unknown>;
+
+export const failedToOpenSocketErrorCode = "FailedToOpenSocket";
+export const connectionRefusedErrorCode = "ConnectionRefused";
+
+const networkRestrictedSandboxErrorCodes = [
+    failedToOpenSocketErrorCode,
+    connectionRefusedErrorCode,
+] as const;
+
+type NetworkRestrictedSandboxErrorCode
+    = typeof networkRestrictedSandboxErrorCodes[number];
+
+// The service subdomains an oo request may target. The host template
+// `https://<service>.<endpoint>` lives in this module only; the one sanctioned
+// second site is `llm/config.ts`, whose base URL is itself user-facing output
+// and reaches this module as a `{ baseUrl }` host.
+type OoService
+    = | "api"
+        | "cli-api"
+        | "fusion-api"
+        | "registry"
+        | "relation-control"
+        | "search";
+
+export type OoRequestHost
+    = | { endpoint: string; service: OoService }
+        | { baseUrl: string };
+
+type ErrorScopeOf<Key, Suffix extends string>
+    = Key extends `errors.${infer Scope}.${Suffix}` ? Scope : never;
+
+// Scopes whose full error triplet exists in the catalog. Derived from the
+// catalog keys, so a typo'd scope is a type error rather than a raw key
+// leaking into user output.
+type OoTripletErrorScope
+    = ErrorScopeOf<MessageKey, "requestFailed">
+        & ErrorScopeOf<MessageKey, "requestError">
+        & ErrorScopeOf<MessageKey, "invalidResponse">;
+
+// Scopes carrying at least the requestFailed/requestError pair — what the raw
+// response path needs (`fileDownload` has no invalidResponse key, by design).
+// Caveat: `skills.publish` also matches, but its requestFailed template takes
+// a {message} param — its caller stays on a hand-rolled path (out of scope).
+type OoPairErrorScope
+    = ErrorScopeOf<MessageKey, "requestFailed">
+        & ErrorScopeOf<MessageKey, "requestError">;
+
+export type OoRequestErrors
+    = | { scope: OoTripletErrorScope }
+        | { invalidResponse: MessageKey; requestError: MessageKey; requestFailed: MessageKey };
+
+type OoResponseRequestErrors
+    = | { scope: OoPairErrorScope }
+        | { requestError: MessageKey; requestFailed: MessageKey };
+
+export interface OoRequestFailure {
+    /** Non-ok body read before throwing; undefined when the read fails. */
+    bodyText: string | undefined;
+    response: Response;
+    status: number;
+}
+
+export interface OoRequestLogFields {
+    /** Merged into every log call. */
+    common?: LogFields;
+    /** Extra warn fields on a non-ok response that will throw. */
+    nonSuccess?: (failure: OoRequestFailure) => LogFields;
+    start?: LogFields;
+    success?: (response: Response) => LogFields;
+}
+
+interface OoRequestBaseOptions {
+    /** Full header value (raw API key or `Bearer <token>`); absent → no header. */
+    authorization?: string;
+    context: OoRequestContext;
+    /** Extra headers; spread last, so they win over module-set defaults. */
+    headers?: Record<string, string>;
+    /** Serialized with JSON.stringify and sent with Content-Type: application/json. */
+    jsonBody?: unknown;
+    /** Log message prefix, e.g. "Variables list" → "Variables list request started." */
+    label: string;
+    host: OoRequestHost;
+    logFields?: OoRequestLogFields;
+    /** Defaults to GET. */
+    method?: string;
+    /** Appended to the host base; caller pre-encodes segments. Omit for full-URL hosts. */
+    path?: string;
+    /** Array values are appended per item, preserving order. */
+    query?: Record<string, string | readonly string[]>;
+    /** Status-specific error mapping; undefined falls through to requestFailed. */
+    statusErrors?: (failure: OoRequestFailure) => CliUserError | undefined;
+    /** Overrides the transport-error message; undefined keeps the hinted default. */
+    unexpectedMessage?: (error: unknown) => string | undefined;
+}
+
+interface OoRequestOptions<Value> extends OoRequestBaseOptions {
+    errors: OoRequestErrors;
+    schema: { parse: (input: unknown) => Value };
+}
+
+interface OoResponseRequestOptions extends OoRequestBaseOptions {
+    /** Statuses that bypass failure handling; the response returns body-unconsumed. */
+    allowedStatuses?: readonly number[];
+    /** Raw request body; no automatic Content-Type. Not combinable with jsonBody. */
+    body?: Bun.BodyInit;
+    errors: OoResponseRequestErrors;
+}
+
+export type OoProbeResult
+    = | { bodyText: string | undefined; kind: "response"; status: number }
+        | { kind: "failed" }
+        | { kind: "failed_sandbox" };
+
+interface OoProbeOptions {
+    authorization?: string;
+    context: Pick<CliExecutionContext, "fetcher" | "logger">;
+    host: OoRequestHost;
+    label: string;
+    /** Merged into every log call. */
+    logFields?: LogFields;
+    path: string;
+}
+
+// Performs an oo request and decodes the JSON body against the schema.
+// Owns host construction, the auth header, logging, credit detection, the
+// sandbox hint (exactly once), and the error-triplet mapping: non-ok →
+// requestFailed (or a statusErrors match), transport failures — including a
+// body read that dies on an ok response — → requestError, undecodable bodies
+// → invalidResponse.
+export async function requestOo<Value>(
+    options: OoRequestOptions<Value>,
+): Promise<Value> {
+    const keys = resolveTripletErrorKeys(options.errors);
+    const request = prepareOoRequest(options);
+    const response = await performOoFetch(options, request, keys, []);
+
+    let bodyText: string;
+
+    try {
+        bodyText = await response.text();
+    }
+    catch (error) {
+        throw createOoTransportError(options, request, keys.requestError, error);
+    }
+
+    try {
+        return options.schema.parse(JSON.parse(bodyText) as unknown);
+    }
+    catch {
+        throw new CliUserError(keys.invalidResponse, 1);
+    }
+}
+
+// The raw-response variant of requestOo for callers that stream, ignore, or
+// hand-parse the body. The response comes back with its body unconsumed;
+// statuses in allowedStatuses skip failure handling entirely.
+export async function requestOoResponse(
+    options: OoResponseRequestOptions,
+): Promise<Response> {
+    return await performOoFetch(
+        options,
+        prepareOoRequest(options),
+        resolvePairErrorKeys(options.errors),
+        options.allowedStatuses ?? [],
+    );
+}
+
+// The never-throw variant for diagnostic probes: any response comes back as a
+// status plus best-effort body text (a failed body read keeps the status), and
+// thrown fetch errors classify as failed / failed_sandbox. Callers own the
+// interpretation of both status and body.
+export async function probeOo(options: OoProbeOptions): Promise<OoProbeResult> {
+    const requestUrl = buildOoRequestUrl(options);
+    const baseFields = {
+        method: "GET",
+        ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+        ...options.logFields,
+    };
+    const requestStartedAt = Date.now();
+
+    options.context.logger.debug(baseFields, `${options.label} request started.`);
+
+    try {
+        const response = await options.context.fetcher(requestUrl, {
+            headers: options.authorization === undefined
+                ? {}
+                : { Authorization: options.authorization },
+        });
+        const bodyText = await readBodyTextSafely(response);
+
+        options.context.logger.debug(
+            {
+                durationMs: Date.now() - requestStartedAt,
+                ...baseFields,
+                status: response.status,
+            },
+            `${options.label} request completed.`,
+        );
+
+        return { bodyText, kind: "response", status: response.status };
+    }
+    catch (error) {
+        options.context.logger.warn(
+            {
+                durationMs: Date.now() - requestStartedAt,
+                err: error,
+                ...baseFields,
+            },
+            `${options.label} request failed unexpectedly.`,
+        );
+
+        return {
+            kind: isNetworkRestrictedSandboxError(error) ? "failed_sandbox" : "failed",
+        };
+    }
+}
+
+export function getUnexpectedRequestErrorMessage(
+    error: unknown,
+    translator: Pick<CliExecutionContext["translator"], "t">,
+): string {
+    const baseMessage = error instanceof Error ? error.message : String(error);
+
+    if (!isNetworkRestrictedSandboxError(error)) {
+        return baseMessage;
+    }
+
+    return `${baseMessage}\n${translator.t("errors.shared.networkRestrictedSandboxHint")}`;
+}
+
+export function isNetworkRestrictedSandboxError(
+    error: unknown,
+): error is Error & { code: NetworkRestrictedSandboxErrorCode } {
+    return error instanceof Error
+        && "code" in error
+        && typeof error.code === "string"
+        && (networkRestrictedSandboxErrorCodes as readonly string[]).includes(error.code);
+}
+
+interface PreparedOoRequest {
+    baseFields: LogFields;
+    body: Bun.BodyInit | undefined;
+    commonFields: LogFields;
+    method: string;
+    requestInit: RequestInit;
+    requestStartedAt: number;
+    requestUrl: URL;
+}
+
+interface FetchingOptions extends OoRequestBaseOptions {
+    body?: Bun.BodyInit;
+    errors: OoRequestErrors | OoResponseRequestErrors;
+}
+
+function prepareOoRequest(options: FetchingOptions): PreparedOoRequest {
+    if (options.jsonBody !== undefined && options.body !== undefined) {
+        throw new TypeError("jsonBody and body are mutually exclusive");
+    }
+
+    const requestUrl = buildOoRequestUrl(options);
+    const method = options.method ?? "GET";
+    const headers: Record<string, string> = {};
+
+    if (options.authorization !== undefined) {
+        headers.Authorization = options.authorization;
+    }
+
+    let body: Bun.BodyInit | undefined = options.body;
+    let bodyLength: number | undefined = measureRawBodyLength(options.body);
+
+    if (options.jsonBody !== undefined) {
+        const serialized = JSON.stringify(options.jsonBody);
+
+        body = serialized;
+        bodyLength = serialized.length;
+        headers["Content-Type"] = "application/json";
+    }
+
+    Object.assign(headers, options.headers);
+
+    const baseFields: LogFields = {
+        method,
+        ...withRequestTarget(requestUrl.host, requestUrl.pathname),
+    };
+    const commonFields = options.logFields?.common ?? {};
+    const startFields: LogFields = {
+        ...baseFields,
+        ...(bodyLength === undefined ? {} : { bodyLength }),
+        ...commonFields,
+        ...options.logFields?.start,
+    };
+
+    options.context.logger.debug(startFields, `${options.label} request started.`);
+
+    return {
+        baseFields,
+        body,
+        commonFields,
+        method,
+        requestInit: { body, headers, method },
+        requestStartedAt: Date.now(),
+        requestUrl,
+    };
+}
+
+async function performOoFetch(
+    options: FetchingOptions,
+    request: PreparedOoRequest,
+    keys: { requestError: string; requestFailed: string },
+    allowedStatuses: readonly number[],
+): Promise<Response> {
+    let response: Response;
+
+    try {
+        response = await options.context.fetcher(request.requestUrl, request.requestInit);
+    }
+    catch (error) {
+        throw createOoTransportError(options, request, keys.requestError, error);
+    }
+
+    const status = response.status;
+    const durationMs = Date.now() - request.requestStartedAt;
+
+    if (!response.ok && !allowedStatuses.includes(status)) {
+        const failure: OoRequestFailure = {
+            bodyText: await readBodyTextSafely(response),
+            response,
+            status,
+        };
+
+        options.context.logger.warn(
+            {
+                durationMs,
+                ...request.baseFields,
+                ...request.commonFields,
+                ...options.logFields?.nonSuccess?.(failure),
+                status,
+            },
+            `${options.label} request returned a non-success status.`,
+        );
+
+        if (isInsufficientCreditHttpStatus(status)) {
+            throw createInsufficientCreditError();
+        }
+
+        throw options.statusErrors?.(failure)
+            ?? new CliUserError(keys.requestFailed, 1, { status });
+    }
+
+    options.context.logger.debug(
+        {
+            durationMs,
+            ...request.baseFields,
+            ...request.commonFields,
+            ...options.logFields?.success?.(response),
+            status,
+        },
+        `${options.label} request completed.`,
+    );
+
+    return response;
+}
+
+function createOoTransportError(
+    options: FetchingOptions,
+    request: PreparedOoRequest,
+    requestErrorKey: string,
+    error: unknown,
+): CliUserError {
+    options.context.logger.warn(
+        {
+            durationMs: Date.now() - request.requestStartedAt,
+            err: error,
+            ...request.baseFields,
+            ...request.commonFields,
+        },
+        `${options.label} request failed unexpectedly.`,
+    );
+
+    const message = options.unexpectedMessage?.(error)
+        ?? getUnexpectedRequestErrorMessage(error, options.context.translator);
+
+    return new CliUserError(requestErrorKey, 1, { message });
+}
+
+function buildOoRequestUrl(
+    options: Pick<OoRequestBaseOptions, "host" | "path" | "query">,
+): URL {
+    const base = "baseUrl" in options.host
+        ? options.host.baseUrl
+        : `https://${options.host.service}.${options.host.endpoint}`;
+    // Concatenation (never `new URL(path, base)`) so a base URL behind a path
+    // prefix keeps that prefix, and a full-URL host keeps its embedded query.
+    const requestUrl = new URL(`${base}${options.path ?? ""}`);
+
+    for (const [name, value] of Object.entries(options.query ?? {})) {
+        if (typeof value === "string") {
+            requestUrl.searchParams.set(name, value);
+        }
+        else {
+            for (const item of value) {
+                requestUrl.searchParams.append(name, item);
+            }
+        }
+    }
+
+    return requestUrl;
+}
+
+function resolveTripletErrorKeys(errors: OoRequestErrors): {
+    invalidResponse: string;
+    requestError: string;
+    requestFailed: string;
+} {
+    if ("scope" in errors) {
+        return {
+            invalidResponse: `errors.${errors.scope}.invalidResponse`,
+            ...resolvePairErrorKeys({ scope: errors.scope }),
+        };
+    }
+
+    return errors;
+}
+
+// The only place the scope -> requestFailed/requestError key templates exist.
+function resolvePairErrorKeys(errors: OoResponseRequestErrors): {
+    requestError: string;
+    requestFailed: string;
+} {
+    if ("scope" in errors) {
+        return {
+            requestError: `errors.${errors.scope}.requestError`,
+            requestFailed: `errors.${errors.scope}.requestFailed`,
+        };
+    }
+
+    return errors;
+}
+
+async function readBodyTextSafely(response: Response): Promise<string | undefined> {
+    try {
+        return await response.text();
+    }
+    catch {
+        return undefined;
+    }
+}
+
+function measureRawBodyLength(body: Bun.BodyInit | undefined): number | undefined {
+    if (typeof body === "string") {
+        return body.length;
+    }
+
+    if (body instanceof Uint8Array || body instanceof ArrayBuffer) {
+        return body.byteLength;
+    }
+
+    return undefined;
+}

--- a/src/application/commands/shared/oo-request.ts
+++ b/src/application/commands/shared/oo-request.ts
@@ -68,6 +68,7 @@ type OoResponseRequestErrors
 export interface OoRequestFailure {
     /** Non-ok body read before throwing; undefined when the read fails. */
     bodyText: string | undefined;
+    /** Headers/status only — the body is already consumed into `bodyText`. */
     response: Response;
     status: number;
 }

--- a/src/application/commands/shared/request.ts
+++ b/src/application/commands/shared/request.ts
@@ -6,21 +6,23 @@ import {
     createInsufficientCreditError,
     isInsufficientCreditHttpStatus,
 } from "./billing.ts";
+import {
+    getUnexpectedRequestErrorMessage,
+    isNetworkRestrictedSandboxError,
+} from "./oo-request.ts";
+
+// The sandbox vocabulary now lives in oo-request.ts; these re-exports keep the
+// not-yet-migrated callers stable until this module is deleted.
+export {
+    connectionRefusedErrorCode,
+    failedToOpenSocketErrorCode,
+    getUnexpectedRequestErrorMessage,
+    isNetworkRestrictedSandboxError,
+} from "./oo-request.ts";
 
 type RequestContext = Pick<CliExecutionContext, "fetcher" | "logger" | "translator">;
 type LogFields = Record<string, unknown>;
 type LogFieldsResolver<TValue> = LogFields | ((input: TValue) => LogFields);
-
-export const failedToOpenSocketErrorCode = "FailedToOpenSocket";
-export const connectionRefusedErrorCode = "ConnectionRefused";
-
-const networkRestrictedSandboxErrorCodes = [
-    failedToOpenSocketErrorCode,
-    connectionRefusedErrorCode,
-] as const;
-
-type NetworkRestrictedSandboxErrorCode
-    = typeof networkRestrictedSandboxErrorCodes[number];
 
 interface ExecuteCliRequestOptions {
     allowedStatusCodes?: readonly number[];
@@ -160,19 +162,6 @@ function resolveLogFields<TValue>(
     return value ?? {};
 }
 
-export function getUnexpectedRequestErrorMessage(
-    error: unknown,
-    translator: Pick<CliExecutionContext["translator"], "t">,
-): string {
-    const baseMessage = error instanceof Error ? error.message : String(error);
-
-    if (!isNetworkRestrictedSandboxError(error)) {
-        return baseMessage;
-    }
-
-    return `${baseMessage}\n${translator.t("errors.shared.networkRestrictedSandboxHint")}`;
-}
-
 function enhanceUnexpectedRequestError(
     error: unknown,
     translator: Pick<CliExecutionContext["translator"], "t">,
@@ -182,21 +171,12 @@ function enhanceUnexpectedRequestError(
     }
 
     const enhanced = new Error(getUnexpectedRequestErrorMessage(error, translator)) as
-        Error & { code: NetworkRestrictedSandboxErrorCode };
+        Error & { code: string };
 
     enhanced.code = error.code;
     enhanced.stack = error.stack;
 
     return enhanced;
-}
-
-export function isNetworkRestrictedSandboxError(
-    error: unknown,
-): error is Error & { code: NetworkRestrictedSandboxErrorCode } {
-    return error instanceof Error
-        && "code" in error
-        && typeof error.code === "string"
-        && (networkRestrictedSandboxErrorCodes as readonly string[]).includes(error.code);
 }
 
 export async function performLoggedRequest(

--- a/src/application/commands/team/shared.test.ts
+++ b/src/application/commands/team/shared.test.ts
@@ -162,6 +162,23 @@ describe("listMemberTeams", () => {
 
         expect(error.key).toBe("errors.team.requestFailed");
     });
+
+    test("appends the sandbox hint to a network-restricted failure exactly once", async () => {
+        const error = await expectCliUserError(listMemberTeams(
+            testAccount,
+            createRequestContext({
+                fetcher: async () => {
+                    throw createFailedToOpenSocketError("network down");
+                },
+            }),
+        ));
+
+        expect(error.key).toBe("errors.team.requestError");
+        expect(error.params).toEqual({
+            message: "network down\nCurrent environment may be running in a "
+                + "network-restricted sandbox. Try requesting elevated permissions.",
+        });
+    });
 });
 
 describe("fetchTeamById", () => {

--- a/src/application/commands/team/shared.ts
+++ b/src/application/commands/team/shared.ts
@@ -2,12 +2,7 @@ import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
 
 import { z } from "zod";
-import { CliUserError } from "../../contracts/cli.ts";
-import {
-    getUnexpectedRequestErrorMessage,
-    isNetworkRestrictedSandboxError,
-    requestText,
-} from "../shared/request.ts";
+import { probeOo, requestOo } from "../shared/oo-request.ts";
 
 export const teamFormatValues = ["json"] as const;
 
@@ -50,40 +45,17 @@ export async function listMemberTeams(
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
     context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<TeamView[]> {
-    const requestUrl = new URL(
-        `https://relation-control.${account.endpoint}/v1/me/teams`,
-    );
-
-    const rawResponse = await requestText({
+    const parsed = await requestOo({
+        authorization: account.apiKey,
         context,
-        createRequestFailedError: status => new CliUserError(
-            "errors.team.requestFailed",
-            1,
-            { status },
-        ),
-        createUnexpectedError: error => new CliUserError(
-            "errors.team.requestError",
-            1,
-            { message: getUnexpectedRequestErrorMessage(error, context.translator) },
-        ),
-        init: {
-            headers: {
-                Authorization: account.apiKey,
-            },
-        },
-        requestLabel: "Team list",
-        requestUrl,
+        errors: { scope: "team" },
+        host: { endpoint: account.endpoint, service: "relation-control" },
+        label: "Team list",
+        path: "/v1/me/teams",
+        schema: teamsResponseSchema,
     });
 
-    try {
-        return teamsResponseSchema
-            .parse(JSON.parse(rawResponse) as unknown)
-            .teams
-            .map(toTeamView);
-    }
-    catch {
-        throw new CliUserError("errors.team.invalidResponse", 1);
-    }
+    return parsed.teams.map(toTeamView);
 }
 
 // How a team-id lookup ended. Only `valid` carries a team; every other value
@@ -125,25 +97,26 @@ export async function fetchTeamById(
     teamId: string,
     context: Pick<CliExecutionContext, "fetcher" | "logger">,
 ): Promise<TeamLookupResult> {
-    const requestUrl = new URL(
-        `https://relation-control.${account.endpoint}/v1/teams/${encodeURIComponent(teamId)}`,
-    );
+    return lookupTeam(
+        account,
+        "id",
+        `/v1/teams/${encodeURIComponent(teamId)}`,
+        (bodyText, status) => {
+            if (status !== 200) {
+                return {
+                    status: teamLookupStatusByHttpStatus[status] ?? "request_failed",
+                };
+            }
 
-    return runTeamLookup(account, requestUrl, "id", async (response) => {
-        if (response.status !== 200) {
             return {
-                status: teamLookupStatusByHttpStatus[response.status]
-                    ?? "request_failed",
+                status: "valid",
+                team: toTeamView(
+                    teamResponseItemSchema.parse(parseLookupBody(bodyText)),
+                ),
             };
-        }
-
-        return {
-            status: "valid",
-            team: toTeamView(
-                teamResponseItemSchema.parse(await response.json() as unknown),
-            ),
-        };
-    }, context);
+        },
+        context,
+    );
 }
 
 // Resolves one team name to its team through the account's membership listing —
@@ -156,81 +129,75 @@ export async function fetchTeamByName(
     teamName: string,
     context: Pick<CliExecutionContext, "fetcher" | "logger">,
 ): Promise<TeamLookupResult> {
-    const requestUrl = new URL(
-        `https://relation-control.${account.endpoint}/v1/me/teams`,
+    return lookupTeam(
+        account,
+        "name",
+        "/v1/me/teams",
+        (bodyText, status) => {
+            if (status !== 200) {
+                return { status: "request_failed" };
+            }
+
+            const teams = teamsResponseSchema
+                .parse(parseLookupBody(bodyText))
+                .teams
+                .map(toTeamView);
+            const match = teams.find(team => team.name === teamName);
+
+            return match === undefined
+                ? { status: "not_a_member" }
+                : { status: "valid", team: match };
+        },
+        context,
     );
-
-    return runTeamLookup(account, requestUrl, "name", async (response) => {
-        if (response.status !== 200) {
-            return { status: "request_failed" };
-        }
-
-        const teams = teamsResponseSchema
-            .parse(await response.json() as unknown)
-            .teams
-            .map(toTeamView);
-        const match = teams.find(team => team.name === teamName);
-
-        return match === undefined
-            ? { status: "not_a_member" }
-            : { status: "valid", team: match };
-    }, context);
 }
 
-// Shared fetch/log/catch skeleton of the two team lookups. Any failure the
-// handler does not classify — network errors, non-JSON bodies, schema
-// mismatches — comes back as a request-failed status instead of an error,
-// which is what keeps the lookups' never-throw contract honest.
-async function runTeamLookup(
+// Shared interpretation skeleton of the two team lookups, on top of the probe
+// seam. Any failure the interpreter does not classify — non-JSON bodies,
+// schema mismatches, an unreadable body — comes back as a request-failed
+// status instead of an error, which is what keeps the lookups' never-throw
+// contract honest.
+async function lookupTeam(
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
-    requestUrl: URL,
     direction: "id" | "name",
-    toResult: (response: Response) => Promise<TeamLookupResult>,
+    path: string,
+    interpret: (bodyText: string | undefined, status: number) => TeamLookupResult,
     context: Pick<CliExecutionContext, "fetcher" | "logger">,
 ): Promise<TeamLookupResult> {
-    const requestStartedAt = Date.now();
+    const probe = await probeOo({
+        authorization: account.apiKey,
+        context,
+        host: { endpoint: account.endpoint, service: "relation-control" },
+        label: "Team lookup",
+        logFields: { direction, endpoint: account.endpoint },
+        path,
+    });
 
-    context.logger.debug(
-        { direction, endpoint: account.endpoint },
-        "Team lookup request started.",
-    );
-
-    try {
-        const response = await context.fetcher(requestUrl, {
-            headers: {
-                Authorization: account.apiKey,
-            },
-        });
-
-        context.logger.debug(
-            {
-                direction,
-                durationMs: Date.now() - requestStartedAt,
-                endpoint: account.endpoint,
-                status: response.status,
-            },
-            "Team lookup request completed.",
-        );
-
-        return await toResult(response);
-    }
-    catch (error) {
-        context.logger.warn(
-            {
-                direction,
-                durationMs: Date.now() - requestStartedAt,
-                endpoint: account.endpoint,
-                err: error,
-            },
-            "Team lookup request failed unexpectedly.",
-        );
-
+    if (probe.kind !== "response") {
         return {
-            status: isNetworkRestrictedSandboxError(error)
+            status: probe.kind === "failed_sandbox"
                 ? "request_failed_sandbox"
                 : "request_failed",
         };
     }
+
+    try {
+        return interpret(probe.bodyText, probe.status);
+    }
+    catch (error) {
+        context.logger.warn(
+            { direction, endpoint: account.endpoint, err: error },
+            "Team lookup request failed unexpectedly.",
+        );
+
+        return { status: "request_failed" };
+    }
+}
+
+// An unreadable body parses as no JSON at all, so both lookups classify it
+// through their interpreter's failure path.
+function parseLookupBody(bodyText: string | undefined): unknown {
+    return JSON.parse(bodyText ?? "") as unknown;
 }
 
 function toTeamView(

--- a/src/application/commands/variables/shared.ts
+++ b/src/application/commands/variables/shared.ts
@@ -6,7 +6,7 @@ import { readFile } from "node:fs/promises";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
-import { performLoggedRequest } from "../shared/request.ts";
+import { requestOo, requestOoResponse } from "../shared/oo-request.ts";
 import { readStdinToEnd } from "../shared/stdin.ts";
 
 export const MAX_VARIABLE_NAME_LENGTH = 256;
@@ -118,58 +118,27 @@ const variableListSchema = z.object({
     variables: z.array(variableSchema),
 });
 
-export function createVariablesRequestUrl(endpoint: string, name?: string): URL {
-    const base = `https://cli-api.${endpoint}/v1/variables`;
-    return new URL(name === undefined ? base : `${base}/${encodeURIComponent(name)}`);
-}
-
-function unexpectedError(error: unknown): CliUserError {
-    return new CliUserError("errors.variables.requestError", 1, {
-        message: error instanceof Error ? error.message : String(error),
-    });
-}
-
-function requestFailedError(status: number): CliUserError {
-    return new CliUserError("errors.variables.requestFailed", 1, { status });
-}
-
-async function parseVariable(response: Response): Promise<Variable> {
-    const parsed = variableSchema.safeParse(await readJson(response));
-    if (!parsed.success) {
-        throw new CliUserError("errors.variables.invalidResponse", 1);
-    }
-
-    return parsed.data;
-}
-
-async function readJson(response: Response): Promise<unknown> {
-    try {
-        return JSON.parse(await response.text()) as unknown;
-    }
-    catch {
-        throw new CliUserError("errors.variables.invalidResponse", 1);
-    }
+function variablePath(name?: string): string {
+    return name === undefined
+        ? "/v1/variables"
+        : `/v1/variables/${encodeURIComponent(name)}`;
 }
 
 export async function listVariables(
     account: VariableAccount,
     context: RequestContext,
 ): Promise<Variable[]> {
-    const response = await performLoggedRequest({
+    const parsed = await requestOo({
+        authorization: account.apiKey,
         context,
-        createRequestFailedError: requestFailedError,
-        createUnexpectedError: unexpectedError,
-        init: { headers: { Authorization: account.apiKey } },
-        requestLabel: "Variables list",
-        requestUrl: createVariablesRequestUrl(account.endpoint),
+        errors: { scope: "variables" },
+        host: { endpoint: account.endpoint, service: "cli-api" },
+        label: "Variables list",
+        path: variablePath(),
+        schema: variableListSchema,
     });
 
-    const parsed = variableListSchema.safeParse(await readJson(response));
-    if (!parsed.success) {
-        throw new CliUserError("errors.variables.invalidResponse", 1);
-    }
-
-    return parsed.data.variables;
+    return parsed.variables;
 }
 
 export async function getVariable(
@@ -177,18 +146,18 @@ export async function getVariable(
     name: string,
     context: RequestContext,
 ): Promise<Variable> {
-    const response = await performLoggedRequest({
+    return await requestOo({
+        authorization: account.apiKey,
         context,
-        createRequestFailedError: status => status === 404
+        errors: { scope: "variables" },
+        host: { endpoint: account.endpoint, service: "cli-api" },
+        label: "Variables get",
+        path: variablePath(name),
+        schema: variableSchema,
+        statusErrors: failure => failure.status === 404
             ? new CliUserError("errors.variables.notFound", 1, { name })
-            : requestFailedError(status),
-        createUnexpectedError: unexpectedError,
-        init: { headers: { Authorization: account.apiKey } },
-        requestLabel: "Variables get",
-        requestUrl: createVariablesRequestUrl(account.endpoint, name),
+            : undefined,
     });
-
-    return await parseVariable(response);
 }
 
 export async function putVariable(
@@ -197,25 +166,20 @@ export async function putVariable(
     value: string,
     context: RequestContext,
 ): Promise<Variable> {
-    const response = await performLoggedRequest({
+    return await requestOo({
+        authorization: account.apiKey,
         context,
-        createRequestFailedError: status => status === 409
+        errors: { scope: "variables" },
+        host: { endpoint: account.endpoint, service: "cli-api" },
+        jsonBody: { value },
+        label: "Variables create",
+        method: "PUT",
+        path: variablePath(name),
+        schema: variableSchema,
+        statusErrors: failure => failure.status === 409
             ? new CliUserError("errors.variables.quotaExceeded", 1)
-            : requestFailedError(status),
-        createUnexpectedError: unexpectedError,
-        init: {
-            body: JSON.stringify({ value }),
-            headers: {
-                "Authorization": account.apiKey,
-                "Content-Type": "application/json",
-            },
-            method: "PUT",
-        },
-        requestLabel: "Variables create",
-        requestUrl: createVariablesRequestUrl(account.endpoint, name),
+            : undefined,
     });
-
-    return await parseVariable(response);
 }
 
 export async function deleteVariable(
@@ -223,15 +187,13 @@ export async function deleteVariable(
     name: string,
     context: RequestContext,
 ): Promise<void> {
-    await performLoggedRequest({
+    await requestOoResponse({
+        authorization: account.apiKey,
         context,
-        createRequestFailedError: requestFailedError,
-        createUnexpectedError: unexpectedError,
-        init: {
-            headers: { Authorization: account.apiKey },
-            method: "DELETE",
-        },
-        requestLabel: "Variables delete",
-        requestUrl: createVariablesRequestUrl(account.endpoint, name),
+        errors: { scope: "variables" },
+        host: { endpoint: account.endpoint, service: "cli-api" },
+        label: "Variables delete",
+        method: "DELETE",
+        path: variablePath(name),
     });
 }


### PR DESCRIPTION
Part 1 of a 3-PR stack that collapses the per-caller request rituals (host template, auth header, error triplet, JSON decode, sandbox hint) into one deep request module.

## What

Introduces `commands/shared/oo-request.ts` as the single owner of backend request knowledge:

- **`requestOo`** — throwing JSON+zod path: builds the host (`https://<service>.<endpoint>` or a base URL), sets the auth header, logs the request lifecycle, detects insufficient credit, applies the network-restricted sandbox hint exactly once, and maps failures to the caller's `requestFailed`/`requestError`/`invalidResponse` error triplet with catalog-derived scope typing. Status-specific keys are passed as `statusErrors` data.
- **`requestOoResponse`** — raw path with `allowedStatuses` bypass and a raw-body slot; the response returns body-unconsumed (streaming/416-resume safe).
- **`probeOo`** — never-throw diagnostic probe returning `response`/`failed`/`failed_sandbox`; a failed body read keeps the status, so callers own all status interpretation.

The sandbox vocabulary (error-code constants, classifier, hinted message) moves in with the module; `request.ts` re-imports it so nothing is defined twice while the remaining callers migrate (they move in the next two PRs).

## Migrated callers

- **variables**: list/get/put via `requestOo` (404 `notFound` / 409 `quotaExceeded` as data), delete via `requestOoResponse` (204 empty body stays exit 0).
- **team**: `listMemberTeams` via `requestOo` — **fixes the sandbox hint printing twice** on network-restricted team-list failures (the old caller re-applied the already-applied hint); a new test pins the single-hint message. `fetchTeamById`/`fetchTeamByName` sit on `probeOo` through a thin interpretation skeleton, keeping the never-throw contract and the per-status tables; `runTeamLookup` is deleted.

## Behavior changes

Only the double-hint fix is user-visible. Error keys, exit codes, wire shapes, and JSON output are unchanged; telemetry manifest untouched.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#320** 👈 current
2. #321
3. #322
<!-- stack:links:end -->