### PR TITLE
fix(console): update outdated billing and connection links

### DIFF
--- a/contrib/skills/shared/oo-find-skills/SKILL.md
+++ b/contrib/skills/shared/oo-find-skills/SKILL.md
@@ -207,7 +207,7 @@ oo skills install "<packageName2>" -s "<skillName2>"
 14. If the command output shows HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`,
    stop immediately, tell the user their current account has insufficient
    credit or is overdue, and direct them to
-   `https://console.oomol.com/billing/token-recharge` before retrying.
+   `https://console.oomol.com/billing` before retrying.
 15. If a command fails with a message saying the self-hosted connector only
    supports connector commands, or with JSON error code `not_authenticated`
    in self-hosted connector mode, an OOMOL account is required. Ask the user

--- a/contrib/skills/shared/oo-find-skills/references/oo-cli-contract.md
+++ b/contrib/skills/shared/oo-find-skills/references/oo-cli-contract.md
@@ -106,7 +106,7 @@ Failure handling:
 - If any `oo` output shows HTTP `402` or `OOMOL_INSUFFICIENT_CREDIT`, stop
   immediately, tell the user their current account has insufficient credit or
   is overdue, and direct them to
-  `https://console.oomol.com/billing/token-recharge` before retrying.
+  `https://console.oomol.com/billing` before retrying.
 - If a command fails with a message saying the self-hosted connector only
   supports connector commands, or with JSON error code `not_authenticated` in
   self-hosted connector mode, an OOMOL account is required. Ask the user to

--- a/contrib/skills/shared/oo/references/auth-and-billing.md
+++ b/contrib/skills/shared/oo/references/auth-and-billing.md
@@ -93,7 +93,7 @@ When either appears in any `oo` command output:
 - Ask the user to recharge before retrying at:
 
 ```text
-https://console.oomol.com/billing/token-recharge
+https://console.oomol.com/billing
 ```
 
 ## Other blockers

--- a/contrib/skills/shared/oo/references/connector-execution.md
+++ b/contrib/skills/shared/oo/references/connector-execution.md
@@ -342,17 +342,19 @@ Return only:
 Use this URL:
 
 ```text
-https://console.oomol.com/app-connections?provider=${serviceName}
+https://console.oomol.com/team/${teamName}/connections/${serviceName}
 ```
 
-Replace `${serviceName}` with the selected connector service.
+Replace `${teamName}` with the team already selected for the connector
+operation and `${serviceName}` with the selected connector service. Never
+guess a team name or substitute a team id. If no team name is available, use
+`https://console.oomol.com/connections` instead.
 
 That URL applies to the OOMOL-hosted connector. When the user is on a
 self-hosted connector (see the self-hosted connector mode in
 [auth-and-billing.md](auth-and-billing.md)), point connection fixes at the
 self-hosted console instead: use the `connector.url` value from
-`oo auth status --json` as the console address, not
-`https://console.oomol.com/app-connections?provider=...`.
+`oo auth status --json` as the console address, not an OOMOL Console URL.
 
 For `connection_required`, `app_not_found`, or `app_not_ready`, explain that
 the connector has not been connected or authorized yet. For

--- a/contrib/skills/shared/oo/references/connector-execution.md
+++ b/contrib/skills/shared/oo/references/connector-execution.md
@@ -347,7 +347,9 @@ https://console.oomol.com/team/${teamName}/connections/${serviceName}
 
 Replace `${teamName}` with the team already selected for the connector
 operation and `${serviceName}` with the selected connector service. Never
-guess a team name or substitute a team id. If no team name is available, use
+guess a team name or substitute a team id. Percent-encode both values as
+individual URL path segments using `encodeURIComponent` semantics before
+substitution. If no team name is available, use
 `https://console.oomol.com/connections` instead.
 
 That URL applies to the OOMOL-hosted connector. When the user is on a

--- a/contrib/skills/shared/oo/references/search-and-selection.md
+++ b/contrib/skills/shared/oo/references/search-and-selection.md
@@ -179,13 +179,14 @@ Tie-breakers:
   explicitly requested that service, or no authenticated fallback can satisfy
   the same outcome, stop before schema inspection. Report that the connector is
   not connected, provide
-  `https://console.oomol.com/app-connections?provider=<service>`, and ask the
-  user to connect it first. Do not run `oo connector schema`, inspect adjacent
-  actions, or provide usage examples until the user confirms the service is
-  connected. On a self-hosted connector the `authenticated` field reflects the
-  server's connected apps; when a needed connector is not connected, direct
-  the user to the self-hosted console at the `connector.url` from
-  `oo auth status --json` instead of console.oomol.com.
+  `https://console.oomol.com/team/<team>/connections/<service>` when the
+  selected team name is known, or `https://console.oomol.com/connections`
+  otherwise, and ask the user to connect it first. Do not run
+  `oo connector schema`, inspect adjacent actions, or provide usage examples
+  until the user confirms the service is connected. On a self-hosted connector
+  the `authenticated` field reflects the server's connected apps; when a needed
+  connector is not connected, direct the user to the self-hosted console at the
+  `connector.url` from `oo auth status --json` instead of console.oomol.com.
 - If both `fusion-api` and an authenticated non-Fusion connector are suitable,
   choose the one whose output contract best matches the user's requested result.
   Ask the user only when the choice changes provider, account, cost, compliance,

--- a/contrib/skills/shared/oo/references/search-and-selection.md
+++ b/contrib/skills/shared/oo/references/search-and-selection.md
@@ -181,12 +181,14 @@ Tie-breakers:
   not connected, provide
   `https://console.oomol.com/team/<team>/connections/<service>` when the
   selected team name is known, or `https://console.oomol.com/connections`
-  otherwise, and ask the user to connect it first. Do not run
-  `oo connector schema`, inspect adjacent actions, or provide usage examples
-  until the user confirms the service is connected. On a self-hosted connector
-  the `authenticated` field reflects the server's connected apps; when a needed
-  connector is not connected, direct the user to the self-hosted console at the
-  `connector.url` from `oo auth status --json` instead of console.oomol.com.
+  otherwise. Percent-encode `<team>` and `<service>` as individual URL path
+  segments using `encodeURIComponent` semantics before substitution, then ask
+  the user to connect the service first. Do not run `oo connector schema`,
+  inspect adjacent actions, or provide usage examples until the user confirms
+  the service is connected. On a self-hosted connector the `authenticated`
+  field reflects the server's connected apps; when a needed connector is not
+  connected, direct the user to the self-hosted console at the `connector.url`
+  from `oo auth status --json` instead of console.oomol.com.
 - If both `fusion-api` and an authenticated non-Fusion connector are suitable,
   choose the one whose output contract best matches the user's requested result.
   Ask the user only when the choice changes provider, account, cost, compliance,

--- a/src/application/commands/connector/shared.test.ts
+++ b/src/application/commands/connector/shared.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../../__tests__/helpers.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
 import {
-    billingTokenRechargeUrl,
+    billingUrl,
     insufficientCreditErrorCode,
 } from "../shared/billing.ts";
 import {
@@ -658,7 +658,7 @@ describe("connector shared requests", () => {
 
             expect(error.key).toBe("errors.billing.insufficientCredit");
             expect(error.params).toEqual({
-                url: billingTokenRechargeUrl,
+                url: billingUrl,
             });
         });
 

--- a/src/application/commands/shared/billing.ts
+++ b/src/application/commands/shared/billing.ts
@@ -2,12 +2,11 @@ import { CliUserError } from "../../contracts/cli.ts";
 
 export const insufficientCreditHttpStatus = 402;
 export const insufficientCreditErrorCode = "OOMOL_INSUFFICIENT_CREDIT";
-export const billingTokenRechargeUrl
-    = "https://console.oomol.com/billing/token-recharge";
+export const billingUrl = "https://console.oomol.com/billing";
 
 export function createInsufficientCreditError(): CliUserError {
     return new CliUserError("errors.billing.insufficientCredit", 1, {
-        url: billingTokenRechargeUrl,
+        url: billingUrl,
     });
 }
 

--- a/src/application/commands/shared/oo-request.test.ts
+++ b/src/application/commands/shared/oo-request.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../../__tests__/helpers.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
 import { CliUserError } from "../../contracts/cli.ts";
-import { billingTokenRechargeUrl } from "./billing.ts";
+import { billingUrl } from "./billing.ts";
 import {
     isNetworkRestrictedSandboxError,
     probeOo,
@@ -329,7 +329,7 @@ describe("requestOo", () => {
                 },
             })).rejects.toMatchObject({
                 key: "errors.billing.insufficientCredit",
-                params: { url: billingTokenRechargeUrl },
+                params: { url: billingUrl },
             });
 
             expect(statusErrorsCalled).toBeFalse();


### PR DESCRIPTION
## Summary

- replace the outdated billing recharge URL with the current billing page
- point connector authorization guidance to team-scoped connection URLs
- retain the generic connections page as a fallback when no team is known
- rename the billing URL constant and update its existing tests

## Testing

- `bun run lint:fix`
- `bun run ts-check`
- `bun run test` — 1946 passed, 9 skipped, 0 failed