### PR TITLE
chore(skills): drop the legacy untyped skill metadata parsing

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1540,8 +1540,8 @@ Install bundled or published skills into supported local skill directories.
   that follow `--skill` are read as skill names, not package names, until the
   next option such as `--json`.
 - Options: `-f, --force` overrides install when the target directory exists
-  with the same skill name but is **not** managed by oo (no readable
-  `.oo-metadata.json`). The previous directory contents are removed before the
+  with the same skill name but is **not** managed by oo (no valid `oo`
+  metadata). The previous directory contents are removed before the
   new skill is written; a `warn` log records the overwrite. `--force` does
   **not** bypass path containment, package validation, auth, or download
   validation; and it does **not** affect startup auto-sync, `oo skills update`,
@@ -1624,8 +1624,9 @@ Install bundled or published skills into supported local skill directories.
 - Metadata: new bundled and registry writes include a hidden
   `.oo-metadata.json` file with an oo source marker and schema version.
   Bundled metadata records the current `oo` version; registry metadata records
-  the source package and package version. Existing legacy bundled and registry
-  metadata remains readable.
+  the source package and package version. Metadata files from older releases
+  that lack the schema version marker are no longer recognized as `oo`
+  metadata.
 - Notes: all registry requests for published skills send the active account's
   `Authorization` header.
 - Notes: a same-name target directory without valid `oo` metadata is treated as a

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -1286,8 +1286,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
 - 选项：由于 `-s, --skill` 接受多个值，请把所有 package 名称放在它**之前**
   （例如 `oo skills install @scope/pkg -s foo bar`）。`--skill` 之后、直到下一个
   选项（如 `--json`）之前的 token 都会被当作 skill 名称，而非 package 名称。
-- 选项：`-f, --force` 在目标目录存在同名 skill 但**不受 oo 管理**（缺少可读
-  `.oo-metadata.json`）时，允许覆盖安装。覆盖会先移除原目录内容再写入新
+- 选项：`-f, --force` 在目标目录存在同名 skill 但**不受 oo 管理**（没有有效的
+  `oo` 元数据）时，允许覆盖安装。覆盖会先移除原目录内容再写入新
   skill，并以 `warn` 日志记录此事件。`--force` **不会**绕过路径校验、
   package 校验、auth 或下载校验；**不影响**启动自动同步、`oo skills update`、
   `oo skills sync`、`oo skills uninstall`、`oo skills publish`。
@@ -1351,8 +1351,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   oo-managed 软链接目标，会在显式安装、刷新或更新该 skill 时替换为复制目录。
 - 元数据：新写入的 bundled 和 registry skill 都会包含隐藏的
   `.oo-metadata.json` 文件，记录 oo 来源标记和 schema version。bundled metadata
-  记录当前 `oo` 版本；registry metadata 记录来源 package 与 package 版本。已有的
-  legacy bundled 和 registry metadata 仍可读取。
+  记录当前 `oo` 版本；registry metadata 记录来源 package 与 package 版本。旧版本
+  留下的、缺少 schema version 标记的 metadata 文件不再被识别为 `oo` metadata。
 - 说明：安装已发布 skill 时，所有 registry 请求都会携带当前激活账号的
   `Authorization` header。
 - 说明：如果同名目标目录没有有效的 `oo` 元数据，会被视为非 OOMOL skill；该

--- a/src/application/commands/skills/index.cli.test.ts
+++ b/src/application/commands/skills/index.cli.test.ts
@@ -24,6 +24,7 @@ import {
 import {
     createBundledSkillMetadata,
     createLocalSkillMetadata,
+    createRegistrySkillMetadata,
     renderSkillMetadataJson,
 } from "./skill-metadata.ts";
 
@@ -106,9 +107,7 @@ describe("skills CLI", () => {
             await mkdir(skillDirectoryPath, { recursive: true });
             await Bun.write(
                 metadataFilePath,
-                renderSkillMetadataJson({
-                    version: "0.0.1",
-                }),
+                renderSkillMetadataJson(createBundledSkillMetadata("0.0.1")),
             );
             await Bun.write(skillFilePath, "stale\n");
 
@@ -149,9 +148,9 @@ describe("skills CLI", () => {
                 await mkdir(skillTarget.directoryPath, { recursive: true });
                 await Bun.write(
                     resolveBundledSkillMetadataFilePath(skillTarget.directoryPath),
-                    renderSkillMetadataJson({
-                        version: installedVersion,
-                    }),
+                    renderSkillMetadataJson(
+                        createBundledSkillMetadata(installedVersion),
+                    ),
                 );
                 await Bun.write(
                     join(skillTarget.directoryPath, "SKILL.md"),
@@ -178,9 +177,9 @@ describe("skills CLI", () => {
                         resolveBundledSkillMetadataFilePath(skillTarget.directoryPath),
                         "utf8",
                     ),
-                ).toBe(renderSkillMetadataJson({
-                    version: installedVersion,
-                }));
+                ).toBe(renderSkillMetadataJson(
+                    createBundledSkillMetadata(installedVersion),
+                ));
             }
             expect(content).toContain(
                 `"msg":"Bundled skill startup synchronization skipped because the current CLI version is a development version."`,
@@ -207,9 +206,9 @@ describe("skills CLI", () => {
                 await mkdir(skillTarget.directoryPath, { recursive: true });
                 await Bun.write(
                     resolveBundledSkillMetadataFilePath(skillTarget.directoryPath),
-                    renderSkillMetadataJson({
-                        version: bundledSkillDevelopmentVersion,
-                    }),
+                    renderSkillMetadataJson(
+                        createBundledSkillMetadata(bundledSkillDevelopmentVersion),
+                    ),
                 );
                 await Bun.write(
                     join(skillTarget.directoryPath, "SKILL.md"),
@@ -236,9 +235,9 @@ describe("skills CLI", () => {
                         resolveBundledSkillMetadataFilePath(skillTarget.directoryPath),
                         "utf8",
                     ),
-                ).toBe(renderSkillMetadataJson({
-                    version: bundledSkillDevelopmentVersion,
-                }));
+                ).toBe(renderSkillMetadataJson(
+                    createBundledSkillMetadata(bundledSkillDevelopmentVersion),
+                ));
             }
             expect(content).toContain(
                 `"msg":"Bundled skill startup synchronization skipped because the installed skill is a development version."`,
@@ -275,10 +274,10 @@ describe("skills CLI", () => {
             );
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "openai",
                     version: "0.0.3",
-                }),
+                })),
             );
 
             const result = await sandbox.run(["--help"], {
@@ -332,10 +331,10 @@ describe("skills CLI", () => {
             );
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(canonicalSkillDirectoryPath),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "openai",
                     version: "0.0.3",
-                }),
+                })),
             );
             // The universal host is always provisioned, so it must already hold a
             // correct symlink for the registry skill to stay unchanged at startup.
@@ -452,10 +451,10 @@ describe("skills CLI", () => {
             );
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(registryCanonicalSkillDirectoryPath),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "openai",
                     version: "0.0.3",
-                }),
+                })),
             );
             await Bun.write(
                 join(codeBuddySkillDirectoryPath, "SKILL.md"),
@@ -481,10 +480,10 @@ describe("skills CLI", () => {
             expect(await readFile(
                 resolveManagedSkillMetadataFilePath(universalSkillDirectoryPath),
                 "utf8",
-            )).toBe(renderSkillMetadataJson({
+            )).toBe(renderSkillMetadataJson(createRegistrySkillMetadata({
                 packageName: "openai",
                 version: "0.0.3",
-            }));
+            })));
             expect(content).toContain(
                 `"msg":"Registry skill synchronized during CLI startup."`,
             );

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -422,9 +422,9 @@ describe("skills commands", () => {
             await mkdir(join(skillDirectoryPath, "agents"), { recursive: true });
             await Bun.write(
                 metadataFilePath,
-                renderSkillMetadataJson({
-                    version: bundledSkillDevelopmentVersion,
-                }),
+                renderSkillMetadataJson(
+                    createBundledSkillMetadata(bundledSkillDevelopmentVersion),
+                ),
             );
             await Bun.write(skillFilePath, "stale\n");
 
@@ -2864,23 +2864,21 @@ describe("skills commands", () => {
             await Bun.write(join(registryCanonicalSkillDirectoryPath, "SKILL.md"), "# ChatGPT\n");
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(registrySkillDirectoryPath),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "openai",
                     version: "0.0.3",
-                }),
+                })),
             );
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(registryCanonicalSkillDirectoryPath),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "openai",
                     version: "0.0.4",
-                }),
+                })),
             );
             await Bun.write(
                 resolveBundledSkillMetadataFilePath(bundledSkillDirectoryPath),
-                renderSkillMetadataJson({
-                    version: "9.9.9",
-                }),
+                renderSkillMetadataJson(createBundledSkillMetadata("9.9.9")),
             );
             await Bun.write(
                 join(localSkillDirectoryPath, "SKILL.md"),
@@ -2952,17 +2950,17 @@ describe("skills commands", () => {
             await writeAuthFile(sandbox);
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(chatSkillDirectoryPath),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "openai",
                     version: "0.0.3",
-                }),
+                })),
             );
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(captionSkillDirectoryPath),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@private/vision",
                     version: "1.0.0",
-                }),
+                })),
             );
 
             const result = await sandbox.run([

--- a/src/application/commands/skills/installed-skills.test.ts
+++ b/src/application/commands/skills/installed-skills.test.ts
@@ -200,7 +200,7 @@ describe("readInstalledSkills", () => {
         ]);
     });
 
-    test("parses legacy metadata without a schema version", async () => {
+    test("ignores legacy metadata without a schema version", async () => {
         const sandbox = await createInventorySandbox();
 
         await sandbox.seedHost("universal", "old-registry", `${JSON.stringify({
@@ -213,11 +213,7 @@ describe("readInstalledSkills", () => {
 
         const skills = await readInstalledSkills(sandbox.env, sandbox.settingsFilePath);
 
-        expect(skills.map(skill => [skill.kind, skill.name, skill.packageName, skill.version]))
-            .toEqual([
-                ["bundled", "old-bundled", undefined, "0.2.0"],
-                ["registry", "old-registry", "@scope/old", "0.9.0"],
-            ]);
+        expect(skills).toEqual([]);
     });
 
     test("ignores non-registry entries under the canonical registry root", async () => {

--- a/src/application/commands/skills/list.cli.test.ts
+++ b/src/application/commands/skills/list.cli.test.ts
@@ -19,6 +19,7 @@ import {
 } from "./managed-skill-paths.ts";
 import {
     createLocalSkillMetadata,
+    createRegistrySkillMetadata,
     renderSkillMetadataJson,
 } from "./skill-metadata.ts";
 
@@ -44,10 +45,10 @@ describe("skills info CLI", () => {
             await mkdir(alphaSkillDirectoryPath, { recursive: true });
             await writeFile(
                 join(alphaSkillDirectoryPath, ".oo-metadata.json"),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/alpha",
                     version: "1.2.3",
-                }),
+                })),
             );
 
             const result = await sandbox.run(["skills", "info"], {
@@ -91,10 +92,10 @@ describe("skills info CLI", () => {
             await mkdir(alphaSkillDirectoryPath, { recursive: true });
             await writeFile(
                 join(alphaSkillDirectoryPath, ".oo-metadata.json"),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/alpha",
                     version: "1.2.3",
-                }),
+                })),
             );
 
             const result = await sandbox.run(["skills", "info"], {
@@ -181,10 +182,10 @@ describe("skills info CLI", () => {
             await mkdir(alphaSkillDirectoryPath, { recursive: true });
             await writeFile(
                 join(alphaSkillDirectoryPath, ".oo-metadata.json"),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/alpha",
                     version: "1.2.3",
-                }),
+                })),
             );
 
             const infoResult = await sandbox.run(["skills", "info"], { version: "9.9.9" });
@@ -244,10 +245,10 @@ describe("skills info CLI", () => {
             await mkdir(alphaSkillDirectoryPath, { recursive: true });
             await writeFile(
                 join(alphaSkillDirectoryPath, ".oo-metadata.json"),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/alpha",
                     version: "1.2.3",
-                }),
+                })),
             );
             await writeLocalSkillDirectory(localSkillDirectoryPath, "campaign-writer");
 
@@ -354,10 +355,10 @@ describe("skills info CLI", () => {
             await mkdir(alphaSkillDirectoryPath, { recursive: true });
             await writeFile(
                 join(alphaSkillDirectoryPath, ".oo-metadata.json"),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/alpha",
                     version: "1.2.3",
-                }),
+                })),
             );
 
             const result = await sandbox.run(["skills", "info", "--json"], {
@@ -680,17 +681,17 @@ describe("skills info CLI", () => {
             await mkdir(claudeAlphaSkillDirectory, { recursive: true });
             await writeFile(
                 join(universalAlphaSkillDirectory, ".oo-metadata.json"),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/alpha",
                     version: "1.2.3",
-                }),
+                })),
             );
             await writeFile(
                 join(claudeAlphaSkillDirectory, ".oo-metadata.json"),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/alpha",
                     version: "1.5.0",
-                }),
+                })),
             );
 
             const result = await sandbox.run(["skills", "info", "--json"]);
@@ -727,10 +728,10 @@ describe("skills info CLI", () => {
             await mkdir(alphaSkillDirectoryPath, { recursive: true });
             await writeFile(
                 join(alphaSkillDirectoryPath, ".oo-metadata.json"),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/alpha",
                     version: "1.2.3",
-                }),
+                })),
             );
 
             const fullResult = await sandbox.run(["skills", "info", "--json"], {
@@ -789,17 +790,17 @@ describe("skills info CLI", () => {
             );
             await writeFile(
                 resolveManagedSkillMetadataFilePath(canonicalDirectory),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/alpha",
                     version: "1.2.3",
-                }),
+                })),
             );
             await writeFile(
                 join(hostDirectory, ".oo-metadata.json"),
-                renderSkillMetadataJson({
+                renderSkillMetadataJson(createRegistrySkillMetadata({
                     packageName: "@oomol/alpha",
                     version: "1.2.3",
-                }),
+                })),
             );
 
             const result = await sandbox.run(["skills", "info", "--json"]);

--- a/src/application/commands/skills/skill-directory-state.test.ts
+++ b/src/application/commands/skills/skill-directory-state.test.ts
@@ -91,7 +91,18 @@ describe("readSkillDirectoryState", () => {
         },
         {
             content: renderSkillMetadataJson({ version: 1 }),
-            title: "legacy metadata with a non-string version",
+            title: "untyped metadata with a non-string version",
+        },
+        {
+            content: renderSkillMetadataJson({
+                packageName: "@scope/package",
+                version: "1.2.3",
+            }),
+            title: "legacy untyped registry metadata",
+        },
+        {
+            content: renderSkillMetadataJson({ version: "1.2.3" }),
+            title: "legacy untyped bundled metadata",
         },
     ] as const;
 
@@ -128,22 +139,6 @@ describe("readSkillDirectoryState", () => {
             content: renderSkillMetadataJson(createLocalSkillMetadata()),
             metadata: createLocalSkillMetadata(),
             title: "local metadata",
-        },
-        {
-            content: renderSkillMetadataJson({
-                packageName: "@scope/package",
-                version: "1.2.3",
-            }),
-            metadata: createRegistrySkillMetadata({
-                packageName: "@scope/package",
-                version: "1.2.3",
-            }),
-            title: "legacy untyped registry metadata",
-        },
-        {
-            content: renderSkillMetadataJson({ version: "1.2.3" }),
-            metadata: createBundledSkillMetadata("1.2.3"),
-            title: "legacy untyped bundled metadata",
         },
     ] as const;
 

--- a/src/application/commands/skills/skill-metadata.test.ts
+++ b/src/application/commands/skills/skill-metadata.test.ts
@@ -30,17 +30,53 @@ describe("skill metadata", () => {
         }))).toEqual(createLocalSkillMetadata());
     });
 
-    test("parses legacy untyped metadata at the parser boundary", () => {
-        expect(parseSkillMetadataContent("{\"version\":\" 1.2.3 \"}\n")).toEqual(
-            createBundledSkillMetadata("1.2.3"),
-        );
+    test("trims surrounding whitespace from typed identity fields", () => {
         expect(parseSkillMetadataContent(JSON.stringify({
-            packageName: "@foo/bar",
-            version: "2.0.0",
+            kind: "bundled",
+            schemaVersion: 1,
+            version: " 1.2.3 ",
+        }))).toEqual(createBundledSkillMetadata("1.2.3"));
+        expect(parseSkillMetadataContent(JSON.stringify({
+            icon: " star ",
+            kind: "registry",
+            packageName: " @foo/bar ",
+            schemaVersion: 1,
+            version: " 2.0.0 ",
         }))).toEqual(createRegistrySkillMetadata({
+            icon: "star",
             packageName: "@foo/bar",
             version: "2.0.0",
         }));
+    });
+
+    test("rejects typed metadata with blank identity fields", () => {
+        expect(parseSkillMetadataContent(JSON.stringify({
+            kind: "bundled",
+            schemaVersion: 1,
+            version: "",
+        }))).toBeUndefined();
+        expect(parseSkillMetadataContent(JSON.stringify({
+            kind: "registry",
+            packageName: "  ",
+            schemaVersion: 1,
+            version: "1.2.3",
+        }))).toBeUndefined();
+        expect(parseSkillMetadataContent(JSON.stringify({
+            icon: "  ",
+            kind: "registry",
+            packageName: "@foo/bar",
+            schemaVersion: 1,
+            version: "1.2.3",
+        }))).toBeUndefined();
+    });
+
+    test("rejects legacy untyped metadata", () => {
+        expect(parseSkillMetadataContent("{\"version\":\" 1.2.3 \"}\n"))
+            .toBeUndefined();
+        expect(parseSkillMetadataContent(JSON.stringify({
+            packageName: "@foo/bar",
+            version: "2.0.0",
+        }))).toBeUndefined();
     });
 
     test("rejects unsupported typed metadata", () => {
@@ -52,16 +88,6 @@ describe("skill metadata", () => {
             kind: "registry",
             packageName: "@foo/bar",
             schemaVersion: 1,
-        }))).toBeUndefined();
-    });
-
-    test("rejects legacy metadata with blank identity fields", () => {
-        expect(parseSkillMetadataContent(JSON.stringify({
-            version: "",
-        }))).toBeUndefined();
-        expect(parseSkillMetadataContent(JSON.stringify({
-            packageName: "  ",
-            version: "1.2.3",
         }))).toBeUndefined();
     });
 

--- a/src/application/commands/skills/skill-metadata.ts
+++ b/src/application/commands/skills/skill-metadata.ts
@@ -66,15 +66,7 @@ export function parseSkillMetadataContent(
         return undefined;
     }
 
-    const typedMetadata = parseTypedSkillMetadata(fields);
-
-    if (typedMetadata !== undefined) {
-        return typedMetadata;
-    }
-
-    // TODO: Remove legacy untyped metadata parsing after existing installs have migrated.
-    return parseRegistrySkillMetadataFields(fields)
-        ?? parseLegacyBundledSkillMetadata(fields);
+    return parseTypedSkillMetadata(fields);
 }
 
 export function renderSkillMetadataJson(
@@ -158,14 +150,4 @@ function parseRegistrySkillMetadataFields(
     }
 
     return createRegistrySkillMetadata({ packageName, version });
-}
-
-function parseLegacyBundledSkillMetadata(
-    fields: Readonly<Record<string, unknown>>,
-): BundledSkillMetadata | undefined {
-    if (fields.packageName !== undefined) {
-        return undefined;
-    }
-
-    return parseBundledSkillMetadataFields(fields);
 }

--- a/src/application/commands/skills/update.test.ts
+++ b/src/application/commands/skills/update.test.ts
@@ -26,6 +26,7 @@ import {
     resolveManagedSkillMetadataFilePath,
 } from "./managed-skill-paths.ts";
 import {
+    createBundledSkillMetadata,
     createRegistrySkillMetadata,
     renderSkillMetadataJson,
 } from "./skill-metadata.ts";
@@ -53,11 +54,11 @@ describe("skills update command", () => {
             await Bun.write(join(ooInstalledDirectoryPath, "SKILL.md"), "# oo\n");
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(ooCanonicalDirectoryPath),
-                renderSkillMetadataJson({ version: "1.0.0" }),
+                renderSkillMetadataJson(createBundledSkillMetadata("1.0.0")),
             );
             await Bun.write(
                 resolveManagedSkillMetadataFilePath(ooInstalledDirectoryPath),
-                renderSkillMetadataJson({ version: "1.0.0" }),
+                renderSkillMetadataJson(createBundledSkillMetadata("1.0.0")),
             );
 
             const result = await sandbox.run(["skills", "update"]);


### PR DESCRIPTION
`parseSkillMetadataContent` still accepted `.oo-metadata.json` files that predate the typed format, reading `{version}` as bundled metadata and `{packageName, version}` as registry metadata. The TODO guarding that fallback assumed existing installs had migrated by now, so this removes it along with `parseLegacyBundledSkillMetadata`; only metadata carrying `schemaVersion` and a valid `kind` is recognized from here on.

Worth a careful look before approving: that "already migrated" assumption holds for bundled skills but not for registry ones. Startup auto-sync re-stamps a bundled skill whenever the installed version differs from the CLI version, so bundled installs migrated themselves on the first run after upgrading. Nothing ever did the equivalent for registry skills — `listCanonicalRegistrySkills` only reads the canonical directory, which is written solely by install and update — so a registry skill installed before the typed format landed and never updated since still carries legacy metadata today.

Those directories now classify as `unmanaged`, which drops them out of `readInstalledSkills` and everything built on it. The consequence I'd most want a second opinion on is `oo skills sync upload`: it is a full-replace `PUT /v1/skills`, so a user whose registry skills are all legacy would silently push a shorter list — or `[]` — and wipe their account manifest, with a success message and exit code 0. Two smaller ones: `oo skills share <id>` falls back to treating the skill id as a package name (`isSkillDirectoryAbsent` covers only `missing`/`not-directory`, so a legacy directory still yields a share target with no `packageName`), and `oo uninstall --purge` now retains legacy bundled directories instead of removing them. All three are left unmitigated here so the removal stays reviewable on its own — happy to add a guard on the upload path in a follow-up if we think legacy metadata is still out in the wild.

The rest is fixture work. Tests that seeded managed skills with untyped literals move to the typed constructors. The blank-identity cases in `skill-metadata.test.ts` are restored against typed input rather than deleted — they were the only coverage of the `toNonBlankString` wiring, and swapping it for a bare `typeof` check otherwise passed the entire suite. Docs in both languages drop the "legacy metadata remains readable" promise, and the `--force` gloss changes from "no readable `.oo-metadata.json`" to "no valid `oo` metadata", which a legacy file now fails despite being perfectly readable.