### PR TITLE
refactor(connector): contract the action-schema cache to four operations

### DIFF
--- a/src/application/commands/connector/index.cli.test.ts
+++ b/src/application/commands/connector/index.cli.test.ts
@@ -1,8 +1,5 @@
 import type { AppSettings } from "../../schemas/settings.ts";
-import type {
-    ConnectorActionDefinition,
-    ConnectorActionMetadata,
-} from "./shared.ts";
+import type { ConnectorActionMetadata } from "./shared.ts";
 
 import { join } from "node:path";
 
@@ -20,6 +17,7 @@ import {
     writeConnectorFile,
 } from "../../../../__tests__/helpers.ts";
 import { SqliteCacheStore } from "../../../adapters/cache/sqlite-cache.ts";
+import { createTranslator } from "../../../i18n/translator.ts";
 import { APP_NAME } from "../../config/app-config.ts";
 import {
     parseTelemetryRowPayload,
@@ -27,8 +25,8 @@ import {
 } from "../../telemetry/outbox.ts";
 import { createTerminalColors } from "../../terminal-colors.ts";
 import {
-    cacheConnectorActionSchemas,
     createConnectorSchemaCacheScope,
+    loadConnectorActionSchema,
 } from "./schema-cache.ts";
 import {
     connectorSearchActionColor,
@@ -3976,7 +3974,13 @@ describe("connectorCommand CLI", () => {
             );
 
             expect(result.exitCode).toBe(0);
-            expect(JSON.parse(result.stdout)).toMatchObject({
+            // Exact equality: the async lifecycle steering the submit flow
+            // must never leak into the five-field schema output.
+            expect(JSON.parse(result.stdout)).toEqual({
+                description: "Submit OpenAI image generation.",
+                inputSchema: {
+                    type: "object",
+                },
                 name: "openai_image_async_submit",
                 outputSchema: {
                     properties: {
@@ -3991,6 +3995,104 @@ describe("connectorCommand CLI", () => {
             expect(requests.map(request => request.url)).toEqual([
                 "https://connector.oomol.com/v1/actions/fusion-api.openai_image_async_submit",
             ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("preserves an anyOf output schema for async result actions in connector schema output", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            // No top-level `type`: a state-machine result contract that only a
+            // byte-identical passthrough keeps intact.
+            const anyOfOutputSchema = {
+                anyOf: [
+                    {
+                        properties: {
+                            data: {
+                                properties: {
+                                    images: {
+                                        items: {
+                                            type: "string",
+                                        },
+                                        type: "array",
+                                    },
+                                },
+                                type: "object",
+                            },
+                            state: {
+                                enum: ["completed"],
+                                type: "string",
+                            },
+                        },
+                        required: ["state", "data"],
+                        type: "object",
+                    },
+                    {
+                        properties: {
+                            progress: {
+                                type: "number",
+                            },
+                            state: {
+                                enum: ["processing"],
+                                type: "string",
+                            },
+                        },
+                        required: ["state", "progress"],
+                        type: "object",
+                    },
+                ],
+            };
+            const result = await sandbox.run(
+                [
+                    "connector",
+                    "schema",
+                    "fusion-api.openai_image_async_result",
+                ],
+                {
+                    fetcher: async () => new Response(JSON.stringify({
+                        data: {
+                            asyncLifecycle: {
+                                role: "result",
+                                wait: {
+                                    intervalSeconds: 3,
+                                    resultField: "data",
+                                    state: {
+                                        failure: ["not_found"],
+                                        field: "state",
+                                        running: ["processing"],
+                                        success: ["completed"],
+                                    },
+                                },
+                            },
+                            description: "Get OpenAI image generation result.",
+                            inputSchema: {
+                                type: "object",
+                            },
+                            name: "openai_image_async_result",
+                            outputSchema: anyOfOutputSchema,
+                            providerPermissions: [],
+                            requiredScopes: [],
+                            service: "fusion-api",
+                        },
+                    })),
+                },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(JSON.parse(result.stdout)).toEqual({
+                description: "Get OpenAI image generation result.",
+                inputSchema: {
+                    type: "object",
+                },
+                name: "openai_image_async_result",
+                outputSchema: anyOfOutputSchema,
+                service: "fusion-api",
+            });
         }
         finally {
             await sandbox.cleanup();
@@ -5241,7 +5343,10 @@ describe("connectorCommand CLI", () => {
     });
 });
 
-type SeedConnectorAction = ConnectorActionDefinition & Partial<Pick<
+type SeedConnectorAction = Pick<
+    ConnectorActionMetadata,
+    "description" | "inputSchema" | "name" | "outputSchema" | "service"
+> & Partial<Pick<
     ConnectorActionMetadata,
     "asyncLifecycle" | "providerPermissions" | "requiredScopes"
 >>;
@@ -5369,18 +5474,33 @@ async function seedConnectorActionSchema(
     );
 
     try {
-        await cacheConnectorActionSchemas(
-            [action],
-            createConnectorSchemaCacheScope({
-                accountId: "user-1",
-                endpoint: "oomol.com",
-            }),
+        // Seed through the loader's real write path with a stub metadata
+        // response: unlike warming from search results, this keeps async
+        // lifecycle fields on the seeded entry.
+        await loadConnectorActionSchema(
+            {
+                actionName: action.name,
+                serviceName: action.service,
+                target: {
+                    authorization: "secret-1",
+                    baseUrl: "https://connector.oomol.com",
+                    kind: "oomol",
+                    cacheScope: createConnectorSchemaCacheScope({
+                        accountId: "user-1",
+                        endpoint: "oomol.com",
+                    }),
+                },
+            },
             {
                 cacheStore,
+                fetcher: async () => new Response(JSON.stringify({
+                    data: action,
+                })),
                 logger: pino({
                     enabled: false,
                 }),
                 settingsStore: createSettingsStoreForSandbox(sandbox),
+                translator: createTranslator("en"),
             },
         );
     }

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -17,8 +17,7 @@ import { createFormatInputError } from "../shared/input-parsing.ts";
 import { readJsonInputValue } from "../shared/json-input.ts";
 import { TerminalProgressRenderer } from "../shared/terminal-progress-renderer.ts";
 import {
-    deleteConnectorActionSchemaCache,
-    isConnectorActionSchemaNotFoundError,
+    invalidateConnectorActionSchemaOnNotFound,
     loadConnectorActionSchema,
 } from "./schema-cache.ts";
 import {
@@ -285,16 +284,15 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
         catch (error) {
             progressReporter?.abort();
             recordConnectorFailureTelemetry(error, context.telemetry);
-            if (isConnectorActionSchemaNotFoundError(error)) {
-                deleteConnectorActionSchemaCache(
-                    {
-                        actionName: currentTarget.actionName,
-                        cacheScope: target.cacheScope,
-                        serviceName: currentTarget.serviceName,
-                    },
-                    context,
-                );
-            }
+            invalidateConnectorActionSchemaOnNotFound(
+                {
+                    actionName: currentTarget.actionName,
+                    cacheScope: target.cacheScope,
+                    error,
+                    serviceName: currentTarget.serviceName,
+                },
+                context,
+            );
             throw error;
         }
 

--- a/src/application/commands/connector/schema-cache.test.ts
+++ b/src/application/commands/connector/schema-cache.test.ts
@@ -1,7 +1,12 @@
+import type { Logger } from "pino";
 import type { Cache, CacheOptions } from "../../contracts/cache.ts";
 import type { AppSettings } from "../../schemas/settings.ts";
 
-import type { ConnectorActionMetadata } from "./shared.ts";
+import type { ConnectorSchemaCacheScope } from "./schema-cache.ts";
+import type {
+    ConnectorActionMetadata,
+    ConnectorActionSearchResult,
+} from "./shared.ts";
 import { mkdir, rm } from "node:fs/promises";
 
 import { join } from "node:path";
@@ -12,6 +17,7 @@ import {
     createCacheStore,
     createConnectorActionFixture,
     createConnectorTargetFixture,
+    createLogCapture,
     createMemoryCache,
     createTemporaryDirectory,
 } from "../../../../__tests__/helpers.ts";
@@ -19,105 +25,26 @@ import { createTranslator } from "../../../i18n/translator.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 
 import {
-    cacheConnectorActionSchemas,
     clearConnectorActionSchemaCache,
-    createConnectorActionSchemaCacheKey,
-    createConnectorActionSchemaOutput,
     createConnectorSchemaCacheScope,
-    deleteConnectorActionSchemaCache,
-    isConnectorActionSchemaNotFoundError,
+    invalidateConnectorActionSchemaOnNotFound,
     loadConnectorActionSchema,
+    warmConnectorActionSchemas,
 } from "./schema-cache.ts";
 
 // The scope every fixture-backed test shares; variant scopes are built
-// inline where a test exists to prove key divergence.
+// inline where a test exists to prove entry isolation.
 const userScope = createConnectorSchemaCacheScope({
     accountId: "user-1",
     endpoint: "oomol.com",
 });
 
 describe("connector schema cache", () => {
-    test("createConnectorActionSchemaCacheKey includes scope, service, and action identity", () => {
-        const baseKey = createConnectorActionSchemaCacheKey({
-            actionName: "send_mail",
-            cacheScope: userScope,
-            serviceName: "gmail",
-        });
-
-        expect(JSON.parse(baseKey)).toEqual({
-            scope: userScope,
-            actionName: "send_mail",
-            serviceName: "gmail",
-        });
-        expect(baseKey).not.toBe(createConnectorActionSchemaCacheKey({
-            actionName: "send_mail",
-            cacheScope: createConnectorSchemaCacheScope({
-                accountId: "user-2",
-                endpoint: "oomol.com",
-            }),
-            serviceName: "gmail",
-        }));
-        expect(baseKey).not.toBe(createConnectorActionSchemaCacheKey({
-            actionName: "send_mail",
-            cacheScope: createConnectorSchemaCacheScope({
-                accountId: "user-1",
-                endpoint: "staging.oomol.com",
-            }),
-            serviceName: "gmail",
-        }));
-        expect(baseKey).not.toBe(createConnectorActionSchemaCacheKey({
-            actionName: "get_message",
-            cacheScope: userScope,
-            serviceName: "gmail",
-        }));
-    });
-
-    test("cacheConnectorActionSchemas stores search results in the SQLite cache namespace shape", async () => {
+    test("loadConnectorActionSchema caches fetched metadata and reuses it without a second fetch", async () => {
         const cache = createMemoryCache();
-        const cacheOptions: CacheOptions[] = [];
-
-        await cacheConnectorActionSchemas(
-            [createConnectorActionFixture()],
-            userScope,
-            createCacheContext({
-                cache,
-                cacheOptions,
-            }),
-        );
-
-        expect(cacheOptions).toEqual([
-            {
-                defaultTtlMs: 60 * 60 * 1000,
-                id: "connector-action-schema",
-                maxEntries: 1000,
-            },
-        ]);
-        expect(cache.get(createConnectorActionSchemaCacheKey({
-            actionName: "send_mail",
-            cacheScope: userScope,
-            serviceName: "gmail",
-        }))).toEqual({
-            ...createConnectorActionFixture(),
-            providerPermissions: [],
-            requiredScopes: [],
-        });
-    });
-
-    test("loadConnectorActionSchema reuses a cached schema without fetching", async () => {
-        const cache = createMemoryCache();
-        cache.set(
-            createConnectorActionSchemaCacheKey({
-                actionName: "send_mail",
-                cacheScope: userScope,
-                serviceName: "gmail",
-            }),
-            createConnectorActionFixture({
-                description: "Cached schema.",
-            }),
-        );
-
         let fetchCount = 0;
-        const schema = await loadConnectorActionSchema(
+
+        const fetched = await loadConnectorActionSchema(
             {
                 target: createConnectorTargetFixture(),
                 actionName: "send_mail",
@@ -128,38 +55,50 @@ describe("connector schema cache", () => {
                 fetcher: async () => {
                     fetchCount += 1;
 
-                    return new Response("unexpected");
+                    return createMetadataResponse({
+                        description: "Fetched schema.",
+                    });
                 },
             }),
         );
 
-        expect(schema).toEqual({
-            description: "Cached schema.",
-            inputSchema: {
-                type: "object",
-            },
-            name: "send_mail",
-            outputSchema: {
-                type: "object",
-            },
-            providerPermissions: [],
-            requiredScopes: [],
-            service: "gmail",
+        expect(fetched).toMatchObject({
+            description: "Fetched schema.",
         });
-        expect(fetchCount).toBe(0);
+        expect(fetchCount).toBe(1);
+
+        // The second load must be served from the cache: the default context
+        // fetcher rejects every request.
+        const cached = await loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture(),
+                actionName: "send_mail",
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+            }),
+        );
+
+        expect(cached).toMatchObject({
+            description: "Fetched schema.",
+        });
     });
 
     test("loadConnectorActionSchema refetches lifecycle-less cache entries when the async lifecycle is required", async () => {
         const cache = createMemoryCache();
-        const cacheKey = createConnectorActionSchemaCacheKey({
-            actionName: "send_mail",
-            cacheScope: userScope,
-            serviceName: "gmail",
-        });
 
-        cache.set(cacheKey, createConnectorActionFixture({
-            description: "Search-seeded schema.",
-        }));
+        // Warm from a search result: warmed entries never carry an async
+        // lifecycle, which is exactly what this test needs.
+        await warmConnectorActionSchemas(
+            [createSearchResultFixture({
+                description: "Search-seeded schema.",
+            })],
+            userScope,
+            createCacheContext({
+                cache,
+            }),
+        );
 
         const schema = await loadConnectorActionSchema(
             {
@@ -190,7 +129,21 @@ describe("connector schema cache", () => {
             },
             description: "Fresh schema.",
         });
-        expect(cache.get(cacheKey)).toMatchObject({
+
+        // The refetched metadata replaced the lifecycle-less entry.
+        const cached = await loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture(),
+                actionName: "send_mail",
+                requireAsyncLifecycle: true,
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+            }),
+        );
+
+        expect(cached).toMatchObject({
             description: "Fresh schema.",
         });
     });
@@ -198,29 +151,29 @@ describe("connector schema cache", () => {
     test("loadConnectorActionSchema reuses cached entries with an async lifecycle when it is required", async () => {
         const cache = createMemoryCache();
 
-        cache.set(
-            createConnectorActionSchemaCacheKey({
-                actionName: "openai_image_async_submit",
-                cacheScope: userScope,
-                serviceName: "fusion-api",
-            }),
+        await loadConnectorActionSchema(
             {
-                ...createConnectorActionFixture({
+                target: createConnectorTargetFixture(),
+                actionName: "openai_image_async_submit",
+                serviceName: "fusion-api",
+            },
+            createCacheContext({
+                cache,
+                fetcher: async () => createMetadataResponse({
+                    asyncLifecycle: {
+                        role: "submit",
+                        resultAction: "openai_image_async_result",
+                        handle: {
+                            inputField: "sessionID",
+                            outputField: "sessionId",
+                        },
+                    },
                     name: "openai_image_async_submit",
                     service: "fusion-api",
                 }),
-                asyncLifecycle: {
-                    role: "submit",
-                    resultAction: "openai_image_async_result",
-                    handle: {
-                        inputField: "sessionID",
-                        outputField: "sessionId",
-                    },
-                },
-            },
+            }),
         );
 
-        let fetchCount = 0;
         const schema = await loadConnectorActionSchema(
             {
                 target: createConnectorTargetFixture(),
@@ -230,11 +183,6 @@ describe("connector schema cache", () => {
             },
             createCacheContext({
                 cache,
-                fetcher: async () => {
-                    fetchCount += 1;
-
-                    return new Response("unexpected");
-                },
             }),
         );
 
@@ -244,20 +192,21 @@ describe("connector schema cache", () => {
             },
             name: "openai_image_async_submit",
         });
-        expect(fetchCount).toBe(0);
     });
 
     test("loadConnectorActionSchema refreshes invalid cache content from metadata", async () => {
         const cache = createMemoryCache();
-        const cacheKey = createConnectorActionSchemaCacheKey({
-            actionName: "get_message",
-            cacheScope: userScope,
-            serviceName: "gmail",
-        });
 
-        cache.set(cacheKey, {
-            name: "",
-        });
+        cache.set(
+            createRawCacheKey({
+                actionName: "get_message",
+                cacheScope: userScope,
+                serviceName: "gmail",
+            }),
+            {
+                name: "",
+            },
+        );
 
         const schema = await loadConnectorActionSchema(
             {
@@ -279,24 +228,40 @@ describe("connector schema cache", () => {
             name: "get_message",
             service: "gmail",
         });
-        expect(cache.get(cacheKey)).toMatchObject({
+
+        // The corrupt entry was replaced, so the next load needs no fetch.
+        const cached = await loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture(),
+                actionName: "get_message",
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+            }),
+        );
+
+        expect(cached).toMatchObject({
             description: "Get one Gmail message.",
-            name: "get_message",
-            service: "gmail",
         });
     });
 
     test("loadConnectorActionSchema refresh bypasses cache and preserves metadata fields", async () => {
         const cache = createMemoryCache();
-        const cacheKey = createConnectorActionSchemaCacheKey({
-            actionName: "send_mail",
-            cacheScope: userScope,
-            serviceName: "gmail",
-        });
 
-        cache.set(cacheKey, createConnectorActionFixture({
-            description: "Cached schema.",
-        }));
+        await loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture(),
+                actionName: "send_mail",
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+                fetcher: async () => createMetadataResponse({
+                    description: "Cached schema.",
+                }),
+            }),
+        );
 
         const schema = await loadConnectorActionSchema(
             {
@@ -330,7 +295,19 @@ describe("connector schema cache", () => {
             providerPermissions: ["gmail.send"],
             requiredScopes: ["gmail.send"],
         });
-        expect(cache.get(cacheKey)).toMatchObject({
+
+        const cached = await loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture(),
+                actionName: "send_mail",
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+            }),
+        );
+
+        expect(cached).toMatchObject({
             description: "Fresh schema.",
             providerPermissions: ["gmail.send"],
             requiredScopes: ["gmail.send"],
@@ -373,13 +350,18 @@ describe("connector schema cache", () => {
 
     test("loadConnectorActionSchema deletes stale entries when metadata reports not found", async () => {
         const cache = createMemoryCache();
-        const cacheKey = createConnectorActionSchemaCacheKey({
-            actionName: "send_mail",
-            cacheScope: userScope,
-            serviceName: "gmail",
-        });
 
-        cache.set(cacheKey, createConnectorActionFixture());
+        await loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture(),
+                actionName: "send_mail",
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+                fetcher: async () => createMetadataResponse(),
+            }),
+        );
 
         await expect(loadConnectorActionSchema(
             {
@@ -395,260 +377,188 @@ describe("connector schema cache", () => {
                 }),
             }),
         )).rejects.toThrow("errors.connectorMetadata.requestFailed");
-        expect(cache.get(cacheKey)).toBeNull();
+
+        // The stale entry is gone, so the next load must fetch again.
+        let fetchCount = 0;
+
+        await loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture(),
+                actionName: "send_mail",
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+                fetcher: async () => {
+                    fetchCount += 1;
+
+                    return createMetadataResponse();
+                },
+            }),
+        );
+
+        expect(fetchCount).toBe(1);
     });
 
-    test("deleteConnectorActionSchemaCache removes only the selected identity", () => {
+    test("warmConnectorActionSchemas populates entries a later load serves without fetching", async () => {
         const cache = createMemoryCache();
-        const firstKey = createConnectorActionSchemaCacheKey({
-            actionName: "send_mail",
-            cacheScope: userScope,
-            serviceName: "gmail",
-        });
-        const secondKey = createConnectorActionSchemaCacheKey({
-            actionName: "send_mail",
-            cacheScope: createConnectorSchemaCacheScope({
-                accountId: "user-2",
-                endpoint: "oomol.com",
+        const cacheOptions: CacheOptions[] = [];
+
+        await warmConnectorActionSchemas(
+            [createSearchResultFixture()],
+            userScope,
+            createCacheContext({
+                cache,
+                cacheOptions,
             }),
-            serviceName: "gmail",
-        });
+        );
 
-        cache.set(firstKey, createConnectorActionFixture());
-        cache.set(secondKey, createConnectorActionFixture({
-            description: "Second account schema.",
-        }));
-
-        expect(deleteConnectorActionSchemaCache(
+        expect(cacheOptions).toEqual([
             {
+                defaultTtlMs: 60 * 60 * 1000,
+                id: "connector-action-schema",
+                maxEntries: 1000,
+            },
+        ]);
+
+        const schema = await loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture(),
                 actionName: "send_mail",
-                cacheScope: userScope,
                 serviceName: "gmail",
             },
             createCacheContext({
                 cache,
             }),
-        )).toBeTrue();
-        expect(cache.get(firstKey)).toBeNull();
-        expect(cache.get(secondKey)).toMatchObject({
-            description: "Second account schema.",
+        );
+
+        expect(schema).toEqual({
+            description: "Send a Gmail message.",
+            inputSchema: {
+                type: "object",
+            },
+            name: "send_mail",
+            outputSchema: {
+                type: "object",
+            },
+            providerPermissions: [],
+            requiredScopes: [],
+            service: "gmail",
         });
     });
 
-    test("clearConnectorActionSchemaCache clears the schema namespace and legacy directory", async () => {
-        const rootPath = await createTemporaryDirectory("connector-schema-cache-clear");
+    test("warmConnectorActionSchemas strips identity-scoped fields from cached entries", async () => {
         const cache = createMemoryCache();
-        const firstKey = createConnectorActionSchemaCacheKey({
-            actionName: "send_mail",
-            cacheScope: userScope,
-            serviceName: "gmail",
-        });
-        const secondKey = createConnectorActionSchemaCacheKey({
-            actionName: "get_message",
-            cacheScope: createConnectorSchemaCacheScope({
-                accountId: "user-2",
-                endpoint: "oomol.com",
+
+        await warmConnectorActionSchemas(
+            [createSearchResultFixture({
+                authenticated: true,
+            })],
+            userScope,
+            createCacheContext({
+                cache,
             }),
-            serviceName: "gmail",
+        );
+
+        // `authenticated` is scoped to the effective identity while the cache
+        // key carries no team dimension, so the flag must never be stored.
+        const schema = await loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture(),
+                actionName: "send_mail",
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+            }),
+        );
+
+        expect("authenticated" in schema).toBeFalse();
+    });
+
+    test("warmConnectorActionSchemas caches only actions carrying both schema payloads", async () => {
+        const cache = createMemoryCache();
+
+        await warmConnectorActionSchemas(
+            [
+                createSearchResultFixture(),
+                createSearchResultFixture({
+                    inputSchema: undefined,
+                    name: "get_message",
+                }),
+            ],
+            userScope,
+            createCacheContext({
+                cache,
+            }),
+        );
+
+        const cacheable = await loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture(),
+                actionName: "send_mail",
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+            }),
+        );
+
+        expect(cacheable).toMatchObject({
+            name: "send_mail",
         });
+        await expect(isSchemaCacheMiss(cache, {
+            actionName: "get_message",
+            serviceName: "gmail",
+        })).resolves.toBeTrue();
+    });
+
+    test("warmConnectorActionSchemas never touches the cache store when nothing is cacheable", async () => {
+        const cacheOptions: CacheOptions[] = [];
+
+        await warmConnectorActionSchemas(
+            [createSearchResultFixture({
+                inputSchema: undefined,
+                outputSchema: undefined,
+            })],
+            userScope,
+            createCacheContext({
+                cacheOptions,
+            }),
+        );
+
+        expect(cacheOptions).toEqual([]);
+    });
+
+    test("warmConnectorActionSchemas resolves and warns when the cache write fails", async () => {
+        const cache = createMemoryCache();
+        const logCapture = createLogCapture();
+
+        cache.set = () => {
+            throw new Error("cache write failed");
+        };
 
         try {
-            const legacyDirectoryPath = join(rootPath, "connector-actions");
+            // Warming is best-effort: the returned promise must not reject.
+            await warmConnectorActionSchemas(
+                [createSearchResultFixture()],
+                userScope,
+                createCacheContext({
+                    cache,
+                    logger: logCapture.logger,
+                }),
+            );
 
-            await mkdir(legacyDirectoryPath, { recursive: true });
-            await Bun.write(join(legacyDirectoryPath, "old.json"), "{}");
-            cache.set(firstKey, createConnectorActionFixture());
-            cache.set(secondKey, createConnectorActionFixture({
-                description: "Second schema.",
-            }));
-
-            await clearConnectorActionSchemaCache(createCacheContext({
-                cache,
-                settingsFilePath: join(rootPath, "settings.toml"),
-            }));
-
-            expect(cache.get(firstKey)).toBeNull();
-            expect(cache.get(secondKey)).toBeNull();
-            await expect(Bun.file(legacyDirectoryPath).exists()).resolves.toBeFalse();
+            expect(logCapture.read()).toContain(
+                "Failed to warm the connector action schema cache.",
+            );
         }
         finally {
-            await rm(rootPath, { force: true, recursive: true });
+            logCapture.close();
         }
     });
 
-    test("createConnectorActionSchemaOutput exposes only the stable schema contract", () => {
-        const schema = {
-            description: "Fresh schema.",
-            inputSchema: {
-                type: "object",
-            },
-            name: "send_mail",
-            outputSchema: {
-                type: "object",
-            },
-            providerPermissions: ["gmail.send"],
-            requiredScopes: ["gmail.send"],
-            service: "gmail",
-        } satisfies ConnectorActionMetadata;
-
-        expect(createConnectorActionSchemaOutput(schema)).toEqual({
-            description: "Fresh schema.",
-            inputSchema: {
-                type: "object",
-            },
-            name: "send_mail",
-            outputSchema: {
-                type: "object",
-            },
-            service: "gmail",
-        });
-    });
-
-    test("createConnectorActionSchemaOutput preserves async submit output schema", () => {
-        const schema = {
-            asyncLifecycle: {
-                role: "submit",
-                resultAction: "openai_image_async_result",
-                handle: {
-                    inputField: "sessionID",
-                    outputField: "sessionId",
-                },
-            },
-            description: "Submit OpenAI image generation.",
-            inputSchema: {
-                type: "object",
-            },
-            name: "openai_image_async_submit",
-            outputSchema: {
-                properties: {
-                    sessionId: {
-                        type: "string",
-                    },
-                },
-                type: "object",
-            },
-            providerPermissions: [],
-            requiredScopes: [],
-            service: "fusion-api",
-        } satisfies ConnectorActionMetadata;
-
-        expect(createConnectorActionSchemaOutput(schema)).toEqual({
-            description: "Submit OpenAI image generation.",
-            inputSchema: {
-                type: "object",
-            },
-            name: "openai_image_async_submit",
-            outputSchema: {
-                properties: {
-                    sessionId: {
-                        type: "string",
-                    },
-                },
-                type: "object",
-            },
-            service: "fusion-api",
-        });
-    });
-
-    test("createConnectorActionSchemaOutput preserves async result output schema", () => {
-        const schema = {
-            asyncLifecycle: {
-                role: "result",
-                wait: {
-                    intervalSeconds: 3,
-                    resultField: "data",
-                    state: {
-                        failure: ["not_found"],
-                        field: "state",
-                        running: ["processing"],
-                        success: ["completed"],
-                    },
-                },
-            },
-            description: "Get OpenAI image generation result.",
-            inputSchema: {
-                type: "object",
-            },
-            name: "openai_image_async_result",
-            outputSchema: {
-                anyOf: [
-                    {
-                        properties: {
-                            data: {
-                                properties: {
-                                    images: {
-                                        items: {
-                                            type: "string",
-                                        },
-                                        type: "array",
-                                    },
-                                },
-                                type: "object",
-                            },
-                            state: {
-                                enum: ["completed"],
-                                type: "string",
-                            },
-                        },
-                        required: ["state", "data"],
-                        type: "object",
-                    },
-                    {
-                        properties: {
-                            progress: {
-                                type: "number",
-                            },
-                            state: {
-                                enum: ["processing"],
-                                type: "string",
-                            },
-                        },
-                        required: ["state", "progress"],
-                        type: "object",
-                    },
-                ],
-            },
-            providerPermissions: [],
-            requiredScopes: [],
-            service: "fusion-api",
-        } satisfies ConnectorActionMetadata;
-
-        expect(createConnectorActionSchemaOutput(schema)).toEqual({
-            description: "Get OpenAI image generation result.",
-            inputSchema: {
-                type: "object",
-            },
-            name: "openai_image_async_result",
-            outputSchema: schema.outputSchema,
-            service: "fusion-api",
-        });
-    });
-
-    test("isConnectorActionSchemaNotFoundError detects 404 and action_not_found failures", () => {
-        expect(isConnectorActionSchemaNotFoundError(new Error("nope"))).toBeFalse();
-        expect(isConnectorActionSchemaNotFoundError({
-            params: {
-                status: 404,
-            },
-        })).toBeFalse();
-        expect(isConnectorActionSchemaNotFoundError(new CliUserError(
-            "errors.connectorMetadata.requestFailed",
-            1,
-            {
-                status: 404,
-            },
-        ))).toBeTrue();
-        expect(isConnectorActionSchemaNotFoundError(new CliUserError(
-            "errors.connectorRun.requestFailedWithCode",
-            1,
-            {
-                errorCode: "action_not_found",
-                status: 400,
-            },
-        ))).toBeTrue();
-    });
-
-    test("cache writes clean up the legacy connector-actions directory without failing command flow", async () => {
+    test("warmConnectorActionSchemas cleans up the legacy connector-actions directory without failing command flow", async () => {
         const rootPath = await createTemporaryDirectory("connector-schema-cache");
 
         try {
@@ -657,8 +567,8 @@ describe("connector schema cache", () => {
             await mkdir(legacyDirectoryPath, { recursive: true });
             await Bun.write(join(legacyDirectoryPath, "old.json"), "{}");
 
-            await cacheConnectorActionSchemas(
-                [createConnectorActionFixture()],
+            await warmConnectorActionSchemas(
+                [createSearchResultFixture()],
                 userScope,
                 createCacheContext({
                     cache: createMemoryCache(),
@@ -672,7 +582,299 @@ describe("connector schema cache", () => {
             await rm(rootPath, { force: true, recursive: true });
         }
     });
+
+    const invalidateCases: {
+        error: unknown;
+        evicted: boolean;
+        name: string;
+    }[] = [
+        {
+            error: new CliUserError("errors.connectorMetadata.requestFailed", 1, {
+                status: 404,
+            }),
+            evicted: true,
+            name: "deletes the entry on an http 404 failure",
+        },
+        {
+            error: new CliUserError("errors.connectorRun.requestFailedWithCode", 1, {
+                errorCode: "action_not_found",
+                status: 400,
+            }),
+            evicted: true,
+            name: "deletes the entry on an action_not_found failure",
+        },
+        {
+            error: new Error("nope"),
+            evicted: false,
+            name: "keeps the entry on unrelated errors",
+        },
+        {
+            error: {
+                params: {
+                    status: 404,
+                },
+            },
+            evicted: false,
+            name: "keeps the entry on non-CliUserError 404 shapes",
+        },
+    ];
+
+    for (const invalidateCase of invalidateCases) {
+        test(`invalidateConnectorActionSchemaOnNotFound ${invalidateCase.name}`, async () => {
+            const cache = createMemoryCache();
+
+            await warmConnectorActionSchemas(
+                [createSearchResultFixture()],
+                userScope,
+                createCacheContext({
+                    cache,
+                }),
+            );
+
+            invalidateConnectorActionSchemaOnNotFound(
+                {
+                    actionName: "send_mail",
+                    cacheScope: userScope,
+                    error: invalidateCase.error,
+                    serviceName: "gmail",
+                },
+                createCacheContext({
+                    cache,
+                }),
+            );
+
+            await expect(isSchemaCacheMiss(cache, {
+                actionName: "send_mail",
+                serviceName: "gmail",
+            })).resolves.toBe(invalidateCase.evicted);
+        });
+    }
+
+    test("invalidateConnectorActionSchemaOnNotFound removes only the selected identity", async () => {
+        const cache = createMemoryCache();
+        // Every cache-key dimension gets a neighbor differing in exactly that
+        // dimension: account, endpoint, and service.
+        const otherAccountScope = createConnectorSchemaCacheScope({
+            accountId: "user-2",
+            endpoint: "oomol.com",
+        });
+        const otherEndpointScope = createConnectorSchemaCacheScope({
+            accountId: "user-1",
+            endpoint: "staging.oomol.com",
+        });
+
+        await warmConnectorActionSchemas(
+            [
+                createSearchResultFixture(),
+                createSearchResultFixture({
+                    description: "Same account Slack schema.",
+                    service: "slack",
+                }),
+            ],
+            userScope,
+            createCacheContext({
+                cache,
+            }),
+        );
+        await warmConnectorActionSchemas(
+            [createSearchResultFixture({
+                description: "Second account schema.",
+            })],
+            otherAccountScope,
+            createCacheContext({
+                cache,
+            }),
+        );
+        await warmConnectorActionSchemas(
+            [createSearchResultFixture({
+                description: "Staging endpoint schema.",
+            })],
+            otherEndpointScope,
+            createCacheContext({
+                cache,
+            }),
+        );
+
+        invalidateConnectorActionSchemaOnNotFound(
+            {
+                actionName: "send_mail",
+                cacheScope: userScope,
+                error: new CliUserError("errors.connectorMetadata.requestFailed", 1, {
+                    status: 404,
+                }),
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+            }),
+        );
+
+        await expect(isSchemaCacheMiss(cache, {
+            actionName: "send_mail",
+            serviceName: "gmail",
+        })).resolves.toBeTrue();
+        await expect(loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture(),
+                actionName: "send_mail",
+                serviceName: "slack",
+            },
+            createCacheContext({
+                cache,
+            }),
+        )).resolves.toMatchObject({
+            description: "Same account Slack schema.",
+        });
+        await expect(loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture({
+                    cacheScope: otherAccountScope,
+                }),
+                actionName: "send_mail",
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+            }),
+        )).resolves.toMatchObject({
+            description: "Second account schema.",
+        });
+        await expect(loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture({
+                    cacheScope: otherEndpointScope,
+                }),
+                actionName: "send_mail",
+                serviceName: "gmail",
+            },
+            createCacheContext({
+                cache,
+            }),
+        )).resolves.toMatchObject({
+            description: "Staging endpoint schema.",
+        });
+    });
+
+    test("clearConnectorActionSchemaCache clears the schema namespace and legacy directory", async () => {
+        const rootPath = await createTemporaryDirectory("connector-schema-cache-clear");
+        const cache = createMemoryCache();
+        const otherScope = createConnectorSchemaCacheScope({
+            accountId: "user-2",
+            endpoint: "oomol.com",
+        });
+
+        try {
+            const legacyDirectoryPath = join(rootPath, "connector-actions");
+
+            await mkdir(legacyDirectoryPath, { recursive: true });
+            await Bun.write(join(legacyDirectoryPath, "old.json"), "{}");
+            await warmConnectorActionSchemas(
+                [createSearchResultFixture()],
+                userScope,
+                createCacheContext({
+                    cache,
+                }),
+            );
+            await warmConnectorActionSchemas(
+                [createSearchResultFixture({
+                    name: "get_message",
+                })],
+                otherScope,
+                createCacheContext({
+                    cache,
+                }),
+            );
+
+            await clearConnectorActionSchemaCache(createCacheContext({
+                cache,
+                settingsFilePath: join(rootPath, "settings.toml"),
+            }));
+
+            await expect(isSchemaCacheMiss(cache, {
+                actionName: "send_mail",
+                serviceName: "gmail",
+            })).resolves.toBeTrue();
+            await expect(isSchemaCacheMiss(cache, {
+                actionName: "get_message",
+                cacheScope: otherScope,
+                serviceName: "gmail",
+            })).resolves.toBeTrue();
+            await expect(Bun.file(legacyDirectoryPath).exists()).resolves.toBeFalse();
+        }
+        finally {
+            await rm(rootPath, { force: true, recursive: true });
+        }
+    });
 });
+
+// Probes whether the cache misses for the given identity through the public
+// loader: a miss reaches the metadata fetcher, a hit never does. The probe
+// serves a real metadata response, so a missed identity is cached afterwards —
+// call it only once per identity, after the assertions that need a cold entry.
+async function isSchemaCacheMiss(
+    cache: Cache<unknown>,
+    identity: {
+        actionName: string;
+        cacheScope?: ConnectorSchemaCacheScope;
+        serviceName: string;
+    },
+): Promise<boolean> {
+    let fetched = false;
+
+    await loadConnectorActionSchema(
+        {
+            target: createConnectorTargetFixture(
+                identity.cacheScope === undefined
+                    ? {}
+                    : {
+                            cacheScope: identity.cacheScope,
+                        },
+            ),
+            actionName: identity.actionName,
+            serviceName: identity.serviceName,
+        },
+        createCacheContext({
+            cache,
+            fetcher: async () => {
+                fetched = true;
+
+                return createMetadataResponse({
+                    name: identity.actionName,
+                    service: identity.serviceName,
+                });
+            },
+        }),
+    );
+
+    return fetched;
+}
+
+function createSearchResultFixture(
+    overrides: Partial<ConnectorActionSearchResult> = {},
+): ConnectorActionSearchResult {
+    return {
+        authenticated: true,
+        ...createConnectorActionFixture(),
+        ...overrides,
+    };
+}
+
+// Deliberate replica of the module's private cache-key encoding. The cache
+// contract cannot enumerate or address entries, and a corrupt entry is the one
+// cache state the public interface can never produce, so the parse-failure
+// test seeds it at the raw key. Keep in sync with the encoding in
+// schema-cache.ts; every other test goes through the public operations.
+function createRawCacheKey(identity: {
+    actionName: string;
+    cacheScope: ConnectorSchemaCacheScope;
+    serviceName: string;
+}): string {
+    return JSON.stringify({
+        scope: identity.cacheScope,
+        serviceName: identity.serviceName,
+        actionName: identity.actionName,
+    });
+}
 
 function createMetadataResponse(overrides: {
     asyncLifecycle?: ConnectorActionMetadata["asyncLifecycle"];
@@ -710,6 +912,7 @@ function createCacheContext(options: {
     cache?: Cache<unknown>;
     cacheOptions?: CacheOptions[];
     fetcher?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+    logger?: Logger;
     settingsFilePath?: string;
 } = {}) {
     const emptySettings = {} as AppSettings;
@@ -719,7 +922,7 @@ function createCacheContext(options: {
         fetcher: options.fetcher ?? (async () => {
             throw new Error("Unexpected fetch");
         }),
-        logger: pino({
+        logger: options.logger ?? pino({
             enabled: false,
         }),
         settingsStore: {

--- a/src/application/commands/connector/schema-cache.ts
+++ b/src/application/commands/connector/schema-cache.ts
@@ -2,8 +2,8 @@ import type { Cache } from "../../contracts/cache.ts";
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 
 import type {
-    ConnectorActionDefinition,
     ConnectorActionMetadata,
+    ConnectorActionSearchResult,
 } from "./shared.ts";
 import type { ConnectorRequestTarget } from "./target.ts";
 import { rm } from "node:fs/promises";
@@ -11,6 +11,7 @@ import { dirname, join } from "node:path";
 import { CliUserError } from "../../contracts/cli.ts";
 
 import {
+    connectorActionDefinitionSchema,
     connectorActionMetadataSchema,
     getConnectorActionMetadata,
 } from "./shared.ts";
@@ -63,14 +64,6 @@ type ConnectorActionSchemaLoaderContext = Pick<
     CliExecutionContext,
     "cacheStore" | "fetcher" | "logger" | "settingsStore" | "translator"
 >;
-
-export interface ConnectorActionSchemaOutput {
-    description: string;
-    inputSchema: unknown;
-    name: string;
-    outputSchema: unknown;
-    service: string;
-}
 
 export async function loadConnectorActionSchema(
     options: {
@@ -160,30 +153,81 @@ export async function loadConnectorActionSchema(
 }
 
 /**
- * Bulk cache populator used to warm the connector action schema cache from
- * connector search responses (which carry `inputSchema` / `outputSchema` but
- * never an `asyncLifecycle`). `loadConnectorActionSchema` still fills the
- * cache lazily from the metadata API for anything search did not cover.
+ * Best-effort bulk populator that warms the action schema cache from connector
+ * search responses. Owns the whole warm-time policy: results without both
+ * schema payloads are not cacheable and are skipped, identity-scoped fields
+ * (notably the team-scoped `authenticated` flag, which must not enter a cache
+ * keyed without a team dimension) are stripped before storing, and failures
+ * are logged instead of surfacing — the caller's flow never fails on a cache
+ * write. `loadConnectorActionSchema` still fills the cache lazily from the
+ * metadata API for anything search did not cover.
  */
-export async function cacheConnectorActionSchemas(
-    actions: readonly ConnectorActionDefinition[],
+export async function warmConnectorActionSchemas(
+    actions: readonly ConnectorActionSearchResult[],
     cacheScope: ConnectorSchemaCacheScope,
     context: ConnectorActionSchemaCacheContext,
 ): Promise<void> {
-    await cleanupLegacyConnectorActionSchemaCache(context);
+    const cacheableActions = actions.filter(action =>
+        action.inputSchema !== undefined && action.outputSchema !== undefined);
 
-    const cache = openConnectorActionSchemaCache(context);
+    if (cacheableActions.length === 0) {
+        return;
+    }
 
-    for (const action of actions) {
-        cache.set(
-            createConnectorActionSchemaCacheKey({
-                actionName: action.name,
-                cacheScope,
-                serviceName: action.service,
-            }),
-            connectorActionMetadataSchema.parse(action),
+    try {
+        await cleanupLegacyConnectorActionSchemaCache(context);
+
+        const cache = openConnectorActionSchemaCache(context);
+
+        for (const action of cacheableActions) {
+            cache.set(
+                createConnectorActionSchemaCacheKey({
+                    actionName: action.name,
+                    cacheScope,
+                    serviceName: action.service,
+                }),
+                // The definition schema strips every non-schema field the
+                // search response carries; the metadata parse then restores
+                // the metadata defaults on the stored entry.
+                connectorActionMetadataSchema.parse(
+                    connectorActionDefinitionSchema.parse(action),
+                ),
+            );
+        }
+    }
+    catch (error) {
+        context.logger.warn(
+            {
+                err: error,
+            },
+            "Failed to warm the connector action schema cache.",
         );
     }
+}
+
+/**
+ * The single owner of the "not-found evicts" rule: when `error` reports that
+ * the action no longer exists (HTTP 404 or an `action_not_found` error code),
+ * the cached schema for that identity is deleted so the next load refetches.
+ * Any other error leaves the cache untouched.
+ */
+export function invalidateConnectorActionSchemaOnNotFound(
+    options: ConnectorActionSchemaIdentity & {
+        error: unknown;
+    },
+    context: Pick<CliExecutionContext, "cacheStore">,
+): void {
+    if (!isConnectorActionSchemaNotFoundError(options.error)) {
+        return;
+    }
+
+    openConnectorActionSchemaCache(context).delete(
+        createConnectorActionSchemaCacheKey({
+            actionName: options.actionName,
+            cacheScope: options.cacheScope,
+            serviceName: options.serviceName,
+        }),
+    );
 }
 
 export async function clearConnectorActionSchemaCache(
@@ -193,30 +237,7 @@ export async function clearConnectorActionSchemaCache(
     openConnectorActionSchemaCache(context).clear();
 }
 
-export function deleteConnectorActionSchemaCache(
-    identity: ConnectorActionSchemaIdentity,
-    context: Pick<CliExecutionContext, "cacheStore">,
-): boolean {
-    return openConnectorActionSchemaCache(context).delete(
-        createConnectorActionSchemaCacheKey(identity),
-    );
-}
-
-export function createConnectorActionSchemaOutput(
-    schema: ConnectorActionMetadata,
-): ConnectorActionSchemaOutput {
-    const output: ConnectorActionSchemaOutput = {
-        description: schema.description,
-        inputSchema: schema.inputSchema,
-        name: schema.name,
-        outputSchema: schema.outputSchema,
-        service: schema.service,
-    };
-
-    return output;
-}
-
-export function createConnectorActionSchemaCacheKey(
+function createConnectorActionSchemaCacheKey(
     identity: ConnectorActionSchemaIdentity,
 ): string {
     return JSON.stringify({
@@ -226,7 +247,7 @@ export function createConnectorActionSchemaCacheKey(
     });
 }
 
-export function isConnectorActionSchemaNotFoundError(error: unknown): boolean {
+function isConnectorActionSchemaNotFoundError(error: unknown): boolean {
     if (!(error instanceof CliUserError)) {
         return false;
     }

--- a/src/application/commands/connector/schema.ts
+++ b/src/application/commands/connector/schema.ts
@@ -1,15 +1,12 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
-import type { ConnectorActionSchemaOutput } from "./schema-cache.ts";
+import type { ConnectorActionMetadata } from "./shared.ts";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { writeJsonOutput } from "../json-output.ts";
 import { createFormatInputError } from "../shared/input-parsing.ts";
-import {
-    createConnectorActionSchemaOutput,
-    loadConnectorActionSchema,
-} from "./schema-cache.ts";
+import { loadConnectorActionSchema } from "./schema-cache.ts";
 import { connectorSchemaRefreshCommand } from "./schema-refresh.ts";
 import { requireConnectorActionName } from "./shared.ts";
 import { resolveConnectorTarget } from "./target.ts";
@@ -137,6 +134,29 @@ function parseQualifiedActionId(rawActionId: string): QualifiedActionTarget {
     return {
         actionName: trimmed.slice(separatorIndex + 1),
         serviceName: trimmed.slice(0, separatorIndex),
+    };
+}
+
+// The stable `oo connector schema` output contract: exactly the five schema
+// fields, so cache-internal metadata (permissions, lifecycle, passthrough
+// fields) never leaks into the CLI output.
+interface ConnectorActionSchemaOutput {
+    description: string;
+    inputSchema: unknown;
+    name: string;
+    outputSchema: unknown;
+    service: string;
+}
+
+function createConnectorActionSchemaOutput(
+    schema: ConnectorActionMetadata,
+): ConnectorActionSchemaOutput {
+    return {
+        description: schema.description,
+        inputSchema: schema.inputSchema,
+        name: schema.name,
+        outputSchema: schema.outputSchema,
+        service: schema.service,
     };
 }
 

--- a/src/application/commands/connector/search-provider.test.ts
+++ b/src/application/commands/connector/search-provider.test.ts
@@ -13,10 +13,7 @@ import {
 } from "../../../../__tests__/helpers.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
 
-import {
-    createConnectorActionSchemaCacheKey,
-    createConnectorSchemaCacheScope,
-} from "./schema-cache.ts";
+import { loadConnectorActionSchema } from "./schema-cache.ts";
 import { loadConnectorSearchResults } from "./search-provider.ts";
 
 describe("connector search provider", () => {
@@ -73,14 +70,25 @@ describe("connector search provider", () => {
         expect(requests.map(request => request.url)).toEqual([
             "https://connector.oomol.com/v1/actions/search?q=send+mail",
         ]);
-        expect(cache.get(createConnectorActionSchemaCacheKey({
-            actionName: "send_mail",
-            cacheScope: createConnectorSchemaCacheScope({
-                accountId: "user-1",
-                endpoint: "oomol.com",
+
+        // The warmed entry serves a later schema load without a fetch (the
+        // context fetcher rejects every request), and the identity-scoped
+        // `authenticated` flag from the search response is not stored.
+        const warmed = await loadConnectorActionSchema(
+            {
+                target: createConnectorTargetFixture(),
+                actionName: "send_mail",
+                serviceName: "gmail",
+            },
+            createSearchContext({
+                cache,
+                fetcher: async () => {
+                    throw new Error("Unexpected fetch");
+                },
             }),
-            serviceName: "gmail",
-        }))).toMatchObject({
+        );
+
+        expect(warmed).toMatchObject({
             description: "Send a Gmail message.",
             inputSchema: {
                 type: "object",
@@ -91,42 +99,7 @@ describe("connector search provider", () => {
             },
             service: "gmail",
         });
-    });
-
-    test("skips schema cache warming for results without schema payloads", async () => {
-        const cache = createMemoryCache();
-
-        const results = await loadConnectorSearchResults(
-            {
-                target: createConnectorTargetFixture(),
-                text: "send mail",
-            },
-            createSearchContext({
-                cache,
-                fetcher: async () => new Response(JSON.stringify({
-                    success: true,
-                    message: "ok",
-                    data: [
-                        {
-                            authenticated: true,
-                            description: "Send a Gmail message.",
-                            name: "send_mail",
-                            service: "gmail",
-                        },
-                    ],
-                })),
-            }),
-        );
-
-        expect(results).toHaveLength(1);
-        expect(cache.get(createConnectorActionSchemaCacheKey({
-            actionName: "send_mail",
-            cacheScope: createConnectorSchemaCacheScope({
-                accountId: "user-1",
-                endpoint: "oomol.com",
-            }),
-            serviceName: "gmail",
-        }))).toBeNull();
+        expect("authenticated" in warmed).toBeFalse();
     });
 
     test("returns search results when schema cache warming fails", async () => {

--- a/src/application/commands/connector/search-provider.ts
+++ b/src/application/commands/connector/search-provider.ts
@@ -2,13 +2,9 @@ import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { TerminalColors } from "../../terminal-colors.ts";
 
 import type { TeamIdentity } from "../team/identity.ts";
-import type {
-    ConnectorSchemaCacheScope,
-    ConnectorSchemaRequestTarget,
-} from "./schema-cache.ts";
-import type { ConnectorActionSearchResult } from "./shared.ts";
+import type { ConnectorSchemaRequestTarget } from "./schema-cache.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
-import { cacheConnectorActionSchemas } from "./schema-cache.ts";
+import { warmConnectorActionSchemas } from "./schema-cache.ts";
 
 import { searchConnectorActions } from "./shared.ts";
 
@@ -41,7 +37,7 @@ export async function loadConnectorSearchResults(
         text: options.text,
     }, context);
 
-    await warmConnectorActionSchemaCache(actions, options.target.cacheScope, context);
+    await warmConnectorActionSchemas(actions, options.target.cacheScope, context);
 
     return actions.map(action => ({
         authenticated: action.authenticated,
@@ -49,33 +45,6 @@ export async function loadConnectorSearchResults(
         name: action.name,
         service: action.service,
     }));
-}
-
-async function warmConnectorActionSchemaCache(
-    actions: readonly ConnectorActionSearchResult[],
-    cacheScope: ConnectorSchemaCacheScope,
-    context: Pick<CliExecutionContext, "cacheStore" | "logger" | "settingsStore">,
-): Promise<void> {
-    const cacheableActions = actions.filter(action =>
-        action.inputSchema !== undefined && action.outputSchema !== undefined);
-
-    if (cacheableActions.length === 0) {
-        return;
-    }
-
-    try {
-        await cacheConnectorActionSchemas(cacheableActions, cacheScope, context);
-    }
-    catch (error) {
-        // Cache warming is a best-effort optimization; search results must
-        // still be returned when the local cache cannot be written.
-        context.logger.warn(
-            {
-                err: error,
-            },
-            "Failed to warm connector action schemas during search.",
-        );
-    }
 }
 
 export function formatConnectorSearchResultsAsText(

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -183,7 +183,6 @@ export function requireConnectorActionName(rawAction: string | undefined): strin
     return trimmed;
 }
 
-export type ConnectorActionDefinition = z.output<typeof connectorActionDefinitionSchema>;
 export type ConnectorActionSearchResult = z.output<typeof connectorActionSearchResultSchema>;
 export type ConnectorActionAsyncLifecycle = z.output<typeof connectorActionAsyncLifecycleSchema>;
 export type ConnectorActionMetadata = z.output<typeof connectorActionMetadataSchema>;


### PR DESCRIPTION
Candidate 07 of the architecture-deepening series (after #310–#322): let the action-schema cache own its key and its eviction rule.

## Problem

`schema-cache.ts` exported eleven symbols, and three of its own invariants lived at callers:

- **Not-found-evicts rule, two copies** — the loader's fetch path and `run.ts`'s catch each combined the exported 404 predicate with a delete call.
- **Warm-time policy at the caller** — `search-provider.ts` owned the cacheability filter and the best-effort try/catch around the bulk cache write.
- **Identity-scoped field under an identity-blind key** — the passthrough metadata parse stored the team-scoped `authenticated` search field (#306) in a cache keyed only by account+endpoint. Harmless today solely because the output formatter picks five fields; a live trap.

Tests in three files additionally pinned the private cache-key encoding.

## Change

`schema-cache.ts` now exports exactly **four operations** plus the opaque cache-scope pieces from #319:

| Operation | Owns |
|---|---|
| `loadConnectorActionSchema` | unchanged: fetch-or-cache, refresh bypass, async-lifecycle miss rule, parse-failure self-heal, evict-on-not-found on its fetch path |
| `warmConnectorActionSchemas` | replaces `cacheConnectorActionSchemas`; cacheability filter, stripping of non-definition fields (`authenticated` never enters the cache), and its own best-effort catch |
| `invalidateConnectorActionSchemaOnNotFound` | replaces the exported 404 predicate + delete pair; the not-found-evicts rule now has one implementation |
| `clearConnectorActionSchemaCache` | unchanged |

The key builder and not-found predicate are no longer exported. The output formatter moved into `schema.ts` next to its only consumer. `run.ts`'s catch is one invalidate call; `search-provider.ts`'s private warm wrapper is gone.

## Tests

Rewritten to seed and probe through the public operations only: cache hits are proven by a loader call whose fetcher rejects, misses by a fetch-count probe. The CLI seed helper now goes through the loader with a stub metadata response (the real write path — and the only way to seed async-lifecycle entries, which warming deliberately cannot produce). The one sanctioned exception is the parse-failure self-heal test, which keeps a commented local replica of the key encoding because the cache contract cannot enumerate or address entries.

Scope-isolation coverage is mutation-verified: dropping either the `endpoint` or the `serviceName` dimension from the key encoding fails a test (it previously passed the entire suite). New CLI tests pin exact schema-output equality, including an `anyOf` output schema without a top-level `type` and the exclusion of `asyncLifecycle` from the output.

## Behavior

No CLI contract changes; `docs/commands*.md` untouched. The key encoding is unchanged, so existing caches stay warm. Warmed entries no longer store `authenticated` (no code path read it from the cache; stale entries age out via the 1 h TTL). Pure refactor: no telemetry manifest changes.