### PR TITLE
feat(skills): expand oo routing for OOMOL operations

### DIFF
--- a/contrib/skills/shared/oo/SKILL.md
+++ b/contrib/skills/shared/oo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oo
-description: Use OO for connected accounts, APIs, hosted AI, and Flow authoring; the first-choice router for tasks whose outcome lives outside this workspace or in a persistent Open Flow, including connected third-party accounts (email, calendar, drive, chat, notes, issue tracker, code host, CRM, storage, etc.), an external API, a managed AI pipeline (OCR, translation, transcription, TTS, text-to-image, subtitles, long-document understanding), creating, editing, checking, running, publishing, or opening an Open Flow workflow, and converting n8n workflow or template JSON into Open Flow. Use when local code needs OOMOL LLM client configuration such as an OpenAI-compatible base URL, API key, or model name. Otherwise use only when the user wants an existing hosted capability, connector workflow, or Open Flow operation, not a local implementation. Concrete capabilities are discovered at runtime, so no package, block, connector, action, or Trigger key names are assumed in advance. Match intent across languages. Skip other pure local coding, shell glue, repo edits, and text-only answers an LLM can complete without hosted capability execution.
+description: For connected accounts, APIs, hosted AI, Flow, OOMOL ops. Covers email, calendar, drive, chat, notes, issue trackers, code hosts, CRM, and storage; OOMOL billing, usage, teams, members, Connections, and permissions; OCR, translation, transcription, TTS, image generation, subtitles, and long-document understanding; persistent Open Flow creation, editing, checking, running, publishing, opening, and n8n workflow or template conversion; and OOMOL OpenAI-compatible LLM setup for local code. Match intent across languages. Excludes local implementations, repo edits, shell glue, and text-only work needing no hosted capability.
 disable-model-invocation: <!-- agentic:var disableModelInvocation -->
 <!-- agentic:if agent=claude|hermes -->
 allowed-tools: [Bash(oo *)]
@@ -17,6 +17,9 @@ If the user wants to find, compare, or install published OOMOL/oo skills, use
 `oo-find-skills` instead of this skill.
 
 Read only the reference file needed for the current state.
+
+OOMOL ops use provider `oomol_console` with the current credential and team
+context.
 
 ## Open Flow mode
 

--- a/src/application/commands/skills/bundled-oo-skill-index.test.ts
+++ b/src/application/commands/skills/bundled-oo-skill-index.test.ts
@@ -26,7 +26,7 @@ async function readBundledOoDescription(): Promise<string> {
 }
 
 describe("bundled oo skill Hermes index prefix", () => {
-    test("front-loads the connected accounts, APIs, hosted AI, and Flow routing signals within the Hermes truncation budget", async () => {
+    test("front-loads the connected accounts, APIs, hosted AI, Flow, and OOMOL routing signals within the Hermes truncation budget", async () => {
         const description = await readBundledOoDescription();
         const indexPrefix = description
             .slice(0, hermesSkillIndexPrefixLength)
@@ -36,6 +36,7 @@ describe("bundled oo skill Hermes index prefix", () => {
         expect(indexPrefix).toContain("api");
         expect(indexPrefix).toContain("hosted ai");
         expect(indexPrefix).toContain("flow");
+        expect(indexPrefix).toContain("oomol");
     });
 
     test("keeps the full description detailed instead of narrowing it to a single service", async () => {


### PR DESCRIPTION
## Summary

- Expand the bundled `oo` skill description to cover OOMOL operations, including billing, usage, teams, members, Connections, and permissions
- Add `oomol_console` provider guidance for OOMOL operations
- Update the Hermes index-prefix unit test to verify OOMOL routing signals

## Testing

- Unit tests updated for the expanded Hermes routing description