### PR TITLE
ci: disable checkout credential persistence where unused

### DIFF
--- a/.github/workflows/deploy-install-worker.yaml
+++ b/.github/workflows/deploy-install-worker.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           ref: ${{ inputs.tag != '' && format('refs/tags/{0}', inputs.tag) || github.sha }}
+          persist-credentials: false
 
       - name: Prepare install worker assets
         run: |

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
@@ -50,6 +52,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -39,6 +39,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
@@ -84,6 +85,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
@@ -134,6 +136,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0
@@ -227,6 +230,8 @@ jobs:
       - name: Checkout
         if: env.FEISHU_RELEASE_WEBHOOK != ''
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         if: env.FEISHU_RELEASE_WEBHOOK != ''

--- a/.github/workflows/reject-large-external-pr.yaml
+++ b/.github/workflows/reject-large-external-pr.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.2.0

--- a/.github/workflows/upload-skill-install-guide-to-oss.yaml
+++ b/.github/workflows/upload-skill-install-guide-to-oss.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Configure Alibaba Cloud CLI
         id: aliyun_credentials


### PR DESCRIPTION
actions/checkout writes the job token into .git/config by default, so every later step in the job, including third-party actions and anything a build script pulls in, can read a credential it was never handed. The most exposed case here is the `notify-feishu-release` job in _.github/workflows/publish.yaml_, which inherits `contents: write` from the workflow.

All ten checkout steps in _.github/workflows/_ were audited against the steps that follow them, and none needs the persisted credential. Release automation reaches GitHub over the REST API or through `gh` with `GH_TOKEN`, and the only git commands that run after checkout are local reads, `git tag -l` in _contrib/ci/compute-release-version.ts_ and `git rev-parse HEAD` in _contrib/ci/npm-packages.ts_. Nine steps gain `persist-credentials: false` here. The tenth, in _.github/workflows/upload-release-binaries-to-oss.yaml_, already carried it and is the convention the rest now match. CodeRabbit raised the same point on #341.
