### PR TITLE
feat(telemetry): report the hosting agent client on command events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "oo",
       "dependencies": {
+        "@vercel/detect-agent": "^1.2.5",
         "@wopjs/cast": "^0.1.16",
         "agentic-markdown": "^0.0.4",
         "ajv": "^8.18.0",
@@ -265,6 +266,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.57.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.57.1", "@typescript-eslint/types": "8.57.1", "@typescript-eslint/typescript-estree": "8.57.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.57.1", "", { "dependencies": { "@typescript-eslint/types": "8.57.1", "eslint-visitor-keys": "^5.0.0" } }, "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A=="],
+
+    "@vercel/detect-agent": ["@vercel/detect-agent@1.2.5", "", {}, "sha512-0krENrjuitlW8s6TJu0MlqCevyCU7K7JK63jZAf7xZ6n17tx+vUEwzHT3sTxawtwZxaW21hu+oFUpoOrm49FsQ=="],
 
     "@vitest/eslint-plugin": ["@vitest/eslint-plugin@1.6.12", "", { "dependencies": { "@typescript-eslint/scope-manager": "^8.55.0", "@typescript-eslint/utils": "^8.55.0" }, "peerDependencies": { "eslint": ">=8.57.0", "typescript": ">=5.0.0", "vitest": "*" }, "optionalPeers": ["typescript", "vitest"] }, "sha512-4kI47BJNFE+EQ5bmPbHzBF+ibNzx2Fj0Jo9xhWsTPxMddlHwIWl6YAxagefh461hrwx/W0QwBZpxGS404kBXyg=="],
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "@vercel/detect-agent": "^1.2.5",
     "@wopjs/cast": "^0.1.16",
     "agentic-markdown": "^0.0.4",
     "ajv": "^8.18.0",

--- a/src/application/bootstrap/run-cli.test.ts
+++ b/src/application/bootstrap/run-cli.test.ts
@@ -448,6 +448,43 @@ describe("runCli bootstrap", () => {
         }
     });
 
+    test("reports the detected agent client in telemetry", async () => {
+        const sandbox = await createCliSandbox();
+        // @vercel/detect-agent reads process.env directly and AI_AGENT
+        // outranks every other marker, so setting it keeps this test
+        // deterministic no matter which host runs the suite.
+        const originalAiAgent = process.env.AI_AGENT;
+
+        try {
+            process.env.AI_AGENT = "v0";
+
+            const result = await sandbox.run(["config", "list"]);
+            const rows = readTelemetryRowsForTest(
+                resolveSandboxTelemetryDirectory(sandbox),
+            );
+            const payload = parseTelemetryRowPayload(rows[0]!);
+
+            expect(result.exitCode).toBe(0);
+            expect(rows).toHaveLength(1);
+            expect(payload).toMatchObject({
+                properties: {
+                    agent_client: "v0",
+                    command_full: "config.list",
+                },
+            });
+        }
+        finally {
+            if (originalAiAgent === undefined) {
+                delete process.env.AI_AGENT;
+            }
+            else {
+                process.env.AI_AGENT = originalAiAgent;
+            }
+
+            await sandbox.cleanup();
+        }
+    });
+
     test("runs the internal telemetry flusher without recursive telemetry", async () => {
         const sandbox = await createCliSandbox();
         const stdout = createTextBuffer();

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -769,6 +769,7 @@ function readForbiddenTelemetryDecisionPropertyReason(
 function createBaseTelemetryPropertyNames(): ReadonlySet<string> {
     const item = createCliCommandTelemetryPayload({
         accountState: "authenticated",
+        agentClient: "unknown",
         arch: "arm64",
         ciName: "github_actions",
         cliCommit: "test-commit",

--- a/src/application/telemetry/__tests__/helpers.ts
+++ b/src/application/telemetry/__tests__/helpers.ts
@@ -5,6 +5,7 @@ export function createTelemetryItemForTest(index: number) {
 
     return createCliCommandTelemetryPayload({
         accountState: "anonymous",
+        agentClient: "unknown",
         arch: "arm64",
         ciName: "none",
         cliCommit: "unknown",

--- a/src/application/telemetry/agent-client.test.ts
+++ b/src/application/telemetry/agent-client.test.ts
@@ -1,0 +1,108 @@
+import process from "node:process";
+import { describe, expect, test } from "bun:test";
+import { detectTelemetryAgentClient } from "./agent-client.ts";
+
+describe("detectTelemetryAgentClient", () => {
+    test("reports unknown when no agent marker is present", async () => {
+        await withScrubbedAgentEnvironment(async () => {
+            expect(await detectTelemetryAgentClient()).toBe("unknown");
+        });
+    });
+
+    test("maps library agent names onto the telemetry enum", async () => {
+        await withScrubbedAgentEnvironment(async () => {
+            process.env.CLAUDECODE = "1";
+            expect(await detectTelemetryAgentClient()).toBe("claude");
+
+            process.env.CLAUDE_CODE_IS_COWORK = "1";
+            expect(await detectTelemetryAgentClient()).toBe("cowork");
+        });
+
+        await withScrubbedAgentEnvironment(async () => {
+            process.env.CURSOR_TRACE_ID = "trace-1";
+            expect(await detectTelemetryAgentClient()).toBe("cursor");
+        });
+
+        await withScrubbedAgentEnvironment(async () => {
+            process.env.CURSOR_AGENT = "1";
+            expect(await detectTelemetryAgentClient()).toBe("cursor-cli");
+        });
+
+        await withScrubbedAgentEnvironment(async () => {
+            process.env.CODEX_THREAD_ID = "thread-1";
+            expect(await detectTelemetryAgentClient()).toBe("codex");
+        });
+
+        await withScrubbedAgentEnvironment(async () => {
+            process.env.AUGMENT_AGENT = "1";
+            expect(await detectTelemetryAgentClient()).toBe("augment-cli");
+        });
+
+        await withScrubbedAgentEnvironment(async () => {
+            process.env.COPILOT_MODEL = "gpt";
+            expect(await detectTelemetryAgentClient()).toBe("github-copilot");
+        });
+    });
+
+    test("honors the AI_AGENT override for known agent names", async () => {
+        await withScrubbedAgentEnvironment(async () => {
+            process.env.AI_AGENT = "v0";
+            expect(await detectTelemetryAgentClient()).toBe("v0");
+        });
+    });
+
+    test("maps free-form AI_AGENT values to other instead of passing them through", async () => {
+        await withScrubbedAgentEnvironment(async () => {
+            process.env.AI_AGENT = "my-homegrown-agent";
+            expect(await detectTelemetryAgentClient()).toBe("other");
+        });
+    });
+});
+
+// Every marker @vercel/detect-agent inspects; scrubbing them keeps the tests
+// deterministic even when the suite itself runs inside one of these agents.
+const agentEnvironmentKeys = [
+    "AI_AGENT",
+    "ANTIGRAVITY_AGENT",
+    "AUGMENT_AGENT",
+    "CLAUDECODE",
+    "CLAUDE_CODE",
+    "CLAUDE_CODE_IS_COWORK",
+    "CODEX_CI",
+    "CODEX_SANDBOX",
+    "CODEX_THREAD_ID",
+    "COPILOT_ALLOW_ALL",
+    "COPILOT_GITHUB_TOKEN",
+    "COPILOT_MODEL",
+    "CURSOR_AGENT",
+    "CURSOR_EXTENSION_HOST_ROLE",
+    "CURSOR_TRACE_ID",
+    "GEMINI_CLI",
+    "OPENCODE_CLIENT",
+    "REPL_ID",
+] as const;
+
+async function withScrubbedAgentEnvironment(
+    run: () => Promise<void>,
+): Promise<void> {
+    const savedValues = new Map<string, string | undefined>();
+
+    for (const key of agentEnvironmentKeys) {
+        savedValues.set(key, process.env[key]);
+        delete process.env[key];
+    }
+
+    try {
+        await run();
+    }
+    finally {
+        for (const [key, value] of savedValues) {
+            if (value === undefined) {
+                delete process.env[key];
+            }
+            else {
+                process.env[key] = value;
+            }
+        }
+    }
+}

--- a/src/application/telemetry/agent-client.ts
+++ b/src/application/telemetry/agent-client.ts
@@ -1,0 +1,43 @@
+import type { KnownAgentNames } from "@vercel/detect-agent";
+import { determineAgent, KNOWN_AGENTS } from "@vercel/detect-agent";
+
+// Reported values are the library's agent names verbatim, plus two sentinels:
+// "other" means an agent was detected but is not in the library's known set
+// (for example a free-form AI_AGENT value, which must never reach telemetry
+// as-is), and "unknown" means no agent marker was detected at all.
+export type TelemetryAgentClient = KnownAgentNames | "other" | "unknown";
+
+// Derived from the library so a dependency upgrade extends the accepted
+// values without any code change here.
+const knownAgentClientNames = new Set<string>(Object.values(KNOWN_AGENTS));
+
+function isKnownAgentClientName(value: string): value is KnownAgentNames {
+    return knownAgentClientNames.has(value);
+}
+
+export function isTelemetryAgentClient(
+    value: string,
+): value is TelemetryAgentClient {
+    return isKnownAgentClientName(value)
+        || value === "other"
+        || value === "unknown";
+}
+
+// The library reads process.env directly (there is no injection point), which
+// matches the real invocation environment in production.
+export async function detectTelemetryAgentClient(): Promise<TelemetryAgentClient> {
+    try {
+        const result = await determineAgent();
+
+        if (!result.isAgent) {
+            return "unknown";
+        }
+
+        return isKnownAgentClientName(result.agent.name)
+            ? result.agent.name
+            : "other";
+    }
+    catch {
+        return "unknown";
+    }
+}

--- a/src/application/telemetry/emitter.ts
+++ b/src/application/telemetry/emitter.ts
@@ -10,6 +10,7 @@ import process from "node:process";
 import { buildEnvApiKeyAccount } from "../auth/identity.ts";
 import { getCurrentAuthAccount } from "../schemas/auth.ts";
 import { detectInstallationMethodFromExecPath } from "../self-update/installation.ts";
+import { detectTelemetryAgentClient } from "./agent-client.ts";
 import {
     telemetryInternalCommand,
     telemetryInternalEnvKey,
@@ -89,6 +90,7 @@ export async function emitCliCommandTelemetry(
                 options.authStore,
                 options.env,
             ),
+            agentClient: await detectTelemetryAgentClient(),
             arch: arch(),
             ciName: ci.name,
             cliCommit: options.buildCommit,

--- a/src/application/telemetry/payload.test.ts
+++ b/src/application/telemetry/payload.test.ts
@@ -33,6 +33,7 @@ describe("telemetry payload", () => {
         expect(request.batch[0].properties.distinct_id).toBe(
             "019a0cca-0000-7000-8000-000000000001",
         );
+        expect(request.batch[0].properties.agent_client).toBe("claude");
         expect(request.batch[0].properties.$ip).toBe("");
         expect(request.batch[0].properties.$geoip_disable).toBe(true);
         expect(request.batch[0].properties.$process_person_profile).toBe(false);
@@ -224,6 +225,13 @@ describe("telemetry payload", () => {
                 ...itemRecord,
                 properties: {
                     ...properties,
+                    agent_client: "not-an-allowlisted-agent",
+                },
+            },
+            {
+                ...itemRecord,
+                properties: {
+                    ...properties,
                     error_message: "full error text",
                 },
             },
@@ -267,6 +275,7 @@ describe("telemetry payload", () => {
             { command_full: "malicious.override" },
             { distinct_id: "019a0cca-0000-7000-8000-000000000002" },
             { schema_version: "2" },
+            { agent_client: "cursor" },
         ];
 
         for (const properties of reservedProperties) {
@@ -369,6 +378,7 @@ function createCanonicalTelemetryItem() {
 function createCanonicalTelemetryOptions() {
     return {
         accountState: "authenticated",
+        agentClient: "claude",
         arch: "arm64",
         ciName: "none",
         cliCommit: "abcdef0",

--- a/src/application/telemetry/payload.ts
+++ b/src/application/telemetry/payload.ts
@@ -1,6 +1,8 @@
 import type { CliTelemetryPropertyValue } from "../contracts/cli.ts";
+import type { TelemetryAgentClient } from "./agent-client.ts";
 import { Buffer } from "node:buffer";
 import { z } from "zod";
+import { isTelemetryAgentClient } from "./agent-client.ts";
 import {
     telemetryEventName,
     telemetryMaxEventBytes,
@@ -40,6 +42,7 @@ export interface TelemetryCommandOutcome {
 
 export interface CreateCliCommandTelemetryPayloadOptions {
     accountState: TelemetryAccountState;
+    agentClient: TelemetryAgentClient;
     arch: string;
     cliCommit: string;
     cliInstallMethod: string;
@@ -82,6 +85,9 @@ const telemetryPropertiesSchema = z.object({
     $ip: z.literal(""),
     $process_person_profile: z.literal(false),
     account_state: z.enum(["authenticated", "anonymous", "unknown"]),
+    // Validated against the library-derived allowlist plus the two sentinel
+    // values, so a dependency upgrade needs no schema change here.
+    agent_client: z.string().refine(isTelemetryAgentClient),
     arch: z.string().min(1),
     arg_count: z.number().int().nonnegative(),
     ci_name: z.string().min(1),
@@ -175,6 +181,7 @@ export function createCliCommandTelemetryPayload(
         $ip: "",
         $process_person_profile: false,
         account_state: options.accountState,
+        agent_client: options.agentClient,
         arch: options.arch,
         arg_count: options.command.argCount ?? 0,
         ci_name: options.ciName,


### PR DESCRIPTION
Connector growth analysis needs to know which AI agent host each `oo` invocation runs under. This adds an `agent_client` base property to the `cli_command_executed` telemetry event, detected at runtime through `@vercel/detect-agent`, so it covers every install method and needs no persisted state.

The property stays a closed low-cardinality enum. Reported values are the library's agent names, validated against an allowlist derived from its `KNOWN_AGENTS` export, so a dependency upgrade extends the accepted set without any code change here. A free-form `AI_AGENT` value folds to `other`, an undetected environment reports `unknown`, and arbitrary strings never reach telemetry. The detection tests scrub every marker the library inspects, keeping the suite deterministic even when it runs inside one of these agents.
