### PR TITLE
fix(skills): keep unusable skill target paths from failing installs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1145,6 +1145,11 @@ missing), and for every other supported host directory that already exists.
   any newly detected supported host that is missing it.
 - Local skills: agent-native local skills are not synchronized during startup.
   A local skill belongs to the agent skill directory where it was created.
+- Unusable host directories: a supported host is skipped when its skill
+  directory path is occupied by something `oo` cannot create a directory at,
+  such as a symbolic link whose target has been removed or a regular file. The
+  remaining hosts still install, and `oo info` keeps reporting the host so the
+  broken path stays visible.
 - Shared host directories: supported hosts whose skill directories resolve to
   the same location — for example `~/.claude/skills` symlinked to
   `~/.agents/skills` — are one host. The skill is installed there once and is
@@ -1656,6 +1661,8 @@ Install bundled or published skills into supported local skill directories.
   non-OOMOL skill; the install fails with `name_conflict` for that skill unless
   `--force` is used (which overwrites it). A same-name skill already managed by
   `oo` is overwritten, including when it was installed from a different package.
+  An empty target directory holds no skill, so it never conflicts: the install
+  writes into it and reports `previousState: "absent"`.
 - Notes: the universal `~/.agents` host is always available (created when
   missing), so the command always has at least one install target.
 - Notes: an existing bundled or registry skill installation is considered

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1663,8 +1663,11 @@ Install bundled or published skills into supported local skill directories.
   `oo` is overwritten, including when it was installed from a different package.
   An empty target directory holds no skill, so it never conflicts: the install
   writes into it and reports `previousState: "absent"`.
-- Notes: the universal `~/.agents` host is always available (created when
-  missing), so the command always has at least one install target.
+- Notes: the universal `~/.agents` host is available whenever its skill
+  directory can be created (the directory itself is created when missing), so
+  the command normally has at least one install target. It drops out only when
+  something `oo` cannot create a directory at occupies `~/.agents/skills`, and
+  the command reports `no_supported_hosts` when that leaves no usable host.
 - Notes: an existing bundled or registry skill installation is considered
   managed by `oo` only when its `.oo-metadata.json` identifies that source.
   Otherwise `oo` treats it as a different skill and will not overwrite it.

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -1381,7 +1381,10 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   skill 的安装会以 `name_conflict` 失败，除非使用 `--force`（会覆盖它）。如果同名
   skill 已由 `oo` 管理，则会被覆盖，即使它来自另一个 package。空目录里没有任何
   skill，因此不构成冲突：安装会直接写入，并报告 `previousState: "absent"`。
-- 说明：通用 `~/.agents` host 始终可用（缺失时自动创建），因此命令始终至少有一个安装目标。
+- 说明：只要通用 `~/.agents` host 的 skill 目录能被创建，它就始终可用（该目录缺失
+  时自动创建），因此命令通常至少有一个安装目标。只有当 `~/.agents/skills` 被
+  `oo` 无法在其上创建目录的东西占用时它才会被排除；如果因此没有任何可用 host，
+  命令会报告 `no_supported_hosts`。
 - 说明：只有当 bundled 或 registry skill 的 `.oo-metadata.json` 能识别对应来源
   时，`oo` 才会认为这是自己管理的安装；否则会视为其他 skill，并拒绝覆盖。
 - 选项：`--json` / `--format json` 输出结构化 payload（见下方"mutation 命令的

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -963,6 +963,9 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   到且尚未安装它的受支持 Agent。
 - 本地 skill：agent-native local skill 不会在启动时同步。本地 skill 归属于创建它
   的 Agent skill 目录。
+- 不可用的 Agent 目录：如果某个受支持 Agent 的 skill 目录路径被 `oo` 无法在其上
+  创建目录的东西占用（例如目标已被删除的软链接，或一个普通文件），该 Agent 会被
+  跳过，其余 Agent 仍正常安装；`oo info` 仍会列出该 Agent，便于发现损坏路径。
 - 共享 Agent 目录：如果多个受支持 Agent 的 skill 目录指向同一个位置（例如
   `~/.claude/skills` 软链接到 `~/.agents/skills`），它们会被视为同一个 host：
   skill 只安装一次，并归属到更具体的 Agent，即通用 `~/.agents` host 让位于与
@@ -1376,7 +1379,8 @@ CLI 默认记录受隐私约束的命令使用 telemetry。事件不包含 free-
   `Authorization` header。
 - 说明：如果同名目标目录没有有效的 `oo` 元数据，会被视为非 OOMOL skill；该
   skill 的安装会以 `name_conflict` 失败，除非使用 `--force`（会覆盖它）。如果同名
-  skill 已由 `oo` 管理，则会被覆盖，即使它来自另一个 package。
+  skill 已由 `oo` 管理，则会被覆盖，即使它来自另一个 package。空目录里没有任何
+  skill，因此不构成冲突：安装会直接写入，并报告 `previousState: "absent"`。
 - 说明：通用 `~/.agents` host 始终可用（缺失时自动创建），因此命令始终至少有一个安装目标。
 - 说明：只有当 bundled 或 registry skill 的 `.oo-metadata.json` 能识别对应来源
   时，`oo` 才会认为这是自己管理的安装；否则会视为其他 skill，并拒绝覆盖。

--- a/src/application/commands/skills/auto-sync.ts
+++ b/src/application/commands/skills/auto-sync.ts
@@ -215,8 +215,11 @@ async function canWriteBundledCanonicalSkill(
         canonicalSkillDirectoryPath,
     );
 
+    // A path occupied by a non-directory is not writable, so "absent" is too
+    // wide here; an empty directory is reclaimable like a missing one.
     if (
         canonicalState.kind === "missing"
+        || canonicalState.kind === "empty"
         || (canonicalState.kind === "managed"
             && canonicalState.metadata.kind === "bundled")
     ) {

--- a/src/application/commands/skills/index.test.ts
+++ b/src/application/commands/skills/index.test.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, readFile, realpath, stat } from "node:fs/promises";
+import { lstat, mkdir, readFile, realpath, rm, stat } from "node:fs/promises";
 
 import { dirname, join } from "node:path";
 import { stripVTControlCharacters } from "node:util";
@@ -410,6 +410,81 @@ describe("skills commands", () => {
             expect(
                 await readFile(join(sharedSkillsDirectoryPath, "runtime", "SKILL.md"), "utf8"),
             ).toContain("# Runtime");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("installs a registry skill over an empty target directory without --force", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+        const skillDirectoryPath = resolveManagedSkillDirectoryPath(
+            universalHomeDirectory,
+            "runtime",
+        );
+
+        try {
+            // An install interrupted after the target directory was created but
+            // before its files were written leaves exactly this state.
+            await mkdir(skillDirectoryPath, { recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "oo@0.0.2"],
+                { fetcher: createRuntimeRegistryFetcher() },
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Skill: runtime\nInstalled skill runtime to ${skillDirectoryPath}.\n`,
+            );
+            expect(await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8")).toContain(
+                "# Runtime",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("installs a registry skill when one agent skills directory is a dangling symbolic link", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+        const claudeHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "claude");
+        const removedSkillsDirectoryPath = join(sandbox.env.HOME!, ".removed", "skills");
+        const skillDirectoryPath = resolveManagedSkillDirectoryPath(
+            claudeHomeDirectory,
+            "runtime",
+        );
+
+        try {
+            await mkdir(removedSkillsDirectoryPath, { recursive: true });
+            await mkdir(universalHomeDirectory, { recursive: true });
+            await mkdir(join(claudeHomeDirectory, "skills"), { recursive: true });
+            await createDirectorySymbolicLinkForTest(
+                removedSkillsDirectoryPath,
+                join(universalHomeDirectory, "skills"),
+            );
+            await rm(join(sandbox.env.HOME!, ".removed"), { force: true, recursive: true });
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(
+                ["skills", "install", "oo@0.0.2"],
+                { fetcher: createRuntimeRegistryFetcher() },
+            );
+
+            // The universal skills directory cannot be created through the
+            // dangling link, which used to fail the whole install with EEXIST.
+            expect(result.exitCode).toBe(0);
+            expect(result.stderr).toBe("");
+            expect(result.stdout).toBe(
+                `Skill: runtime\nInstalled skill runtime to ${skillDirectoryPath}.\n`,
+            );
+            expect(await readFile(join(skillDirectoryPath, "SKILL.md"), "utf8")).toContain(
+                "# Runtime",
+            );
         }
         finally {
             await sandbox.cleanup();
@@ -2171,6 +2246,7 @@ describe("skills commands", () => {
 
         try {
             await mkdir(skillDirectoryPath, { recursive: true });
+            await Bun.write(join(skillDirectoryPath, "SKILL.md"), "# system\n");
 
             const result = await sandbox.run(["skills", "remove", ".system"]);
 
@@ -2178,6 +2254,30 @@ describe("skills commands", () => {
             expect(result.stdout).toBe("");
             expect(result.stderr).toBe(
                 ".system is not managed by oo and cannot be removed.\n",
+            );
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("reports an empty skill directory as nothing to remove", async () => {
+        const sandbox = await createCliSandbox();
+        const universalHomeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+
+        try {
+            await mkdir(join(universalHomeDirectory, "skills", ".system"), {
+                recursive: true,
+            });
+
+            const result = await sandbox.run(["skills", "remove", ".system"]);
+
+            // An empty directory holds no skill, so it is reported as absent
+            // rather than as an unmanaged skill oo refuses to touch.
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toBe("");
+            expect(result.stderr).toBe(
+                "No installed oo-managed skill belongs to .system.\n",
             );
         }
         finally {

--- a/src/application/commands/skills/managed-skill-hosts.test.ts
+++ b/src/application/commands/skills/managed-skill-hosts.test.ts
@@ -119,6 +119,50 @@ describe("resolveAvailableManagedSkillHosts", () => {
             await hostSandbox.cleanup();
         }
     });
+
+    test("drops a host whose skills directory is a symbolic link to a removed target", async () => {
+        const hostSandbox = await createManagedSkillHostSandbox();
+        const rootDirectory = hostSandbox.rootDirectory;
+
+        try {
+            const removedSkillsDirectory = join(rootDirectory, ".removed", "skills");
+
+            await mkdir(removedSkillsDirectory, { recursive: true });
+            await mkdir(join(rootDirectory, ".agents"), { recursive: true });
+            await mkdir(join(rootDirectory, ".claude", "skills"), { recursive: true });
+            await createDirectorySymbolicLinkForTest(
+                removedSkillsDirectory,
+                join(rootDirectory, ".agents", "skills"),
+            );
+            await rm(join(rootDirectory, ".removed"), { force: true, recursive: true });
+
+            const hosts = await resolveAvailableManagedSkillHosts(hostSandbox.env);
+
+            // The dangling link can never be created, so publishing through it
+            // would fail with EEXIST; the intact host still installs.
+            expect(hosts.map(host => host.agentName)).toEqual(["claude"]);
+        }
+        finally {
+            await hostSandbox.cleanup();
+        }
+    });
+
+    test("drops a host whose skills path is occupied by a file", async () => {
+        const hostSandbox = await createManagedSkillHostSandbox();
+        const rootDirectory = hostSandbox.rootDirectory;
+
+        try {
+            await mkdir(join(rootDirectory, ".agents"), { recursive: true });
+            await Bun.write(join(rootDirectory, ".agents", "skills"), "not a directory\n");
+
+            const hosts = await resolveAvailableManagedSkillHosts(hostSandbox.env);
+
+            expect(hosts).toEqual([]);
+        }
+        finally {
+            await hostSandbox.cleanup();
+        }
+    });
 });
 
 // Every host test needs an empty home directory tree plus the environment that

--- a/src/application/commands/skills/managed-skill-hosts.ts
+++ b/src/application/commands/skills/managed-skill-hosts.ts
@@ -1,7 +1,9 @@
+import type { Stats } from "node:fs";
 import type { BundledSkillAgentName } from "./managed-skill-agents.ts";
 
-import { realpath } from "node:fs/promises";
+import { lstat, realpath } from "node:fs/promises";
 import { CliUserError } from "../../contracts/cli.ts";
+import { isFileMissingError, isPathMissingError } from "../../shared/fs-errors.ts";
 import { directoryExists } from "./bundled-skill-observation.ts";
 import {
     availableBundledSkillAgentNames,
@@ -40,6 +42,10 @@ export async function resolveAvailableManagedSkillHosts(
                 return undefined;
             }
 
+            if (!(await isManagedSkillsDirectoryProvisionable(homeDirectory))) {
+                return undefined;
+            }
+
             return {
                 agentName,
                 homeDirectory,
@@ -50,6 +56,42 @@ export async function resolveAvailableManagedSkillHosts(
     return collapseAliasedManagedSkillHosts(
         hosts.filter(host => host !== undefined),
     );
+}
+
+// Every publication starts by creating the host's skills directory, so a host
+// is only usable while that path is a directory or free to become one. A path
+// occupied by anything else — most often a symlink whose target has since been
+// removed, but a regular file too — can never be created: `mkdir` reports
+// EEXIST for the entry that is already there, and the recursive mode cannot
+// treat it as an existing directory either. Such a host is dropped rather than
+// left to fail mid-install; `oo info` still reports its skill directory so the
+// broken path stays visible.
+async function isManagedSkillsDirectoryProvisionable(
+    homeDirectory: string,
+): Promise<boolean> {
+    const skillsDirectoryPath = resolveManagedSkillsDirectoryPath(homeDirectory);
+    let entry: Stats;
+
+    try {
+        entry = await lstat(skillsDirectoryPath);
+    }
+    catch (error) {
+        if (isFileMissingError(error)) {
+            // Nothing occupies the path: it is created on demand.
+            return true;
+        }
+
+        // ENOTDIR means an ancestor is a file, which no publication can fix.
+        if (isPathMissingError(error)) {
+            return false;
+        }
+
+        throw error;
+    }
+
+    return entry.isSymbolicLink()
+        ? await directoryExists(skillsDirectoryPath)
+        : entry.isDirectory();
 }
 
 // Several supported agents can share one physical skills directory: a

--- a/src/application/commands/skills/skill-directory-state.test.ts
+++ b/src/application/commands/skills/skill-directory-state.test.ts
@@ -9,6 +9,7 @@ import { createTemporaryDirectory } from "../../../../__tests__/helpers.ts";
 import { resolveManagedSkillMetadataFilePath } from "./managed-skill-paths.ts";
 import {
     isCurrentRegistryPublication,
+    isSkillDirectoryAbsent,
     readSkillDirectoryState,
 } from "./skill-directory-state.ts";
 import {
@@ -71,10 +72,21 @@ describe("readSkillDirectoryState", () => {
         ).resolves.toEqual({ kind: "not-directory" });
     });
 
+    test("classifies an empty directory as empty", async () => {
+        const skillDirectoryPath = join(rootDirectoryPath, "skill");
+
+        await mkdir(skillDirectoryPath);
+
+        await expect(
+            readSkillDirectoryState(skillDirectoryPath),
+        ).resolves.toEqual({ kind: "empty" });
+    });
+
     test("classifies a directory without metadata as unmanaged", async () => {
         const skillDirectoryPath = join(rootDirectoryPath, "skill");
 
         await mkdir(skillDirectoryPath);
+        await writeFile(join(skillDirectoryPath, "SKILL.md"), "# skill\n");
 
         await expect(
             readSkillDirectoryState(skillDirectoryPath),
@@ -207,6 +219,7 @@ describe("isCurrentRegistryPublication", () => {
     const rejectedCases = [
         { state: { kind: "missing" }, title: "a missing state" },
         { state: { kind: "not-directory" }, title: "a not-directory state" },
+        { state: { kind: "empty" }, title: "an empty state" },
         {
             state: { kind: "unmanaged", metadataFilePresent: true },
             title: "an unmanaged state",
@@ -256,6 +269,41 @@ describe("isCurrentRegistryPublication", () => {
     for (const { state, title } of rejectedCases) {
         test(`rejects ${title}`, () => {
             expect(isCurrentRegistryPublication(state, expected)).toBeFalse();
+        });
+    }
+});
+
+describe("isSkillDirectoryAbsent", () => {
+    const absentCases = [
+        { state: { kind: "missing" }, title: "a missing state" },
+        { state: { kind: "not-directory" }, title: "a not-directory state" },
+        { state: { kind: "empty" }, title: "an empty state" },
+    ] satisfies readonly { state: SkillDirectoryState; title: string }[];
+
+    const presentCases = [
+        {
+            state: { kind: "unmanaged", metadataFilePresent: false },
+            title: "an unmanaged state",
+        },
+        {
+            state: {
+                kind: "managed",
+                metadata: createBundledSkillMetadata("1.2.3"),
+                publicationCurrent: true,
+            },
+            title: "a managed state",
+        },
+    ] satisfies readonly { state: SkillDirectoryState; title: string }[];
+
+    for (const { state, title } of absentCases) {
+        test(`reports ${title} as absent`, () => {
+            expect(isSkillDirectoryAbsent(state)).toBeTrue();
+        });
+    }
+
+    for (const { state, title } of presentCases) {
+        test(`reports ${title} as present`, () => {
+            expect(isSkillDirectoryAbsent(state)).toBeFalse();
         });
     }
 });

--- a/src/application/commands/skills/skill-directory-state.ts
+++ b/src/application/commands/skills/skill-directory-state.ts
@@ -1,6 +1,6 @@
 import type { SkillMetadata } from "./skill-metadata.ts";
 
-import { lstat, readFile, stat } from "node:fs/promises";
+import { lstat, readdir, readFile, stat } from "node:fs/promises";
 import { isPathMissingError } from "../../shared/fs-errors.ts";
 import { isNodeNotFoundError } from "./bundled-skill-filesystem.ts";
 import { resolveManagedSkillMetadataFilePath } from "./managed-skill-paths.ts";
@@ -12,7 +12,12 @@ import { parseSkillMetadataContent } from "./skill-metadata.ts";
 // - "missing":       nothing exists at the path (broken symlinks included).
 // - "not-directory": the path exists but is not a directory; oo must not
 //                    manage or overwrite it.
-// - "unmanaged":     a directory without parseable oo metadata.
+// - "empty":         a directory holding no entries at all. It carries nothing
+//                    oo could destroy, so it counts as absent rather than as
+//                    somebody else's skill: an install interrupted between
+//                    creating the target directory and writing its files must
+//                    not leave a target that only `--force` can reclaim.
+// - "unmanaged":     a non-empty directory without parseable oo metadata.
 //                    metadataFilePresent distinguishes "no .oo-metadata.json"
 //                    from "present but unparseable".
 // - "managed":       a directory carrying parseable oo metadata; match on
@@ -25,6 +30,7 @@ import { parseSkillMetadataContent } from "./skill-metadata.ts";
 export type SkillDirectoryState
     = | { kind: "missing" }
         | { kind: "not-directory" }
+        | { kind: "empty" }
         | { kind: "unmanaged"; metadataFilePresent: boolean }
         | { kind: "managed"; metadata: SkillMetadata; publicationCurrent: boolean };
 
@@ -58,7 +64,7 @@ export async function readSkillDirectoryState(
     }
     catch (error) {
         if (isNodeNotFoundError(error)) {
-            return { kind: "unmanaged", metadataFilePresent: false };
+            return await readSkillDirectoryStateWithoutMetadata(skillDirectoryPath);
         }
 
         throw error;
@@ -75,6 +81,28 @@ export async function readSkillDirectoryState(
         metadata,
         publicationCurrent: await isCurrentPublicationPath(skillDirectoryPath),
     };
+}
+
+async function readSkillDirectoryStateWithoutMetadata(
+    skillDirectoryPath: string,
+): Promise<SkillDirectoryState> {
+    let entries: string[];
+
+    try {
+        entries = await readdir(skillDirectoryPath);
+    }
+    catch (error) {
+        if (isPathMissingError(error)) {
+            // The directory disappeared while it was being classified.
+            return { kind: "missing" };
+        }
+
+        throw error;
+    }
+
+    return entries.length === 0
+        ? { kind: "empty" }
+        : { kind: "unmanaged", metadataFilePresent: false };
 }
 
 async function isCurrentPublicationPath(
@@ -94,11 +122,13 @@ async function isCurrentPublicationPath(
     }
 }
 
-// True when no directory is present at the path — nothing exists there, or a
-// non-directory occupies it. The classification-side equivalent of the old
-// `!directoryExists(path)` guards.
+// True when the path holds no skill oo has to account for — nothing exists
+// there, a non-directory occupies it, or the directory is empty. The
+// classification-side equivalent of the old `!directoryExists(path)` guards.
 export function isSkillDirectoryAbsent(state: SkillDirectoryState): boolean {
-    return state.kind === "missing" || state.kind === "not-directory";
+    return state.kind === "missing"
+        || state.kind === "not-directory"
+        || state.kind === "empty";
 }
 
 export function managedMetadataOfKind<Kind extends SkillMetadata["kind"]>(

--- a/src/application/commands/skills/sync.cli.test.ts
+++ b/src/application/commands/skills/sync.cli.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { describe, expect, test } from "bun:test";
 
@@ -282,7 +282,7 @@ describe("skills sync upload --json", () => {
         }
     });
 
-    test("unexpected filesystem throw is normalized to unknown error JSON", async () => {
+    test("a host skills path occupied by a file reports no supported hosts", async () => {
         const sandbox = await createCliSandbox();
 
         try {
@@ -290,13 +290,61 @@ describe("skills sync upload --json", () => {
             const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
 
             await mkdir(homeDirectory, { recursive: true });
-            // Make <home>/skills be a regular file rather than a directory.
-            // readSkillsDirectoryEntries on it will throw ENOTDIR (not ENOENT),
-            // which is *not* covered by any inner try/catch in the upload path.
-            // The outer safety net must convert it to a stable JSON payload.
-            const skillsPath = join(homeDirectory, "skills");
+            await writeFile(join(homeDirectory, "skills"), "not a directory\n");
 
-            await writeFile(skillsPath, "not a directory\n");
+            const result = await sandbox.run(
+                ["skills", "sync", "upload", "--json"],
+                {
+                    version: TEST_CLI_VERSION,
+                    fetcher: async () => new Response("[]"),
+                },
+            );
+
+            expect(result.exitCode).toBe(1);
+            const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+            const errors = payload.errors as Array<Record<string, unknown>>;
+
+            // No skill directory can be created at that path, so the host is
+            // dropped and the command reports the defined error instead of
+            // failing on the raw ENOTDIR later on.
+            expect(payload.status).toBe("failed");
+            expect(errors).toHaveLength(1);
+            expect(errors[0]).toMatchObject({ code: "no_supported_hosts" });
+            expect(result.stdout).not.toContain("ENOTDIR");
+            expect(result.stdout).not.toContain("not a directory");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("unexpected filesystem throw is normalized to unknown error JSON", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+            const homeDirectory = resolveManagedSkillAgentHomeDirectory(sandbox.env, "universal");
+            const storePaths = resolveStorePaths({
+                appName: APP_NAME,
+                env: sandbox.env,
+                platform: process.platform,
+            });
+
+            await mkdir(join(homeDirectory, "skills"), { recursive: true });
+            // Make the canonical registry root a regular file rather than a
+            // directory. readSkillsDirectoryEntries on it will throw ENOTDIR
+            // (not ENOENT), which is *not* covered by any inner try/catch in the
+            // upload path. The outer safety net must convert it to a stable JSON
+            // payload.
+            const canonicalRootPath = dirname(
+                resolveManagedSkillCanonicalDirectoryPath(
+                    storePaths.settingsFilePath,
+                    "demo",
+                ),
+            );
+
+            await mkdir(dirname(canonicalRootPath), { recursive: true });
+            await writeFile(canonicalRootPath, "not a directory\n");
 
             const result = await sandbox.run(
                 ["skills", "sync", "upload", "--json"],


### PR DESCRIPTION
Installing a skill died with `EEXIST: file already exists, mkdir ~/.agents/skills` on a machine where an agent home's skills directory is a symbolic link whose target has been removed. Recursive `mkdir` treats such a link as an occupied path it cannot turn into a directory, and since every publication starts by creating that directory, one broken agent home failed the install for every other host too. Host resolution now drops a host whose skills directory is neither a directory nor a free path, and the intact hosts install as usual.

https://github.com/oomol-lab/oo-cli/blob/349ca8dda2661fa41c591e0e8cc7153cd5eb678c/src/application/commands/skills/bundled-skill-filesystem.ts#L11-L22

That crash left a second trap behind: it created the target directory and exited before writing any files, and an empty directory carrying no `.oo-metadata.json` counted as a non-OOMOL skill, so the next attempt refused it with `name_conflict` and only `--force` could reclaim it. `readSkillDirectoryState` now gives an empty directory its own state and reports it as absent, since nothing is there to protect. Every consumer of that state was reviewed, and the one place that compares against `missing` directly, the bundled canonical storage guard, was widened with it while still refusing a path occupied by a file.

One existing sync test used a regular file at `<home>/skills` to reach the unexpected-throw safety net, and that case is now a defined `no_supported_hosts` result, so the test keeps its purpose through the canonical registry root and the defined outcome gets a test of its own. Follow-up to #336, which fixed the aliased-host half of the same report.
