### PR TITLE
feat(variables): resolve team identity for variables commands

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -73,17 +73,17 @@ use. Truthy values are `1`, `true`, `yes`, or `on` (case-insensitive).
 - Connector commands resolve their target server with this precedence:
   `OO_CONNECTOR_URL` > `OO_API_KEY` > the saved self-hosted connector
   configuration (`oo connector login`) > the active account.
-- `OO_TEAM_ID`: Run connector commands (`oo connector run`, `oo connector
-  proxy`, `oo connector apps`, `oo connector search` / `oo search`) under the
-  team with this id. It takes precedence
-  over `OO_TEAM_NAME` and the account's default team; the per-run
+- `OO_TEAM_ID`: Run team-aware commands (`oo connector run`, `oo connector
+  proxy`, `oo connector apps`, `oo connector search` / `oo search`, and
+  `oo variables list/get/create/delete`) under the team with this id. It takes
+  precedence over `OO_TEAM_NAME` and the account's default team; the per-run
   `--team` and `--personal` flags still outrank it. Before execution the CLI
   validates the id and resolves its team name (one extra request per
   invocation), so requests carry both the name and the id; an id the account
   cannot use — not a member, no such team, team deleted — fails with exit
   `1`. If the lookup itself cannot complete, the id is sent on its own and
-  the backend stays the judge. Ignored when the connector target is
-  self-hosted.
+  the backend stays the judge. Connector commands ignore it when the connector
+  target is self-hosted; variables commands always honor it.
 - `OO_TEAM_NAME`: Same as `OO_TEAM_ID`, but selects the team by name. Before
   execution the CLI resolves the name to its team id through the account's
   team memberships (one extra request per invocation), so requests carry both
@@ -91,10 +91,12 @@ use. Truthy values are `1`, `true`, `yes`, or `on` (case-insensitive).
   If the lookup itself cannot complete, the name is sent on its own and the
   backend stays the judge. `oo connector run --dry-run` sends no execution
   request and skips the lookup entirely, so it stays offline. Ignored when
-  `OO_TEAM_ID` is set or the connector target is self-hosted.
-- Connector commands resolve their team identity with this precedence:
+  `OO_TEAM_ID` is set, and ignored by connector commands when the connector
+  target is self-hosted; variables commands always honor it.
+- Team-aware commands resolve their team identity with this precedence:
   `--personal` / `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` > the active account's
-  default team > your personal identity.
+  default team > your personal identity. Variables commands have no personal
+  scope: with nothing selected they fall back to the server-side default team.
 - `OO_SKILLS_SYNC_DISABLED`: A truthy value disables the startup managed-skill
   synchronization, so the CLI writes no skill files into agent home directories
   such as `~/.agents` or `~/.claude`.
@@ -567,12 +569,15 @@ Alias for `oo auth logout`.
 
 ## Teams
 
-Team identity lets connector commands (`oo connector run`, `oo connector proxy`,
-`oo connector apps`) act as a team instead of your personal account. One ladder
-selects it: the per-run `--personal` (force your personal identity) or `--team
-<name>` first, then the `OO_TEAM_ID` / `OO_TEAM_NAME` environment overrides,
-then the default saved on the active account. These commands help discover
-which teams your account can use and manage that default.
+Team identity lets team-aware commands act as a team instead of your personal
+account: the connector commands (`oo connector run`, `oo connector proxy`,
+`oo connector apps`) and the variables commands (`oo variables
+list/get/create/delete`), whose data is team-owned in the first place. One
+ladder selects it: the per-run `--personal` (drop every saved and env-selected
+team) or `--team <name>` first, then the `OO_TEAM_ID` / `OO_TEAM_NAME`
+environment overrides, then the default saved on the active account. These
+commands help discover which teams your account can use and manage that
+default.
 
 The default team belongs to the saved account, so switching accounts with
 `oo auth switch` switches the default with it, and `oo auth logout` removes it
@@ -607,16 +612,17 @@ read-only.
   and the `id` value to `OO_TEAM_ID`.
 - Output: text output prints one column-aligned row per team and marks the
   current default. When the account has no teams, it reports that connector
-  commands run under your personal identity.
+  commands run under your personal identity and variables commands use the
+  server-side default team.
 - Behavior: when the account's default team was stored without its id, this
   command fills the id in from the listing it already fetched. No extra
   request is sent, and a failure to write is ignored.
 
 ### `oo team current`
 
-Show the team identity used by connector commands when no `--team` /
-`--personal` flag is given: the `OO_TEAM_ID` / `OO_TEAM_NAME` environment
-override when set, otherwise the active account's default team.
+Show the team identity used by team-aware commands (connector, variables) when
+no `--team` / `--personal` flag is given: the `OO_TEAM_ID` / `OO_TEAM_NAME`
+environment override when set, otherwise the active account's default team.
 
 - Sends one request only when `OO_TEAM_ID` or `OO_TEAM_NAME` supplies the
   identity, to complete and validate the missing half: an id resolves to its
@@ -663,19 +669,20 @@ access it.
 ### `oo team clear`
 
 Clear the active account's default team identity. Connector commands then run
-under your personal identity, unless `OO_TEAM_ID` / `OO_TEAM_NAME` still
-selects a team — this command removes only the saved default and does not
-affect the environment override. This command is offline.
+under your personal identity and variables commands use the server-side default
+team, unless `OO_TEAM_ID` / `OO_TEAM_NAME` still selects a team — this command
+removes only the saved default and does not affect the environment override.
+This command is offline.
 
 - Behavior: removes the default team from the active account. When no default
   is saved it reports that connector commands already run under your personal
-  identity.
+  identity and variables commands use the server-side default team.
 - Behavior: with `OO_API_KEY` set the command clears nothing, exits `0`, and
   reports that this variable already runs under your personal identity.
 - Behavior: when `OO_TEAM_ID` / `OO_TEAM_NAME` is set, the output reports that
-  the environment variable still selects a team for connector commands, so
-  clearing the default does not switch them to your personal identity. Unset
-  the variable to do that.
+  the environment variable still selects a team for team-aware commands, so
+  clearing the default does not stop a team from being selected. Unset the
+  variable to do that.
 
 ## LLM
 
@@ -2626,34 +2633,55 @@ Delete expired or stale file transfer records.
 
 ## Variables
 
-Store and read named string variables for the current account in the
-OOMOL cloud. Aliases: `oo variable`, `oo var`, `oo vars`. All subcommands
-require the current account; values are stored as strings (serialize JSON
-yourself if needed).
+Store and read named string variables in the OOMOL cloud. Aliases:
+`oo variable`, `oo var`, `oo vars`. All subcommands require the current
+account; values are stored as strings (serialize JSON yourself if needed).
+
+Variables belong to a team, not to a single user: every member of the team
+reads and writes the same set, and the last write wins. Each subcommand
+resolves the team it acts for with the shared ladder `--personal` > `--team
+<team>` > `OO_TEAM_ID` > `OO_TEAM_NAME` > the active account's default team >
+the server-side default team. `--personal` means "send no team selection", so
+the server applies its own default team; it does not create a private,
+per-user scope, and it cannot be combined with `--team` (exit `2`, as is an
+empty `--team` value).
+
+Every subcommand accepts `--team <team>` and `--personal`. An account that
+belongs to no team at all cannot use variables: the command exits `1` and says
+so. Selecting a team the account is not a member of, or one that does not
+exist, also exits `1`.
 
 ### `oo variables list`
 
-List all variables for the current account, most recently updated first (no
-pagination; up to 200 per account).
+List all variables of the current team, most recently updated first (no
+pagination; up to 200 per team).
 
 - Text output: one line per variable, `name` and `updatedAt` only. Full values
   are not printed; use `oo variables get` or `--json` to read a value.
+- Options: `--team <team>` runs the command for that team; `--personal` uses
+  the server-side default team, ignoring `OO_TEAM_ID` / `OO_TEAM_NAME` and any
+  saved default team.
 - Options: `--format <format>` / `--json` return structured output as
-  `{ "variables": [{ "name", "value", "updatedAt" }] }` with full values.
+  `{ "variables": [{ "name", "value", "updatedAt", "updatedBy" }] }` with full
+  values. `updatedBy` is the id of the team member who last wrote the variable
+  and is absent when the service does not report one.
 
 ### `oo variables get <name>`
 
-Read the value of a variable.
+Read the value of a variable of the current team.
 
 - Arguments: `<name>` is required (1-256 characters; no `/` or control
   characters).
 - Text output: the raw value followed by a newline.
-- Options: `--format <format>` / `--json` return `{ "name", "value", "updatedAt" }`.
+- Options: `--team <team>` and `--personal` select the team, as for
+  `oo variables list`.
+- Options: `--format <format>` / `--json` return
+  `{ "name", "value", "updatedAt", "updatedBy" }`.
 - Notes: exits non-zero if the variable does not exist.
 
 ### `oo variables create <name> [value]` (alias: `oo variables update`)
 
-Create or replace a variable for the current account (last-write-wins).
+Create or replace a variable for the current team (last-write-wins).
 `create` and `update` are identical.
 
 - Arguments: `<name>` is required. `[value]` is an optional positional value.
@@ -2662,15 +2690,22 @@ Create or replace a variable for the current account (last-write-wins).
 - Options: `--from-file <path>` reads the value verbatim from a UTF-8 file.
 - Options: `--stdin` reads the value verbatim from standard input until EOF;
   it errors if stdin is an interactive terminal.
-- Options: `--format <format>` / `--json` return `{ "name", "value", "updatedAt" }`.
+- Options: `--team <team>` and `--personal` select the team, as for
+  `oo variables list`.
+- Options: `--format <format>` / `--json` return
+  `{ "name", "value", "updatedAt", "updatedBy" }`.
 - Notes: the value is limited to 64 KiB (65536 bytes, UTF-8).
+- Notes: each team can store at most 200 variables; exceeding the quota exits
+  `1`.
 
 ### `oo variables delete <name>`
 
-Delete a variable for the current account. Idempotent: succeeds even if the
-name does not exist.
+Delete a variable of the current team. Idempotent: succeeds even if the name
+does not exist.
 
 - Arguments: `<name>` is required.
+- Options: `--team <team>` and `--personal` select the team, as for
+  `oo variables list`.
 - Options: `--json` returns `{ "name", "deleted": true }`.
 
 ## Shell Completion

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -59,23 +59,26 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
 - Connector 相关命令按以下优先级解析目标服务：
   `OO_CONNECTOR_URL` > `OO_API_KEY` > 已保存的自部署 Connector 配置
   （`oo connector login`）> 当前激活账号。
-- `OO_TEAM_ID`：让 connector 命令（`oo connector run`、`oo connector proxy`、
-  `oo connector apps`、`oo connector search` / `oo search`）以该 id 对应的团队
-  身份运行。优先级高于 `OO_TEAM_NAME`
-  和账号保存的默认团队；每次运行的 `--team` 与 `--personal`
-  标志仍然优先于它。执行前 CLI 会校验该 id 并解析出团队名称（每次调用多一个
-  请求），因此请求会同时携带名称与 id；账号无法使用的 id——不是成员、团队
-  不存在、团队已删除——以退出码 `1` 失败。若查询本身无法完成，则只按原样
-  发送 id，由服务端裁决。当 connector 目标为自部署服务时会被忽略。
+- `OO_TEAM_ID`：让团队相关命令（`oo connector run`、`oo connector proxy`、
+  `oo connector apps`、`oo connector search` / `oo search`，以及
+  `oo variables list/get/create/delete`）以该 id 对应的团队身份运行。
+  优先级高于 `OO_TEAM_NAME` 和账号保存的默认团队；每次运行的 `--team`
+  与 `--personal` 标志仍然优先于它。执行前 CLI 会校验该 id 并解析出团队
+  名称（每次调用多一个请求），因此请求会同时携带名称与 id；账号无法使用
+  的 id——不是成员、团队不存在、团队已删除——以退出码 `1` 失败。若查询
+  本身无法完成，则只按原样发送 id，由服务端裁决。connector 目标为自部署
+  服务时，只有 connector 命令会忽略它；variables 命令始终遵循它。
 - `OO_TEAM_NAME`：与 `OO_TEAM_ID` 相同，但按名称选择团队。执行前 CLI
   会通过账号的团队成员关系将名称解析为团队 id（每次调用多一个请求），
   因此请求会同时携带名称与 id；账号无法访问的名称以退出码 `1` 失败。
   若查询本身无法完成，则只发送名称，由服务端裁决。`oo connector run
   --dry-run` 不发送执行请求，也会完全跳过该查询，保持离线。设置了
-  `OO_TEAM_ID` 或 connector 目标为自部署服务时会被忽略。
-- Connector 相关命令按以下优先级解析团队身份：
+  `OO_TEAM_ID` 时会被忽略；connector 目标为自部署服务时，只有 connector
+  命令会忽略它，variables 命令始终遵循它。
+- 团队相关命令按以下优先级解析团队身份：
   `--personal` / `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` >
-  当前账号保存的默认团队 > 个人身份。
+  当前账号保存的默认团队 > 个人身份。variables 命令没有个人作用域：
+  没有选中任何团队时回落到服务端默认团队。
 - `OO_SKILLS_SYNC_DISABLED`：设为真值会禁用启动时的 managed skill 同步，
   使 CLI 不会向 `~/.agents`、`~/.claude` 等代理主目录写入任何 skill 文件。
 - `OO_NO_SELF_UPDATE`：设为真值会禁用 `oo update`、`oo install` 和
@@ -470,11 +473,12 @@ oo flow
 
 ## 团队
 
-团队身份让 connector 命令（`oo connector run`、`oo connector proxy`、`oo connector
-apps`）以某个团队身份运行，而非个人账号。它由同一条优先级阶梯选出：先是每次运行的
-`--personal`（强制个人身份）或 `--team <name>`，其次是环境变量 `OO_TEAM_ID` /
-`OO_TEAM_NAME`，最后是保存在当前账号上的默认团队。下列命令用于发现当前账号可用的
-团队并管理该默认值。
+团队身份让团队相关命令以某个团队身份运行，而非个人账号：包括 connector 命令
+（`oo connector run`、`oo connector proxy`、`oo connector apps`）与 variables
+命令（`oo variables list/get/create/delete`，其数据本身就归团队所有）。它由同一条
+优先级阶梯选出：先是每次运行的 `--personal`（放弃所有已保存与 env 选定的团队）或
+`--team <name>`，其次是环境变量 `OO_TEAM_ID` / `OO_TEAM_NAME`，最后是保存在当前
+账号上的默认团队。下列命令用于发现当前账号可用的团队并管理该默认值。
 
 默认团队属于已保存的账号：用 `oo auth switch` 切换账号时默认团队随之切换，
 `oo auth logout` 会连同账号一起移除它。旧版本把默认团队保存在全局配置项
@@ -503,15 +507,16 @@ apps`）以某个团队身份运行，而非个人账号。它由同一条优先
 - 输出：将 `name` 的值传给 `--team <name>`（或 `oo team use <name>`），将 `id`
   的值传给 `OO_TEAM_ID`。
 - 输出：文本输出为每个团队打印一行列对齐的记录，并标出当前默认团队。当账号没有任何
-  团队时，会提示 connector 命令以个人身份运行。
+  团队时，会提示 connector 命令以个人身份运行，variables 命令使用服务端
+  默认团队。
 - 行为：当账号保存的默认团队缺少团队 id 时，该命令会用刚获取的成员关系列表补齐
   它，不发送额外请求；写入失败会被忽略。
 
 ### `oo team current`
 
-显示未传 `--team` / `--personal` 时 connector 命令使用的团队身份：设置了
-`OO_TEAM_ID` / `OO_TEAM_NAME` 环境变量时为 env 指定的团队，否则为当前账号
-保存的默认团队。
+显示未传 `--team` / `--personal` 时团队相关命令（connector、variables）使用的
+团队身份：设置了 `OO_TEAM_ID` / `OO_TEAM_NAME` 环境变量时为 env 指定的团队，
+否则为当前账号保存的默认团队。
 
 - 仅当身份来自 `OO_TEAM_ID` 或 `OO_TEAM_NAME` 时才发送 1 次请求，补全并校验
   缺失的那一半：id 解析出团队名称，名称通过账号的团队成员关系解析出 id——这
@@ -548,16 +553,16 @@ apps`）以某个团队身份运行，而非个人账号。它由同一条优先
 
 ### `oo team clear`
 
-清除当前账号保存的默认团队身份。之后 connector 命令以个人身份运行；但若
-`OO_TEAM_ID` / `OO_TEAM_NAME` 仍在选择团队则不然——该命令只移除已保存的
-默认值，不影响环境变量覆盖。该命令离线运行。
+清除当前账号保存的默认团队身份。之后 connector 命令以个人身份运行，variables
+命令使用服务端默认团队；但若 `OO_TEAM_ID` / `OO_TEAM_NAME` 仍在选择团队则不然
+——该命令只移除已保存的默认值，不影响环境变量覆盖。该命令离线运行。
 
 - 行为：从当前账号移除默认团队。当未保存默认值时，会提示 connector 命令
-  本就以个人身份运行。
+  本就以个人身份运行，variables 命令使用服务端默认团队。
 - 行为：设置了 `OO_API_KEY` 时命令不清除任何内容，以 `0` 退出，并说明该变量
   本就以个人身份运行。
 - 行为：设置了 `OO_TEAM_ID` / `OO_TEAM_NAME` 时，输出会说明该环境变量仍会为
-  connector 命令选择团队，因此清除默认值并不会让它们切换到个人身份；需要取消
+  团队相关命令选择团队，因此清除默认值并不会让它们不再选择团队；需要取消
   该环境变量才可以。
 
 ## LLM
@@ -2201,44 +2206,64 @@ message，也不会出现在 `path` / `sourcePath` 字段之外的额外文件�
 
 ## Variables
 
-在 OOMOL 云端存取当前账号的具名字符串变量。别名：`oo variable`、`oo var`、
+在 OOMOL 云端存取具名字符串变量。别名：`oo variable`、`oo var`、
 `oo vars`。所有子命令都需要当前账号；value 以字符串存储（如需存 JSON 请自行序列化）。
+
+变量属于团队而不是单个用户：团队全体成员读写同一份变量，同名写入 last-write-wins。
+每个子命令按同一条阶梯解析所使用的团队：`--personal` > `--team <team>` >
+`OO_TEAM_ID` > `OO_TEAM_NAME` > 当前账号保存的默认团队 > 服务端默认团队。
+`--personal` 的含义是"不发送任何团队选择"，由服务端套用它自己的默认团队；它不会
+产生按用户私有的作用域，也不能与 `--team` 同时使用（同时使用以退出码 `2` 失败，
+`--team` 传空值同样如此）。
+
+所有子命令都支持 `--team <team>` 与 `--personal`。当前账号不属于任何团队时无法使用
+变量：命令以退出码 `1` 失败并给出说明。选择了账号不是成员的团队，或团队不存在时，
+同样以退出码 `1` 失败。
 
 ### `oo variables list`
 
-列出当前账号的全部变量，按最近更新时间倒序（无分页；每个账号最多 200 个）。
+列出当前团队的全部变量，按最近更新时间倒序（无分页；每个团队最多 200 个）。
 
 - 文本输出：每行一个变量，只显示 `name` 和 `updatedAt`；不打印完整 value。读取
   value 请用 `oo variables get` 或 `--json`。
+- 选项：`--team <team>` 以该团队执行命令；`--personal` 使用服务端默认团队，忽略
+  `OO_TEAM_ID` / `OO_TEAM_NAME` 与已保存的默认团队。
 - 选项：`--format <format>` / `--json` 返回结构化输出
-  `{ "variables": [{ "name", "value", "updatedAt" }] }`，包含完整 value。
+  `{ "variables": [{ "name", "value", "updatedAt", "updatedBy" }] }`，包含完整
+  value。`updatedBy` 为最后写入该变量的团队成员 id，服务端未提供时不出现。
 
 ### `oo variables get <name>`
 
-读取变量的值。
+读取当前团队指定变量的值。
 
 - 参数：`<name>` 必填（1-256 个字符；不能包含 `/` 或控制字符）。
 - 文本输出：原始 value，并追加换行。
-- 选项：`--format <format>` / `--json` 返回 `{ "name", "value", "updatedAt" }`。
+- 选项：`--team <team>` 与 `--personal` 用于选择团队，含义同 `oo variables list`。
+- 选项：`--format <format>` / `--json` 返回
+  `{ "name", "value", "updatedAt", "updatedBy" }`。
 - 说明：变量不存在时以非零码退出。
 
 ### `oo variables create <name> [value]`（别名：`oo variables update`）
 
-为当前账号创建或替换变量（last-write-wins）。`create` 与 `update` 完全等价。
+为当前团队创建或替换变量（last-write-wins）。`create` 与 `update` 完全等价。
 
 - 参数：`<name>` 必填。`[value]` 为可选的位置参数值。
 - value 来源：`[value]`、`--from-file <path>`、`--stdin` 三者必须且只能提供一个。
   允许空字符串。
 - 选项：`--from-file <path>` 按 UTF-8 原文读取文件内容作为 value。
 - 选项：`--stdin` 从标准输入读取到 EOF 作为 value（原文）；当 stdin 是交互式终端时报错。
-- 选项：`--format <format>` / `--json` 返回 `{ "name", "value", "updatedAt" }`。
+- 选项：`--team <team>` 与 `--personal` 用于选择团队，含义同 `oo variables list`。
+- 选项：`--format <format>` / `--json` 返回
+  `{ "name", "value", "updatedAt", "updatedBy" }`。
 - 说明：value 上限为 64 KiB（65536 字节，UTF-8）。
+- 说明：每个团队最多存储 200 个变量；超出配额时以退出码 `1` 失败。
 
 ### `oo variables delete <name>`
 
-删除当前账号的变量。幂等：即使 name 不存在也成功。
+删除当前团队的变量。幂等：即使 name 不存在也成功。
 
 - 参数：`<name>` 必填。
+- 选项：`--team <team>` 与 `--personal` 用于选择团队，含义同 `oo variables list`。
 - 选项：`--json` 返回 `{ "name", "deleted": true }`。
 
 ## Shell 补全

--- a/src/application/commands/auth/index.cli.test.ts
+++ b/src/application/commands/auth/index.cli.test.ts
@@ -2621,7 +2621,7 @@ describe("auth CLI login default team", () => {
                 "Default team identity: alice-team",
             );
             expect(result.stdout).toContain(
-                "Connector commands keep using the team from OO_TEAM_ID, not this default.",
+                "Team-aware commands keep using the team from OO_TEAM_ID, not this default.",
             );
             // The default is still persisted; only its effect is deferred
             // while the env override is set.
@@ -2642,7 +2642,7 @@ describe("auth CLI login default team", () => {
 
             expect(result.exitCode).toBe(0);
             expect(result.stdout).toContain(
-                "Connector commands keep using the team from OO_TEAM_NAME, not this default.",
+                "Team-aware commands keep using the team from OO_TEAM_NAME, not this default.",
             );
         }
         finally {

--- a/src/application/commands/connector/apps.ts
+++ b/src/application/commands/connector/apps.ts
@@ -8,12 +8,12 @@ import { z } from "zod";
 import { bucketTelemetryCount } from "../../telemetry/buckets.ts";
 import { createWriterColors } from "../../terminal-colors.ts";
 import { formatTextTable } from "../shared/text-table.ts";
-import { connectorSearchServiceColor } from "./search-provider.ts";
 import {
-    resolveConnectorSession,
     teamIdentityInputShape,
     teamIdentityOptions,
-} from "./session.ts";
+} from "../team/identity.ts";
+import { connectorSearchServiceColor } from "./search-provider.ts";
+import { resolveConnectorSession } from "./session.ts";
 import {
     listConnectorApps,
     listConnectorAppsByService,

--- a/src/application/commands/connector/proxy.ts
+++ b/src/application/commands/connector/proxy.ts
@@ -7,10 +7,10 @@ import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
 import { readJsonInputValue } from "../shared/json-input.ts";
 import {
-    resolveConnectorSession,
     teamIdentityInputShape,
     teamIdentityOptions,
-} from "./session.ts";
+} from "../team/identity.ts";
+import { resolveConnectorSession } from "./session.ts";
 import { runConnectorProxy } from "./shared.ts";
 import { recordConnectorFailureTelemetry } from "./telemetry.ts";
 

--- a/src/application/commands/connector/run.ts
+++ b/src/application/commands/connector/run.ts
@@ -15,14 +15,14 @@ import { createWriterColors } from "../../terminal-colors.ts";
 import { readJsonInputValue } from "../shared/json-input.ts";
 import { TerminalProgressRenderer } from "../shared/terminal-progress-renderer.ts";
 import {
+    teamIdentityInputShape,
+    teamIdentityOptions,
+} from "../team/identity.ts";
+import {
     invalidateConnectorActionSchemaOnNotFound,
     loadConnectorActionSchema,
 } from "./schema-cache.ts";
-import {
-    resolveConnectorSession,
-    teamIdentityInputShape,
-    teamIdentityOptions,
-} from "./session.ts";
+import { resolveConnectorSession } from "./session.ts";
 import {
     requireConnectorActionName,
     runConnectorAction,

--- a/src/application/commands/connector/search.ts
+++ b/src/application/commands/connector/search.ts
@@ -6,14 +6,14 @@ import {
     bucketTelemetryStringLength,
 } from "../../telemetry/buckets.ts";
 import {
+    teamIdentityInputShape,
+    teamIdentityOptions,
+} from "../team/identity.ts";
+import {
     formatConnectorSearchResultsAsText,
     loadConnectorSearchResults,
 } from "./search-provider.ts";
-import {
-    resolveConnectorSession,
-    teamIdentityInputShape,
-    teamIdentityOptions,
-} from "./session.ts";
+import { resolveConnectorSession } from "./session.ts";
 
 interface ConnectorSearchInput {
     team?: string;

--- a/src/application/commands/connector/session.test.ts
+++ b/src/application/commands/connector/session.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../../__tests__/helpers.ts";
 import { createTranslator } from "../../../i18n/translator.ts";
 import { createConnectorSchemaCacheScope } from "./schema-cache.ts";
-import { resolveConnectorSession, teamIdentityOptions } from "./session.ts";
+import { resolveConnectorSession } from "./session.ts";
 
 const testAccount = {
     id: "user-1",
@@ -47,7 +47,7 @@ describe("resolveConnectorSession flag guards", () => {
             resolveConnectorSession({ personal: true, team: "acme" }, context),
         );
 
-        expect(error.key).toBe("errors.connectorRun.identityConflict");
+        expect(error.key).toBe("errors.team.identityConflict");
         expect(error.exitCode).toBe(2);
         expect(context.requests).toHaveLength(0);
     });
@@ -62,7 +62,7 @@ describe("resolveConnectorSession flag guards", () => {
             resolveConnectorSession({ team }, context),
         );
 
-        expect(error.key).toBe("errors.connectorRun.teamEmpty");
+        expect(error.key).toBe("errors.team.teamEmpty");
         expect(error.exitCode).toBe(2);
         expect(context.requests).toHaveLength(0);
     });
@@ -296,27 +296,6 @@ describe("resolveConnectorSession backend policy", () => {
         });
         expect(context.recordedProperties).toEqual([
             { connector_kind: "oomol", identity_source: "env_id" },
-        ]);
-    });
-});
-
-describe("teamIdentityOptions", () => {
-    test("declares the shared flags with the caller's description keys", () => {
-        expect(teamIdentityOptions({
-            personal: "options.connectorRunPersonal",
-            team: "options.connectorRunTeam",
-        })).toEqual([
-            {
-                name: "team",
-                longFlag: "--team",
-                valueName: "team",
-                descriptionKey: "options.connectorRunTeam",
-            },
-            {
-                name: "personal",
-                longFlag: "--personal",
-                descriptionKey: "options.connectorRunPersonal",
-            },
         ]);
     });
 });

--- a/src/application/commands/connector/session.ts
+++ b/src/application/commands/connector/session.ts
@@ -1,8 +1,8 @@
 // The connector session: which connector server this invocation talks to, and
 // under whose team identity — resolved once, behind one call. Handlers do
 // their own pure input validation first, then everything identity-shaped
-// happens here: the --team/--personal flag guards, target resolution, the
-// self-hosted team rejection, the configured default, the team identity
+// happens here: the shared --team/--personal flag guards, target resolution,
+// the self-hosted team rejection, the configured default, the team identity
 // ladder with its execution gate, and the identity telemetry.
 //
 // The self-hosted runtime is single-user and has no team concept: an explicit
@@ -10,14 +10,14 @@
 // override is silently ignored so a shared config does not break self-hosted
 // usage. This module is the only place that rule exists.
 
-import type { CliExecutionContext, CliOptionDefinition } from "../../contracts/cli.ts";
+import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { TeamIdentity } from "../team/identity.ts";
 import type { ConnectorTarget } from "./target.ts";
 
-import { z } from "zod";
 import { readDefaultTeam } from "../../auth/default-team.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import {
+    assertTeamIdentityFlags,
     requireValidTeamIdentity,
     resolveTeamIdentity,
 } from "../team/identity.ts";
@@ -65,15 +65,7 @@ export async function resolveConnectorSession(
     },
     context: ConnectorSessionContext,
 ): Promise<ConnectorSession> {
-    if (options.personal === true && options.team !== undefined) {
-        throw new CliUserError("errors.connectorRun.identityConflict", 2);
-    }
-
-    const teamFlag = options.team?.trim();
-
-    if (options.team !== undefined && teamFlag === "") {
-        throw new CliUserError("errors.connectorRun.teamEmpty", 2);
-    }
+    const teamFlag = assertTeamIdentityFlags(options);
 
     const target = await resolveConnectorTarget(context);
 
@@ -110,34 +102,3 @@ export async function resolveConnectorSession(
 
     return { identity, target };
 }
-
-/**
- * The `--team` / `--personal` option pair every session-resolving command
- * declares. Flags and value names live here once; each command supplies its
- * own description keys so the help text keeps its verb.
- */
-export function teamIdentityOptions(descriptionKeys: {
-    personal: string;
-    team: string;
-}): readonly CliOptionDefinition[] {
-    return [
-        {
-            name: "team",
-            longFlag: "--team",
-            valueName: "team",
-            descriptionKey: descriptionKeys.team,
-        },
-        {
-            name: "personal",
-            longFlag: "--personal",
-            descriptionKey: descriptionKeys.personal,
-        },
-    ];
-}
-
-// The input-schema counterpart of teamIdentityOptions, spread into each
-// command's zod object so the field pair cannot drift across commands.
-export const teamIdentityInputShape = {
-    personal: z.boolean().optional(),
-    team: z.string().optional(),
-};

--- a/src/application/commands/team/identity.test.ts
+++ b/src/application/commands/team/identity.test.ts
@@ -12,9 +12,11 @@ import {
 import { createTranslator } from "../../../i18n/translator.ts";
 import {
     appendTeamIdentityStatus,
+    assertTeamIdentityFlags,
     formatTeamIdentityValue,
     requireValidTeamIdentity,
     resolveTeamIdentity,
+    teamIdentityOptions,
     teamNameStatusForTelemetry,
 } from "./identity.ts";
 
@@ -669,6 +671,56 @@ describe("teamNameStatusForTelemetry", () => {
         },
     ])("collapses $case to $expected", ({ expected, identity }) => {
         expect(teamNameStatusForTelemetry(identity)).toBe(expected);
+    });
+});
+
+describe("assertTeamIdentityFlags", () => {
+    test("rejects combining --team and --personal", () => {
+        const error = expectCliUserError(
+            () => assertTeamIdentityFlags({ personal: true, team: "acme" }),
+        );
+
+        expect(error.key).toBe("errors.team.identityConflict");
+        expect(error.exitCode).toBe(2);
+    });
+
+    test.each([
+        { case: "an empty --team value", team: "" },
+        { case: "a whitespace --team value", team: "   " },
+    ])("rejects $case", ({ team }) => {
+        const error = expectCliUserError(() => assertTeamIdentityFlags({ team }));
+
+        expect(error.key).toBe("errors.team.teamEmpty");
+        expect(error.exitCode).toBe(2);
+    });
+
+    test.each([
+        { case: "no flags", expected: undefined, input: {} },
+        { case: "--personal alone", expected: undefined, input: { personal: true } },
+        { case: "a padded --team value", expected: "acme", input: { team: "  acme  " } },
+    ])("returns $expected for $case", ({ expected, input }) => {
+        expect(assertTeamIdentityFlags(input)).toBe(expected);
+    });
+});
+
+describe("teamIdentityOptions", () => {
+    test("declares the shared flags with the caller's description keys", () => {
+        expect(teamIdentityOptions({
+            personal: "options.connectorRunPersonal",
+            team: "options.connectorRunTeam",
+        })).toEqual([
+            {
+                name: "team",
+                longFlag: "--team",
+                valueName: "team",
+                descriptionKey: "options.connectorRunTeam",
+            },
+            {
+                name: "personal",
+                longFlag: "--personal",
+                descriptionKey: "options.connectorRunPersonal",
+            },
+        ]);
     });
 });
 

--- a/src/application/commands/team/identity.ts
+++ b/src/application/commands/team/identity.ts
@@ -13,10 +13,11 @@
 // explicitly (`--personal`) or by nothing else selecting a team.
 
 import type { AccountDefaultTeam } from "../../auth/default-team.ts";
-import type { CliExecutionContext } from "../../contracts/cli.ts";
+import type { CliExecutionContext, CliOptionDefinition } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
 
 import type { TeamLookupStatus } from "./shared.ts";
+import { z } from "zod";
 import { readTrimmedEnv } from "../../auth/identity.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { fetchTeamById, fetchTeamByName } from "./shared.ts";
@@ -196,6 +197,63 @@ export function teamIdentityHeaders(
 
     return headers;
 }
+
+/**
+ * The usage guards on the `--team` / `--personal` pair, shared by every
+ * team-aware command so one flag combination cannot be a usage error in one
+ * command and accepted in another: the two flags are mutually exclusive, and a
+ * `--team` that was passed but is blank is a typo, not an unset flag.
+ *
+ * Returns the trimmed `--team` value, ready for the ladder — `undefined` when
+ * the flag was not passed, and never the empty string.
+ */
+export function assertTeamIdentityFlags(input: {
+    personal?: boolean;
+    team?: string;
+}): string | undefined {
+    if (input.personal === true && input.team !== undefined) {
+        throw new CliUserError("errors.team.identityConflict", 2);
+    }
+
+    const teamFlag = input.team?.trim();
+
+    if (input.team !== undefined && teamFlag === "") {
+        throw new CliUserError("errors.team.teamEmpty", 2);
+    }
+
+    return teamFlag;
+}
+
+/**
+ * The `--team` / `--personal` option pair every team-aware command declares.
+ * Flags and value names live here once; each command supplies its own
+ * description keys so the help text keeps its verb.
+ */
+export function teamIdentityOptions(descriptionKeys: {
+    personal: string;
+    team: string;
+}): readonly CliOptionDefinition[] {
+    return [
+        {
+            name: "team",
+            longFlag: "--team",
+            valueName: "team",
+            descriptionKey: descriptionKeys.team,
+        },
+        {
+            name: "personal",
+            longFlag: "--personal",
+            descriptionKey: descriptionKeys.personal,
+        },
+    ];
+}
+
+// The input-schema counterpart of teamIdentityOptions, spread into each
+// command's zod object so the field pair cannot drift across commands.
+export const teamIdentityInputShape = {
+    personal: z.boolean().optional(),
+    team: z.string().optional(),
+};
 
 // Renders the identity for humans: the name with its id in parentheses when
 // both are known, otherwise whichever one is.

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -613,20 +613,24 @@ const commandTelemetryDecisions = {
         reason: "Command group; child commands never record variable names or values.",
     },
     "variables.list": {
-        kind: "generic",
-        reason: "Generic command telemetry is enough; variable names and values are not recorded.",
+        kind: "properties",
+        properties: ["identity_source"],
+        reason: "Records the identity source (personal/flag/env_id/env_name/account) that selected the team; never records team names or ids, variable names, or values.",
     },
     "variables.get": {
-        kind: "generic",
-        reason: "Generic command telemetry is enough; the variable name and value are not recorded.",
+        kind: "properties",
+        properties: ["identity_source"],
+        reason: "Records the identity source (personal/flag/env_id/env_name/account) that selected the team; never records team names or ids, the variable name, or its value.",
     },
     "variables.create": {
-        kind: "generic",
-        reason: "Generic command telemetry is enough; the variable name and value are not recorded.",
+        kind: "properties",
+        properties: ["identity_source"],
+        reason: "Records the identity source (personal/flag/env_id/env_name/account) that selected the team; never records team names or ids, the variable name, or its value.",
     },
     "variables.delete": {
-        kind: "generic",
-        reason: "Generic command telemetry is enough; the variable name is not recorded.",
+        kind: "properties",
+        properties: ["identity_source"],
+        reason: "Records the identity source (personal/flag/env_id/env_name/account) that selected the team; never records team names or ids or the variable name.",
     },
     "version": {
         kind: "generic",

--- a/src/application/commands/variables/create.ts
+++ b/src/application/commands/variables/create.ts
@@ -2,9 +2,11 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import { z } from "zod";
 import { requireIdentity } from "../../auth/identity.ts";
 import { writeLine } from "../shared/output.ts";
+import { teamIdentityInputShape, teamIdentityOptions } from "../team/identity.ts";
 import {
     mapVariablesInputError,
     putVariable,
+    resolveVariablesIdentity,
     resolveVariableValue,
     variableNameSchema,
 } from "./shared.ts";
@@ -14,6 +16,8 @@ interface VariablesCreateInput {
     value?: string;
     fromFile?: string;
     stdin?: boolean;
+    team?: string;
+    personal?: boolean;
 }
 
 export const variablesCreateCommand: CliCommandDefinition<VariablesCreateInput> = {
@@ -46,9 +50,14 @@ export const variablesCreateCommand: CliCommandDefinition<VariablesCreateInput> 
             longFlag: "--stdin",
             descriptionKey: "options.variablesStdin",
         },
+        ...teamIdentityOptions({
+            personal: "options.variablesPersonal",
+            team: "options.variablesTeam",
+        }),
     ],
     output: "standard",
     inputSchema: z.object({
+        ...teamIdentityInputShape,
         name: variableNameSchema,
         value: z.string().optional(),
         fromFile: z.string().optional(),
@@ -57,8 +66,9 @@ export const variablesCreateCommand: CliCommandDefinition<VariablesCreateInput> 
     mapInputError: mapVariablesInputError,
     handler: async (input, context) => {
         const { account } = await requireIdentity(context);
+        const identity = await resolveVariablesIdentity(input, account, context);
         const value = await resolveVariableValue(input, context);
-        const variable = await putVariable(account, input.name, value, context);
+        const variable = await putVariable(account, identity, input.name, value, context);
 
         context.output.emit(variable, () => {
             writeLine(context.stdout, context.translator.t("variables.create.success", {

--- a/src/application/commands/variables/delete.ts
+++ b/src/application/commands/variables/delete.ts
@@ -2,10 +2,18 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import { z } from "zod";
 import { requireIdentity } from "../../auth/identity.ts";
 import { writeLine } from "../shared/output.ts";
-import { deleteVariable, mapVariablesInputError, variableNameSchema } from "./shared.ts";
+import { teamIdentityInputShape, teamIdentityOptions } from "../team/identity.ts";
+import {
+    deleteVariable,
+    mapVariablesInputError,
+    resolveVariablesIdentity,
+    variableNameSchema,
+} from "./shared.ts";
 
 interface VariablesDeleteInput {
     name: string;
+    team?: string;
+    personal?: boolean;
 }
 
 export const variablesDeleteCommand: CliCommandDefinition<VariablesDeleteInput> = {
@@ -20,14 +28,22 @@ export const variablesDeleteCommand: CliCommandDefinition<VariablesDeleteInput> 
             required: true,
         },
     ],
+    options: [
+        ...teamIdentityOptions({
+            personal: "options.variablesPersonal",
+            team: "options.variablesTeam",
+        }),
+    ],
     output: "standard",
     inputSchema: z.object({
+        ...teamIdentityInputShape,
         name: variableNameSchema,
     }),
     mapInputError: mapVariablesInputError,
     handler: async (input, context) => {
         const { account } = await requireIdentity(context);
-        await deleteVariable(account, input.name, context);
+        const identity = await resolveVariablesIdentity(input, account, context);
+        await deleteVariable(account, identity, input.name, context);
 
         context.output.emit({ name: input.name, deleted: true }, () => {
             writeLine(context.stdout, context.translator.t("variables.delete.success", {

--- a/src/application/commands/variables/get.ts
+++ b/src/application/commands/variables/get.ts
@@ -2,10 +2,18 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import { z } from "zod";
 import { requireIdentity } from "../../auth/identity.ts";
 import { writeLine } from "../shared/output.ts";
-import { getVariable, mapVariablesInputError, variableNameSchema } from "./shared.ts";
+import { teamIdentityInputShape, teamIdentityOptions } from "../team/identity.ts";
+import {
+    getVariable,
+    mapVariablesInputError,
+    resolveVariablesIdentity,
+    variableNameSchema,
+} from "./shared.ts";
 
 interface VariablesGetInput {
     name: string;
+    team?: string;
+    personal?: boolean;
 }
 
 export const variablesGetCommand: CliCommandDefinition<VariablesGetInput> = {
@@ -20,14 +28,22 @@ export const variablesGetCommand: CliCommandDefinition<VariablesGetInput> = {
             required: true,
         },
     ],
+    options: [
+        ...teamIdentityOptions({
+            personal: "options.variablesPersonal",
+            team: "options.variablesTeam",
+        }),
+    ],
     output: "standard",
     inputSchema: z.object({
+        ...teamIdentityInputShape,
         name: variableNameSchema,
     }),
     mapInputError: mapVariablesInputError,
     handler: async (input, context) => {
         const { account } = await requireIdentity(context);
-        const variable = await getVariable(account, input.name, context);
+        const identity = await resolveVariablesIdentity(input, account, context);
+        const variable = await getVariable(account, identity, input.name, context);
 
         context.output.emit(variable, () => {
             writeLine(context.stdout, variable.value);

--- a/src/application/commands/variables/index.cli.test.ts
+++ b/src/application/commands/variables/index.cli.test.ts
@@ -1,10 +1,18 @@
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import {
     createCliSandbox,
     createInteractiveInput,
+    expectTelemetryFreeOfTeamIdentity,
     toRequest,
     writeAuthFile,
+    writeAuthFileWithDefaultTeam,
 } from "../../../../__tests__/helpers.ts";
+import { APP_NAME } from "../../config/app-config.ts";
+import {
+    parseTelemetryRowPayload,
+    readTelemetryRowsForTest,
+} from "../../telemetry/outbox.ts";
 
 const VARIABLE = {
     name: "model-config",
@@ -442,6 +450,324 @@ describe("variables validation & auth", () => {
             });
 
             expect(result.exitCode).toBe(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});
+
+describe("variables team identity", () => {
+    test("sends the account default team as x-oo-team-name", async () => {
+        const sandbox = await createCliSandbox();
+        const requests: Request[] = [];
+
+        try {
+            await writeAuthFileWithDefaultTeam(sandbox, "acme", { teamId: "team-1" });
+
+            const result = await sandbox.run(["variables", "list"], {
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+                    return new Response(JSON.stringify({ variables: [VARIABLE] }));
+                },
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(requests).toHaveLength(1);
+            expect(requests[0]!.headers.get("x-oo-team-name")).toBe("acme");
+            expect(requests[0]!.headers.get("x-oo-team-id")).toBe("team-1");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--team overrides the account default and sends the name only", async () => {
+        const sandbox = await createCliSandbox();
+        const requests: Request[] = [];
+
+        try {
+            await writeAuthFileWithDefaultTeam(sandbox, "acme", { teamId: "team-1" });
+
+            const result = await sandbox.run(["variables", "get", "model-config", "--team", "beta"], {
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+                    return new Response(JSON.stringify(VARIABLE));
+                },
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(requests[0]!.headers.get("x-oo-team-name")).toBe("beta");
+            expect(requests[0]!.headers.get("x-oo-team-id")).toBeNull();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--personal drops the saved default and sends no team header", async () => {
+        const sandbox = await createCliSandbox();
+        const requests: Request[] = [];
+
+        try {
+            await writeAuthFileWithDefaultTeam(sandbox, "acme", { teamId: "team-1" });
+
+            const result = await sandbox.run(["variables", "delete", "k", "--personal"], {
+                fetcher: async (input, init) => {
+                    requests.push(toRequest(input, init));
+                    return new Response("", { status: 204 });
+                },
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(requests[0]!.headers.get("x-oo-team-name")).toBeNull();
+            expect(requests[0]!.headers.get("x-oo-team-id")).toBeNull();
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("OO_TEAM_ID is validated and sends both halves of the identity", async () => {
+        const sandbox = await createCliSandbox();
+        const requests: Request[] = [];
+
+        try {
+            await writeAuthFileWithDefaultTeam(sandbox, "acme", { teamId: "team-1" });
+            sandbox.env.OO_TEAM_ID = "team-9";
+
+            const result = await sandbox.run(["variables", "create", "k", "v"], {
+                fetcher: async (input, init) => {
+                    const request = toRequest(input, init);
+                    requests.push(request);
+
+                    if (new URL(request.url).host === "relation-control.oomol.com") {
+                        return new Response(JSON.stringify({
+                            id: "team-9",
+                            name: "platform",
+                            role: "member",
+                            system_created: false,
+                        }));
+                    }
+
+                    return new Response(JSON.stringify({ ...VARIABLE, name: "k", value: "v" }));
+                },
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect(new URL(requests[0]!.url).pathname).toBe("/v1/teams/team-9");
+
+            const variablesRequest = requests[1]!;
+            expect(new URL(variablesRequest.url).host).toBe("cli-api.oomol.com");
+            expect(variablesRequest.headers.get("x-oo-team-id")).toBe("team-9");
+            expect(variablesRequest.headers.get("x-oo-team-name")).toBe("platform");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("--team with --personal errors with exit 2 and sends no request", async () => {
+        const sandbox = await createCliSandbox();
+        let called = false;
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["variables", "list", "--team", "acme", "--personal"], {
+                fetcher: async () => {
+                    called = true;
+                    return new Response("{}");
+                },
+            });
+
+            expect(result.exitCode).toBe(2);
+            expect(called).toBe(false);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("an empty --team errors with exit 2 and sends no request", async () => {
+        const sandbox = await createCliSandbox();
+        let called = false;
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["variables", "list", "--team", "  "], {
+                fetcher: async () => {
+                    called = true;
+                    return new Response("{}");
+                },
+            });
+
+            expect(result.exitCode).toBe(2);
+            expect(called).toBe(false);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("create rejects a blank --team before it reads the value source", async () => {
+        const sandbox = await createCliSandbox();
+        let called = false;
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const missingPath = `${sandbox.env.HOME}/missing.txt`;
+            const result = await sandbox.run(
+                ["variables", "create", "k", "--from-file", missingPath, "--team", "  "],
+                {
+                    fetcher: async () => {
+                        called = true;
+                        return new Response("{}");
+                    },
+                },
+            );
+
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).not.toContain("Failed to read value file");
+            expect(called).toBe(false);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("401 Team context required reports that the account has no team", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["variables", "list"], {
+                fetcher: async () => new Response(
+                    JSON.stringify({ message: "Team context required" }),
+                    { status: 401 },
+                ),
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("belongs to no team");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("401 without the team-context message stays the generic request failure", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["variables", "list"], {
+                fetcher: async () => new Response(
+                    JSON.stringify({ message: "Invalid API key" }),
+                    { status: 401 },
+                ),
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("status 401");
+            expect(result.stderr).not.toContain("belongs to no team");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("503 reports that the team could not be verified", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["variables", "list"], {
+                fetcher: async () => new Response(
+                    JSON.stringify({ code: "TEAM_UNAVAILABLE" }),
+                    { status: 503 },
+                ),
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("Could not verify your team right now");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("403 reports that the account cannot use the selected team", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["variables", "get", "k", "--team", "beta"], {
+                fetcher: async () => new Response("", { status: 403 }),
+            });
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain("cannot use the selected team");
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("records the identity source without the team name", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const result = await sandbox.run(["variables", "list", "--team", "acme"], {
+                fetcher: async () => new Response(JSON.stringify({ variables: [] })),
+            });
+            const telemetryPayload = parseTelemetryRowPayload(
+                readTelemetryRowsForTest(
+                    join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+                )[0]!,
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(telemetryPayload).toMatchObject({
+                properties: {
+                    command_full: "variables.list",
+                    identity_source: "flag",
+                },
+            });
+            expectTelemetryFreeOfTeamIdentity(telemetryPayload?.properties, ["acme"]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("updatedBy is reported when present and optional when the backend omits it", async () => {
+        const sandbox = await createCliSandbox();
+
+        try {
+            await writeAuthFile(sandbox);
+
+            const withUpdatedBy = await sandbox.run(["variables", "get", "k", "--json"], {
+                fetcher: async () => new Response(
+                    JSON.stringify({ ...VARIABLE, updatedBy: "user-1" }),
+                ),
+            });
+            const withoutUpdatedBy = await sandbox.run(["variables", "get", "k", "--json"], {
+                fetcher: async () => new Response(JSON.stringify(VARIABLE)),
+            });
+
+            expect(withUpdatedBy.exitCode).toBe(0);
+            expect(JSON.parse(withUpdatedBy.stdout)).toMatchObject({ updatedBy: "user-1" });
+            expect(withoutUpdatedBy.exitCode).toBe(0);
+            expect(JSON.parse(withoutUpdatedBy.stdout)).not.toHaveProperty("updatedBy");
         }
         finally {
             await sandbox.cleanup();

--- a/src/application/commands/variables/list.ts
+++ b/src/application/commands/variables/list.ts
@@ -2,18 +2,33 @@ import type { CliCommandDefinition } from "../../contracts/cli.ts";
 import { z } from "zod";
 import { requireIdentity } from "../../auth/identity.ts";
 import { writeLine } from "../shared/output.ts";
-import { listVariables } from "./shared.ts";
+import { teamIdentityInputShape, teamIdentityOptions } from "../team/identity.ts";
+import { listVariables, resolveVariablesIdentity } from "./shared.ts";
 import { formatVariableListLine } from "./text.ts";
 
-export const variablesListCommand: CliCommandDefinition = {
+interface VariablesListInput {
+    team?: string;
+    personal?: boolean;
+}
+
+export const variablesListCommand: CliCommandDefinition<VariablesListInput> = {
     name: "list",
     summaryKey: "commands.variables.list.summary",
     descriptionKey: "commands.variables.list.description",
+    options: [
+        ...teamIdentityOptions({
+            personal: "options.variablesPersonal",
+            team: "options.variablesTeam",
+        }),
+    ],
     output: "standard",
-    inputSchema: z.object({}),
-    handler: async (_input, context) => {
+    inputSchema: z.object({
+        ...teamIdentityInputShape,
+    }),
+    handler: async (input, context) => {
         const { account } = await requireIdentity(context);
-        const variables = await listVariables(account, context);
+        const identity = await resolveVariablesIdentity(input, account, context);
+        const variables = await listVariables(account, identity, context);
 
         context.output.emit({ variables }, () => {
             if (variables.length === 0) {

--- a/src/application/commands/variables/shared.ts
+++ b/src/application/commands/variables/shared.ts
@@ -1,12 +1,21 @@
 import type { ZodError } from "zod";
 import type { CliExecutionContext } from "../../contracts/cli.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
+import type { OoRequestFailure } from "../shared/oo-request.ts";
+import type { TeamIdentity } from "../team/identity.ts";
 import { Buffer } from "node:buffer";
 import { readFile } from "node:fs/promises";
 import { z } from "zod";
+import { readDefaultTeam } from "../../auth/default-team.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { requestOo, requestOoResponse } from "../shared/oo-request.ts";
 import { readStdinToEnd } from "../shared/stdin.ts";
+import {
+    assertTeamIdentityFlags,
+    requireValidTeamIdentity,
+    resolveTeamIdentity,
+    teamIdentityHeaders,
+} from "../team/identity.ts";
 
 export const MAX_VARIABLE_NAME_LENGTH = 256;
 export const MAX_VARIABLE_VALUE_BYTES = 65536;
@@ -15,10 +24,30 @@ export interface Variable {
     name: string;
     value: string;
     updatedAt: string;
+    // The user who last wrote the variable, reported by the service as an
+    // audit hint. Optional so a backend that predates team-scoped variables
+    // still parses.
+    updatedBy?: string;
 }
 
 type RequestContext = Pick<CliExecutionContext, "fetcher" | "logger" | "translator">;
 type VariableAccount = Pick<AuthAccount, "apiKey" | "endpoint">;
+
+type VariablesIdentityContext = Pick<
+    CliExecutionContext,
+    | "authStore"
+    | "env"
+    | "fetcher"
+    | "logger"
+    | "settingsStore"
+    | "telemetry"
+    | "translator"
+>;
+
+interface VariablesIdentityInput {
+    personal?: boolean;
+    team?: string;
+}
 
 // MARK: - Validation
 
@@ -101,12 +130,52 @@ export async function resolveVariableValue(
     return value;
 }
 
+// MARK: - Team identity
+
+/**
+ * Resolves the team the variables commands act for: the shared flag guards,
+ * the one shared identity ladder (`--personal` > `--team` > `OO_TEAM_ID` >
+ * `OO_TEAM_NAME` > the account default), its execution gate, and the identity
+ * telemetry — everything the four subcommands must agree on.
+ *
+ * `undefined` means no team header is sent, which lets the gateway apply the
+ * server-side default team; it is not a private, per-user scope.
+ */
+export async function resolveVariablesIdentity(
+    input: VariablesIdentityInput,
+    account: VariableAccount,
+    context: VariablesIdentityContext,
+): Promise<TeamIdentity | undefined> {
+    const teamFlag = assertTeamIdentityFlags(input);
+
+    const identity = requireValidTeamIdentity(
+        await resolveTeamIdentity(
+            {
+                account,
+                defaultTeam: await readDefaultTeam(context),
+                teamFlag,
+                personalFlag: input.personal === true,
+                resolveAgainstBackend: true,
+            },
+            context,
+        ),
+        context,
+    );
+
+    context.telemetry?.recordProperties({
+        identity_source: identity?.source ?? "personal",
+    });
+
+    return identity;
+}
+
 // MARK: - Requests
 
 const variableSchema = z.object({
     name: z.string(),
     value: z.string(),
     updatedAt: z.string(),
+    updatedBy: z.string().optional(),
 });
 
 const variableListSchema = z.object({
@@ -121,16 +190,19 @@ function variablePath(name?: string): string {
 
 export async function listVariables(
     account: VariableAccount,
+    identity: TeamIdentity | undefined,
     context: RequestContext,
 ): Promise<Variable[]> {
     const parsed = await requestOo({
         authorization: account.apiKey,
         context,
         errors: { scope: "variables" },
+        headers: teamIdentityHeaders(identity),
         host: { endpoint: account.endpoint, service: "cli-api" },
         label: "Variables list",
         path: variablePath(),
         schema: variableListSchema,
+        statusErrors: mapVariablesTeamError,
     });
 
     return parsed.variables;
@@ -138,6 +210,7 @@ export async function listVariables(
 
 export async function getVariable(
     account: VariableAccount,
+    identity: TeamIdentity | undefined,
     name: string,
     context: RequestContext,
 ): Promise<Variable> {
@@ -145,18 +218,21 @@ export async function getVariable(
         authorization: account.apiKey,
         context,
         errors: { scope: "variables" },
+        headers: teamIdentityHeaders(identity),
         host: { endpoint: account.endpoint, service: "cli-api" },
         label: "Variables get",
         path: variablePath(name),
         schema: variableSchema,
-        statusErrors: failure => failure.status === 404
-            ? new CliUserError("errors.variables.notFound", 1, { name })
-            : undefined,
+        statusErrors: failure => mapVariablesTeamError(failure)
+            ?? (failure.status === 404
+                ? new CliUserError("errors.variables.notFound", 1, { name })
+                : undefined),
     });
 }
 
 export async function putVariable(
     account: VariableAccount,
+    identity: TeamIdentity | undefined,
     name: string,
     value: string,
     context: RequestContext,
@@ -165,20 +241,23 @@ export async function putVariable(
         authorization: account.apiKey,
         context,
         errors: { scope: "variables" },
+        headers: teamIdentityHeaders(identity),
         host: { endpoint: account.endpoint, service: "cli-api" },
         jsonBody: { value },
         label: "Variables create",
         method: "PUT",
         path: variablePath(name),
         schema: variableSchema,
-        statusErrors: failure => failure.status === 409
-            ? new CliUserError("errors.variables.quotaExceeded", 1)
-            : undefined,
+        statusErrors: failure => mapVariablesTeamError(failure)
+            ?? (failure.status === 409
+                ? new CliUserError("errors.variables.quotaExceeded", 1)
+                : undefined),
     });
 }
 
 export async function deleteVariable(
     account: VariableAccount,
+    identity: TeamIdentity | undefined,
     name: string,
     context: RequestContext,
 ): Promise<void> {
@@ -186,9 +265,40 @@ export async function deleteVariable(
         authorization: account.apiKey,
         context,
         errors: { scope: "variables" },
+        headers: teamIdentityHeaders(identity),
         host: { endpoint: account.endpoint, service: "cli-api" },
         label: "Variables delete",
         method: "DELETE",
         path: variablePath(name),
+        statusErrors: mapVariablesTeamError,
     });
+}
+
+// The service phrase that separates "this account belongs to no team at all"
+// from every other 401. The gateway only omits the team context when the
+// account has no team to fall back on, so no flag can fix it.
+const teamContextRequiredMessage = "Team context required";
+
+// The team-context refusals every variables request shares. A 401 naming the
+// missing team context means the account has no team; a 403 means the selected
+// team refused the account (not a member, or no such team); a 503 means the
+// gateway could not verify the team at all, which is worth retrying. Every
+// other status stays on the generic request failure.
+function mapVariablesTeamError(
+    failure: OoRequestFailure,
+): CliUserError | undefined {
+    if (
+        failure.status === 401
+        && failure.bodyText?.includes(teamContextRequiredMessage) === true
+    ) {
+        return new CliUserError("errors.variables.teamRequired", 1);
+    }
+
+    if (failure.status === 403) {
+        return new CliUserError("errors.variables.teamAccessDenied", 1);
+    }
+
+    return failure.status === 503
+        ? new CliUserError("errors.variables.teamUnavailable", 1)
+        : undefined;
 }

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -192,19 +192,19 @@ export const enMessages = {
     "commands.logout.summary":
         "Log out the current account (alias for auth logout)",
     "commands.team.description":
-        "List the teams your account can access and manage the default team identity used by connector commands.",
+        "List the teams your account can access and manage the default team identity used by team-aware commands (connector, variables).",
     "commands.team.summary": "Manage team identity",
     "commands.team.list.description":
         "List the teams the active account can authenticate as, marking the current default.",
     "commands.team.list.summary": "List accessible teams",
     "commands.team.current.description":
-        "Show the default team identity used by connector commands when no --team / --personal flag is given.",
+        "Show the default team identity used by team-aware commands (connector, variables) when no --team / --personal flag is given.",
     "commands.team.current.summary": "Show the default team identity",
     "commands.team.use.description":
-        "Set the default team identity used by connector commands, after checking the account can access it.",
+        "Set the default team identity used by team-aware commands (connector, variables), after checking the account can access it.",
     "commands.team.use.summary": "Set the default team identity",
     "commands.team.clear.description":
-        "Clear the default team identity so connector commands run under your personal identity.",
+        "Clear the default team identity so team-aware commands (connector, variables) stop using it.",
     "commands.team.clear.summary": "Clear the default team identity",
     "commands.search.description":
         "Search connector actions with one free-form query.",
@@ -403,6 +403,8 @@ export const enMessages = {
         "The team id \"{teamId}\" from OO_TEAM_ID cannot be used: {reason}. Run `oo team list` to see the teams you can use.",
     "errors.team.envNameNotAccessible":
         "The active account cannot access the team \"{team}\" from OO_TEAM_NAME. Run `oo team list` to see the teams you can use.",
+    "errors.team.identityConflict":
+        "Use either --team or --personal, not both.",
     "errors.team.invalidResponse":
         "The team list response body is unsupported.",
     "errors.team.nameEmpty": "The team name must not be empty.",
@@ -411,6 +413,8 @@ export const enMessages = {
     "errors.team.requestError": "The team list request failed: {message}",
     "errors.team.requestFailed":
         "The team list request returned HTTP {status}.",
+    "errors.team.teamEmpty":
+        "The --team value cannot be empty.",
     "errors.connectorMetadata.invalidResponse":
         "The connector action metadata response body is unsupported.",
     "errors.connectorMetadata.requestError":
@@ -461,10 +465,6 @@ export const enMessages = {
         "The --wait option is only supported for connector actions with an async result lifecycle.",
     "errors.connectorRun.waitModeConflict":
         "Use either --wait or --wait-result, not both.",
-    "errors.connectorRun.identityConflict":
-        "Use either --team or --personal, not both.",
-    "errors.connectorRun.teamEmpty":
-        "The --team value cannot be empty.",
     "errors.connectorRun.waitResultActionUnsupported":
         "The result action {action} configured for --wait-result must declare an async result lifecycle.",
     "errors.connectorRun.waitResultUnsupported":
@@ -1299,10 +1299,10 @@ export const enMessages = {
     "team.list.text.role": "Role",
     "team.list.text.default": "Default",
     "team.list.text.noTeams":
-        "The active account has no teams; connector commands run under your personal identity.",
+        "The active account has no teams; connector commands run under your personal identity and variables commands use the server-side default team.",
     "team.current.text.accountDefault": "Default team identity: {team}",
     "team.current.text.personal":
-        "No default team; connector commands run under your personal identity.",
+        "No default team; connector commands run under your personal identity and variables commands use the server-side default team.",
     "team.current.text.envId":
         "Team identity comes from the OO_TEAM_ID environment variable: {team}",
     "team.current.text.envName":
@@ -1324,15 +1324,15 @@ export const enMessages = {
     "team.use.envOverrideNoop":
         "Nothing was saved: the active credential comes from OO_API_KEY, which has no saved default team. Pin a team with OO_TEAM_ID or OO_TEAM_NAME instead.",
     "team.use.envOverrideHint":
-        "Connector commands keep using the team from {envVar}, not this default. Unset {envVar} to use the saved default.",
+        "Team-aware commands keep using the team from {envVar}, not this default. Unset {envVar} to use the saved default.",
     "team.clear.success":
-        "Cleared the default team identity; connector commands now run under your personal identity.",
+        "Cleared the default team identity; connector commands now run under your personal identity and variables commands use the server-side default team.",
     "team.clear.alreadyPersonal":
-        "No default team was set; connector commands already run under your personal identity.",
+        "No default team was set; connector commands already run under your personal identity and variables commands use the server-side default team.",
     "team.clear.successEnvOverride":
-        "Cleared the default team identity, but {envVar} still selects the team for connector commands. Unset {envVar} to run under your personal identity.",
+        "Cleared the default team identity, but {envVar} still selects the team for team-aware commands. Unset {envVar} to stop selecting a team.",
     "team.clear.alreadyPersonalEnvHint":
-        "No default team was set, but {envVar} still selects a team for connector commands.",
+        "No default team was set, but {envVar} still selects a team for team-aware commands.",
     "team.clear.envOverrideNoop":
         "Nothing was cleared: the active credential comes from OO_API_KEY, which already runs under your personal identity unless OO_TEAM_ID or OO_TEAM_NAME selects a team.",
     "connector.run.text.dryRunPassed": "Validation passed.",
@@ -1381,24 +1381,29 @@ export const enMessages = {
     "arguments.variableName": "Variable name",
     "arguments.variableValue": "Variable value (string)",
     "commands.variables.summary": "Manage cloud-stored variables",
-    "commands.variables.description": "List, read, create, update, and delete cloud-stored string variables for the current account.",
+    "commands.variables.description": "List, read, create, update, and delete cloud-stored string variables for the current team; every member of the team shares them.",
     "commands.variables.list.summary": "List variables",
-    "commands.variables.list.description": "List all variables for the current account, most recently updated first.",
+    "commands.variables.list.description": "List all variables of the current team, most recently updated first.",
     "commands.variables.get.summary": "Read a variable",
-    "commands.variables.get.description": "Read the value of a variable for the current account.",
+    "commands.variables.get.description": "Read the value of a variable of the current team.",
     "commands.variables.create.summary": "Create or update a variable",
-    "commands.variables.create.description": "Create or update the value of a variable for the current account (last-write-wins).",
+    "commands.variables.create.description": "Create or update the value of a variable for the current team (last-write-wins).",
     "commands.variables.delete.summary": "Delete a variable",
-    "commands.variables.delete.description": "Delete a variable for the current account. Idempotent: succeeds even if the name does not exist.",
+    "commands.variables.delete.description": "Delete a variable of the current team. Idempotent: succeeds even if the name does not exist.",
     "options.variablesFromFile": "Read the variable value from a file (UTF-8)",
     "options.variablesStdin": "Read the variable value from standard input (UTF-8)",
+    "options.variablesTeam": "Run the command for the given team",
+    "options.variablesPersonal": "Use the server-side default team, ignoring OO_TEAM_ID / OO_TEAM_NAME and any saved default team",
     "errors.variables.invalidName": "Invalid variable name: {value}. Names must be 1-256 characters and must not contain '/' or control characters.",
     "errors.variables.valueSource": "Provide exactly one variable value source: a value argument, --from-file, or --stdin.",
     "errors.variables.stdinTty": "--stdin requires piped input; refusing to read from an interactive terminal.",
     "errors.variables.fromFileReadFailed": "Failed to read value file: {message}",
     "errors.variables.valueTooLarge": "Variable value exceeds the maximum size of {max} bytes (UTF-8).",
     "errors.variables.notFound": "Variable not found: {name}",
-    "errors.variables.quotaExceeded": "Variable quota exceeded. Each account can store at most 200 variables.",
+    "errors.variables.quotaExceeded": "Variable quota exceeded. Each team can store at most 200 variables.",
+    "errors.variables.teamRequired": "Variables are stored per team, and this account belongs to no team. Create or join a team, then run the command again.",
+    "errors.variables.teamAccessDenied": "This account cannot use the selected team for variables: it is not a member, or the team does not exist.",
+    "errors.variables.teamUnavailable": "Could not verify your team right now; try again later.",
     "errors.variables.requestFailed": "Variables request failed with status {status}.",
     "errors.variables.requestError": "Variables request failed: {message}",
     "errors.variables.invalidResponse": "The variables service returned an unexpected response.",
@@ -1583,19 +1588,19 @@ export const zhMessages = {
     "commands.logout.description": "从持久化认证数据中移除当前账号。是 auth logout 的别名。",
     "commands.logout.summary": "登出当前账号（auth logout 的别名）",
     "commands.team.description":
-        "列出当前账号可访问的团队，并管理 connector 命令使用的默认团队身份。",
+        "列出当前账号可访问的团队，并管理团队相关命令（connector、variables）使用的默认团队身份。",
     "commands.team.summary": "管理团队身份",
     "commands.team.list.description":
         "列出当前活动账号可认证的团队，并标出当前默认团队。",
     "commands.team.list.summary": "列出可访问的团队",
     "commands.team.current.description":
-        "显示未传 --team / --personal 时 connector 命令使用的默认团队身份。",
+        "显示未传 --team / --personal 时团队相关命令（connector、variables）使用的默认团队身份。",
     "commands.team.current.summary": "显示默认团队身份",
     "commands.team.use.description":
-        "在确认账号可访问后，设置 connector 命令使用的默认团队身份。",
+        "在确认账号可访问后，设置团队相关命令（connector、variables）使用的默认团队身份。",
     "commands.team.use.summary": "设置默认团队身份",
     "commands.team.clear.description":
-        "清除默认团队身份，让 connector 命令以个人身份运行。",
+        "清除默认团队身份，让团队相关命令（connector、variables）不再使用它。",
     "commands.team.clear.summary": "清除默认团队身份",
     "commands.search.description":
         "使用一个自由文本查询搜索 connector action。",
@@ -1771,6 +1776,8 @@ export const zhMessages = {
         "无法使用 OO_TEAM_ID 指定的团队 id “{teamId}”：{reason}。运行 `oo team list` 查看可用的团队。",
     "errors.team.envNameNotAccessible":
         "当前活动账号无法访问 OO_TEAM_NAME 指定的团队 “{team}”。运行 `oo team list` 查看可用的团队。",
+    "errors.team.identityConflict":
+        "--team 和 --personal 只能使用其中一个。",
     "errors.team.invalidResponse":
         "团队列表返回了不受支持的响应内容。",
     "errors.team.nameEmpty": "团队名称不能为空。",
@@ -1779,6 +1786,8 @@ export const zhMessages = {
     "errors.team.requestError": "获取团队列表失败：{message}",
     "errors.team.requestFailed":
         "获取团队列表返回了 HTTP {status}。",
+    "errors.team.teamEmpty":
+        "--team 的值不能为空。",
     "errors.connectorMetadata.invalidResponse":
         "connector action 元数据返回了不受支持的响应内容。",
     "errors.connectorMetadata.requestError":
@@ -1829,10 +1838,6 @@ export const zhMessages = {
         "--wait 选项仅支持带有异步结果 lifecycle 的 connector action。",
     "errors.connectorRun.waitModeConflict":
         "--wait 和 --wait-result 只能使用其中一个。",
-    "errors.connectorRun.identityConflict":
-        "--team 和 --personal 只能使用其中一个。",
-    "errors.connectorRun.teamEmpty":
-        "--team 的值不能为空。",
     "errors.connectorRun.waitResultActionUnsupported":
         "--wait-result 配置的结果 action {action} 必须声明异步结果 lifecycle。",
     "errors.connectorRun.waitResultUnsupported":
@@ -2659,10 +2664,10 @@ export const zhMessages = {
     "team.list.text.role": "角色",
     "team.list.text.default": "默认",
     "team.list.text.noTeams":
-        "当前活动账号没有任何团队；connector 命令以个人身份运行。",
+        "当前活动账号没有任何团队；connector 命令以个人身份运行，variables 命令使用服务端默认团队。",
     "team.current.text.accountDefault": "默认团队身份：{team}",
     "team.current.text.personal":
-        "未设置默认团队；connector 命令以个人身份运行。",
+        "未设置默认团队；connector 命令以个人身份运行，variables 命令使用服务端默认团队。",
     "team.current.text.envId":
         "团队身份来自 OO_TEAM_ID 环境变量：{team}",
     "team.current.text.envName":
@@ -2682,15 +2687,15 @@ export const zhMessages = {
     "team.use.envOverrideNoop":
         "未保存任何内容：当前凭据来自 OO_API_KEY，它没有保存的默认团队。如需固定团队，请使用 OO_TEAM_ID 或 OO_TEAM_NAME。",
     "team.use.envOverrideHint":
-        "connector 命令仍会使用 {envVar} 指定的团队，而不是这个默认值。取消 {envVar} 后保存的默认值才会生效。",
+        "团队相关命令仍会使用 {envVar} 指定的团队，而不是这个默认值。取消 {envVar} 后保存的默认值才会生效。",
     "team.clear.success":
-        "已清除默认团队身份；connector 命令现在以个人身份运行。",
+        "已清除默认团队身份；connector 命令现在以个人身份运行，variables 命令使用服务端默认团队。",
     "team.clear.alreadyPersonal":
-        "未设置默认团队；connector 命令本就以个人身份运行。",
+        "未设置默认团队；connector 命令本就以个人身份运行，variables 命令使用服务端默认团队。",
     "team.clear.successEnvOverride":
-        "已清除默认团队身份，但 {envVar} 仍会为 connector 命令选择团队。取消 {envVar} 后才会以个人身份运行。",
+        "已清除默认团队身份，但 {envVar} 仍会为团队相关命令选择团队。取消 {envVar} 后才不会选择团队。",
     "team.clear.alreadyPersonalEnvHint":
-        "未设置默认团队，但 {envVar} 仍会为 connector 命令选择团队。",
+        "未设置默认团队，但 {envVar} 仍会为团队相关命令选择团队。",
     "team.clear.envOverrideNoop":
         "未清除任何内容：当前凭据来自 OO_API_KEY，除非 OO_TEAM_ID 或 OO_TEAM_NAME 选择了团队，否则它本就以个人身份运行。",
     "connector.run.text.dryRunPassed": "校验通过。",
@@ -2737,24 +2742,29 @@ export const zhMessages = {
     "arguments.variableName": "变量 name",
     "arguments.variableValue": "变量值（字符串）",
     "commands.variables.summary": "管理云端变量",
-    "commands.variables.description": "列出、读取、创建、更新和删除当前账号的云端字符串变量。",
+    "commands.variables.description": "列出、读取、创建、更新和删除当前团队的云端字符串变量；团队成员共享同一份变量。",
     "commands.variables.list.summary": "列出变量",
-    "commands.variables.list.description": "列出当前账号的全部变量，按最近更新时间倒序。",
+    "commands.variables.list.description": "列出当前团队的全部变量，按最近更新时间倒序。",
     "commands.variables.get.summary": "读取变量",
-    "commands.variables.get.description": "读取当前账号指定 name 的变量值。",
+    "commands.variables.get.description": "读取当前团队指定 name 的变量值。",
     "commands.variables.create.summary": "创建或更新变量",
-    "commands.variables.create.description": "为当前账号创建或替换指定 name 的变量（last-write-wins）。",
+    "commands.variables.create.description": "为当前团队创建或替换指定 name 的变量（last-write-wins）。",
     "commands.variables.delete.summary": "删除变量",
-    "commands.variables.delete.description": "删除当前账号指定 name 的变量。幂等：即使 name 不存在也成功。",
+    "commands.variables.delete.description": "删除当前团队指定 name 的变量。幂等：即使 name 不存在也成功。",
     "options.variablesFromFile": "从文件读取变量值（UTF-8）",
     "options.variablesStdin": "从标准输入读取变量值（UTF-8）",
+    "options.variablesTeam": "以指定团队执行该命令",
+    "options.variablesPersonal": "使用服务端默认团队，忽略 OO_TEAM_ID / OO_TEAM_NAME 与已保存的默认团队",
     "errors.variables.invalidName": "无效的变量 name：{value}。name 必须为 1-256 个字符，且不能包含 '/' 或控制字符。",
     "errors.variables.valueSource": "请只提供一个变量值来源：value 参数、--from-file 或 --stdin。",
     "errors.variables.stdinTty": "--stdin 需要管道输入；拒绝从交互式终端读取。",
     "errors.variables.fromFileReadFailed": "读取变量值文件失败：{message}",
     "errors.variables.valueTooLarge": "变量值超过最大限制 {max} 字节（UTF-8）。",
     "errors.variables.notFound": "变量不存在：{name}",
-    "errors.variables.quotaExceeded": "变量数量超出上限。每个账号最多存储 200 个变量。",
+    "errors.variables.quotaExceeded": "变量数量超出上限。每个团队最多存储 200 个变量。",
+    "errors.variables.teamRequired": "变量按团队存储，而当前账号不属于任何团队。请先创建或加入团队，然后重新执行该命令。",
+    "errors.variables.teamAccessDenied": "当前账号无法使用所选团队的变量：不是该团队成员，或团队不存在。",
+    "errors.variables.teamUnavailable": "暂时无法校验团队信息，请稍后重试。",
     "errors.variables.requestFailed": "variables 请求失败，状态码 {status}。",
     "errors.variables.requestError": "variables 请求失败：{message}",
     "errors.variables.invalidResponse": "variables 服务返回了非预期的响应。",


### PR DESCRIPTION
cli-api now stores variables per team, so the four `oo variables` subcommands resolve a team through the shared ladder (`--personal` > `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` > the account default) and send `x-oo-team-id` / `x-oo-team-name` with every request. `--personal` means no team selection, which lets the gateway apply the server-side default team, and the docs and catalog strings say so instead of promising a private scope.

The `--team` / `--personal` option pair and its usage guards move to _src/application/commands/team/identity.ts_ as `teamIdentityOptions`, `teamIdentityInputShape` and `assertTeamIdentityFlags`, shared by the connector and variables commands. Variables requests map the service's 401 `Team context required`, the gateway's 403 and 503 to dedicated errors, parse the new optional `updatedBy` field, and record `identity_source` in telemetry. Older CLI releases keep working against the new backend, since the gateway falls back to the default team when no team header is sent.

Ships after the oomol/trafnex and oomol/cli-api team-context PRs.
