### PR TITLE
docs(skills): correct the stale legacy-cleanup wording

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -75,8 +75,8 @@ use. Truthy values are `1`, `true`, `yes`, or `on` (case-insensitive).
   `--personal` / `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` > the active account's
   default team > your personal identity.
 - `OO_SKILLS_SYNC_DISABLED`: A truthy value disables the startup managed-skill
-  synchronization and legacy-cleanup side effects, so the CLI writes no skill
-  files into agent home directories such as `~/.agents` or `~/.claude`.
+  synchronization, so the CLI writes no skill files into agent home directories
+  such as `~/.agents` or `~/.claude`.
 - `OO_NO_SELF_UPDATE`: A truthy value disables `oo update`, `oo install`, and
   `oo check-update` and forces self-update PATH modification off.
 

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -60,9 +60,8 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
 - Connector 相关命令按以下优先级解析团队身份：
   `--personal` / `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` >
   当前账号保存的默认团队 > 个人身份。
-- `OO_SKILLS_SYNC_DISABLED`：设为真值会禁用启动时的 managed skill 同步与 legacy
-  清理副作用，使 CLI 不会向 `~/.agents`、`~/.claude` 等代理主目录写入任何 skill
-  文件。
+- `OO_SKILLS_SYNC_DISABLED`：设为真值会禁用启动时的 managed skill 同步，
+  使 CLI 不会向 `~/.agents`、`~/.claude` 等代理主目录写入任何 skill 文件。
 - `OO_NO_SELF_UPDATE`：设为真值会禁用 `oo update`、`oo install` 和
   `oo check-update`，并强制关闭 self-update 的 PATH 改写。
 

--- a/src/application/commands/uninstall.cli.test.ts
+++ b/src/application/commands/uninstall.cli.test.ts
@@ -281,7 +281,7 @@ describe("oo uninstall", () => {
         const sandbox = await createCliSandbox();
 
         try {
-            // No bundled/preset skills present, so the plan is empty. A
+            // No bundled skills present, so the plan is empty. A
             // package-manager install must still surface binary guidance + exit 1.
             const homeDirectory = sandbox.env.HOME!;
 


### PR DESCRIPTION
`OO_SKILLS_SYNC_DISABLED` is documented in both language docs as disabling "the startup managed-skill synchronization and legacy-cleanup side effects". That was accurate when the env-var guard in `run-cli.ts` wrapped `removeLegacyCodexManagedSkills` and `removeLegacyGptImage2ManagedSkills`, but #329 and #330 deleted both shims and the guarded block now holds only `synchronizeManagedSkillsForAvailableHosts()`, which publishes skills and cleans up nothing. The code comment was corrected alongside the shim removal; neither doc was, so the env-var contract still advertised behavior the CLI no longer has.

The uninstall CLI test carried the same kind of leftover: `// No bundled/preset skills present` named the preset registry-package class that `shouldRemoveManagedSkill()` special-cased before #257 removed the `@alwaysmavs/gpt-image-2` preset. `bundled` is now the only class removed without `--purge`, and this comment was the last place in the source tree describing oo as having preset skills.

Both came out of an audit of whether any trace of the preset auto-downloaded skill mechanism survived #257/#329/#330. Nothing else did — no code path installs a skill package the user did not ask for, and startup sync neither downloads nor deletes.