### PR TITLE
refactor(commands): migrate all standard commands onto the output handle

### DIFF
--- a/src/application/commands/auth/status.ts
+++ b/src/application/commands/auth/status.ts
@@ -15,8 +15,6 @@ import { resolveIdentity } from "../../auth/identity.ts";
 import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { probeOo } from "../shared/oo-request.ts";
 import { writeLine } from "../shared/output.ts";
 import { resolveSelfHostedConnectorTolerantly } from "../shared/self-hosted-connector.ts";
@@ -58,13 +56,6 @@ interface ActiveAccountStatus {
 interface ResolvedStatusIdentity {
     account: AuthAccount;
     source: CredentialSource;
-}
-
-const authStatusFormatValues = ["json"] as const;
-
-interface AuthStatusInput {
-    format?: (typeof authStatusFormatValues)[number];
-    showSchemaVersion?: boolean;
 }
 
 interface AuthStatusJsonAccount {
@@ -128,18 +119,14 @@ type AuthStatusJsonPayload
         connector?: AuthStatusJsonConnector;
     };
 
-export const authStatusCommand: CliCommandDefinition<AuthStatusInput> = {
+export const authStatusCommand: CliCommandDefinition = {
     name: "status",
     aliases: ["info"],
     summaryKey: "commands.auth.status.summary",
     descriptionKey: "commands.auth.status.description",
-    options: [...outputFormatOptions],
-    inputSchema: z.object({
-        format: z.enum(authStatusFormatValues).optional(),
-        showSchemaVersion: z.boolean().optional(),
-    }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
-    handler: async (input, context) => {
+    output: "standard",
+    inputSchema: z.object({}),
+    handler: async (_input, context) => {
         // Tolerant lookup: a broken connector.toml must not take down the
         // whole status report; the block is simply omitted.
         const selfHostedConnector = await resolveSelfHostedConnectorTolerantly(context);
@@ -160,7 +147,7 @@ export const authStatusCommand: CliCommandDefinition<AuthStatusInput> = {
                 { path: context.authStore.getFilePath() },
             );
 
-            if (input.format === "json") {
+            if (context.output.format === "json") {
                 // stdout must stay valid JSON; diagnostics go to stderr.
                 writeLine(context.stderr, corruptWarning);
             }
@@ -201,22 +188,18 @@ export const authStatusCommand: CliCommandDefinition<AuthStatusInput> = {
                 ? undefined
                 : { ...identity, apiKeyStatus };
 
-        if (input.format === "json") {
-            writeJsonOutput(
-                context.stdout,
-                buildAuthStatusJsonPayload(
-                    authFile,
-                    activeStatus,
-                    teamIdentity,
-                    selfHostedConnector,
-                ),
-                { showSchemaVersion: input.showSchemaVersion },
-            );
-            return;
-        }
-
-        writeAuthStatusText(context, authFile, activeStatus, teamIdentity);
-        writeSelfHostedConnectorText(context, selfHostedConnector);
+        context.output.emit(
+            buildAuthStatusJsonPayload(
+                authFile,
+                activeStatus,
+                teamIdentity,
+                selfHostedConnector,
+            ),
+            () => {
+                writeAuthStatusText(context, authFile, activeStatus, teamIdentity);
+                writeSelfHostedConnectorText(context, selfHostedConnector);
+            },
+        );
     },
 };
 

--- a/src/application/commands/check-update.ts
+++ b/src/application/commands/check-update.ts
@@ -1,4 +1,8 @@
-import type { CliCommandDefinition, CliExecutionContext } from "../contracts/cli.ts";
+import type {
+    CliCommandContext,
+    CliCommandDefinition,
+    CliExecutionContext,
+} from "../contracts/cli.ts";
 import type { CliUpdateCheckResult } from "../update/update-notifier.ts";
 
 import { z } from "zod";
@@ -9,16 +13,7 @@ import {
     cliUpdateCommand,
     renderCliUpdateNotice,
 } from "../update/update-notifier.ts";
-import { outputFormatOptions, writeJsonOutput } from "./command-output.ts";
 import { classifyTelemetryVersionKind } from "./self-update-telemetry.ts";
-import { createFormatInputError } from "./shared/input-parsing.ts";
-
-const checkUpdateFormatValues = ["json"] as const;
-
-interface CheckUpdateInput {
-    format?: (typeof checkUpdateFormatValues)[number];
-    showSchemaVersion?: boolean;
-}
 
 interface CheckUpdateJsonPayload {
     status: "update-available" | "up-to-date" | "failed";
@@ -36,17 +31,13 @@ const checkUpdateFailureMessages = {
     string
 >;
 
-export const checkUpdateCommand: CliCommandDefinition<CheckUpdateInput> = {
+export const checkUpdateCommand: CliCommandDefinition = {
     name: "check-update",
     summaryKey: "commands.checkUpdate.summary",
     descriptionKey: "commands.checkUpdate.description",
-    options: [...outputFormatOptions],
-    inputSchema: z.object({
-        format: z.enum(checkUpdateFormatValues).optional(),
-        showSchemaVersion: z.boolean().optional(),
-    }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
-    handler: async (input, context) => {
+    output: "standard",
+    inputSchema: z.object({}),
+    handler: async (_input, context) => {
         // OO_NO_SELF_UPDATE disables the update machinery, including the remote
         // release check that hits the hardcoded static.oomol.com source.
         if (isSelfUpdateDisabledByEnv(context.env)) {
@@ -59,8 +50,8 @@ export const checkUpdateCommand: CliCommandDefinition<CheckUpdateInput> = {
 
         const result = await checkForCliUpdate(context);
 
-        if (input.format === "json") {
-            handleCheckUpdateJson(result, context, input);
+        if (context.output.format === "json") {
+            handleCheckUpdateJson(result, context);
             return;
         }
 
@@ -70,8 +61,7 @@ export const checkUpdateCommand: CliCommandDefinition<CheckUpdateInput> = {
 
 function handleCheckUpdateJson(
     result: CliUpdateCheckResult,
-    context: CliExecutionContext,
-    input: CheckUpdateInput,
+    context: CliCommandContext,
 ): void {
     const payload = buildCheckUpdateJsonPayload(result, context.version);
 
@@ -89,9 +79,7 @@ function handleCheckUpdateJson(
         );
     }
 
-    writeJsonOutput(context.stdout, payload, {
-        showSchemaVersion: input.showSchemaVersion,
-    });
+    context.output.emitJson(payload);
 }
 
 function buildCheckUpdateJsonPayload(

--- a/src/application/commands/connector/apps.ts
+++ b/src/application/commands/connector/apps.ts
@@ -6,8 +6,6 @@ import type { ConnectorAppView } from "./shared.ts";
 import { z } from "zod";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { connectorSearchServiceColor } from "./search-provider.ts";
 import {
     resolveConnectorSession,
@@ -15,7 +13,6 @@ import {
     teamIdentityOptions,
 } from "./session.ts";
 import {
-    connectorFormatValues,
     listConnectorApps,
     listConnectorAppsByService,
 } from "./shared.ts";
@@ -35,11 +32,9 @@ const connectorAppStatusColors = {
 type ConnectorAppsListScope = "all" | "service";
 
 interface ConnectorAppsInput {
-    format?: (typeof connectorFormatValues)[number];
     team?: string;
     personal?: boolean;
     serviceName?: string;
-    showSchemaVersion?: boolean;
 }
 
 interface ConnectorAppListItem {
@@ -69,15 +64,12 @@ export const connectorAppsCommand: CliCommandDefinition<ConnectorAppsInput> = {
             personal: "options.connectorAppsPersonal",
             team: "options.connectorAppsTeam",
         }),
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
-        format: z.enum(connectorFormatValues).optional(),
         ...teamIdentityInputShape,
         serviceName: z.string().optional(),
-        showSchemaVersion: z.boolean().optional(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         const serviceName = input.serviceName?.trim();
         const hasService = serviceName !== undefined && serviceName !== "";
@@ -107,21 +99,16 @@ export const connectorAppsCommand: CliCommandDefinition<ConnectorAppsInput> = {
             result_count_bucket: bucketTelemetryCount(output.length),
         });
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, output, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
-
-        context.stdout.write(
-            `${formatConnectorAppsAsText(
-                output,
-                listScope,
-                context.translator,
-                createWriterColors(context.stdout),
-            )}\n`,
-        );
+        context.output.emit(output, () => {
+            context.stdout.write(
+                `${formatConnectorAppsAsText(
+                    output,
+                    listScope,
+                    context.translator,
+                    createWriterColors(context.stdout),
+                )}\n`,
+            );
+        });
     },
 };
 

--- a/src/application/commands/connector/proxy.ts
+++ b/src/application/commands/connector/proxy.ts
@@ -5,18 +5,13 @@ import { Buffer } from "node:buffer";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { readJsonInputValue } from "../shared/json-input.ts";
 import {
     resolveConnectorSession,
     teamIdentityInputShape,
     teamIdentityOptions,
 } from "./session.ts";
-import {
-    connectorFormatValues,
-    runConnectorProxy,
-} from "./shared.ts";
+import { runConnectorProxy } from "./shared.ts";
 import { recordConnectorFailureTelemetry } from "./telemetry.ts";
 
 const connectorProxyDataErrorKeys = {
@@ -51,14 +46,12 @@ interface ConnectorProxyInput {
     body?: string;
     data?: string;
     endpoint?: string;
-    format?: (typeof connectorFormatValues)[number];
     headers?: string;
     method?: string;
     team?: string;
     personal?: boolean;
     query?: string;
     serviceName: string;
-    showSchemaVersion?: boolean;
 }
 
 export const connectorProxyCommand: CliCommandDefinition<ConnectorProxyInput> = {
@@ -116,21 +109,18 @@ export const connectorProxyCommand: CliCommandDefinition<ConnectorProxyInput> = 
             personal: "options.connectorProxyPersonal",
             team: "options.connectorProxyTeam",
         }),
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
         body: z.string().optional(),
         data: z.string().optional(),
         endpoint: z.string().optional(),
-        format: z.enum(connectorFormatValues).optional(),
         headers: z.string().optional(),
         method: z.string().optional(),
         ...teamIdentityInputShape,
         query: z.string().optional(),
         serviceName: z.string(),
-        showSchemaVersion: z.boolean().optional(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         // Payload parsing must stay ahead of the session: proxy usage errors
         // are reported before any login requirement.
@@ -168,14 +158,9 @@ export const connectorProxyCommand: CliCommandDefinition<ConnectorProxyInput> = 
             throw error;
         }
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, response, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
-
-        context.stdout.write(`${formatConnectorProxyResponseAsText(response, context)}\n`);
+        context.output.emit(response, () => {
+            context.stdout.write(`${formatConnectorProxyResponseAsText(response, context)}\n`);
+        });
     },
 };
 

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -12,8 +12,6 @@ import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { readJsonInputValue } from "../shared/json-input.ts";
 import { TerminalProgressRenderer } from "../shared/terminal-progress-renderer.ts";
 import {
@@ -26,7 +24,6 @@ import {
     teamIdentityOptions,
 } from "./session.ts";
 import {
-    connectorFormatValues,
     requireConnectorActionName,
     runConnectorAction,
 } from "./shared.ts";
@@ -62,11 +59,9 @@ interface ConnectorRunInput {
     connectionName?: string;
     data?: string;
     dryRun?: boolean;
-    format?: (typeof connectorFormatValues)[number];
     team?: string;
     personal?: boolean;
     serviceName: string;
-    showSchemaVersion?: boolean;
     wait?: boolean;
     waitResult?: boolean;
 }
@@ -124,21 +119,18 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             personal: "options.connectorRunPersonal",
             team: "options.connectorRunTeam",
         }),
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
         action: z.string().optional(),
         connectionName: z.string().optional(),
         data: z.string().optional(),
         dryRun: z.boolean().optional(),
-        format: z.enum(connectorFormatValues).optional(),
         ...teamIdentityInputShape,
         serviceName: z.string(),
-        showSchemaVersion: z.boolean().optional(),
         wait: z.boolean().optional(),
         waitResult: z.boolean().optional(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         const actionName = requireConnectorActionName(input.action);
 
@@ -217,12 +209,10 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
         validateConnectorActionInput(inputData, actionSchema.inputSchema, context.translator);
 
         if (input.dryRun === true) {
-            if (input.format === "json") {
-                writeJsonOutput(context.stdout, {
+            if (context.output.format === "json") {
+                context.output.emitJson({
                     dryRun: true,
                     ok: true,
-                }, {
-                    showSchemaVersion: input.showSchemaVersion,
                 });
                 return;
             }
@@ -258,7 +248,7 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             resultLifecycle = resultActionSchema.asyncLifecycle;
         }
 
-        const progressReporter = resultLifecycle === undefined || input.format === "json"
+        const progressReporter = resultLifecycle === undefined || context.output.format === "json"
             ? undefined
             : createConnectorAsyncLifecycleProgressReporter(context);
 
@@ -296,10 +286,8 @@ export const connectorRunCommand: CliCommandDefinition<ConnectorRunInput> = {
             throw error;
         }
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, response, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
+        if (context.output.format === "json") {
+            context.output.emitJson(response);
             return;
         }
 

--- a/src/application/commands/connector/search.ts
+++ b/src/application/commands/connector/search.ts
@@ -5,8 +5,6 @@ import {
     bucketTelemetryCount,
     bucketTelemetryStringLength,
 } from "../../telemetry/buckets.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import {
     formatConnectorSearchResultsAsText,
     loadConnectorSearchResults,
@@ -16,13 +14,10 @@ import {
     teamIdentityInputShape,
     teamIdentityOptions,
 } from "./session.ts";
-import { connectorFormatValues } from "./shared.ts";
 
 interface ConnectorSearchInput {
-    format?: (typeof connectorFormatValues)[number];
     team?: string;
     personal?: boolean;
-    showSchemaVersion?: boolean;
     text: string;
 }
 
@@ -43,15 +38,12 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
             personal: "options.searchPersonal",
             team: "options.searchTeam",
         }),
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
-        format: z.enum(connectorFormatValues).optional(),
         ...teamIdentityInputShape,
-        showSchemaVersion: z.boolean().optional(),
         text: z.string(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         context.telemetry?.recordProperties({
             query_length_bucket: bucketTelemetryStringLength(input.text),
@@ -78,29 +70,17 @@ export const connectorSearchCommand: CliCommandDefinition<ConnectorSearchInput> 
             result_count_bucket: bucketTelemetryCount(results.length),
         });
 
-        if (results.length === 0) {
-            if (input.format === "json") {
-                writeJsonOutput(context.stdout, [], {
-                    showSchemaVersion: input.showSchemaVersion,
-                });
+        context.output.emit(results, () => {
+            if (results.length === 0) {
+                context.stdout.write(
+                    `${context.translator.t("connector.search.text.noResults")}\n`,
+                );
                 return;
             }
 
             context.stdout.write(
-                `${context.translator.t("connector.search.text.noResults")}\n`,
+                `${formatConnectorSearchResultsAsText(results, context)}\n`,
             );
-            return;
-        }
-
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, results, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
-
-        context.stdout.write(
-            `${formatConnectorSearchResultsAsText(results, context)}\n`,
-        );
+        });
     },
 };

--- a/src/application/commands/connector/shared.ts
+++ b/src/application/commands/connector/shared.ts
@@ -167,8 +167,6 @@ const connectorActionFailureResponseSchema = z.object({
     }).partial().optional(),
 }).passthrough();
 
-export const connectorFormatValues = ["json"] as const;
-
 export interface ConnectorConnectionSelector {
     connectionName?: string;
 }

--- a/src/application/commands/file/cleanup.test.ts
+++ b/src/application/commands/file/cleanup.test.ts
@@ -1,10 +1,10 @@
 import type { CliCommandContext } from "../../contracts/cli.ts";
 
 import { describe, expect, test } from "bun:test";
-import { z } from "zod";
 
 import { createTextBuffer } from "../../../../__tests__/helpers.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
+import { createCommandOutput } from "../command-output.ts";
 import { fileCleanupCommand } from "./cleanup.ts";
 
 describe("file cleanup command", () => {
@@ -26,6 +26,7 @@ describe("file cleanup command", () => {
                         return Promise.resolve(1);
                     },
                 },
+                output: createCommandOutput(stdout.writer, {}, "standard"),
                 stdout: stdout.writer,
                 translator: createTranslator("en"),
             } as unknown as CliCommandContext,
@@ -39,9 +40,7 @@ describe("file cleanup command", () => {
         const stdout = createTextBuffer();
 
         await fileCleanupCommand.handler!(
-            {
-                format: "json",
-            },
+            {},
             {
                 fileUploadStore: {
                     deleteExpired() {
@@ -53,6 +52,11 @@ describe("file cleanup command", () => {
                         return Promise.resolve(0);
                     },
                 },
+                output: createCommandOutput(
+                    stdout.writer,
+                    { format: "json" },
+                    "standard",
+                ),
                 stdout: stdout.writer,
                 translator: createTranslator("en"),
             } as unknown as CliCommandContext,
@@ -65,10 +69,7 @@ describe("file cleanup command", () => {
         const stdout = createTextBuffer();
 
         await fileCleanupCommand.handler!(
-            {
-                format: "json",
-                showSchemaVersion: true,
-            },
+            {},
             {
                 fileUploadStore: {
                     deleteExpired() {
@@ -80,6 +81,11 @@ describe("file cleanup command", () => {
                         return Promise.resolve(0);
                     },
                 },
+                output: createCommandOutput(
+                    stdout.writer,
+                    { format: "json", showSchemaVersion: true },
+                    "standard",
+                ),
                 stdout: stdout.writer,
                 translator: createTranslator("en"),
             } as unknown as CliCommandContext,
@@ -95,9 +101,7 @@ describe("file cleanup command", () => {
         const stdout = createTextBuffer();
 
         await fileCleanupCommand.handler!(
-            {
-                showSchemaVersion: true,
-            },
+            {},
             {
                 fileUploadStore: {
                     deleteExpired() {
@@ -109,6 +113,11 @@ describe("file cleanup command", () => {
                         return Promise.resolve(0);
                     },
                 },
+                output: createCommandOutput(
+                    stdout.writer,
+                    { showSchemaVersion: true },
+                    "standard",
+                ),
                 stdout: stdout.writer,
                 translator: createTranslator("en"),
             } as unknown as CliCommandContext,
@@ -117,22 +126,5 @@ describe("file cleanup command", () => {
         expect(stdout.read()).toBe(
             "Deleted 3 expired or stale file transfer records.\n",
         );
-    });
-
-    test("maps invalid format input to a user-facing error", () => {
-        const error = fileCleanupCommand.mapInputError!(
-            new z.ZodError([]),
-            {
-                format: "yaml",
-            },
-        );
-
-        expect(error).toMatchObject({
-            exitCode: 2,
-            key: "errors.shared.invalidFormat",
-            params: {
-                value: "yaml",
-            },
-        });
     });
 });

--- a/src/application/commands/file/cleanup.ts
+++ b/src/application/commands/file/cleanup.ts
@@ -1,28 +1,16 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError, parseFileFormat } from "./shared.ts";
-
-interface FileCleanupInput {
-    format?: string;
-    showSchemaVersion?: boolean;
-}
 
 const staleDownloadSessionTtlMs = 14 * 24 * 60 * 60 * 1000;
 
-export const fileCleanupCommand: CliCommandDefinition<FileCleanupInput> = {
+export const fileCleanupCommand: CliCommandDefinition = {
     name: "cleanup",
     summaryKey: "commands.file.cleanup.summary",
     descriptionKey: "commands.file.cleanup.description",
-    options: [...outputFormatOptions],
-    inputSchema: z.object({
-        format: z.string().optional(),
-        showSchemaVersion: z.boolean().optional(),
-    }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
-    handler: async (input, context) => {
-        const format = parseFileFormat(input.format);
+    output: "standard",
+    inputSchema: z.object({}),
+    handler: async (_input, context) => {
         const now = Date.now();
         const deletedUploadCount = context.fileUploadStore.deleteExpired(now);
         const deletedDownloadSessionCount
@@ -31,19 +19,14 @@ export const fileCleanupCommand: CliCommandDefinition<FileCleanupInput> = {
             );
         const deletedCount = deletedUploadCount + deletedDownloadSessionCount;
 
-        if (format === "json") {
-            writeJsonOutput(context.stdout, {
-                deletedCount,
-            }, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
-
-        context.stdout.write(
-            `${context.translator.t("file.cleanup.success", {
-                deletedCount,
-            })}\n`,
-        );
+        context.output.emit({
+            deletedCount,
+        }, () => {
+            context.stdout.write(
+                `${context.translator.t("file.cleanup.success", {
+                    deletedCount,
+                })}\n`,
+            );
+        });
     },
 };

--- a/src/application/commands/file/list.ts
+++ b/src/application/commands/file/list.ts
@@ -1,10 +1,7 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 
 import { z } from "zod";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
 import {
-    createFormatInputError,
-    parseFileFormat,
     parseFileLimit,
     parseFileStatus,
     serializeFileUploadRecord,
@@ -12,9 +9,7 @@ import {
 import { formatFileUploadListAsText } from "./text.ts";
 
 interface FileListInput {
-    format?: string;
     limit?: string;
-    showSchemaVersion?: boolean;
     status?: string;
 }
 
@@ -23,7 +18,6 @@ export const fileListCommand: CliCommandDefinition<FileListInput> = {
     summaryKey: "commands.file.list.summary",
     descriptionKey: "commands.file.list.description",
     options: [
-        ...outputFormatOptions,
         {
             name: "status",
             longFlag: "--status",
@@ -37,15 +31,12 @@ export const fileListCommand: CliCommandDefinition<FileListInput> = {
             descriptionKey: "options.limit",
         },
     ],
+    output: "standard",
     inputSchema: z.object({
-        format: z.string().optional(),
         limit: z.string().optional(),
-        showSchemaVersion: z.boolean().optional(),
         status: z.string().optional(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: (input, context) => {
-        const format = parseFileFormat(input.format);
         const limit = parseFileLimit(input.limit);
         const status = parseFileStatus(input.status);
         const now = Date.now();
@@ -57,26 +48,21 @@ export const fileListCommand: CliCommandDefinition<FileListInput> = {
             })
             .map(record => serializeFileUploadRecord(record, now, context.logger));
 
-        if (format === "json") {
-            writeJsonOutput(context.stdout, records, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
+        context.output.emit(records, () => {
+            if (records.length === 0) {
+                const message = status === undefined
+                    ? context.translator.t("file.list.noResults")
+                    : context.translator.t("file.list.noResultsForStatus", {
+                            status: context.translator.t(`file.status.${status}`),
+                        });
 
-        if (records.length === 0) {
-            const message = status === undefined
-                ? context.translator.t("file.list.noResults")
-                : context.translator.t("file.list.noResultsForStatus", {
-                        status: context.translator.t(`file.status.${status}`),
-                    });
+                context.stdout.write(`${message}\n`);
+                return;
+            }
 
-            context.stdout.write(`${message}\n`);
-            return;
-        }
-
-        context.stdout.write(
-            `${formatFileUploadListAsText(records, context)}\n`,
-        );
+            context.stdout.write(
+                `${formatFileUploadListAsText(records, context)}\n`,
+            );
+        });
     },
 };

--- a/src/application/commands/file/shared.ts
+++ b/src/application/commands/file/shared.ts
@@ -9,16 +9,11 @@ import type { AuthAccount } from "../../schemas/auth.ts";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { createRetryingFetcher } from "../../shared/retrying-fetcher.ts";
-import { parseEnumOption, parsePositiveIntegerOption } from "../shared/input-parsing.ts";
+import { parsePositiveIntegerOption } from "../shared/input-parsing.ts";
 import { requestOo, requestOoResponse } from "../shared/oo-request.ts";
 
-export { createFormatInputError } from "../shared/input-parsing.ts";
-
-export const fileFormatValues = ["json"] as const;
 export const fileUploadExpiresInMs = ((7 * 24 * 60 * 60) - 1) * 1000;
 export const maxFileUploadSizeBytes = 500 * 1024 * 1024;
-
-export type FileFormat = (typeof fileFormatValues)[number];
 
 export interface FileUploadRecordView {
     downloadUrl: string;
@@ -82,12 +77,6 @@ const completeFileUploadResponseSchema = z.object({
 }).passthrough();
 
 const fileUploadPartExtraRetries = 1;
-
-export function parseFileFormat(
-    value: string | undefined,
-): FileFormat | undefined {
-    return parseEnumOption(value, fileFormatValues, "errors.shared.invalidFormat");
-}
 
 export function parseFileLimit(value: string | undefined): number | undefined {
     return parsePositiveIntegerOption(

--- a/src/application/commands/file/upload.ts
+++ b/src/application/commands/file/upload.ts
@@ -10,24 +10,19 @@ import { z } from "zod";
 import { requireIdentity } from "../../auth/identity.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
 import {
     completeMultipartFileUpload,
-    createFormatInputError,
     createMultipartFileUpload,
     fileUploadExpiresInMs,
     generatePresignedFileUploadPartUrls,
     maxFileUploadSizeBytes,
-    parseFileFormat,
     serializeFileUploadRecord,
     uploadFileParts,
 } from "./shared.ts";
 import { formatFileUploadRecordDetailsAsText } from "./text.ts";
 
 interface FileUploadInput {
-    format?: string;
     filePath: string;
-    showSchemaVersion?: boolean;
 }
 
 type RecordTelemetryProperties = NonNullable<
@@ -46,15 +41,11 @@ export const fileUploadCommand: CliCommandDefinition<FileUploadInput> = {
             required: true,
         },
     ],
-    options: [...outputFormatOptions],
+    output: "standard",
     inputSchema: z.object({
-        format: z.string().optional(),
         filePath: z.string(),
-        showSchemaVersion: z.boolean().optional(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
-        const format = parseFileFormat(input.format);
         const { account } = await requireIdentity(context);
         const sourceFile = await readSourceFile(
             input.filePath,
@@ -106,21 +97,16 @@ export const fileUploadCommand: CliCommandDefinition<FileUploadInput> = {
 
         const view = serializeFileUploadRecord(record, uploadedAtMs, context.logger);
 
-        if (format === "json") {
-            writeJsonOutput(context.stdout, view, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
+        context.output.emit(view, () => {
+            const lines = [
+                context.translator.t("file.upload.success", {
+                    fileName: sourceFile.fileName,
+                }),
+                ...formatFileUploadRecordDetailsAsText(view, context),
+            ];
 
-        const lines = [
-            context.translator.t("file.upload.success", {
-                fileName: sourceFile.fileName,
-            }),
-            ...formatFileUploadRecordDetailsAsText(view, context),
-        ];
-
-        context.stdout.write(`${lines.join("\n")}\n`);
+            context.stdout.write(`${lines.join("\n")}\n`);
+        });
     },
 };
 

--- a/src/application/commands/info.ts
+++ b/src/application/commands/info.ts
@@ -7,18 +7,12 @@ import { z } from "zod";
 import { resolveStorePaths } from "../../adapters/store/store-path.ts";
 import { APP_NAME } from "../config/app-config.ts";
 import { createWriterColors } from "../terminal-colors.ts";
-import { outputFormatOptions, writeJsonOutput } from "./command-output.ts";
-import { createFormatInputError } from "./shared/input-parsing.ts";
 import { directoryExists } from "./skills/bundled-skill-observation.ts";
 import {
     availableBundledSkillAgentNames,
     resolveManagedSkillAgentHomeDirectory,
 } from "./skills/managed-skill-agents.ts";
 import { resolveManagedSkillsDirectoryPath } from "./skills/managed-skill-paths.ts";
-
-const infoFormatValues = ["json"] as const;
-
-type InfoFormat = (typeof infoFormatValues)[number];
 
 type InfoAgentStatus = "available" | "no_skills" | "not_installed";
 
@@ -27,11 +21,6 @@ const infoAgentStatusOrder: Record<InfoAgentStatus, number> = {
     no_skills: 1,
     not_installed: 2,
 };
-
-interface InfoInput {
-    format?: InfoFormat;
-    showSchemaVersion?: boolean;
-}
 
 export interface InfoAgentEntry {
     id: BundledSkillAgentName;
@@ -55,27 +44,16 @@ interface InfoOutput {
     features: readonly string[];
 }
 
-export const infoCommand: CliCommandDefinition<InfoInput> = {
+export const infoCommand: CliCommandDefinition = {
     name: "info",
     summaryKey: "commands.info.summary",
     descriptionKey: "commands.info.description",
-    options: [...outputFormatOptions],
-    inputSchema: z.object({
-        format: z.enum(infoFormatValues).optional(),
-        showSchemaVersion: z.boolean().optional(),
-    }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
-    handler: async (input, context) => {
+    output: "standard",
+    inputSchema: z.object({}),
+    handler: async (_input, context) => {
         const info = await collectInfo(context);
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, info, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
-
-        writeInfoAsText(info, context);
+        context.output.emit(info, () => writeInfoAsText(info, context));
     },
 };
 

--- a/src/application/commands/search.ts
+++ b/src/application/commands/search.ts
@@ -6,7 +6,6 @@ import {
     bucketTelemetryCount,
     bucketTelemetryStringLength,
 } from "../telemetry/buckets.ts";
-import { outputFormatOptions, writeJsonOutput } from "./command-output.ts";
 import {
     formatConnectorSearchResultsAsText,
     loadConnectorSearchResults,
@@ -16,15 +15,10 @@ import {
     teamIdentityInputShape,
     teamIdentityOptions,
 } from "./connector/session.ts";
-import { createFormatInputError } from "./shared/input-parsing.ts";
-
-const searchFormatValues = ["json"] as const;
 
 interface SearchInput {
-    format?: (typeof searchFormatValues)[number];
     team?: string;
     personal?: boolean;
-    showSchemaVersion?: boolean;
     text: string;
 }
 
@@ -45,15 +39,12 @@ export const searchCommand: CliCommandDefinition<SearchInput> = {
             personal: "options.searchPersonal",
             team: "options.searchTeam",
         }),
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
-        format: z.enum(searchFormatValues).optional(),
         ...teamIdentityInputShape,
-        showSchemaVersion: z.boolean().optional(),
         text: z.string(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         context.telemetry?.recordProperties({
             query_length_bucket: bucketTelemetryStringLength(input.text),
@@ -80,22 +71,17 @@ export const searchCommand: CliCommandDefinition<SearchInput> = {
             result_count_bucket: bucketTelemetryCount(results.length),
         });
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, results, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
+        context.output.emit(results, () => {
+            if (results.length === 0) {
+                context.stdout.write(
+                    `${context.translator.t("connector.search.text.noResults")}\n`,
+                );
+                return;
+            }
 
-        if (results.length === 0) {
             context.stdout.write(
-                `${context.translator.t("connector.search.text.noResults")}\n`,
+                `${formatConnectorSearchResultsAsText(results, context)}\n`,
             );
-            return;
-        }
-
-        context.stdout.write(
-            `${formatConnectorSearchResultsAsText(results, context)}\n`,
-        );
+        });
     },
 };

--- a/src/application/commands/skills/__snapshots__/search.cli.test.ts.snap
+++ b/src/application/commands/skills/__snapshots__/search.cli.test.ts.snap
@@ -71,12 +71,12 @@ Arguments:
   text                   Search text
 
 Options:
+  --keywords <keywords>  Specify comma-separated keywords to refine the skill
+                         search
   --format <format>      Specify output format (use json for structured output)
   --json                 Alias for --format=json
   --show-schema-version  Include schemaVersion in JSON output (no effect without
                          --json)
-  --keywords <keywords>  Specify comma-separated keywords to refine the skill
-                         search
   -h, --help             Show help for command
 
 Global Options:
@@ -96,12 +96,12 @@ Arguments:
   text                   Search text
 
 Options:
+  --keywords <keywords>  Specify comma-separated keywords to refine the skill
+                         search
   --format <format>      Specify output format (use json for structured output)
   --json                 Alias for --format=json
   --show-schema-version  Include schemaVersion in JSON output (no effect without
                          --json)
-  --keywords <keywords>  Specify comma-separated keywords to refine the skill
-                         search
   -h, --help             Show help for command
 
 Global Options:

--- a/src/application/commands/skills/check-update.ts
+++ b/src/application/commands/skills/check-update.ts
@@ -9,8 +9,6 @@ import { requireIdentity } from "../../auth/identity.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { compareSemver } from "../../semver.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { writeLine } from "../shared/output.ts";
 import {
     groupInstalledSkillsByPackageName,
@@ -69,11 +67,7 @@ interface CheckUpdateOutcome {
     skills: CheckUpdateResultEntry[];
 }
 
-const checkUpdateFormatValues = ["json"] as const;
-
 interface SkillsCheckUpdateInput {
-    format?: (typeof checkUpdateFormatValues)[number];
-    showSchemaVersion?: boolean;
     packageNames?: string[];
     skill?: string[];
 }
@@ -116,15 +110,12 @@ export const skillsCheckUpdateCommand: CliCommandDefinition<SkillsCheckUpdateInp
             valueName: "skills...",
             descriptionKey: "options.skills.skill",
         },
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
-        format: z.enum(checkUpdateFormatValues).optional(),
-        showSchemaVersion: z.boolean().optional(),
         packageNames: z.array(z.string()).optional(),
         skill: z.array(z.string()).optional(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         const availableHosts = await resolveAvailableManagedSkillHosts(context.env);
 
@@ -184,14 +175,9 @@ export const skillsCheckUpdateCommand: CliCommandDefinition<SkillsCheckUpdateInp
             packageNames,
         });
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, outcome, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
-
-        writeText(context, outcome);
+        context.output.emit(outcome, () => {
+            writeText(context, outcome);
+        });
     },
 };
 

--- a/src/application/commands/skills/install.ts
+++ b/src/application/commands/skills/install.ts
@@ -1,4 +1,5 @@
 import type {
+    CliCommandContext,
     CliCommandDefinition,
     CliExecutionContext,
 } from "../../contracts/cli.ts";
@@ -18,8 +19,6 @@ import { join, resolve } from "node:path";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { parsePackageSpecifier } from "../shared/package-info.ts";
 import {
     availableBundledSkillNames,
@@ -64,8 +63,6 @@ interface SkillsInstallInput {
     skill?: string[];
     outDir?: string;
     agentFormat?: string;
-    format?: "json";
-    showSchemaVersion?: boolean;
 }
 
 type SkillsInstallPackageKind = "bundled" | "registry";
@@ -137,18 +134,15 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
             valueName: "agent",
             descriptionKey: "options.skills.install.agentFormat",
         },
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
         force: z.boolean().optional(),
         packageNames: z.array(z.string()).optional(),
         skill: z.array(z.string()).optional(),
         outDir: z.string().optional(),
         agentFormat: z.string().optional(),
-        format: z.enum(["json"]).optional(),
-        showSchemaVersion: z.boolean().optional(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         // `--agent-format` only shapes the `--out-dir` export; on the normal
         // install path it would be ignored, so reject the combination loudly
@@ -183,13 +177,11 @@ export const skillsInstallCommand: CliCommandDefinition<SkillsInstallInput> = {
             has_skill_filter: skillFilterActive,
         });
 
-        if (input.format === "json") {
+        if (context.output.format === "json") {
             const report = await runInstallJsonReport(input, context, { force });
 
             recordInstallTelemetry(context, report, force);
-            writeJsonOutput(context.stdout, report, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
+            context.output.emitJson(report);
 
             if (report.status === "partial-failure" || report.status === "failed") {
                 throw new CliUserError("errors.skills.install.partialFailure", 1, {
@@ -450,7 +442,7 @@ function resolveBundledSkillSelection(
 // packages are downloaded, extracted, and written in their published form.
 async function runSkillExport(
     input: SkillsInstallInput,
-    context: CliExecutionContext,
+    context: CliCommandContext,
 ): Promise<void> {
     // Reject a blank `--out-dir` before resolving: `resolve("")` would silently
     // fall back to the working directory and the per-skill removePath/cp would
@@ -468,7 +460,7 @@ async function runSkillExport(
         "errors.skills.install.invalidAgentFormat",
     );
     const skillFilterActive = normalizeSkillFilterTokens(input.skill) !== undefined;
-    const wantJson = input.format === "json";
+    const wantJson = context.output.format === "json";
     const packageNames = input.packageNames ?? [];
 
     // Parse every specifier up front so a malformed package name fails the whole
@@ -569,9 +561,7 @@ async function runSkillExport(
             outputDirectoryPath,
         );
 
-        writeJsonOutput(context.stdout, report, {
-            showSchemaVersion: input.showSchemaVersion,
-        });
+        context.output.emitJson(report);
 
         if (report.status === "partial-failure" || report.status === "failed") {
             throw new CliUserError("errors.skills.install.partialFailure", 1, {

--- a/src/application/commands/skills/list.ts
+++ b/src/application/commands/skills/list.ts
@@ -13,7 +13,6 @@ import type { SkillListSource } from "./managed-skill-listings.ts";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
 import { collectSkillsInfoInventory } from "./info-inventory.ts";
 import {
     parseManagedSkillAgentOption,
@@ -27,8 +26,6 @@ const managedSkillVersionColor = "#7DD3FC";
 
 interface SkillsListInput {
     agent?: string;
-    format?: "json";
-    showSchemaVersion?: boolean;
     source?: SkillListSource;
 }
 
@@ -51,12 +48,10 @@ export const skillsListCommand: CliCommandDefinition<SkillsListInput> = {
             valueName: "source",
             descriptionKey: "options.skillListSource",
         },
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
         agent: z.string().optional(),
-        format: z.enum(["json"]).optional(),
-        showSchemaVersion: z.boolean().optional(),
         source: z.enum(skillListSourceValues).optional(),
     }),
     mapInputError: (_, rawInput) => new CliUserError(
@@ -86,14 +81,9 @@ export const skillsListCommand: CliCommandDefinition<SkillsListInput> = {
             "Skills listed.",
         );
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, inventory, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
-
-        context.stdout.write(`${formatInventoryAsText(inventory, context)}\n`);
+        context.output.emit(inventory, () => {
+            context.stdout.write(`${formatInventoryAsText(inventory, context)}\n`);
+        });
     },
 };
 

--- a/src/application/commands/skills/recommend/plan.ts
+++ b/src/application/commands/skills/recommend/plan.ts
@@ -12,8 +12,6 @@ import {
 } from "../../../schemas/settings.ts";
 import { compareSemver } from "../../../semver.ts";
 import { bucketTelemetryCount } from "../../../telemetry/buckets.ts";
-import { outputFormatOptions, writeJsonOutput } from "../../command-output.ts";
-import { createFormatInputError } from "../../shared/input-parsing.ts";
 import { writeLine } from "../../shared/output.ts";
 import {
     groupInstalledSkillsByPackageName,
@@ -28,7 +26,6 @@ import {
     partitionRecommendations,
 } from "./recommendation-plan.ts";
 
-const planFormatValues = ["json"] as const;
 // The package-info endpoint has no rate limit, so a small fixed fan-out keeps
 // the wrap-up snappy without hammering the registry.
 const packageExistenceConcurrency = 3;
@@ -53,8 +50,6 @@ type RemotePackageStatus
 interface SkillsRecommendPlanInput {
     connectorServices?: string[];
     force?: boolean;
-    format?: (typeof planFormatValues)[number];
-    showSchemaVersion?: boolean;
 }
 
 export const skillsRecommendPlanCommand: CliCommandDefinition<SkillsRecommendPlanInput> = {
@@ -75,15 +70,12 @@ export const skillsRecommendPlanCommand: CliCommandDefinition<SkillsRecommendPla
             longFlag: "--force",
             descriptionKey: "options.skills.recommend.plan.force",
         },
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
         connectorServices: z.array(z.string()).optional(),
         force: z.boolean().optional(),
-        format: z.enum(planFormatValues).optional(),
-        showSchemaVersion: z.boolean().optional(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         // Each connector service maps to one published `oo-<service>` package.
         const packageNames = dedupePreserveOrder(
@@ -127,14 +119,9 @@ export const skillsRecommendPlanCommand: CliCommandDefinition<SkillsRecommendPla
             cooldownSuppressedCount,
         });
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, plan, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
-
-        writeText(context, plan);
+        context.output.emit(plan, () => {
+            writeText(context, plan);
+        });
     },
 };
 

--- a/src/application/commands/skills/recommend/suppression-command.ts
+++ b/src/application/commands/skills/recommend/suppression-command.ts
@@ -7,19 +7,13 @@ import {
     getDismissedSkillRecommendations,
     isSkillRecommendationsMuted,
 } from "../../../schemas/settings.ts";
-import { outputFormatOptions, writeJsonOutput } from "../../command-output.ts";
-import { createFormatInputError } from "../../shared/input-parsing.ts";
 import { writeLine } from "../../shared/output.ts";
 import { createPackageNamesTelemetryProperties } from "../telemetry.ts";
 import { dedupePreserveOrder } from "./recommendation-plan.ts";
 
-const suppressionFormatValues = ["json"] as const;
-
 interface SuppressionCommandInput {
     all?: boolean;
     packageNames?: string[];
-    format?: (typeof suppressionFormatValues)[number];
-    showSchemaVersion?: boolean;
 }
 
 interface SuppressionCommandConfig {
@@ -55,15 +49,12 @@ export function createSuppressionCommand(
                 longFlag: "--all",
                 descriptionKey: `options.skills.recommend.${config.name}.all`,
             },
-            ...outputFormatOptions,
         ],
+        output: "standard",
         inputSchema: z.object({
             all: z.boolean().optional(),
             packageNames: z.array(z.string()).optional(),
-            format: z.enum(suppressionFormatValues).optional(),
-            showSchemaVersion: z.boolean().optional(),
         }),
-        mapInputError: (_, rawInput) => createFormatInputError(rawInput),
         handler: async (input, context) => {
             const all = input.all === true;
             const packageNames = dedupePreserveOrder(input.packageNames ?? []);
@@ -92,23 +83,18 @@ export function createSuppressionCommand(
                 dismissed: [...getDismissedSkillRecommendations(next)],
             };
 
-            if (input.format === "json") {
-                writeJsonOutput(context.stdout, state, {
-                    showSchemaVersion: input.showSchemaVersion,
-                });
-                return;
-            }
-
-            writeLine(
-                context.stdout,
-                context.translator.t(
-                    `skills.recommend.${config.name}.success.${all ? "all" : "packages"}`,
-                    {
-                        count: packageNames.length,
-                        packages: packageNames.join(", "),
-                    },
-                ),
-            );
+            context.output.emit(state, () => {
+                writeLine(
+                    context.stdout,
+                    context.translator.t(
+                        `skills.recommend.${config.name}.success.${all ? "all" : "packages"}`,
+                        {
+                            count: packageNames.length,
+                            packages: packageNames.join(", "),
+                        },
+                    ),
+                );
+            });
         },
     };
 }

--- a/src/application/commands/skills/repair.cli.test.ts
+++ b/src/application/commands/skills/repair.cli.test.ts
@@ -22,6 +22,22 @@ import {
 const TEST_CLI_VERSION = "9.9.9";
 
 describe("skills repair CLI", () => {
+    test("--format xml exits 2 with the invalid-format error", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            const result = await sandbox.run(
+                ["skills", "repair", "--skill", "oo", "--format", "xml"],
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("Invalid format: xml");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
     test("rejects when --skill is not provided", async () => {
         const sandbox = await createCliSandbox();
         const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");

--- a/src/application/commands/skills/repair.ts
+++ b/src/application/commands/skills/repair.ts
@@ -6,7 +6,6 @@ import type { BundledSkillAgentName, BundledSkillName } from "./embedded-assets.
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
 import { writeLine } from "../shared/output.ts";
 import { publishBundledSkillInstallation } from "./bundled-skill-filesystem.ts";
 import { directoryExists } from "./bundled-skill-observation.ts";
@@ -39,8 +38,6 @@ import {
 
 interface SkillsRepairInput {
     agent?: string[];
-    format?: "json";
-    showSchemaVersion?: boolean;
     skill?: string[];
 }
 
@@ -123,12 +120,10 @@ export const skillsRepairCommand: CliCommandDefinition<SkillsRepairInput> = {
             valueName: "agents...",
             descriptionKey: "options.skills.repair.agent",
         },
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
         agent: z.array(z.string()).optional(),
-        format: z.enum(["json"]).optional(),
-        showSchemaVersion: z.boolean().optional(),
         skill: z.array(z.string()).optional(),
     }),
     handler: async (input, context) => {
@@ -153,10 +148,8 @@ export const skillsRepairCommand: CliCommandDefinition<SkillsRepairInput> = {
             hasAgentFilter: (input.agent?.length ?? 0) > 0,
         });
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, outcome, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
+        if (context.output.format === "json") {
+            context.output.emitJson(outcome);
         }
         else {
             writeText(context, outcome);

--- a/src/application/commands/skills/search.test.ts
+++ b/src/application/commands/skills/search.test.ts
@@ -125,12 +125,12 @@ describe("skillsSearchCommand", () => {
     test("writes json output without service-only fields", async () => {
         const context = createSearchContext({
             fetcher: async () => new Response(JSON.stringify(fullServerResponse)),
+            format: "json",
         });
 
         await searchHandler(
             {
                 text: "text generation",
-                format: "json",
             },
             context,
         );
@@ -184,6 +184,7 @@ describe("skillsSearchCommand", () => {
 
 function createSearchContext(options: {
     fetcher: Fetcher;
+    format?: "json";
     telemetryProperties?: Record<string, CliTelemetryPropertyValue>;
 }): CliCommandContext & {
     stdoutBuffer: ReturnType<typeof createTextBuffer>;
@@ -192,7 +193,11 @@ function createSearchContext(options: {
     const stderr = createTextBuffer();
 
     return {
-        output: createCommandOutput(stdoutBuffer.writer, {}, undefined),
+        output: createCommandOutput(
+            stdoutBuffer.writer,
+            { format: options.format },
+            "standard",
+        ),
         authStore: createAuthStore(activeAuthFile),
         cacheStore: {
             close() {},

--- a/src/application/commands/skills/search.ts
+++ b/src/application/commands/skills/search.ts
@@ -9,12 +9,9 @@ import {
     bucketTelemetryStringLength,
 } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { parseCommaSeparatedKeywords } from "../shared/keywords.ts";
 import { requestOo } from "../shared/oo-request.ts";
 
-const searchFormatValues = ["json"] as const;
 const skillSearchResultLimit = 5;
 const skillSearchDisplayNameColor = "#59F78D";
 const skillSearchPackageColor = "#CAA8FA";
@@ -44,9 +41,7 @@ type SkillSearchTextContext = Pick<CliExecutionContext, "stdout" | "translator">
 
 interface SkillsSearchInput {
     text: string;
-    format?: (typeof searchFormatValues)[number];
     keywords?: string;
-    showSchemaVersion?: boolean;
 }
 
 export const skillsSearchCommand: CliCommandDefinition<SkillsSearchInput> = {
@@ -63,7 +58,6 @@ export const skillsSearchCommand: CliCommandDefinition<SkillsSearchInput> = {
         },
     ],
     options: [
-        ...outputFormatOptions,
         {
             name: "keywords",
             longFlag: "--keywords",
@@ -71,13 +65,11 @@ export const skillsSearchCommand: CliCommandDefinition<SkillsSearchInput> = {
             descriptionKey: "options.keywords",
         },
     ],
+    output: "standard",
     inputSchema: z.object({
         text: z.string(),
-        format: z.enum(searchFormatValues).optional(),
         keywords: z.string().optional(),
-        showSchemaVersion: z.boolean().optional(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         const keywords = parseCommaSeparatedKeywords(input.keywords);
 
@@ -98,20 +90,15 @@ export const skillsSearchCommand: CliCommandDefinition<SkillsSearchInput> = {
             result_count_bucket: bucketTelemetryCount(response.data.length),
         });
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, response.data, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
+        context.output.emit(response.data, () => {
+            const output = formatSkillsSearchResponseAsText(response, context);
 
-        const output = formatSkillsSearchResponseAsText(response, context);
-
-        context.stdout.write(
-            output === ""
-                ? `${context.translator.t("skills.search.text.noResults")}\n`
-                : `${output}\n`,
-        );
+            context.stdout.write(
+                output === ""
+                    ? `${context.translator.t("skills.search.text.noResults")}\n`
+                    : `${output}\n`,
+            );
+        });
     },
 };
 

--- a/src/application/commands/skills/sync.ts
+++ b/src/application/commands/skills/sync.ts
@@ -13,8 +13,6 @@ import { z } from "zod";
 import { requireIdentity } from "../../auth/identity.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { parseCommaSeparatedValues } from "../shared/list-parsing.ts";
 import { requestOo } from "../shared/oo-request.ts";
 import { writeLine } from "../shared/output.ts";
@@ -49,14 +47,10 @@ export type SkillSyncRecord = z.output<typeof skillSyncRecordSchema>;
 interface SkillsSyncUploadInput {
     ignore?: string[];
     source?: string;
-    format?: "json";
-    showSchemaVersion?: boolean;
 }
 
 interface SkillsSyncApplyInput {
     source?: string;
-    format?: "json";
-    showSchemaVersion?: boolean;
 }
 
 const syncUploadErrorMessages = {
@@ -98,28 +92,23 @@ export const skillsSyncCommand: CliCommandDefinition = {
                     valueName: "patterns...",
                     descriptionKey: "options.skillSyncIgnore",
                 },
-                ...outputFormatOptions,
             ],
+            output: "standard",
             inputSchema: z.object({
                 ignore: z.array(z.string()).optional(),
                 source: z.string().optional(),
-                format: z.enum(["json"]).optional(),
-                showSchemaVersion: z.boolean().optional(),
             }),
-            mapInputError: (_, rawInput) => createFormatInputError(rawInput),
             handler: async (input, context) => {
                 parseSkillSyncSource(input.source);
 
-                if (input.format === "json") {
+                if (context.output.format === "json") {
                     const report = await runSyncUploadJsonReport(
                         { ignorePatterns: parseCommaSeparatedValues(input.ignore) },
                         context,
                     );
 
                     recordSyncUploadTelemetry(context, report);
-                    writeJsonOutput(context.stdout, report, {
-                        showSchemaVersion: input.showSchemaVersion,
-                    });
+                    context.output.emitJson(report);
 
                     if (
                         report.status === "partial-failure"
@@ -153,24 +142,19 @@ export const skillsSyncCommand: CliCommandDefinition = {
                     valueName: "source",
                     descriptionKey: "options.skillSyncSource",
                 },
-                ...outputFormatOptions,
             ],
+            output: "standard",
             inputSchema: z.object({
                 source: z.string().optional(),
-                format: z.enum(["json"]).optional(),
-                showSchemaVersion: z.boolean().optional(),
             }),
-            mapInputError: (_, rawInput) => createFormatInputError(rawInput),
             handler: async (input, context) => {
                 parseSkillSyncSource(input.source);
 
-                if (input.format === "json") {
+                if (context.output.format === "json") {
                     const report = await runSyncApplyJsonReport(context);
 
                     recordSyncApplyTelemetry(context, report);
-                    writeJsonOutput(context.stdout, report, {
-                        showSchemaVersion: input.showSchemaVersion,
-                    });
+                    context.output.emitJson(report);
 
                     if (
                         report.status === "partial-failure"

--- a/src/application/commands/skills/uninstall.ts
+++ b/src/application/commands/skills/uninstall.ts
@@ -17,8 +17,6 @@ import type {
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { removePath } from "./bundled-skill-filesystem.ts";
 import { availableBundledSkillNames } from "./embedded-assets.ts";
 import {
@@ -53,8 +51,6 @@ import {
 interface SkillsUninstallInput {
     agent?: string;
     skills?: string[];
-    format?: "json";
-    showSchemaVersion?: boolean;
 }
 
 type UninstallErrorCode
@@ -96,20 +92,17 @@ export const skillsUninstallCommand: CliCommandDefinition<SkillsUninstallInput> 
             valueName: "agent",
             descriptionKey: "options.agent",
         },
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
         agent: z.string().optional(),
         skills: z.array(z.string()).optional(),
-        format: z.enum(["json"]).optional(),
-        showSchemaVersion: z.boolean().optional(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         const agentName = parseSkillsUninstallAgent(input.agent);
         const skillNames = input.skills ?? [];
 
-        if (input.format === "json") {
+        if (context.output.format === "json") {
             const { report, hasPackageTarget } = await runUninstallJsonReport(
                 { skillNames, agentName },
                 context,
@@ -119,9 +112,7 @@ export const skillsUninstallCommand: CliCommandDefinition<SkillsUninstallInput> 
                 format: "json",
                 hasPackageTarget,
             });
-            writeJsonOutput(context.stdout, report, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
+            context.output.emitJson(report);
 
             if (report.status === "partial-failure" || report.status === "failed") {
                 throw new CliUserError("errors.skills.uninstall.partialFailure", 1, {

--- a/src/application/commands/skills/update.ts
+++ b/src/application/commands/skills/update.ts
@@ -16,8 +16,6 @@ import { z } from "zod";
 import { requireIdentity } from "../../auth/identity.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { writeLine } from "../shared/output.ts";
 import {
     groupInstalledSkillsByPackageName,
@@ -67,8 +65,6 @@ import { SkillsUpdateProgressReporter } from "./update-progress.ts";
 interface SkillsUpdateInput {
     packageNames?: string[];
     skill?: string[];
-    format?: "json";
-    showSchemaVersion?: boolean;
 }
 
 const updateErrorMessages: Record<string, string> = {
@@ -133,15 +129,12 @@ export const skillsUpdateCommand: CliCommandDefinition<SkillsUpdateInput> = {
             valueName: "skills...",
             descriptionKey: "options.skills.skill",
         },
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
         packageNames: z.array(z.string()).optional(),
         skill: z.array(z.string()).optional(),
-        format: z.enum(["json"]).optional(),
-        showSchemaVersion: z.boolean().optional(),
     }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
     handler: async (input, context) => {
         // Record the skill-filter dimension up front so it is present on every
         // path, including the text no-results early return and the no-match
@@ -152,16 +145,14 @@ export const skillsUpdateCommand: CliCommandDefinition<SkillsUpdateInput> = {
             has_skill_filter: normalizeSkillFilterTokens(input.skill) !== undefined,
         });
 
-        if (input.format === "json") {
+        if (context.output.format === "json") {
             const report = await runUpdateJsonReport(
                 { packageNames: input.packageNames ?? [], skillFilter: input.skill },
                 context,
             );
 
             recordUpdateTelemetry(context, report);
-            writeJsonOutput(context.stdout, report, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
+            context.output.emitJson(report);
 
             if (report.status === "partial-failure" || report.status === "failed") {
                 throw new CliUserError("errors.skills.update.partialFailure", 1, {

--- a/src/application/commands/team/current.ts
+++ b/src/application/commands/team/current.ts
@@ -7,8 +7,6 @@ import type {
 import { z } from "zod";
 import { resolveIdentity } from "../../auth/identity.ts";
 import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { writeLine } from "../shared/output.ts";
 import {
     appendTeamIdentityStatus,
@@ -16,12 +14,6 @@ import {
     resolveTeamIdentity,
     teamNameStatusForTelemetry,
 } from "./identity.ts";
-import { teamFormatValues } from "./shared.ts";
-
-interface TeamCurrentInput {
-    format?: (typeof teamFormatValues)[number];
-    showSchemaVersion?: boolean;
-}
 
 // `source` says which mechanism selects the team: the OO_TEAM_ID /
 // OO_TEAM_NAME env override, the `identity.team` config default, or none
@@ -48,17 +40,13 @@ interface TeamCurrentJsonPayload {
 // other dimension. The config default stays offline, as does an
 // unauthenticated run: having no account skips the lookup rather than failing
 // the command, so reading the local default never requires a login.
-export const teamCurrentCommand: CliCommandDefinition<TeamCurrentInput> = {
+export const teamCurrentCommand: CliCommandDefinition = {
     name: "current",
     summaryKey: "commands.team.current.summary",
     descriptionKey: "commands.team.current.description",
-    options: [...outputFormatOptions],
-    inputSchema: z.object({
-        format: z.enum(teamFormatValues).optional(),
-        showSchemaVersion: z.boolean().optional(),
-    }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
-    handler: async (input, context) => {
+    output: "standard",
+    inputSchema: z.object({}),
+    handler: async (_input, context) => {
         const [settings, { account }] = await Promise.all([
             context.settingsStore.read(),
             resolveIdentity(context),
@@ -75,67 +63,62 @@ export const teamCurrentCommand: CliCommandDefinition<TeamCurrentInput> = {
             team_status: teamNameStatusForTelemetry(identity),
         });
 
-        if (input.format === "json") {
-            const payload: TeamCurrentJsonPayload = {
-                team: identity?.name ?? null,
-                teamId: identity?.id ?? null,
-                source: identity?.source ?? null,
-                status: identity?.status ?? null,
-            };
+        const payload: TeamCurrentJsonPayload = {
+            team: identity?.name ?? null,
+            teamId: identity?.id ?? null,
+            source: identity?.source ?? null,
+            status: identity?.status ?? null,
+        };
 
-            writeJsonOutput(context.stdout, payload, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
+        context.output.emit(payload, () => {
+            if (identity === undefined) {
+                writeLine(
+                    context.stdout,
+                    context.translator.t("team.current.text.personal"),
+                );
+                return;
+            }
 
-        if (identity === undefined) {
+            const teamValue = formatTeamIdentityValue(identity, context.translator);
+
+            if (identity.source === "config") {
+                writeLine(
+                    context.stdout,
+                    context.translator.t("team.current.text.configured", {
+                        team: teamValue,
+                    }),
+                );
+                return;
+            }
+
+            // The reason is appended to the finished sentence so it lands last,
+            // where the reader looks for it, instead of mid-line.
             writeLine(
                 context.stdout,
-                context.translator.t("team.current.text.personal"),
-            );
-            return;
-        }
-
-        const teamValue = formatTeamIdentityValue(identity, context.translator);
-
-        if (identity.source === "config") {
-            writeLine(
-                context.stdout,
-                context.translator.t("team.current.text.configured", {
-                    team: teamValue,
-                }),
-            );
-            return;
-        }
-
-        // The reason is appended to the finished sentence so it lands last,
-        // where the reader looks for it, instead of mid-line.
-        writeLine(
-            context.stdout,
-            appendTeamIdentityStatus(
-                context.translator.t(
-                    identity.source === "env_id"
-                        ? "team.current.text.envId"
-                        : "team.current.text.envName",
-                    { team: teamValue },
+                appendTeamIdentityStatus(
+                    context.translator.t(
+                        identity.source === "env_id"
+                            ? "team.current.text.envId"
+                            : "team.current.text.envName",
+                        { team: teamValue },
+                    ),
+                    identity,
+                    context.translator,
                 ),
-                identity,
-                context.translator,
-            ),
-        );
-
-        // The config default is still on disk and takes over the moment the
-        // variable is unset, so saying so here heads off a later "my default
-        // did not apply" report.
-        if (configuredTeam !== undefined && identity.envVar !== undefined) {
-            writeLine(
-                context.stdout,
-                context.translator.t("team.current.text.configIgnored", {
-                    envVar: identity.envVar,
-                    team: configuredTeam,
-                }),
             );
-        }
+
+            // The config default is still on disk and takes over the moment the
+            // variable is unset, so saying so here heads off a later "my default
+            // did not apply" report.
+            if (configuredTeam !== undefined && identity.envVar !== undefined) {
+                writeLine(
+                    context.stdout,
+                    context.translator.t("team.current.text.configIgnored", {
+                        envVar: identity.envVar,
+                        team: configuredTeam,
+                    }),
+                );
+            }
+        });
     },
 };

--- a/src/application/commands/team/list.ts
+++ b/src/application/commands/team/list.ts
@@ -9,15 +9,8 @@ import { requireIdentity } from "../../auth/identity.ts";
 import { getConfiguredIdentityTeam } from "../../schemas/settings.ts";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { resolveTeamIdentity } from "./identity.ts";
-import { listMemberTeams, teamFormatValues } from "./shared.ts";
-
-interface TeamListInput {
-    format?: (typeof teamFormatValues)[number];
-    showSchemaVersion?: boolean;
-}
+import { listMemberTeams } from "./shared.ts";
 
 interface TeamListItem {
     current: boolean;
@@ -26,17 +19,13 @@ interface TeamListItem {
     role: TeamRole;
 }
 
-export const teamListCommand: CliCommandDefinition<TeamListInput> = {
+export const teamListCommand: CliCommandDefinition = {
     name: "list",
     summaryKey: "commands.team.list.summary",
     descriptionKey: "commands.team.list.description",
-    options: [...outputFormatOptions],
-    inputSchema: z.object({
-        format: z.enum(teamFormatValues).optional(),
-        showSchemaVersion: z.boolean().optional(),
-    }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
-    handler: async (input, context) => {
+    output: "standard",
+    inputSchema: z.object({}),
+    handler: async (_input, context) => {
         const { account } = await requireIdentity(context);
         const settings = await context.settingsStore.read();
         // The listing itself is the membership set, so the identity resolves
@@ -59,20 +48,15 @@ export const teamListCommand: CliCommandDefinition<TeamListInput> = {
             result_count_bucket: bucketTelemetryCount(output.length),
         });
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, output, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
-
-        context.stdout.write(
-            `${formatTeamsAsText(
-                output,
-                context.translator,
-                createWriterColors(context.stdout),
-            )}\n`,
-        );
+        context.output.emit(output, () => {
+            context.stdout.write(
+                `${formatTeamsAsText(
+                    output,
+                    context.translator,
+                    createWriterColors(context.stdout),
+                )}\n`,
+            );
+        });
     },
 };
 

--- a/src/application/commands/team/shared.ts
+++ b/src/application/commands/team/shared.ts
@@ -4,8 +4,6 @@ import type { AuthAccount } from "../../schemas/auth.ts";
 import { z } from "zod";
 import { probeOo, requestOo } from "../shared/oo-request.ts";
 
-export const teamFormatValues = ["json"] as const;
-
 // One team the current account belongs to. The membership listing always
 // carries `role` (exactly `creator` or `member`; any other value is treated as
 // a plain membership) and `system_created`, which marks the team the backend

--- a/src/application/commands/variables/create.ts
+++ b/src/application/commands/variables/create.ts
@@ -1,13 +1,11 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import { z } from "zod";
 import { requireIdentity } from "../../auth/identity.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
 import { writeLine } from "../shared/output.ts";
 import {
     mapVariablesInputError,
     putVariable,
     resolveVariableValue,
-    variableFormatValues,
     variableNameSchema,
 } from "./shared.ts";
 
@@ -16,8 +14,6 @@ interface VariablesCreateInput {
     value?: string;
     fromFile?: string;
     stdin?: boolean;
-    format?: (typeof variableFormatValues)[number];
-    showSchemaVersion?: boolean;
 }
 
 export const variablesCreateCommand: CliCommandDefinition<VariablesCreateInput> = {
@@ -50,15 +46,13 @@ export const variablesCreateCommand: CliCommandDefinition<VariablesCreateInput> 
             longFlag: "--stdin",
             descriptionKey: "options.variablesStdin",
         },
-        ...outputFormatOptions,
     ],
+    output: "standard",
     inputSchema: z.object({
         name: variableNameSchema,
         value: z.string().optional(),
         fromFile: z.string().optional(),
         stdin: z.boolean().optional(),
-        format: z.enum(variableFormatValues).optional(),
-        showSchemaVersion: z.boolean().optional(),
     }),
     mapInputError: mapVariablesInputError,
     handler: async (input, context) => {
@@ -66,16 +60,11 @@ export const variablesCreateCommand: CliCommandDefinition<VariablesCreateInput> 
         const value = await resolveVariableValue(input, context);
         const variable = await putVariable(account, input.name, value, context);
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, variable, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
-
-        writeLine(context.stdout, context.translator.t("variables.create.success", {
-            name: variable.name,
-            updatedAt: variable.updatedAt,
-        }));
+        context.output.emit(variable, () => {
+            writeLine(context.stdout, context.translator.t("variables.create.success", {
+                name: variable.name,
+                updatedAt: variable.updatedAt,
+            }));
+        });
     },
 };

--- a/src/application/commands/variables/delete.ts
+++ b/src/application/commands/variables/delete.ts
@@ -1,14 +1,11 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import { z } from "zod";
 import { requireIdentity } from "../../auth/identity.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
 import { writeLine } from "../shared/output.ts";
-import { deleteVariable, mapVariablesInputError, variableFormatValues, variableNameSchema } from "./shared.ts";
+import { deleteVariable, mapVariablesInputError, variableNameSchema } from "./shared.ts";
 
 interface VariablesDeleteInput {
     name: string;
-    format?: (typeof variableFormatValues)[number];
-    showSchemaVersion?: boolean;
 }
 
 export const variablesDeleteCommand: CliCommandDefinition<VariablesDeleteInput> = {
@@ -23,26 +20,19 @@ export const variablesDeleteCommand: CliCommandDefinition<VariablesDeleteInput> 
             required: true,
         },
     ],
-    options: [...outputFormatOptions],
+    output: "standard",
     inputSchema: z.object({
         name: variableNameSchema,
-        format: z.enum(variableFormatValues).optional(),
-        showSchemaVersion: z.boolean().optional(),
     }),
     mapInputError: mapVariablesInputError,
     handler: async (input, context) => {
         const { account } = await requireIdentity(context);
         await deleteVariable(account, input.name, context);
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, { name: input.name, deleted: true }, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
-
-        writeLine(context.stdout, context.translator.t("variables.delete.success", {
-            name: input.name,
-        }));
+        context.output.emit({ name: input.name, deleted: true }, () => {
+            writeLine(context.stdout, context.translator.t("variables.delete.success", {
+                name: input.name,
+            }));
+        });
     },
 };

--- a/src/application/commands/variables/get.ts
+++ b/src/application/commands/variables/get.ts
@@ -1,14 +1,11 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import { z } from "zod";
 import { requireIdentity } from "../../auth/identity.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
 import { writeLine } from "../shared/output.ts";
-import { getVariable, mapVariablesInputError, variableFormatValues, variableNameSchema } from "./shared.ts";
+import { getVariable, mapVariablesInputError, variableNameSchema } from "./shared.ts";
 
 interface VariablesGetInput {
     name: string;
-    format?: (typeof variableFormatValues)[number];
-    showSchemaVersion?: boolean;
 }
 
 export const variablesGetCommand: CliCommandDefinition<VariablesGetInput> = {
@@ -23,24 +20,17 @@ export const variablesGetCommand: CliCommandDefinition<VariablesGetInput> = {
             required: true,
         },
     ],
-    options: [...outputFormatOptions],
+    output: "standard",
     inputSchema: z.object({
         name: variableNameSchema,
-        format: z.enum(variableFormatValues).optional(),
-        showSchemaVersion: z.boolean().optional(),
     }),
     mapInputError: mapVariablesInputError,
     handler: async (input, context) => {
         const { account } = await requireIdentity(context);
         const variable = await getVariable(account, input.name, context);
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, variable, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
-
-        writeLine(context.stdout, variable.value);
+        context.output.emit(variable, () => {
+            writeLine(context.stdout, variable.value);
+        });
     },
 };

--- a/src/application/commands/variables/list.ts
+++ b/src/application/commands/variables/list.ts
@@ -1,44 +1,29 @@
 import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import { z } from "zod";
 import { requireIdentity } from "../../auth/identity.ts";
-import { outputFormatOptions, writeJsonOutput } from "../command-output.ts";
 import { writeLine } from "../shared/output.ts";
-import { listVariables, mapVariablesInputError, variableFormatValues } from "./shared.ts";
+import { listVariables } from "./shared.ts";
 import { formatVariableListLine } from "./text.ts";
 
-interface VariablesListInput {
-    format?: (typeof variableFormatValues)[number];
-    showSchemaVersion?: boolean;
-}
-
-export const variablesListCommand: CliCommandDefinition<VariablesListInput> = {
+export const variablesListCommand: CliCommandDefinition = {
     name: "list",
     summaryKey: "commands.variables.list.summary",
     descriptionKey: "commands.variables.list.description",
-    options: [...outputFormatOptions],
-    inputSchema: z.object({
-        format: z.enum(variableFormatValues).optional(),
-        showSchemaVersion: z.boolean().optional(),
-    }),
-    mapInputError: mapVariablesInputError,
-    handler: async (input, context) => {
+    output: "standard",
+    inputSchema: z.object({}),
+    handler: async (_input, context) => {
         const { account } = await requireIdentity(context);
         const variables = await listVariables(account, context);
 
-        if (input.format === "json") {
-            writeJsonOutput(context.stdout, { variables }, {
-                showSchemaVersion: input.showSchemaVersion,
-            });
-            return;
-        }
+        context.output.emit({ variables }, () => {
+            if (variables.length === 0) {
+                writeLine(context.stdout, context.translator.t("variables.list.empty"));
+                return;
+            }
 
-        if (variables.length === 0) {
-            writeLine(context.stdout, context.translator.t("variables.list.empty"));
-            return;
-        }
-
-        for (const variable of variables) {
-            writeLine(context.stdout, formatVariableListLine(variable));
-        }
+            for (const variable of variables) {
+                writeLine(context.stdout, formatVariableListLine(variable));
+            }
+        });
     },
 };

--- a/src/application/commands/variables/shared.ts
+++ b/src/application/commands/variables/shared.ts
@@ -5,7 +5,6 @@ import { Buffer } from "node:buffer";
 import { readFile } from "node:fs/promises";
 import { z } from "zod";
 import { CliUserError } from "../../contracts/cli.ts";
-import { createFormatInputError } from "../shared/input-parsing.ts";
 import { requestOo, requestOoResponse } from "../shared/oo-request.ts";
 import { readStdinToEnd } from "../shared/stdin.ts";
 
@@ -37,19 +36,15 @@ export const variableNameSchema = z.string()
     .refine(name => !name.includes("/"), "Variable name must not contain '/'")
     .refine(name => !hasControlCharacter(name), "Variable name must not contain control characters");
 
-export const variableFormatValues = ["json"] as const;
-
+// Name is the only fallible field in the variables schemas, so every zod
+// failure maps to the invalid-name error.
 export function mapVariablesInputError(
-    error: ZodError,
+    _error: ZodError,
     rawInput: Record<string, unknown>,
 ): CliUserError {
-    if (error.issues.some(issue => issue.path[0] === "name")) {
-        return new CliUserError("errors.variables.invalidName", 2, {
-            value: String(rawInput.name ?? ""),
-        });
-    }
-
-    return createFormatInputError(rawInput);
+    return new CliUserError("errors.variables.invalidName", 2, {
+        value: String(rawInput.name ?? ""),
+    });
 }
 
 // MARK: - Value source resolution (exactly one of: positional / --from-file / --stdin)

--- a/src/application/commands/version.ts
+++ b/src/application/commands/version.ts
@@ -6,39 +6,22 @@ import {
     resolveCliBuildInfo,
     shortenCommitHash,
 } from "../config/build-info.ts";
-import { outputFormatOptions, writeJsonOutput } from "./command-output.ts";
-import { createFormatInputError } from "./shared/input-parsing.ts";
 
-const versionFormatValues = ["json"] as const;
-
-interface VersionInput {
-    format?: (typeof versionFormatValues)[number];
-    showSchemaVersion?: boolean;
-}
-
-export const versionCommand: CliCommandDefinition<VersionInput> = {
+export const versionCommand: CliCommandDefinition = {
     name: "version",
     summaryKey: "commands.version.summary",
     descriptionKey: "commands.version.description",
-    options: [...outputFormatOptions],
-    inputSchema: z.object({
-        format: z.enum(versionFormatValues).optional(),
-        showSchemaVersion: z.boolean().optional(),
-    }),
-    mapInputError: (_, rawInput) => createFormatInputError(rawInput),
-    handler: (input, context) => {
-        if (input.format === "json") {
+    output: "standard",
+    inputSchema: z.object({}),
+    handler: (_input, context) => {
+        if (context.output.format === "json") {
             const buildInfo = resolveCliBuildInfo(context.version);
 
-            writeJsonOutput(
-                context.stdout,
-                {
-                    version: buildInfo.version,
-                    buildTime: formatBuildTimestampIso(buildInfo.buildTimestamp) ?? null,
-                    commit: shortenCommitHash(buildInfo.commitHash) ?? null,
-                },
-                { showSchemaVersion: input.showSchemaVersion },
-            );
+            context.output.emitJson({
+                version: buildInfo.version,
+                buildTime: formatBuildTimestampIso(buildInfo.buildTimestamp) ?? null,
+                commit: shortenCommitHash(buildInfo.commitHash) ?? null,
+            });
             return;
         }
 


### PR DESCRIPTION
Part 2/3 of the output-contract deepening, stacked on #325.

## What

All 28 standard command files declare `output: "standard"` and consume `context.output` instead of re-deriving the contract:

- Deleted per command: the `outputFormatOptions` spread, `format`/`showSchemaVersion` schema fields, local `["json"]` enum consts, and the `format === "json"` branch. Standard handlers call `output.emit(payload, renderText)`; format-gated engines (version, check-update, auth/status, connector/run, skills install/sync/update/uninstall/repair) gate on `output.format` and write through `output.emitJson`.
- Group-shared format consts die: `teamFormatValues`, `connectorFormatValues`, `variableFormatValues`, and the file group's `fileFormatValues` + `parseFileFormat` (strict `--format` validation now happens in the adapter before the handler, preserving upload's fail-fast property).
- `mapInputError` catch-alls narrowed to fields that can actually fail zod: variables → always invalid-name, skills list → always invalid-source, and commands with no fallible fields drop the mapper.

## Behavior changes (accepted, spec D5)

- `oo skills info --format xml` reports the shared invalid-format error with value `xml` instead of an invalid-source error with an empty value (drift fix).
- `oo skills repair --format xml` exits 2 with the invalid-format error instead of exiting 1 through the unexpected-error fallback (drift fix; pinned by a new CLI test).
- When both a domain field and `--format` are invalid, the format error now wins uniformly.
- Help text for `skills search` and `file list` lists the output flags after command-specific options.

Payload shapes, text output, exit codes on all other paths, and telemetry values are unchanged.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #325
2. **#326** 👈 current
3. #327
<!-- stack:links:end -->