### PR TITLE
feat(file): send team identity on file upload requests

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -74,8 +74,9 @@ use. Truthy values are `1`, `true`, `yes`, or `on` (case-insensitive).
   `OO_CONNECTOR_URL` > `OO_API_KEY` > the saved self-hosted connector
   configuration (`oo connector login`) > the active account.
 - `OO_TEAM_ID`: Run team-aware commands (`oo connector run`, `oo connector
-  proxy`, `oo connector apps`, `oo connector search` / `oo search`, and
-  `oo variables list/get/create/delete`) under the team with this id. It takes
+  proxy`, `oo connector apps`, `oo connector search` / `oo search`,
+  `oo variables list/get/create/delete`, and `oo file upload`) under the team
+  with this id. It takes
   precedence over `OO_TEAM_NAME` and the account's default team; the per-run
   `--team` and `--personal` flags still outrank it. Before execution the CLI
   validates the id and resolves its team name (one extra request per
@@ -95,8 +96,9 @@ use. Truthy values are `1`, `true`, `yes`, or `on` (case-insensitive).
   target is self-hosted; variables commands always honor it.
 - Team-aware commands resolve their team identity with this precedence:
   `--personal` / `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` > the active account's
-  default team > your personal identity. Variables commands have no personal
-  scope: with nothing selected they fall back to the server-side default team.
+  default team > your personal identity. Variables commands and `oo file
+  upload` have no personal scope: with nothing selected they fall back to the
+  server-side default team.
 - `OO_SKILLS_SYNC_DISABLED`: A truthy value disables the startup managed-skill
   synchronization, so the CLI writes no skill files into agent home directories
   such as `~/.agents` or `~/.claude`.
@@ -570,8 +572,9 @@ Alias for `oo auth logout`.
 
 Team identity lets team-aware commands act as a team instead of your personal
 account: the connector commands (`oo connector run`, `oo connector proxy`,
-`oo connector apps`) and the variables commands (`oo variables
-list/get/create/delete`), whose data is team-owned in the first place. One
+`oo connector apps`), the variables commands (`oo variables
+list/get/create/delete`), whose data is team-owned in the first place, and
+`oo file upload`, whose upload is billed and metered under the team. One
 ladder selects it: the per-run `--personal` (drop every saved and env-selected
 team) or `--team <name>` first, then the `OO_TEAM_ID` / `OO_TEAM_NAME`
 environment overrides, then the default saved on the active account. These
@@ -619,9 +622,10 @@ read-only.
 
 ### `oo team current`
 
-Show the team identity used by team-aware commands (connector, variables) when
-no `--team` / `--personal` flag is given: the `OO_TEAM_ID` / `OO_TEAM_NAME`
-environment override when set, otherwise the active account's default team.
+Show the team identity used by team-aware commands (connector, variables, file
+upload) when no `--team` / `--personal` flag is given: the `OO_TEAM_ID` /
+`OO_TEAM_NAME` environment override when set, otherwise the active account's
+default team.
 
 - Sends one request only when `OO_TEAM_ID` or `OO_TEAM_NAME` supplies the
   identity, to complete and validate the missing half: an id resolves to its
@@ -2596,6 +2600,15 @@ Upload one file to the temporary file cache.
 - Options: `--format <format>` returns structured output. Supported value:
   `json`.
 - Options: `--json` is an alias for `--format=json`.
+- Options: `--team <team>` uploads the file under the given team, so the upload
+  is billed and metered under that team. When omitted, the team comes from
+  `OO_TEAM_ID` / `OO_TEAM_NAME` when set, otherwise the active account's
+  default team.
+- Options: `--personal` sends no team selection, ignoring `OO_TEAM_ID` /
+  `OO_TEAM_NAME` and the account default, and lets the server apply its own
+  default team. It cannot be combined with `--team`.
+- Notes: the team selection is sent only to the file service requests; the
+  presigned part uploads go straight to storage without it.
 - Notes: the uploaded file expires after seven days and is deleted on the server.
 - Notes: files larger than `500 MiB` are rejected.
 - Notes: successful uploads persist a local sqlite record with the upload time,

--- a/docs/commands.zh-CN.md
+++ b/docs/commands.zh-CN.md
@@ -60,8 +60,9 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   `OO_CONNECTOR_URL` > `OO_API_KEY` > 已保存的自部署 Connector 配置
   （`oo connector login`）> 当前激活账号。
 - `OO_TEAM_ID`：让团队相关命令（`oo connector run`、`oo connector proxy`、
-  `oo connector apps`、`oo connector search` / `oo search`，以及
-  `oo variables list/get/create/delete`）以该 id 对应的团队身份运行。
+  `oo connector apps`、`oo connector search` / `oo search`、
+  `oo variables list/get/create/delete`，以及 `oo file upload`）以该 id
+  对应的团队身份运行。
   优先级高于 `OO_TEAM_NAME` 和账号保存的默认团队；每次运行的 `--team`
   与 `--personal` 标志仍然优先于它。执行前 CLI 会校验该 id 并解析出团队
   名称（每次调用多一个请求），因此请求会同时携带名称与 id；账号无法使用
@@ -77,8 +78,8 @@ CLI 读取以下环境变量以支持内置和自动化场景。真值为 `1`、
   命令会忽略它，variables 命令始终遵循它。
 - 团队相关命令按以下优先级解析团队身份：
   `--personal` / `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` >
-  当前账号保存的默认团队 > 个人身份。variables 命令没有个人作用域：
-  没有选中任何团队时回落到服务端默认团队。
+  当前账号保存的默认团队 > 个人身份。variables 命令与 `oo file upload`
+  没有个人作用域：没有选中任何团队时回落到服务端默认团队。
 - `OO_SKILLS_SYNC_DISABLED`：设为真值会禁用启动时的 managed skill 同步，
   使 CLI 不会向 `~/.agents`、`~/.claude` 等代理主目录写入任何 skill 文件。
 - `OO_NO_SELF_UPDATE`：设为真值会禁用 `oo update`、`oo install` 和
@@ -473,8 +474,9 @@ oo flow
 ## 团队
 
 团队身份让团队相关命令以某个团队身份运行，而非个人账号：包括 connector 命令
-（`oo connector run`、`oo connector proxy`、`oo connector apps`）与 variables
-命令（`oo variables list/get/create/delete`，其数据本身就归团队所有）。它由同一条
+（`oo connector run`、`oo connector proxy`、`oo connector apps`）、variables
+命令（`oo variables list/get/create/delete`，其数据本身就归团队所有），以及
+`oo file upload`（上传按该团队计费与计量）。它由同一条
 优先级阶梯选出：先是每次运行的 `--personal`（放弃所有已保存与 env 选定的团队）或
 `--team <name>`，其次是环境变量 `OO_TEAM_ID` / `OO_TEAM_NAME`，最后是保存在当前
 账号上的默认团队。下列命令用于发现当前账号可用的团队并管理该默认值。
@@ -513,7 +515,8 @@ oo flow
 
 ### `oo team current`
 
-显示未传 `--team` / `--personal` 时团队相关命令（connector、variables）使用的
+显示未传 `--team` / `--personal` 时团队相关命令（connector、variables、file
+upload）使用的
 团队身份：设置了 `OO_TEAM_ID` / `OO_TEAM_NAME` 环境变量时为 env 指定的团队，
 否则为当前账号保存的默认团队。
 
@@ -2174,6 +2177,12 @@ message，也不会出现在 `path` / `sourcePath` 字段之外的额外文件�
 - 参数：`<filePath>` 为要上传的本地文件路径。
 - 选项：`--format <format>` 返回结构化输出，目前仅支持 `json`。
 - 选项：`--json` 是 `--format=json` 的别名。
+- 选项：`--team <team>` 以指定团队上传该文件，上传按该团队计费与计量。
+  未传时，团队来自已设置的 `OO_TEAM_ID` / `OO_TEAM_NAME`，否则为当前账号
+  保存的默认团队。
+- 选项：`--personal` 不发送任何团队选择，忽略 `OO_TEAM_ID` / `OO_TEAM_NAME`
+  与账号默认团队，由服务端套用它自己的默认团队。不能与 `--team` 同时使用。
+- 说明：团队选择只随文件服务请求发送；分片上传直接发往存储服务，不携带它。
 - 说明：上传后的文件有效期为七天，到期后会由服务端删除。
 - 说明：文件大小超过 `500 MiB` 时会被拒绝。
 - 说明：上传成功后，CLI 会在本地 sqlite 中记录上传时间、文件名、文件大小、

--- a/src/application/commands/file/__snapshots__/upload.cli.test.ts.snap
+++ b/src/application/commands/file/__snapshots__/upload.cli.test.ts.snap
@@ -50,8 +50,9 @@ Arguments:
 
 Options:
   --team <team>          Upload the file under the given team identity
-  --personal             Upload the file under your personal identity, ignoring
-                         any configured default team
+  --personal             Upload the file under the server-side default team,
+                         ignoring OO_TEAM_ID / OO_TEAM_NAME and any saved
+                         default team
   --format <format>      Specify output format (use json for structured output)
   --json                 Alias for --format=json
   --show-schema-version  Include schemaVersion in JSON output (no effect without

--- a/src/application/commands/file/__snapshots__/upload.cli.test.ts.snap
+++ b/src/application/commands/file/__snapshots__/upload.cli.test.ts.snap
@@ -49,6 +49,9 @@ Arguments:
   filePath               File path
 
 Options:
+  --team <team>          Upload the file under the given team identity
+  --personal             Upload the file under your personal identity, ignoring
+                         any configured default team
   --format <format>      Specify output format (use json for structured output)
   --json                 Alias for --format=json
   --show-schema-version  Include schemaVersion in JSON output (no effect without

--- a/src/application/commands/file/shared.ts
+++ b/src/application/commands/file/shared.ts
@@ -5,12 +5,20 @@ import type {
     FileUploadStatus,
 } from "../../contracts/file-upload-store.ts";
 import type { AuthAccount } from "../../schemas/auth.ts";
+import type { TeamIdentity } from "../team/identity.ts";
 
 import { z } from "zod";
+import { readDefaultTeam } from "../../auth/default-team.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { createRetryingFetcher } from "../../shared/retrying-fetcher.ts";
 import { parsePositiveIntegerOption } from "../shared/input-parsing.ts";
 import { requestOo, requestOoResponse } from "../shared/oo-request.ts";
+import {
+    assertTeamIdentityFlags,
+    requireValidTeamIdentity,
+    resolveTeamIdentity,
+    teamIdentityHeaders,
+} from "../team/identity.ts";
 
 export const fileUploadExpiresInMs = ((7 * 24 * 60 * 60) - 1) * 1000;
 export const maxFileUploadSizeBytes = 500 * 1024 * 1024;
@@ -149,8 +157,62 @@ export function normalizeFileUploadDownloadUrlForDisplay(
     }
 }
 
+// MARK: - Team identity
+
+type FileUploadIdentityContext = Pick<
+    CliExecutionContext,
+    | "authStore"
+    | "env"
+    | "fetcher"
+    | "logger"
+    | "settingsStore"
+    | "telemetry"
+    | "translator"
+>;
+
+/**
+ * Resolves the team the upload is attributed to: the shared flag guards, the
+ * one shared identity ladder (`--personal` > `--team` > `OO_TEAM_ID` >
+ * `OO_TEAM_NAME` > the account default), its execution gate, and the identity
+ * telemetry. The gateway bills the resolved team's payer and the file service
+ * meters the upload under that team.
+ *
+ * `undefined` means no team header is sent, which lets the gateway apply the
+ * server-side default team; it is not a private, per-user scope.
+ */
+export async function resolveFileUploadIdentity(
+    input: { personal?: boolean; team?: string },
+    account: Pick<AuthAccount, "apiKey" | "endpoint">,
+    context: FileUploadIdentityContext,
+): Promise<TeamIdentity | undefined> {
+    const teamFlag = assertTeamIdentityFlags(input);
+
+    const identity = requireValidTeamIdentity(
+        await resolveTeamIdentity(
+            {
+                account,
+                defaultTeam: await readDefaultTeam(context),
+                teamFlag,
+                personalFlag: input.personal === true,
+                resolveAgainstBackend: true,
+            },
+            context,
+        ),
+        context,
+    );
+
+    context.telemetry?.recordProperties({
+        identity_source: identity?.source ?? "personal",
+    });
+
+    return identity;
+}
+
+// MARK: - Requests
+
 export async function createMultipartFileUpload(
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
+    identity: TeamIdentity | undefined,
     fileName: string,
     fileSize: number,
     context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
@@ -158,6 +220,7 @@ export async function createMultipartFileUpload(
     const response = await requestFileUploadAction(
         "create-multipart-upload",
         account,
+        identity,
         {
             fileSize,
             filename: fileName,
@@ -176,12 +239,14 @@ export async function createMultipartFileUpload(
 
 export async function generatePresignedFileUploadPartUrls(
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
+    identity: TeamIdentity | undefined,
     session: MultipartUploadSession,
     context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
 ): Promise<PresignedPartUrl[]> {
     const response = await requestFileUploadAction(
         "generate-presigned-urls",
         account,
+        identity,
         {
             key: session.key,
             partNumbers: Array.from(
@@ -231,6 +296,7 @@ export async function uploadFileParts(
 
 export async function completeMultipartFileUpload(
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
+    identity: TeamIdentity | undefined,
     session: MultipartUploadSession,
     parts: readonly UploadedPart[],
     context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
@@ -238,6 +304,7 @@ export async function completeMultipartFileUpload(
     const response = await requestFileUploadAction(
         "complete-multipart-upload",
         account,
+        identity,
         {
             key: session.key,
             parts,
@@ -263,9 +330,12 @@ function normalizeFileUploadDownloadUrlValue(rawUrl: string): string {
     return new URL(rawUrl).href;
 }
 
+// The file service calls carry the team headers; the presigned part uploads
+// go straight to storage and never do (see uploadFilePart).
 async function requestFileUploadAction<Value>(
     actionName: string,
     account: Pick<AuthAccount, "apiKey" | "endpoint">,
+    identity: TeamIdentity | undefined,
     jsonBody: unknown,
     schema: { parse: (input: unknown) => Value },
     context: Pick<CliExecutionContext, "fetcher" | "logger" | "translator">,
@@ -274,6 +344,7 @@ async function requestFileUploadAction<Value>(
         authorization: account.apiKey,
         context,
         errors: { scope: "fileUpload" },
+        headers: teamIdentityHeaders(identity),
         host: { endpoint: account.endpoint, service: "fusion-api" },
         jsonBody,
         label: "File upload",

--- a/src/application/commands/file/upload.cli.test.ts
+++ b/src/application/commands/file/upload.cli.test.ts
@@ -7,8 +7,10 @@ import { describe, expect, test } from "bun:test";
 import {
     createCliSandbox,
     createCliSnapshot,
+    expectTelemetryFreeOfTeamIdentity,
     toRequest,
     writeAuthFile,
+    writeAuthFileWithDefaultTeam,
 } from "../../../../__tests__/helpers.ts";
 import { resolveStorePaths } from "../../../adapters/store/store-path.ts";
 import { APP_NAME } from "../../config/app-config.ts";
@@ -524,6 +526,197 @@ describe("file upload CLI", () => {
         }
     });
 });
+
+describe("file upload team identity", () => {
+    test("sends the account default team headers to the file service only", async () => {
+        const sandbox = await createCliSandbox();
+        const localFilePath = join(sandbox.env.HOME!, "sample.txt");
+
+        try {
+            await writeAuthFileWithDefaultTeam(sandbox, "alice-team", {
+                teamId: "team-system-1",
+            });
+            await Bun.write(localFilePath, "hello world");
+
+            const { requests, result } = await runRecordedUpload(sandbox, [
+                "file",
+                "upload",
+                localFilePath,
+            ]);
+            const telemetryPayload = readUploadTelemetryPayload(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(readTeamHeaders(fileServiceRequests(requests))).toEqual([
+                ["alice-team", "team-system-1"],
+                ["alice-team", "team-system-1"],
+                ["alice-team", "team-system-1"],
+            ]);
+            // The presigned part upload goes straight to storage and must not
+            // leak the team selection outside the OOMOL gateway.
+            expect(readTeamHeaders(storageRequests(requests))).toEqual([
+                [null, null],
+            ]);
+            expect(telemetryPayload?.properties).toMatchObject({
+                identity_source: "account",
+            });
+            expectTelemetryFreeOfTeamIdentity(telemetryPayload?.properties, [
+                "alice-team",
+                "team-system-1",
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("uploads under the team given by --team instead of the account default", async () => {
+        const sandbox = await createCliSandbox();
+        const localFilePath = join(sandbox.env.HOME!, "sample.txt");
+
+        try {
+            await writeAuthFileWithDefaultTeam(sandbox, "alice-team", {
+                teamId: "team-system-1",
+            });
+            await Bun.write(localFilePath, "hello world");
+
+            const { requests, result } = await runRecordedUpload(sandbox, [
+                "file",
+                "upload",
+                localFilePath,
+                "--team",
+                "acme",
+            ]);
+            const telemetryPayload = readUploadTelemetryPayload(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(readTeamHeaders(fileServiceRequests(requests))).toEqual([
+                ["acme", null],
+                ["acme", null],
+                ["acme", null],
+            ]);
+            expect(telemetryPayload?.properties).toMatchObject({
+                identity_source: "flag",
+            });
+            expectTelemetryFreeOfTeamIdentity(telemetryPayload?.properties, [
+                "acme",
+                "alice-team",
+            ]);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("sends no team headers with --personal", async () => {
+        const sandbox = await createCliSandbox();
+        const localFilePath = join(sandbox.env.HOME!, "sample.txt");
+
+        try {
+            await writeAuthFileWithDefaultTeam(sandbox, "alice-team", {
+                teamId: "team-system-1",
+            });
+            await Bun.write(localFilePath, "hello world");
+
+            const { requests, result } = await runRecordedUpload(sandbox, [
+                "file",
+                "upload",
+                localFilePath,
+                "--personal",
+            ]);
+            const telemetryPayload = readUploadTelemetryPayload(sandbox);
+
+            expect(result.exitCode).toBe(0);
+            expect(readTeamHeaders(fileServiceRequests(requests))).toEqual([
+                [null, null],
+                [null, null],
+                [null, null],
+            ]);
+            expect(telemetryPayload?.properties).toMatchObject({
+                identity_source: "personal",
+            });
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+
+    test("rejects --team combined with --personal before any request", async () => {
+        const sandbox = await createCliSandbox();
+        const localFilePath = join(sandbox.env.HOME!, "sample.txt");
+
+        try {
+            await writeAuthFile(sandbox);
+            await Bun.write(localFilePath, "hello world");
+
+            const { requests, result } = await runRecordedUpload(sandbox, [
+                "file",
+                "upload",
+                localFilePath,
+                "--team",
+                "acme",
+                "--personal",
+            ]);
+
+            expect(result.exitCode).toBe(2);
+            expect(requests).toHaveLength(0);
+        }
+        finally {
+            await sandbox.cleanup();
+        }
+    });
+});
+
+async function runRecordedUpload(
+    sandbox: Awaited<ReturnType<typeof createCliSandbox>>,
+    argv: readonly string[],
+): Promise<{
+    requests: Request[];
+    result: Awaited<ReturnType<typeof sandbox.run>>;
+}> {
+    const requests: Request[] = [];
+    const fetcher = createSinglePartUploadFetcher({
+        downloadURL: "https://download.example.com/file-1?signature=abc",
+        key: "file-upload/user-1/file-1/sample.txt",
+    });
+    const result = await sandbox.run([...argv], {
+        fetcher: async (input, init) => {
+            const request = toRequest(input, init);
+
+            requests.push(request);
+
+            return await fetcher(request);
+        },
+    });
+
+    return { requests, result };
+}
+
+function fileServiceRequests(requests: readonly Request[]): Request[] {
+    return requests.filter(request => request.url.startsWith("https://fusion-api.oomol.com/"));
+}
+
+function storageRequests(requests: readonly Request[]): Request[] {
+    return requests.filter(request => request.url.startsWith("https://storage.example.com/"));
+}
+
+function readTeamHeaders(
+    requests: readonly Request[],
+): Array<[string | null, string | null]> {
+    return requests.map(request => [
+        request.headers.get("x-oo-team-name"),
+        request.headers.get("x-oo-team-id"),
+    ]);
+}
+
+function readUploadTelemetryPayload(
+    sandbox: Awaited<ReturnType<typeof createCliSandbox>>,
+) {
+    return parseTelemetryRowPayload(
+        readTelemetryRowsForTest(
+            join(sandbox.env.XDG_CONFIG_HOME!, APP_NAME, "telemetry"),
+        )[0]!,
+    );
+}
 
 function createSinglePartUploadFetcher(options: {
     readonly downloadURL: string;

--- a/src/application/commands/file/upload.ts
+++ b/src/application/commands/file/upload.ts
@@ -11,11 +11,16 @@ import { requireIdentity } from "../../auth/identity.ts";
 import { CliUserError } from "../../contracts/cli.ts";
 import { bucketTelemetryBytes } from "../../telemetry/buckets.ts";
 import {
+    teamIdentityInputShape,
+    teamIdentityOptions,
+} from "../team/identity.ts";
+import {
     completeMultipartFileUpload,
     createMultipartFileUpload,
     fileUploadExpiresInMs,
     generatePresignedFileUploadPartUrls,
     maxFileUploadSizeBytes,
+    resolveFileUploadIdentity,
     serializeFileUploadRecord,
     uploadFileParts,
 } from "./shared.ts";
@@ -23,6 +28,8 @@ import { formatFileUploadRecordDetailsAsText } from "./text.ts";
 
 interface FileUploadInput {
     filePath: string;
+    personal?: boolean;
+    team?: string;
 }
 
 type RecordTelemetryProperties = NonNullable<
@@ -41,12 +48,18 @@ export const fileUploadCommand: CliCommandDefinition<FileUploadInput> = {
             required: true,
         },
     ],
+    options: teamIdentityOptions({
+        personal: "options.fileUploadPersonal",
+        team: "options.fileUploadTeam",
+    }),
     output: "standard",
     inputSchema: z.object({
         filePath: z.string(),
+        ...teamIdentityInputShape,
     }),
     handler: async (input, context) => {
         const { account } = await requireIdentity(context);
+        const identity = await resolveFileUploadIdentity(input, account, context);
         const sourceFile = await readSourceFile(
             input.filePath,
             context.cwd,
@@ -60,12 +73,14 @@ export const fileUploadCommand: CliCommandDefinition<FileUploadInput> = {
 
         const uploadSession = await createMultipartFileUpload(
             account,
+            identity,
             sourceFile.fileName,
             sourceFile.fileSize,
             context,
         );
         const presignedPartUrls = await generatePresignedFileUploadPartUrls(
             account,
+            identity,
             uploadSession,
             context,
         );
@@ -79,6 +94,7 @@ export const fileUploadCommand: CliCommandDefinition<FileUploadInput> = {
 
         const uploadResult = await completeMultipartFileUpload(
             account,
+            identity,
             uploadSession,
             uploadedParts,
             context,

--- a/src/application/commands/telemetry-decisions.test.ts
+++ b/src/application/commands/telemetry-decisions.test.ts
@@ -246,8 +246,8 @@ const commandTelemetryDecisions = {
     },
     "file.upload": {
         kind: "properties",
-        properties: ["bytes_total_bucket", "rejected_too_large"],
-        reason: "Records upload size bucket and rejection state without path or filename.",
+        properties: ["bytes_total_bucket", "identity_source", "rejected_too_large"],
+        reason: "Records upload size bucket, rejection state, and the identity source (personal/flag/env_id/env_name/account) without path, filename, or team name/id.",
     },
     "flow": {
         kind: "generic",

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -1009,6 +1009,10 @@ export const enMessages = {
         "Run the action under the given team identity",
     "options.connectorRunPersonal":
         "Run the action under your personal identity, ignoring any configured default team",
+    "options.fileUploadTeam":
+        "Upload the file under the given team identity",
+    "options.fileUploadPersonal":
+        "Upload the file under your personal identity, ignoring any configured default team",
     "options.connectorLoginToken":
         "Runtime API token for the self-hosted connector (created on the server's /access page)",
     "options.connectorProxyBody":
@@ -2377,6 +2381,10 @@ export const zhMessages = {
         "以指定团队身份运行该 action",
     "options.connectorRunPersonal":
         "以个人身份运行该 action，忽略已配置的默认团队",
+    "options.fileUploadTeam":
+        "以指定团队身份上传该文件",
+    "options.fileUploadPersonal":
+        "以个人身份上传该文件，忽略已配置的默认团队",
     "options.connectorLoginToken":
         "自部署 Connector 的 Runtime API 令牌（在服务的 /access 页面创建）",
     "options.connectorProxyBody":

--- a/src/i18n/catalog.ts
+++ b/src/i18n/catalog.ts
@@ -1012,7 +1012,7 @@ export const enMessages = {
     "options.fileUploadTeam":
         "Upload the file under the given team identity",
     "options.fileUploadPersonal":
-        "Upload the file under your personal identity, ignoring any configured default team",
+        "Upload the file under the server-side default team, ignoring OO_TEAM_ID / OO_TEAM_NAME and any saved default team",
     "options.connectorLoginToken":
         "Runtime API token for the self-hosted connector (created on the server's /access page)",
     "options.connectorProxyBody":
@@ -2384,7 +2384,7 @@ export const zhMessages = {
     "options.fileUploadTeam":
         "以指定团队身份上传该文件",
     "options.fileUploadPersonal":
-        "以个人身份上传该文件，忽略已配置的默认团队",
+        "以服务端默认团队上传该文件，忽略 OO_TEAM_ID / OO_TEAM_NAME 与已保存的默认团队",
     "options.connectorLoginToken":
         "自部署 Connector 的 Runtime API 令牌（在服务的 /access 页面创建）",
     "options.connectorProxyBody":


### PR DESCRIPTION
`oo file upload` sent no team selection, so the gateway checked the upload against the requester's own balance while the action the file feeds runs under a team. The upload now resolves the shared team ladder (`--personal` > `--team` > `OO_TEAM_ID` > `OO_TEAM_NAME` > the account default) and sends `x-oo-team-id` / `x-oo-team-name` on the three fusion-api calls, so the gateway bills the team payer and the file service meters the upload under that team. The presigned part uploads go straight to storage and stay header-free, and telemetry records only the identity source enum.

Pairs with oomol/trafnex#248, which mounts the team plugin on fusion-api. That side must land first so the gateway validates the headers instead of passing them through. Docs for `oo file upload`, the team env variables, and the Teams section are updated in both languages.
