### PR TITLE
chore(ci): bump actions to latest releases

### DIFF
--- a/.github/workflows/deploy-install-worker.yaml
+++ b/.github/workflows/deploy-install-worker.yaml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ inputs.tag != '' && format('refs/tags/{0}', inputs.tag) || github.sha }}
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 1
 
@@ -97,7 +97,7 @@ jobs:
           echo "BUN_INSTALL_CACHE_DIR=${{ github.workspace }}/.bun-install-cache" >> "$GITHUB_ENV"
 
       - name: Cache Bun install dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .bun-install-cache
           key: bun-install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bun.lock', '.bun-version') }}
@@ -130,7 +130,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -141,7 +141,7 @@ jobs:
           bun-version-file: .bun-version
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
@@ -226,7 +226,7 @@ jobs:
     steps:
       - name: Checkout
         if: env.FEISHU_RELEASE_WEBHOOK != ''
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Bun
         if: env.FEISHU_RELEASE_WEBHOOK != ''

--- a/.github/workflows/refresh-cdn-cache.yaml
+++ b/.github/workflows/refresh-cdn-cache.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Cache Aliyun CLI
         id: cache_aliyun_cli
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/bin/aliyun
           key: aliyun-cli-${{ runner.os }}-${{ runner.arch }}-${{ env.PINNED_ALIYUN_CLI_VERSION }}

--- a/.github/workflows/reject-large-external-pr.yaml
+++ b/.github/workflows/reject-large-external-pr.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout Base
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 

--- a/.github/workflows/upload-release-binaries-to-oss.yaml
+++ b/.github/workflows/upload-release-binaries-to-oss.yaml
@@ -75,7 +75,7 @@ jobs:
           echo "ref=${workflow_ref}" >> "${GITHUB_OUTPUT}"
 
       - name: Checkout workflow source
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           repository: ${{ steps.workflow_source.outputs.repository }}
           ref: ${{ steps.workflow_source.outputs.ref }}
@@ -98,7 +98,7 @@ jobs:
           audience: https://github.com/oomol-lab
 
       - name: Cache rclone
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/bin/rclone
           key: rclone-${{ runner.os }}-${{ env.PINNED_RCLONE_VERSION }}

--- a/.github/workflows/upload-skill-install-guide-to-oss.yaml
+++ b/.github/workflows/upload-skill-install-guide-to-oss.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
 
       - name: Configure Alibaba Cloud CLI
         id: aliyun_credentials
@@ -40,7 +40,7 @@ jobs:
           audience: https://github.com/oomol-lab
 
       - name: Cache rclone
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.local/bin/rclone
           key: rclone-${{ runner.os }}-${{ env.PINNED_RCLONE_VERSION }}


### PR DESCRIPTION
The pinned action refs had drifted a few releases behind. This moves them to current so every action in these workflows keeps running on a Node 24 runtime, ahead of GitHub retiring the older ones.

`actions/checkout` goes v6.0.2 to v7.0.1, `actions/setup-node` v6.4.0 to v7.0.0, and `actions/cache` v5 to v6, each keeping the pin style already on that line.

None of the three was assumed drop-in. checkout v7 refuses fork PR checkouts from `pull_request_target`, but _.github/workflows/reject-large-external-pr.yaml_ checks out `pull_request.base.sha`, which the new guard leaves alone. setup-node v7 removes the `always-auth` input and the dummy `NODE_AUTH_TOKEN` fallback, and this repo needs neither: the publish step sets `NODE_AUTH_TOKEN` from a secret itself, and no workflow passes a `cache` input while _package.json_ carries no `packageManager` field, so auto-cache stays off exactly as before. cache v6 is a runtime and ESM migration with identical inputs and outputs.
